### PR TITLE
Update dev.sh

### DIFF
--- a/dev.sh
+++ b/dev.sh
@@ -1,7 +1,7 @@
 function generate_certificates {
   docker run --rm --entrypoint "" \
     -v $PWD/certificates:/certificates \
-    mcr.microsoft.com/dotnet/core/sdk:5.0 \
+    mcr.microsoft.com/dotnet/sdk:5.0 \
     sh -c "dotnet dev-certs https --clean && dotnet dev-certs https -ep /certificates/aspnetapp.pfx -p ${1}"
 
   if [ $? == 0 ]; then


### PR DESCRIPTION
```
generate_certificates test
Unable to find image 'mcr.microsoft.com/dotnet/core/sdk:5.0' locally
docker: Error response from daemon: manifest for mcr.microsoft.com/dotnet/core/sdk:5.0 not found: manifest unknown: manifest tagged by "5.0" is not found.
```

remove 'core' helps

https://hub.docker.com/_/microsoft-dotnet-sdk/