### PR TITLE
Fix development Linux setup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM mcr.microsoft.com/dotnet/core/sdk:3.1 AS build
 
 # Requirements for the typescript compiler
-RUN apt-get update
-RUN apt-get install npm -y
-RUN npm i -g typescript
+RUN apt-get update && \
+  apt-get install npm -y && \
+  npm i -g typescript
 
 COPY src/ ./app/src
 

--- a/QuickStart.md
+++ b/QuickStart.md
@@ -14,16 +14,29 @@ This guide describes two ways of starting the server. Use Docker, if you just wa
 
 This guide assumes you know how to use docker in general and have docker installed (e.g. by using Docker Desktop on Windows).
 
-### Generates certificate (Linux)
+### Generates certificate
+The project needs a certificate to run the public API.
+  * How to create one depends on your host OS, see below.
+  * `{ password here }` must be replaced with your certificate password.
+  * It needs to be run once on the host. If you forgot your password, you can run it again.
+
+#### Linux
 
 Build shell commands and run:
 
 ```bash
 source dev.sh
-generate_certificate <your_password>
+generate_certificate { password here }
 ```
 
-`<your_password>` must be replaced by your certificate password. After generate certificate, is needed export `CERTIFICATE_PASSWORD` variable for docker-compose to use.
+The script generates the certificate on a dedicated docker container and exports the environment variable `CERTIFICATE_PASSWORD` which can be used at docker-compose.
+
+#### Windows
+```cmd
+dotnet dev-certs https -ep %USERPROFILE%\.aspnet\https\aspnetapp.pfx -p { password here }
+dotnet dev-certs https --trust
+setx CERTIFICATE_PASSWORD "{ password here }"
+```
 
 ### Demo Mode
 If you just want to play around with the server, you can find the newest docker image on the Docker Hub:
@@ -52,7 +65,7 @@ It's possible to define additional environment variables to influence the postgr
 | DB_HOST | The hostname of the database. If the local configuration file is still configured to use 'localhost', the value of this variable replaces it |
 | DB_ADMIN_USER | The user name of the postgres admin account. If the local configuration file is still configured to use 'postgres' for the user name of the admin (first entry in the ConnectionSettings.xml), the value of this variable replaces it. |
 | DB_ADMIN_PW | The user name of the postgres admin account. If the local configuration file is still configured to use 'admin' for the user password of the admin (first entry in the ConnectionSettings.xml), the value of this variable replaces it. |
-| ASPNETCORE_Kestrel__Certificates__Default__Password | The ASP NET application certificate password. The CERTIFICATE_PASSWORD must be exported |
+| ASPNETCORE_Kestrel__Certificates__Default__Password | The ASP NET application certificate password. When docker-compose-dev is used, the environment variable CERTIFICATE_PASSWORD must be exported/set on the host system instead. |
 
 ## Manually
 

--- a/QuickStart.md
+++ b/QuickStart.md
@@ -14,6 +14,17 @@ This guide describes two ways of starting the server. Use Docker, if you just wa
 
 This guide assumes you know how to use docker in general and have docker installed (e.g. by using Docker Desktop on Windows).
 
+### Generates certificate (Linux)
+
+Build shell commands and run:
+
+```bash
+source dev.sh
+generate_certificate <your_password>
+```
+
+`<your_password>` must be replaced by your certificate password. After generate certificate, is needed export `CERTIFICATE_PASSWORD` variable for docker-compose to use.
+
 ### Demo Mode
 If you just want to play around with the server, you can find the newest docker image on the Docker Hub:
 https://hub.docker.com/r/munique/openmu
@@ -41,6 +52,7 @@ It's possible to define additional environment variables to influence the postgr
 | DB_HOST | The hostname of the database. If the local configuration file is still configured to use 'localhost', the value of this variable replaces it |
 | DB_ADMIN_USER | The user name of the postgres admin account. If the local configuration file is still configured to use 'postgres' for the user name of the admin (first entry in the ConnectionSettings.xml), the value of this variable replaces it. |
 | DB_ADMIN_PW | The user name of the postgres admin account. If the local configuration file is still configured to use 'admin' for the user password of the admin (first entry in the ConnectionSettings.xml), the value of this variable replaces it. |
+| ASPNETCORE_Kestrel__Certificates__Default__Password | The ASP NET application certificate password. The CERTIFICATE_PASSWORD must be exported |
 
 ## Manually
 

--- a/dev.sh
+++ b/dev.sh
@@ -5,8 +5,7 @@ function generate_certificates {
     sh -c "dotnet dev-certs https --clean && dotnet dev-certs https -ep /certificates/aspnetapp.pfx -p ${1}"
 
   if [ $? == 0 ]; then
-    echo ""
-    echo "Run:"
-    echo "  export CERTIFICATE_PASSWORD=${1}"
+    export CERTIFICATE_PASSWORD=${1}
+    echo "success"
   fi
 }

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,12 @@
+function generate_certificates {
+  docker run --rm --entrypoint "" \
+    -v $PWD/certificates:/certificates \
+    mcr.microsoft.com/dotnet/core/sdk:3.1 \
+    sh -c "dotnet dev-certs https --clean && dotnet dev-certs https -ep /certificates/aspnetapp.pfx -p ${1}"
+
+  if [ $? == 0 ]; then
+    echo ""
+    echo "Run:"
+    echo "  export CERTIFICATE_PASSWORD=${1}"
+  fi
+}

--- a/docker-compose-dev.yml
+++ b/docker-compose-dev.yml
@@ -4,7 +4,9 @@ version: '3'
 services:
   # Deploy MUnique OpenMU from docker hub
   munique:
-    image: munique/openmu
+    image: openmu
+    build:
+      context: .
     container_name: munique
     restart: unless-stopped
     tty: true
@@ -19,6 +21,12 @@ services:
       SERVICE_NAME: munique
       SERVICE_TAGS: dev
       DB_HOST: database
+      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_URLS: https://+:443;http://+:80
+      ASPNETCORE_Kestrel__Certificates__Default__Password: ${CERTIFICATE_PASSWORD}
+      ASPNETCORE_Kestrel__Certificates__Default__Path: /https/aspnetapp.pfx
+    volumes:
+      - $PWD/certificates:/https:ro
     working_dir: /app/
     links:
       - database

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,9 @@ version: '3'
 services:
   # Deploy MUnique OpenMU from docker hub
   munique:
-    image: munique/openmu
+    image: openmu
+    build:
+      context: .
     container_name: munique
     restart: unless-stopped
     tty: true
@@ -19,6 +21,12 @@ services:
       SERVICE_NAME: munique
       SERVICE_TAGS: dev
       DB_HOST: database
+      ASPNETCORE_ENVIRONMENT: Development
+      ASPNETCORE_URLS: https://+:443;http://+:80
+      ASPNETCORE_Kestrel__Certificates__Default__Password: ${CERTIFICATE_PASSWORD}
+      ASPNETCORE_Kestrel__Certificates__Default__Path: /https/aspnetapp.pfx
+    volumes:
+      - $PWD/certificates:/https:ro
     working_dir: /app/
     links:
       - database


### PR DESCRIPTION
## Fix Linux development setup

For Linux, it's neccessary generate SSL certificate for the application to use. If the application doesn't find the certificate, an error is thrown. This PR creates shell command to generate this certificate and a docker-compose file for development mode.

- Created a docker-compose dev file for development mode
- Fixed Dockerfile to use layer cache
- Created a shell scripts file to generate ASP NET application certificate

Issue: https://github.com/MUnique/OpenMU/issues/189