### PR TITLE
Remove Durability from create Learnable

### DIFF
--- a/src/Persistence/Initialization/DataInitialization.cs
+++ b/src/Persistence/Initialization/DataInitialization.cs
@@ -463,7 +463,6 @@ namespace MUnique.OpenMU.Persistence.Initialization
         {
             var potion = this.context.CreateNew<Item>();
             potion.Definition = this.gameConfiguration.Items.FirstOrDefault(def => def.Group == 12 && def.Number == itemNumber);
-            potion.Durability = 1;
             potion.ItemSlot = itemSlot;
             return potion;
         }


### PR DESCRIPTION
Durability on learnable item causes item remain in the inventory when being used. It will disappear on relog.
But in the same time it is removed from Context so it become acting as bugged item.
Like simply you can grab it in inventory but it is not moving e.t.c.