### PR TITLE
Added missing ClientTimeout column to migrations

### DIFF
--- a/src/Persistence/EntityFramework/Migrations/00000000000000_Initial.cs
+++ b/src/Persistence/EntityFramework/Migrations/00000000000000_Initial.cs
@@ -35,6 +35,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     ServerId = table.Column<byte>(nullable: false),
                     Description = table.Column<string>(nullable: true),
                     MaximumConnections = table.Column<int>(nullable: false),
+                    ClientTimeout = table.Column<TimeSpan>(nullable: false),
                     ClientCleanUpInterval = table.Column<TimeSpan>(nullable: false),
                     RoomCleanUpInterval = table.Column<TimeSpan>(nullable: false),
                     Id = table.Column<Guid>(nullable: false)

--- a/src/Persistence/EntityFramework/Migrations/00000000000000_Initial.designer.cs
+++ b/src/Persistence/EntityFramework/Migrations/00000000000000_Initial.designer.cs
@@ -307,6 +307,8 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 
                     b.Property<int>("MaximumConnections");
 
+                    b.Property<TimeSpan>("ClientTimeout");
+
                     b.Property<TimeSpan>("RoomCleanUpInterval");
 
                     b.Property<byte>("ServerId");

--- a/src/Persistence/EntityFramework/Migrations/EntityDataContextModelSnapshot.cs
+++ b/src/Persistence/EntityFramework/Migrations/EntityDataContextModelSnapshot.cs
@@ -305,6 +305,8 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 
                     b.Property<int>("MaximumConnections");
 
+                    b.Property<TimeSpan>("ClientTimeout");
+
                     b.Property<TimeSpan>("RoomCleanUpInterval");
 
                     b.Property<byte>("ServerId");


### PR DESCRIPTION
This fixes initial StartUp error regarding missing ClientTimeout column in ChatServerDefinition table