### PR TITLE
Implemented automatic health and shield regeneration at safezone

### DIFF
--- a/src/GameLogic/Attributes/Stats.cs
+++ b/src/GameLogic/Attributes/Stats.cs
@@ -487,6 +487,11 @@ namespace MUnique.OpenMU.GameLogic.Attributes
         public static AttributeDefinition AmmunitionAmount { get; } = new AttributeDefinition(new Guid("064543E6-2559-4033-B363-AE76214E7DEE"), "The amount of ammo which is equipped.", "You can only execute certain skills if you have enough ammo, or if the ammo consumption rate is 0.");
 
         /// <summary>
+        /// Gets the <see cref="IsInSafezone"/> attribute which defines if the character is located in a safezone of a game map.
+        /// </summary>
+        public static AttributeDefinition IsInSafezone { get; } = new AttributeDefinition(new Guid("82044DF9-F528-4AD6-9AAA-6FEAA4C786E7"), "Flag, if the character is located in a safezone of a game map", "Characters at the safezone recover additional health and shield.");
+
+        /// <summary>
         /// Gets the attributes which are regenerated in an interval.
         /// </summary>
         public static IEnumerable<Regeneration> IntervalRegenerationAttributes

--- a/src/GameLogic/MapInitializer.cs
+++ b/src/GameLogic/MapInitializer.cs
@@ -10,6 +10,7 @@ namespace MUnique.OpenMU.GameLogic
     using MUnique.OpenMU.DataModel.Configuration;
     using MUnique.OpenMU.GameLogic.NPC;
     using MUnique.OpenMU.Interfaces;
+    using MUnique.OpenMU.PlugIns;
 
     /// <summary>
     /// A basic map initializer.
@@ -35,6 +36,11 @@ namespace MUnique.OpenMU.GameLogic
             this.ChunkSize = 8;
             this.mapStateObserver = mapStateObserver;
         }
+
+        /// <summary>
+        /// Gets or sets the plug in manager.
+        /// </summary>
+        public PlugInManager PlugInManager { get; set; }
 
         /// <summary>
         /// Gets or sets the duration of the item drop on created <see cref="GameMap"/>s.
