### PR TITLE
[FIX] add command existance validation

### DIFF
--- a/src/GameLogic/PlayerActions/ChatMessageAction.cs
+++ b/src/GameLogic/PlayerActions/ChatMessageAction.cs
@@ -57,9 +57,14 @@ namespace MUnique.OpenMU.GameLogic.PlayerActions
                 case ChatMessageType.Command:
                     var commandKey = message.Split(' ').First();
                     var commandHandler = sender.GameContext.PlugInManager.GetStrategy<IChatCommandPlugIn>(commandKey);
+                    if (commandHandler == null)
+                    {
+                        break;
+                    }
+
                     if (sender.SelectedCharacter.CharacterStatus >= commandHandler.MinCharacterStatusRequirement)
                     {
-                        commandHandler?.HandleCommand(sender, message);
+                        commandHandler.HandleCommand(sender, message);
                     }
                     else
                     {


### PR DESCRIPTION
exit command handling if command does not exists, because it fails to get MinCharacterStatusRequirement property.