### PR TITLE
Feature/walk fixes

### DIFF
--- a/docs/Packets/C1-D4-WalkRequest_by-client.md
+++ b/docs/Packets/C1-D4-WalkRequest_by-client.md
@@ -17,4 +17,6 @@ The player gets moved on the map, visible for other surrounding players.
 | 2 | 1 |    Byte   | 0xD4  | Packet header - packet type identifier |
 | 3 | 1 | Byte |  | SourceX |
 | 4 | 1 | Byte |  | SourceY |
-| 5 |  | Binary |  | Directions; The directions of the walking path. The target is calculated by taking the source coordinates and applying the directions to it. |
+| 5 | 4 bit | Byte |  | TargetRotation |
+| 5 | 4 bit | Byte |  | StepCount |
+| 6 |  | Binary |  | Directions; The directions of the walking path. The target is calculated by taking the source coordinates and applying the directions to it. |

--- a/src/GameLogic/Walker.cs
+++ b/src/GameLogic/Walker.cs
@@ -19,7 +19,7 @@ namespace MUnique.OpenMU.GameLogic
     {
         private readonly ISupportWalk walkSupporter;
         private readonly Func<TimeSpan> stepDelay;
-        private readonly Stack<WalkingStep> nextSteps = new Stack<WalkingStep>(5);
+        private readonly Queue<WalkingStep> nextSteps = new Queue<WalkingStep>(5);
         private readonly ReaderWriterLockSlim walkLock;
         private Timer? walkTimer;
         private bool isDisposed;
@@ -60,7 +60,7 @@ namespace MUnique.OpenMU.GameLogic
                 this.nextSteps.Clear();
                 foreach (var step in steps)
                 {
-                    this.nextSteps.Push(step);
+                    this.nextSteps.Enqueue(step);
                 }
             }
             finally
@@ -209,7 +209,7 @@ namespace MUnique.OpenMU.GameLogic
         {
             if (!this.ShouldWalkerStop())
             {
-                var nextStep = this.nextSteps.Pop();
+                var nextStep = this.nextSteps.Dequeue();
                 this.walkSupporter.Position = nextStep.To;
 
                 if (this.walkSupporter is IRotatable rotatable)


### PR DESCRIPTION
**Description**
This PR fixes steps/directions computation and consumption when the walking path to the target location is not a straight line.

**How to reproduce the issue**
1. Log in to any character and go to Lorencia, position (137, 122).
2. Switch character and log back in to the same character and check the current position.
3. If the position is different from (137, 122), then the issue was reproduced successfully.
4. If not, go to (136, 124) and switch character and log back in. The current position will be (136, 123), instead of (136, 124).