### PR TITLE
Fixed exceptions during walks of entites

### DIFF
--- a/src/AdminPanel/Hubs/WorldObserverToHubAdapter.cs
+++ b/src/AdminPanel/Hubs/WorldObserverToHubAdapter.cs
@@ -81,11 +81,13 @@ namespace MUnique.OpenMU.AdminPanel.Hubs
             Point targetPoint = new Point(movedObject.X, movedObject.Y);
             object steps = null;
             int walkDelay = 0;
-            if (movedObject is ISupportWalk walkable && moveType == MoveType.Walk)
+            if (movedObject is ISupportWalk walker && moveType == MoveType.Walk)
             {
-                targetPoint = walkable.WalkTarget;
-                walkDelay = (int)walkable.StepDelay.TotalMilliseconds;
-                var walkSteps = walkable.NextDirections.Select(step => new { x = step.To.X, y = step.To.Y, direction = step.Direction }).ToList();
+                targetPoint = walker.WalkTarget;
+                walkDelay = (int)walker.StepDelay.TotalMilliseconds;
+                Span<WalkingStep> walkingSteps = new WalkingStep[16];
+                var stepCount = walker.GetSteps(walkingSteps);
+                var walkSteps = walkingSteps.Slice(0, stepCount).ToArray().Select(step => new { x = step.To.X, y = step.To.Y, direction = step.Direction }).ToList();
 
                 var lastStep = walkSteps.LastOrDefault();
                 if (lastStep != null)

--- a/src/GameLogic/IRotatable.cs
+++ b/src/GameLogic/IRotatable.cs
@@ -7,9 +7,9 @@ namespace MUnique.OpenMU.GameLogic
     using MUnique.OpenMU.DataModel.Configuration;
 
     /// <summary>
-    /// Interface for a rotateable class. An instance implementing this interface can be rotated on its game map.
+    /// Interface for a rotatable class. An instance implementing this interface can be rotated on its game map.
     /// </summary>
-    public interface IRotateable
+    public interface IRotatable
     {
         /// <summary>
         /// Gets or sets the rotation.

--- a/src/GameLogic/IRotatable.cs
+++ b/src/GameLogic/IRotatable.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="IRotateable.cs" company="MUnique">
+﻿// <copyright file="IRotatable.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 

--- a/src/GameLogic/ISupportWalk.cs
+++ b/src/GameLogic/ISupportWalk.cs
@@ -5,7 +5,6 @@
 namespace MUnique.OpenMU.GameLogic
 {
     using System;
-    using System.Collections.Generic;
     using MUnique.OpenMU.DataModel.Configuration;
     using MUnique.OpenMU.Pathfinding;
 
@@ -25,14 +24,23 @@ namespace MUnique.OpenMU.GameLogic
         TimeSpan StepDelay { get; }
 
         /// <summary>
-        /// Gets the next walking steps.
-        /// </summary>
-        Stack<WalkingStep> NextDirections { get; }
-
-        /// <summary>
         /// Gets or sets the walk target coordinate.
         /// </summary>
-        Point WalkTarget { get; set; }
+        Point WalkTarget { get; }
+
+        /// <summary>
+        /// Gets the steps which are about to happen next by writing them into the given span.
+        /// </summary>
+        /// <param name="steps">The steps.</param>
+        /// <returns>The number of written steps.</returns>
+        int GetSteps(Span<WalkingStep> steps);
+
+        /// <summary>
+        /// Gets the directions of the steps which are about to happen next by writing them into the given span.
+        /// </summary>
+        /// <param name="directions">The directions.</param>
+        /// <returns>The number of written directions.</returns>
+        int GetDirections(Span<Direction> directions);
     }
 
     /// <summary>

--- a/src/GameLogic/MUnique.OpenMU.GameLogic.csproj
+++ b/src/GameLogic/MUnique.OpenMU.GameLogic.csproj
@@ -1,9 +1,10 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -26,6 +27,7 @@
   <ItemGroup>
     <PackageReference Include="log4net" Version="2.0.8" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.0.2" />
+    <PackageReference Include="System.Memory" Version="4.5.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/GameLogic/NPC/NonPlayerCharacter.cs
+++ b/src/GameLogic/NPC/NonPlayerCharacter.cs
@@ -15,7 +15,7 @@ namespace MUnique.OpenMU.GameLogic.NPC
     /// <summary>
     /// The implementation of a non-player-character (Monster) which can not be attacked or attack.
     /// </summary>
-    public class NonPlayerCharacter : IObservable, IRotateable, ILocateable, IHasBucketInformation, IDisposable
+    public class NonPlayerCharacter : IObservable, IRotatable, ILocateable, IHasBucketInformation, IDisposable
     {
         /// <summary>
         /// Initializes a new instance of the <see cref="NonPlayerCharacter"/> class.

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -51,7 +51,7 @@ namespace MUnique.OpenMU.GameLogic
     /// <summary>
     /// The base implementation of a player.
     /// </summary>
-    public class Player : IBucketMapObserver, IAttackable, ITrader, IPartyMember, IRotateable, IHasBucketInformation, IDisposable, ISupportWalk
+    public class Player : IBucketMapObserver, IAttackable, ITrader, IPartyMember, IRotatable, IHasBucketInformation, IDisposable, ISupportWalk
     {
         private static readonly ILog Logger = LogManager.GetLogger(typeof(Player));
 

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -82,7 +82,7 @@ namespace MUnique.OpenMU.GameLogic
             this.gameContext = gameContext;
             this.PlayerView = playerView;
             this.PersistenceContext = this.gameContext.PersistenceContextProvider.CreateNewPlayerContext(gameContext.Configuration);
-            this.walker = new Walker(this);
+            this.walker = new Walker(this, this.GetStepDelay);
         }
 
         /// <summary>
@@ -111,29 +111,12 @@ namespace MUnique.OpenMU.GameLogic
         public event EventHandler PlayerLeftWorld;
 
         /// <inheritdoc />
-        public bool IsWalking { get; set; }
+        public bool IsWalking => this.walker.CurrentTarget != default;
+
+        public TimeSpan StepDelay => this.GetStepDelay();
 
         /// <inheritdoc />
-        public TimeSpan StepDelay
-        {
-            get
-            {
-                if (this.Inventory.EquippedItems.Any(item => item.Definition.ItemSlot.ItemSlots.Contains(7)))
-                {
-                    // Wings
-                    return TimeSpan.FromMilliseconds(300);
-                }
-
-                // TODO: Consider pets etc.
-                return TimeSpan.FromMilliseconds(500);
-            }
-        }
-
-        /// <inheritdoc />
-        public Stack<WalkingStep> NextDirections { get; } = new Stack<WalkingStep>(10);
-
-        /// <inheritdoc />
-        public Point WalkTarget { get; set; }
+        public Point WalkTarget => this.walker.CurrentTarget;
 
         /// <inheritdoc/>
         public int Money
@@ -577,19 +560,32 @@ namespace MUnique.OpenMU.GameLogic
         /// </summary>
         /// <param name="newx">The new x coordinate.</param>
         /// <param name="newy">The new y coordinate.</param>
-        /// <param name="moveType">Type of the move.</param>
-        public void Move(byte newx, byte newy, MoveType moveType)
+        public void Move(byte newx, byte newy)
         {
-            Logger.DebugFormat("Move: Player is moving to {0} {1}, Type {2}", newx, newy, moveType);
+            Logger.DebugFormat("Move: Player is moving to {0} {1}", newx, newy);
             this.walker.Stop();
-            this.CurrentMap.Move(this, newx, newy, this.moveLock, moveType);
-            if (moveType == MoveType.Walk)
-            {
-                this.walker.Start();
-            }
-
+            this.CurrentMap.Move(this, newx, newy, this.moveLock, MoveType.Instant);
             Logger.DebugFormat("Move: Observer Count: {0}", this.Observers.Count);
         }
+
+        /// <summary>
+        /// Walks to the specified target coordinates using the specified steps.
+        /// </summary>
+        /// <param name="target">The target.</param>
+        /// <param name="steps">The steps.</param>
+        public void WalkTo(Point target, Span<WalkingStep> steps)
+        {
+            Logger.DebugFormat("WalkTo: Player is walking to {0}", target);
+            this.walker.WalkTo(target, steps);
+            this.CurrentMap.Move(this, target.X, target.Y, this.moveLock, MoveType.Walk);
+            Logger.DebugFormat("WalkTo: Observer Count: {0}", this.Observers.Count);
+        }
+
+        /// <inheritdoc />
+        public int GetDirections(Span<Direction> directions) => this.walker.GetDirections(directions);
+
+        /// <inheritdoc />
+        public int GetSteps(Span<WalkingStep> steps) => this.walker.GetSteps(steps);
 
         /// <summary>
         /// Regenerates the attributes specified in <see cref="Stats.IntervalRegenerationAttributes"/>.
@@ -763,6 +759,22 @@ namespace MUnique.OpenMU.GameLogic
                 this.respawnAfterDeathToken.ThrowIfCancellationRequested();
                 this.WarpTo(this.GetSpawnGateOfCurrentMap());
             }
+        }
+
+        /// <summary>
+        /// Gets the step delay depending on the equipped items.
+        /// </summary>
+        /// <returns></returns>
+        private TimeSpan GetStepDelay()
+        {
+            if (this.Inventory.EquippedItems.Any(item => item.Definition.ItemSlot.ItemSlots.Contains(7)))
+            {
+                // Wings
+                return TimeSpan.FromMilliseconds(300);
+            }
+
+            // TODO: Consider pets etc.
+            return TimeSpan.FromMilliseconds(500);
         }
 
         private ExitGate GetSpawnGateOfCurrentMap()

--- a/src/GameLogic/PlayerActions/ChatMessageAction.cs
+++ b/src/GameLogic/PlayerActions/ChatMessageAction.cs
@@ -116,7 +116,7 @@ namespace MUnique.OpenMU.GameLogic.PlayerActions
                 case "/teleport":
                     if (sa.Length > 2)
                     {
-                        player.Move(byte.Parse(sa[1]), byte.Parse(sa[2]), MoveType.Instant);
+                        player.Move(byte.Parse(sa[1]), byte.Parse(sa[2]));
                     }
 
                     break;

--- a/src/GameLogic/Walker.cs
+++ b/src/GameLogic/Walker.cs
@@ -192,7 +192,7 @@ namespace MUnique.OpenMU.GameLogic
                     this.walkSupporter.X = nextStep.To.X;
                     this.walkSupporter.Y = nextStep.To.Y;
 
-                    if (this.walkSupporter is IRotateable rotateable)
+                    if (this.walkSupporter is IRotatable rotateable)
                     {
                         rotateable.Rotation = nextStep.Direction;
                     }

--- a/src/GameServer/RemoteView/WorldView.cs
+++ b/src/GameServer/RemoteView/WorldView.cs
@@ -110,7 +110,7 @@ namespace MUnique.OpenMU.GameServer.RemoteView
                         }
                     }
 
