### PR TITLE
Fixed Network Analyzer publishing

### DIFF
--- a/src/Network/Analyzer/MUnique.OpenMU.Network.Analyzer.csproj
+++ b/src/Network/Analyzer/MUnique.OpenMU.Network.Analyzer.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UseWindowsForms>true</UseWindowsForms>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -45,12 +45,8 @@
     <ProjectReference Include="..\Packets\MUnique.OpenMU.Network.Packets.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Update="MainForm.cs">
-      <SubType>Form</SubType>
-    </Compile>
-    <Compile Update="PacketSenderForm.cs">
-      <SubType>Form</SubType>
-    </Compile>
+    <Compile Update="MainForm.cs" />
+    <Compile Update="PacketSenderForm.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Update="Readme.md">


### PR DESCRIPTION
I was playing with the Network Analyzer tool and I wanted to run it as  an application outside VS, so I tried to publish it but I got this error :

![image](https://user-images.githubusercontent.com/29358436/91640438-d7946800-ea1d-11ea-82a3-5341ad1ae7b6.png)

I found the solution in this [stackoverflow post](https://stackoverflow.com/questions/43320772/the-publish-target-is-not-supported-without-specifying-a-target-framework), but I'm not really sure it is the correct one. However now everything works fine

![image](https://user-images.githubusercontent.com/29358436/91640546-a0728680-ea1e-11ea-8d3b-2fe3f4e47bfa.png)