@@ -79,7 +85,7 @@ namespace MUnique.OpenMU.GameLogic
                     if (monsterDef.AttackDelay > TimeSpan.Zero)
                     {
                         Logger.Debug($"Creating monster {spawn}");
-                        npc = new Monster(spawn, monsterDef, createdMap, this.defaultDropGenerator, new BasicMonsterIntelligence(createdMap));
+                        npc = new Monster(spawn, monsterDef, createdMap, this.defaultDropGenerator, new BasicMonsterIntelligence(createdMap), this.PlugInManager);
                     }
                     else
                     {
@@ -109,7 +115,9 @@ namespace MUnique.OpenMU.GameLogic
         /// Creates the game map instance with the specified definition.
         /// </summary>
         /// <param name="definition">The definition.</param>
-        /// <returns>The created game map instance.</returns>
+        /// <returns>
+        /// The created game map instance.
+        /// </returns>
         protected virtual GameMap InternalCreateGameMap(GameMapDefinition definition)
         {
             return new GameMap(definition, this.ItemDropDuration, this.ChunkSize, this.mapStateObserver);

--- a/src/GameLogic/NPC/NonPlayerCharacter.cs
+++ b/src/GameLogic/NPC/NonPlayerCharacter.cs
@@ -39,7 +39,7 @@ namespace MUnique.OpenMU.GameLogic.NPC
         public MonsterDefinition Definition { get; set; }
 
         /// <inheritdoc/>
-        public Point Position { get; set; }
+        public virtual Point Position { get; set; }
 
         /// <inheritdoc/>
         public Direction Rotation { get; set; }

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -46,6 +46,7 @@ namespace MUnique.OpenMU.GameLogic
         private Character selectedCharacter;
 
         private ICustomPlugInContainer<IViewPlugIn> viewPlugIns;
+        private GameMap currentMap;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="Player" /> class.
@@ -194,7 +195,19 @@ namespace MUnique.OpenMU.GameLogic
         public int TradingMoney { get; set; }
 
         /// <inheritdoc/>
-        public GameMap CurrentMap { get; private set; }
+        public GameMap CurrentMap
+        {
+            get => this.currentMap;
+
+            private set
+            {
+                if (this.currentMap != value)
+                {
+                    this.currentMap = value;
+                    this.GameContext.PlugInManager?.GetPlugInPoint<IAttackableMovedPlugIn>()?.AttackableMoved(this);
+                }
+            }
+        }
 
         /// <inheritdoc/>
         public ISet<IWorldObserver> Observers { get; } = new HashSet<IWorldObserver>();
@@ -232,8 +245,12 @@ namespace MUnique.OpenMU.GameLogic
 
             set
             {
-                this.SelectedCharacter.PositionX = value.X;
-                this.SelectedCharacter.PositionY = value.Y;
+                if (this.Position != value)
+                {
+                    this.SelectedCharacter.PositionX = value.X;
+                    this.SelectedCharacter.PositionY = value.Y;
+                    this.GameContext.PlugInManager?.GetPlugInPoint<IAttackableMovedPlugIn>()?.AttackableMoved(this);
+                }
             }
         }
 

--- a/src/GameLogic/PlugIns/IAttackableMovedPlugIn.cs
+++ b/src/GameLogic/PlugIns/IAttackableMovedPlugIn.cs
@@ -1,0 +1,23 @@
+﻿// <copyright file="IAttackableMovedPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.PlugIns
+{
+    using System.Runtime.InteropServices;
+    using MUnique.OpenMU.PlugIns;
+
+    /// <summary>
+    /// A plugin interface which Is called when a <see cref="IAttackable"/> moved on the game map.
+    /// </summary>
+    [Guid("ABD191BC-AEA2-4308-8EAA-CAF0A0D6B46B")]
+    [PlugInPoint("Attackable moved", "Plugins which are called when an attackable object moved on the game map.")]
+    public interface IAttackableMovedPlugIn
+    {
+        /// <summary>
+        /// Is called when a <see cref="IAttackable"/> moved on the game map.
+        /// </summary>
+        /// <param name="attackable">The <see cref="IAttackable"/>.</param>
+        void AttackableMoved(IAttackable attackable);
+    }
+}

--- a/src/GameLogic/PlugIns/UpdateIsInSafezoneAfterPlayerMoved.cs
+++ b/src/GameLogic/PlugIns/UpdateIsInSafezoneAfterPlayerMoved.cs
@@ -1,0 +1,27 @@
+﻿// <copyright file="UpdateIsInSafezoneAfterPlayerMoved.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.PlugIns
+{
+    using System.Runtime.InteropServices;
+    using MUnique.OpenMU.GameLogic.Attributes;
+    using MUnique.OpenMU.PlugIns;
+
+    /// <summary>
+    /// Updates the <see cref="Stats.IsInSafezone"/>. For example, this activates the automatic health and shield recover.
+    /// </summary>
+    [PlugIn(nameof(UpdateIsInSafezoneAfterPlayerMoved), "Updates the attribute if a player is located in the safezone. For example, this activates the automatic health and shield recover.")]
+    [Guid("396617CA-954A-45A1-A6DB-1AA65309A03D")]
+    public class UpdateIsInSafezoneAfterPlayerMoved : IAttackableMovedPlugIn
+    {
+        /// <inheritdoc />
+        public void AttackableMoved(IAttackable attackable)
+        {
+            if (attackable is Player player)
+            {
+                player.Attributes.SetStatAttribute(Stats.IsInSafezone, attackable.IsAtSafezone() ? 1.0f : 0.0f);
+            }
+        }
+    }
+}

--- a/src/GameServer/GameServer.cs
+++ b/src/GameServer/GameServer.cs
@@ -57,6 +57,7 @@ namespace MUnique.OpenMU.GameServer
             {
                 var mapInitializer = new GameServerMapInitializer(gameServerDefinition, this.Id, stateObserver);
                 this.gameContext = new GameServerContext(gameServerDefinition, guildServer, loginServer, friendServer, persistenceContextProvider, stateObserver, mapInitializer);
+                mapInitializer.PlugInManager = this.gameContext.PlugInManager;
             }
             catch (Exception ex)
             {

--- a/src/GameServer/GameServerMapInitializer.cs
+++ b/src/GameServer/GameServerMapInitializer.cs
@@ -8,6 +8,7 @@ namespace MUnique.OpenMU.GameServer
     using MUnique.OpenMU.DataModel.Configuration;
     using MUnique.OpenMU.GameLogic;
     using MUnique.OpenMU.Interfaces;
+    using MUnique.OpenMU.PlugIns;
 
     /// <summary>
     /// A game map initializer which takes aspects of the <see cref="GameServer"/> into account.

--- a/src/Persistence/Initialization/CharacterClasses/ClassDarkKnight.cs
+++ b/src/Persistence/Initialization/CharacterClasses/ClassDarkKnight.cs
@@ -46,6 +46,7 @@ namespace MUnique.OpenMU.Persistence.Initialization.CharacterClasses
             result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.CurrentMana, 20, false));
             result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.CurrentAbility, 1, false));
             result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.CurrentShield, 1, false));