-                    if (obj is IRotateable rotatable)
+                    if (obj is IRotatable rotatable)
                     {
                         rotation = rotatable.Rotation.RotateLeft();
                     }

--- a/tests/MUnique.OpenMU.Tests/CharacterMoveTest.cs
+++ b/tests/MUnique.OpenMU.Tests/CharacterMoveTest.cs
@@ -4,7 +4,7 @@
 
 namespace MUnique.OpenMU.Tests
 {
-    using System.Linq;
+    using System;
     using MUnique.OpenMU.GameLogic;
     using MUnique.OpenMU.GameServer;
     using MUnique.OpenMU.GameServer.MessageHandler;
@@ -39,12 +39,14 @@ namespace MUnique.OpenMU.Tests
             var player = this.DoTheWalk();
 
             // the next check is questionable - there is a timer which is removing a direction every 500ms. If the test runs "too slow", the count is 3 ;-)
-            Assert.That(player.NextDirections.Count, Is.EqualTo(4));
+            Span<WalkingStep> steps = new WalkingStep[16];
+            var count = player.GetSteps(steps);
+            Assert.That(count, Is.EqualTo(4));
 
-            var directions = player.NextDirections.ToArray();
-            Assert.That(directions.First().From, Is.EqualTo(StartPoint));
-            Assert.That(directions.Last().To, Is.EqualTo(EndPoint));
-            foreach (var direction in directions)
+            steps = steps.Slice(0, count);
+            Assert.That(steps[0].From, Is.EqualTo(StartPoint));
+            Assert.That(steps[steps.Length - 1].To, Is.EqualTo(EndPoint));
+            foreach (var direction in steps)
             {
                 Assert.That(direction.From, Is.Not.EqualTo(direction.To));
             }


### PR DESCRIPTION
The stack of the walking steps need to be hidden, read and write access must be thread-safe. This required some refactoring.
I also used the new Span<> type to reduce heap allocations.