### PR TITLE
Updated nuget package MUnique.Log4Net.CoreSignalR to 1.0.0-beta6

### DIFF
--- a/src/AdminPanel/MUnique.OpenMU.AdminPanel.csproj
+++ b/src/AdminPanel/MUnique.OpenMU.AdminPanel.csproj
@@ -92,7 +92,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="munique.log4net.coresignalr" Version="1.0.0-beta5" />
+    <PackageReference Include="munique.log4net.coresignalr" Version="1.0.0-beta6" />
     <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="1.0.0-beta0006" />
     <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This fixes the problem of missing log levels in transferred log messages.