+            result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.IsInSafezone, 1, false));
 
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.TotalStrength, 1, Stats.BaseStrength));
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.TotalAgility, 1, Stats.BaseAgility));
@@ -92,6 +93,9 @@ namespace MUnique.OpenMU.Persistence.Initialization.CharacterClasses
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1, Stats.MaximumPhysBaseDmgByWeapon));
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.SkillMultiplier, 0.01f, Stats.TotalEnergy));
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumGuildSize, 0.1f, Stats.Level));
+
+            result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.HealthRecoveryMultiplier, 0.01f, Stats.IsInSafezone));
+            result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.ShieldRecoveryMultiplier, 0.01f, Stats.IsInSafezone));
 
             result.BaseAttributeValues.Add(this.CreateConstValueAttribute(10, Stats.MaximumMana));
             result.BaseAttributeValues.Add(this.CreateConstValueAttribute(35, Stats.MaximumHealth));

--- a/src/Persistence/Initialization/CharacterClasses/ClassDarkLord.cs
+++ b/src/Persistence/Initialization/CharacterClasses/ClassDarkLord.cs
@@ -47,6 +47,7 @@ namespace MUnique.OpenMU.Persistence.Initialization.CharacterClasses
             result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.CurrentMana, 1, false));
             result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.CurrentAbility, 1, false));
             result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.CurrentShield, 1, false));
+            result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.IsInSafezone, 1, false));
 
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.TotalStrength, 1, Stats.BaseStrength));
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.TotalAgility, 1, Stats.BaseAgility));
@@ -99,6 +100,10 @@ namespace MUnique.OpenMU.Persistence.Initialization.CharacterClasses
 
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumGuildSize, 0.1f, Stats.Level));
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumGuildSize, 0.1f, Stats.TotalLeadership));
+
+            result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.HealthRecoveryMultiplier, 0.01f, Stats.IsInSafezone));
+            result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.ShieldRecoveryMultiplier, 0.01f, Stats.IsInSafezone));
+
             /* TODO: Add these stats
                                         Critical dmg = cmd/25+str/30
                                         Fireburst bonus min dmg = 100+str/25+ene/50

--- a/src/Persistence/Initialization/CharacterClasses/ClassDarkWizard.cs
+++ b/src/Persistence/Initialization/CharacterClasses/ClassDarkWizard.cs
@@ -46,6 +46,7 @@ namespace MUnique.OpenMU.Persistence.Initialization.CharacterClasses
             result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.CurrentMana, 60, false));
             result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.CurrentAbility, 1, false));
             result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.CurrentShield, 1, false));
+            result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.IsInSafezone, 1, false));
 
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.TotalStrength, 1, Stats.BaseStrength));
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.TotalAgility, 1, Stats.BaseAgility));
@@ -91,6 +92,9 @@ namespace MUnique.OpenMU.Persistence.Initialization.CharacterClasses
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumWizBaseDmg, 1.0f / 9, Stats.TotalEnergy));
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumWizBaseDmg, 1.0f / 4, Stats.TotalEnergy));
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumGuildSize, 0.1f, Stats.Level));
+
+            result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.HealthRecoveryMultiplier, 0.01f, Stats.IsInSafezone));
+            result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.ShieldRecoveryMultiplier, 0.01f, Stats.IsInSafezone));
 
             result.BaseAttributeValues.Add(this.CreateConstValueAttribute(30, Stats.MaximumHealth));
             result.BaseAttributeValues.Add(this.CreateConstValueAttribute(1, Stats.SkillMultiplier));

--- a/src/Persistence/Initialization/CharacterClasses/ClassFairyElf.cs
+++ b/src/Persistence/Initialization/CharacterClasses/ClassFairyElf.cs
@@ -47,6 +47,7 @@ namespace MUnique.OpenMU.Persistence.Initialization.CharacterClasses
             result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.CurrentAbility, 1, false));
             result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.CurrentShield, 1, false));
             result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.AmmunitionAmount, 0, false));
+            result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.IsInSafezone, 1, false));
 
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.TotalStrength, 1, Stats.BaseStrength));
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.TotalAgility, 1, Stats.BaseAgility));
@@ -92,6 +93,9 @@ namespace MUnique.OpenMU.Persistence.Initialization.CharacterClasses
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumPhysBaseDmg, 1, Stats.MinimumPhysBaseDmgByWeapon));
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1, Stats.MaximumPhysBaseDmgByWeapon));
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumGuildSize, 0.1f, Stats.Level));
+
+            result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.HealthRecoveryMultiplier, 0.01f, Stats.IsInSafezone));
+            result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.ShieldRecoveryMultiplier, 0.01f, Stats.IsInSafezone));
 
             result.BaseAttributeValues.Add(this.CreateConstValueAttribute(39, Stats.MaximumHealth));
             result.BaseAttributeValues.Add(this.CreateConstValueAttribute(6, Stats.MaximumMana));

--- a/src/Persistence/Initialization/CharacterClasses/ClassMagicGladiator.cs
+++ b/src/Persistence/Initialization/CharacterClasses/ClassMagicGladiator.cs
@@ -42,6 +42,7 @@ namespace MUnique.OpenMU.Persistence.Initialization.CharacterClasses
             result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.CurrentMana, 60, false));
             result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.CurrentAbility, 1, false));
             result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.CurrentShield, 1, false));
+            result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.IsInSafezone, 1, false));
 
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.TotalStrength, 1, Stats.BaseStrength));
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.TotalAgility, 1, Stats.BaseAgility));
@@ -91,6 +92,9 @@ namespace MUnique.OpenMU.Persistence.Initialization.CharacterClasses
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumWizBaseDmg, 1.0f / 9, Stats.TotalEnergy));
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumWizBaseDmg, 1.0f / 4, Stats.TotalEnergy));
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumGuildSize, 0.1f, Stats.Level));
+
+            result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.HealthRecoveryMultiplier, 0.01f, Stats.IsInSafezone));
+            result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.ShieldRecoveryMultiplier, 0.01f, Stats.IsInSafezone));
 
             result.BaseAttributeValues.Add(this.CreateConstValueAttribute(57, Stats.MaximumHealth));
             result.BaseAttributeValues.Add(this.CreateConstValueAttribute(7, Stats.MaximumMana));

--- a/src/Persistence/Initialization/CharacterClasses/ClassRageFighter.cs
+++ b/src/Persistence/Initialization/CharacterClasses/ClassRageFighter.cs
@@ -42,6 +42,7 @@ namespace MUnique.OpenMU.Persistence.Initialization.CharacterClasses
             result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.CurrentMana, 40, false));
             result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.CurrentAbility, 1, false));
             result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.CurrentShield, 1, false));
+            result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.IsInSafezone, 1, false));
 
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.TotalStrength, 1, Stats.BaseStrength));
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.TotalAgility, 1, Stats.BaseAgility));
@@ -90,6 +91,9 @@ namespace MUnique.OpenMU.Persistence.Initialization.CharacterClasses
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumWizBaseDmg, 1.0f / 9, Stats.TotalEnergy));
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumWizBaseDmg, 1.0f / 4, Stats.TotalEnergy));
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumGuildSize, 0.1f, Stats.Level));
+
+            result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.HealthRecoveryMultiplier, 0.01f, Stats.IsInSafezone));
+            result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.ShieldRecoveryMultiplier, 0.01f, Stats.IsInSafezone));
 
             result.BaseAttributeValues.Add(this.CreateConstValueAttribute(57, Stats.MaximumHealth));
             result.BaseAttributeValues.Add(this.CreateConstValueAttribute(7, Stats.MaximumMana));

--- a/src/Persistence/Initialization/CharacterClasses/ClassSummoner.cs
+++ b/src/Persistence/Initialization/CharacterClasses/ClassSummoner.cs
@@ -46,6 +46,7 @@ namespace MUnique.OpenMU.Persistence.Initialization.CharacterClasses
             result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.CurrentMana, 20, false));
             result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.CurrentAbility, 1, false));
             result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.CurrentShield, 1, false));
+            result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.IsInSafezone, 1, false));
 
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.TotalStrength, 1, Stats.BaseStrength));
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.TotalAgility, 1, Stats.BaseAgility));
@@ -93,6 +94,9 @@ namespace MUnique.OpenMU.Persistence.Initialization.CharacterClasses
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumWizBaseDmg, 1.0f / 9, Stats.TotalEnergy));
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumWizBaseDmg, 1.0f / 4, Stats.TotalEnergy));
             result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumGuildSize, 0.1f, Stats.Level));
+
+            result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.HealthRecoveryMultiplier, 0.01f, Stats.IsInSafezone));
+            result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.ShieldRecoveryMultiplier, 0.01f, Stats.IsInSafezone));
 
             result.BaseAttributeValues.Add(this.CreateConstValueAttribute(39, Stats.MaximumHealth));
             result.BaseAttributeValues.Add(this.CreateConstValueAttribute(6, Stats.MaximumMana));


### PR DESCRIPTION
See #149.

> It would be great to have two Plugin Extension Points for that, so that the update can be implemented in a plugin. This allows us to write more plugins which react on this event in the future.

We could add a more generic Plugin Extension Point which is called when a attribute value changed. So, at the moment, I wouldn't want to add the two points.