### PR TITLE
[WIP] add create mode for a new MonsterSpawn in MapEditor component

### DIFF
--- a/src/AdminPanel/Components/MapEditor.razor
+++ b/src/AdminPanel/Components/MapEditor.razor
@@ -14,10 +14,30 @@
 
 <h3>@this.Map.Name</h3>
 
-@if (this.AreaFactory is not null)
-{
-    <button type="button" class="primary-button" @onclick=this.AddSpawn disabled="@createMode">Add Spawn</button>
-}
+<div class="btn-toolbar mb-2" role="toolbar" aria-label="Toolbar">
+    <div class="btn-group mr-2" role="group" aria-label="Creation Group">
+        <button type="button" class="btn btn-secondary" @onclick="@this.CreateNewSpawnArea" disabled="@this.createMode">
+            <span class="oi oi-plus"></span> Spawn Area
+        </button>
+        <button type="button" class="btn btn-secondary" @onclick="@this.CreateNewEnterGate" disabled="@this.createMode">
+            <span class="oi oi-plus"></span> Enter Gate
+        </button>
+        <button type="button" class="btn btn-secondary" @onclick="@this.CreateNewExitGate" disabled="@this.createMode">
+            <span class="oi oi-plus"></span> Exit Gate
+        </button>
+    </div>
+    <div class="btn-group" role="group" aria-label="Control Group">
+        @if (this.createMode)
+        {
+            <button id="applyCreate" type="button" class="btn btn-primary" @onclick="@(_ => this.createMode = false)"><span class="oi oi-circle-check"></span></button>
+            <button id="cancelCreate" type="button" class="btn btn-secondary" @onclick="@this.CancelCreation"><span class="oi oi-circle-x"></span></button>
+        }
+        else if (this.focusedObject is not null)
+        {
+            <button id="removeFocused" type="button" class="btn btn-secondary" @onclick="@this.RemoveFocusedObject"><span class="oi oi-x"></span> Remove</button>
+        }
+    </div>
+</div>
 
 <div class="map-host" width="@(scale * 255)" height="@(scale * 255)">
     <img src="@(this.terrainImage.ToBase64String(PngFormat.Instance))"
@@ -28,7 +48,7 @@
         <div class="gate-enter"
              title="@enterGate.ToString()"
              style="@this.GetSizeAndPositionStyle(enterGate)"
-             @onclick="@(_ => this.focusedObject = enterGate)">
+             @onclick="@(_ => { if (!this.createMode) { this.focusedObject = enterGate; } })">
             @if (this.focusedObject == enterGate)
             {
                 <Resizers CoordinatesGetter="@this.OnGetObjectCoordinates" Resizing="@this.OnGateResizing" />
@@ -41,7 +61,7 @@
         <div class="gate-exit"
              title="@exitGate.ToString()"
              style="@this.GetSizeAndPositionStyle(exitGate)"
-             @onclick="@(_ => this.focusedObject = exitGate)">
+             @onclick="@(_ => { if (!this.createMode) { this.focusedObject = exitGate; } })">
             @if (this.focusedObject == exitGate)
             {
                 <Resizers CoordinatesGetter="@this.OnGetObjectCoordinates" Resizing="@this.OnGateResizing" />
@@ -54,7 +74,7 @@
         <div class="@this.GetSpawnClass(spawn)"
              title="@spawn.ToString()"
              style="@this.GetSizeAndPositionStyle(spawn)"
-             @onclick="@(_ => this.focusedObject = spawn)">
+             @onclick="@(_ => { if (!this.createMode) { this.focusedObject = spawn; } })">
             @if (this.focusedObject == spawn)
             {
                 if (spawn.X1 != spawn.X2 || spawn.Y1 != spawn.Y2)
@@ -72,35 +92,13 @@
             }
         </div>
     }
-
-    @if (this.createMode == true && this.focusedObject is MonsterSpawnArea newSpawn)
-    {
-        <div class="@this.GetSpawnClass(newSpawn)"
-             title="@newSpawn.ToString()"
-             style="@this.GetSizeAndPositionStyle(newSpawn)"
-             @onclick="@(_ => this.focusedObject = newSpawn)">
-                @if (newSpawn.X1 != newSpawn.X2 || newSpawn.Y1 != newSpawn.Y2)
-                {
-                    <Resizers CoordinatesGetter="@this.OnGetObjectCoordinates" Resizing="@this.OnSpawnResizing" />
-                }
-                else if (newSpawn.Direction != Direction.Undefined)
-                {
-                    <div class="arrow @this.GetFocusedRotation()"></div>
-                }
-                else
-                {
-                    // show nothing
-                }
-            }
-        </div>
-    }
 </div>
 
-@if (this.createMode == false)
+@if (!this.createMode)
 {
     <div class="map-object-select">
         <label for="objectSelect">Selected Object:</label>
-        <select title="Object" @onchange=this.OnObjectSelected id="objectSelect" autocomplete="off">
+        <select title="Object" @onchange=this.OnObjectSelected id="objectSelect" autocomplete="off" disabled="@this.createMode">
             <option value="@Guid.Empty" selected=@(this.focusedObject is null)></option>
             @foreach (var enterGate in this.Map.EnterGates)
             {
@@ -143,7 +141,7 @@
     private float scale = 3;
 
     private object? focusedObject;
-    private bool createMode = false;
+    private bool createMode;
 
     /// <summary>
     /// Gets or sets the map which is edited in this component.
@@ -158,10 +156,10 @@
     public EventCallback OnValidSubmit { get; set; }
 
     /// <summary>
-    /// Gets or sets a factory to create new instances of <see cref="MonsterSpawnArea"/>.
+    /// Gets or sets the persistence context.
     /// </summary>
-    [Parameter]
-    public Func<MonsterSpawnArea>? AreaFactory { get; set; }
+    [CascadingParameter]
+    public IContext PersistenceContext { get; set; } = null!;
 
     /// <summary>
     /// Gets or sets the javascript runtime.
@@ -354,9 +352,79 @@
         return null;
     }
 
-    private void AddSpawn()
+    private void CreateNewSpawnArea()
     {
         this.createMode = true;
-        this.focusedObject = this.AreaFactory?.Invoke();
+
+        var area = this.PersistenceContext.CreateNew<MonsterSpawnArea>();
+        area.GameMap = this.Map;
+        this.Map.MonsterSpawns.Add(area);
+        area.X1 = 100;
+        area.Y1 = 100;
+        area.X2 = 200;
+        area.Y2 = 200;
+        area.Quantity = 1;
+
+        this.focusedObject = area;
+    }
+
+    private void CreateNewEnterGate()
+    {
+        this.createMode = true;
+
+        var enterGate = this.PersistenceContext.CreateNew<EnterGate>();
+        this.Map.EnterGates.Add(enterGate);
+        enterGate.X1 = 120;
+        enterGate.Y1 = 120;
+        enterGate.X2 = 140;
+        enterGate.Y2 = 140;
+
+        this.focusedObject = enterGate;
+    }
+
+    private void CreateNewExitGate()
+    {
+        this.createMode = true;
+
+        var exitGate = this.PersistenceContext.CreateNew<ExitGate>();
+        this.Map.ExitGates.Add(exitGate);
+        exitGate.X1 = 120;
+        exitGate.Y1 = 120;
+        exitGate.X2 = 140;
+        exitGate.Y2 = 140;
+
+        this.focusedObject = exitGate;
+    }
+
+    private void CancelCreation()
+    {
+        if (!this.createMode)
+        {
+            return;
+        }
+
+        this.createMode = false;
+        this.RemoveFocusedObject();
+    }
+
+    private void RemoveFocusedObject()
+    {
+        switch (this.focusedObject)
+        {
+            case MonsterSpawnArea spawnArea:
+                this.Map.MonsterSpawns.Remove(spawnArea);
+                break;
+            case EnterGate enterGate:
+                this.Map.EnterGates.Remove(enterGate);
+                break;
+            case ExitGate exitGate:
+                this.Map.ExitGates.Remove(exitGate);
+                break;
+            default:
+                return;
+        }
+
+        this.PersistenceContext.Delete(this.focusedObject);
+        this.focusedObject = null;
     }
 }

--- a/src/AdminPanel/Components/MapEditor.razor
+++ b/src/AdminPanel/Components/MapEditor.razor
@@ -14,6 +14,8 @@
 
 <h3>@this.Map.Name</h3>
 
+<button type="button" class="primary-button" @onclick=this.AddSpawn disabled="@createMode">Add Spawn</button>
+
 <div class="map-host" width="@(scale * 255)" height="@(scale * 255)">
     <img src="@(this.terrainImage.ToBase64String(PngFormat.Instance))"
          width="@(scale * 255)"
@@ -67,41 +69,66 @@
             }
         </div>
     }
+
+    @if (this.createMode == true && this.focusedObject is MonsterSpawnArea newSpawn)
+    {
+        <div class="@this.GetSpawnClass(newSpawn)"
+             title="@newSpawn.ToString()"
+             style="@this.GetSizeAndPositionStyle(newSpawn)"
+             @onclick="@(_ => this.focusedObject = newSpawn)">
+                @if (newSpawn.X1 != newSpawn.X2 || newSpawn.Y1 != newSpawn.Y2)
+                {
+                    <Resizers CoordinatesGetter="@this.OnGetObjectCoordinates" Resizing="@this.OnSpawnResizing" />
+                }
+                else if (newSpawn.Direction != Direction.Undefined)
+                {
+                    <div class="arrow @this.GetFocusedRotation()"></div>
+                }
+                else
+                {
+                    // show nothing
+                }
+            }
+        </div>
+    }
 </div>
 
-<div class="map-object-select">
-    <label for="objectSelect">Selected Object:</label>
-    <select title="Object" @onchange=this.OnObjectSelected id="objectSelect" autocomplete="off">
-        <option value="@Guid.Empty" selected=@(this.focusedObject is null)></option>
-        @foreach (var enterGate in this.Map.EnterGates)
-        {
-            <option value="@enterGate.GetId()" selected=@(object.Equals(this.focusedObject, enterGate))>EnterGate: @enterGate.ToString()</option>
-        }
-        @foreach (var exitGate in this.Map.ExitGates)
-        {
-            <option value="@exitGate.GetId()" selected=@(object.Equals(this.focusedObject, exitGate))>ExitGate: @exitGate.ToString()</option>
-        }
-        @foreach (var spawn in this.Map.MonsterSpawns)
-        {
-            <option value="@spawn.GetId()" selected=@(object.Equals(this.focusedObject, spawn))>Spawn: @spawn.ToString()</option>
-        }
-    </select>
-</div>
+@if (this.createMode == false)
+{
+    <div class="map-object-select">
+        <label for="objectSelect">Selected Object:</label>
+        <select title="Object" @onchange=this.OnObjectSelected id="objectSelect" autocomplete="off">
+            <option value="@Guid.Empty" selected=@(this.focusedObject is null)></option>
+            @foreach (var enterGate in this.Map.EnterGates)
+            {
+                <option value="@enterGate.GetId()" selected=@(object.Equals(this.focusedObject, enterGate))>EnterGate: @enterGate.ToString()</option>
+            }
+            @foreach (var exitGate in this.Map.ExitGates)
+            {
+                <option value="@exitGate.GetId()" selected=@(object.Equals(this.focusedObject, exitGate))>ExitGate: @exitGate.ToString()</option>
+            }
+            @foreach (var spawn in this.Map.MonsterSpawns)
+            {
+                <option value="@spawn.GetId()" selected=@(object.Equals(this.focusedObject, spawn))>Spawn: @spawn.ToString()</option>
+            }
+        </select>
+    </div>
+}
 
 @if (this.focusedObject != null)
 {
     <div class="map-object-form">
         @if (focusedObject is EnterGate enterGate)
         {
-            <AutoForm Model="@enterGate" OnValidSubmit="@this.OnValidSubmit"></AutoForm>
+            <AutoForm Model="@enterGate" OnValidSubmit="@this.Save"></AutoForm>
         }
         else if (focusedObject is ExitGate exitGate)
         {
-            <AutoForm Model="@exitGate" OnValidSubmit="@this.OnValidSubmit"></AutoForm>
+            <AutoForm Model="@exitGate" OnValidSubmit="@this.Save"></AutoForm>
         }
         else if (focusedObject is MonsterSpawnArea spawn)
         {
-            <AutoForm Model="@spawn" OnValidSubmit="@this.OnValidSubmit"></AutoForm>
+            <AutoForm Model="@spawn" OnValidSubmit="@this.Save"></AutoForm>
         }
     </div>
 }
@@ -113,6 +140,7 @@
     private float scale = 3;
 
     private object? focusedObject;
+    private bool createMode = false;
 
     /// <summary>
     /// Gets or sets the map which is edited in this component.
@@ -125,6 +153,12 @@
     /// </summary>
     [Parameter]
     public EventCallback OnValidSubmit { get; set; }
+
+    /// <summary>
+    /// Gets new MonsterSpawnArena <see cref="EditForm.OnValidSubmit"/> instance.
+    /// </summary>
+    [Parameter]
+    public EventCallback SaveSpawn { get; set; }
 
     /// <summary>
     /// Gets or sets the javascript runtime.
@@ -169,6 +203,12 @@
         {
             this.StateHasChanged();
         }
+    }
+
+    private Task? OnCancel()
+    {
+        this.focusedObject = null;
+        return null;
     }
 
     private string GetSpawnClass(MonsterSpawnArea spawn)
@@ -216,7 +256,8 @@
         var left = this.scale * spawn.Y1 - xyOffset;
         result.Append($"width: {width.ToString(CultureInfo.InvariantCulture)}px;")
             .Append($"height: {height.ToString(CultureInfo.InvariantCulture)}px;")
-            .Append($"top: {top.ToString(CultureInfo.InvariantCulture)}px; left: {left.ToString(CultureInfo.InvariantCulture)}px;");
+            .Append($"top: {top.ToString(CultureInfo.InvariantCulture)}px;")
+            .Append($"left: {left.ToString(CultureInfo.InvariantCulture)}px;");
 
         return result.ToString();
     }
@@ -308,5 +349,28 @@
         }
 
         return null;
+    }
+
+    private void AddSpawn()
+        {
+        this.createMode = true;
+        this.focusedObject = new MonsterSpawnArea
+        {
+            GameMap = this.Map,
+            X1 = 100,
+            Y1 = 100,
+            X2 = 200,
+            Y2 = 200
+        };
+    }
+
+    private async Task Save()
+    {
+        if (this.createMode) {
+            await this.SaveSpawn.InvokeAsync(this.focusedObject);
+            this.createMode = false;
+            this.focusedObject = null;
+        }
+        await this.OnValidSubmit.InvokeAsync();
     }
 }

--- a/src/AdminPanel/Components/MapEditor.razor
+++ b/src/AdminPanel/Components/MapEditor.razor
@@ -14,7 +14,10 @@
 
 <h3>@this.Map.Name</h3>
 
-<button type="button" class="primary-button" @onclick=this.AddSpawn disabled="@createMode">Add Spawn</button>
+@if (this.AreaFactory is not null)
+{
+    <button type="button" class="primary-button" @onclick=this.AddSpawn disabled="@createMode">Add Spawn</button>
+}
 
 <div class="map-host" width="@(scale * 255)" height="@(scale * 255)">
     <img src="@(this.terrainImage.ToBase64String(PngFormat.Instance))"
@@ -120,15 +123,15 @@
     <div class="map-object-form">
         @if (focusedObject is EnterGate enterGate)
         {
-            <AutoForm Model="@enterGate" OnValidSubmit="@this.Save"></AutoForm>
+            <AutoForm Model="@enterGate" OnValidSubmit="@this.OnValidSubmit"></AutoForm>
         }
         else if (focusedObject is ExitGate exitGate)
         {
-            <AutoForm Model="@exitGate" OnValidSubmit="@this.Save"></AutoForm>
+            <AutoForm Model="@exitGate" OnValidSubmit="@this.OnValidSubmit"></AutoForm>
         }
         else if (focusedObject is MonsterSpawnArea spawn)
         {
-            <AutoForm Model="@spawn" OnValidSubmit="@this.Save"></AutoForm>
+            <AutoForm Model="@spawn" OnValidSubmit="@this.OnValidSubmit"></AutoForm>
         }
     </div>
 }
@@ -155,10 +158,10 @@
     public EventCallback OnValidSubmit { get; set; }
 
     /// <summary>
-    /// Gets new MonsterSpawnArena <see cref="EditForm.OnValidSubmit"/> instance.
+    /// Gets or sets a factory to create new instances of <see cref="MonsterSpawnArea"/>.
     /// </summary>
     [Parameter]
-    public EventCallback SaveSpawn { get; set; }
+    public Func<MonsterSpawnArea>? AreaFactory { get; set; }
 
     /// <summary>
     /// Gets or sets the javascript runtime.
@@ -352,25 +355,8 @@
     }
 
     private void AddSpawn()
-        {
-        this.createMode = true;
-        this.focusedObject = new MonsterSpawnArea
-        {
-            GameMap = this.Map,
-            X1 = 100,
-            Y1 = 100,
-            X2 = 200,
-            Y2 = 200
-        };
-    }
-
-    private async Task Save()
     {
-        if (this.createMode) {
-            await this.SaveSpawn.InvokeAsync(this.focusedObject);
-            this.createMode = false;
-            this.focusedObject = null;
-        }
-        await this.OnValidSubmit.InvokeAsync();
+        this.createMode = true;
+        this.focusedObject = this.AreaFactory?.Invoke();
     }
 }

--- a/src/AdminPanel/Pages/EditMap.cs
+++ b/src/AdminPanel/Pages/EditMap.cs
@@ -23,7 +23,7 @@ namespace MUnique.OpenMU.AdminPanel.Pages
     public sealed class EditMap : ComponentBase, IDisposable
     {
         private static readonly ILog Log = LogManager.GetLogger(MethodBase.GetCurrentMethod()!.DeclaringType);
-        private object? model;
+        private GameMapDefinition? model;
         private IContext? persistenceContext;
         private CancellationTokenSource? disposeCts;
 
@@ -124,6 +124,14 @@ namespace MUnique.OpenMU.AdminPanel.Pages
                 // It would be great to have an async api with cancellation token support in the persistence layer
                 // For the moment, we swallow the exception
             }
+        }
+
+        private async Task SaveSpawn(MonsterSpawnArea spawn)
+        {
+            this.model!.MonsterSpawns.Add(spawn);
+            this.persistenceContext?.CreateNew<MonsterSpawnArea>(spawn);
+            this.persistenceContext?.SaveChanges();
+            this.StateHasChanged();
         }
 
         private Task SaveChanges()

--- a/src/AdminPanel/Pages/EditMap.cs
+++ b/src/AdminPanel/Pages/EditMap.cs
@@ -71,7 +71,6 @@ namespace MUnique.OpenMU.AdminPanel.Pages
                     builder2.OpenComponent(5, typeof(MapEditor));
                     builder2.AddAttribute(6, nameof(MapEditor.Map), this.model);
                     builder2.AddAttribute(7, nameof(MapEditor.OnValidSubmit), EventCallback.Factory.Create(this, this.SaveChangesAsync));
-                    builder2.AddAttribute(8, nameof(MapEditor.AreaFactory), (Func<MonsterSpawnArea>)(() => this.CreateNewSpawnArea()));
                     builder2.CloseComponent();
                 }));
 
@@ -89,29 +88,6 @@ namespace MUnique.OpenMU.AdminPanel.Pages
             this.model = null;
             Task.Run(() => this.LoadData(cts.Token), cts.Token);
             return base.OnParametersSetAsync();
-        }
-
-        private MonsterSpawnArea CreateNewSpawnArea()
-        {
-            if (this.persistenceContext is null)
-            {
-                throw new InvalidOperationException("PersistenceContext not initialized.");
-            }
-
-            if (this.model is null)
-            {
-                throw new InvalidOperationException("Model not initialized.");
-            }
-
-            var area = this.persistenceContext.CreateNew<MonsterSpawnArea>();
-            area.GameMap = this.model;
-            this.model.MonsterSpawns.Add(area);
-            area.X1 = 100;
-            area.Y1 = 100;
-            area.X2 = 200;
-            area.Y2 = 200;
-            area.Quantity = 1;
-            return area;
         }
 
         private async Task LoadData(CancellationToken cancellationToken)
@@ -149,6 +125,7 @@ namespace MUnique.OpenMU.AdminPanel.Pages
                 // For the moment, we swallow the exception
             }
         }
+
         private Task SaveChangesAsync()
         {
             string text;

--- a/src/AdminPanel/Pages/EditMap.cs
+++ b/src/AdminPanel/Pages/EditMap.cs
@@ -126,12 +126,11 @@ namespace MUnique.OpenMU.AdminPanel.Pages
             }
         }
 
-        private async Task SaveSpawn(MonsterSpawnArea spawn)
+        private Task SaveSpawnAsync(MonsterSpawnArea spawn)
         {
-            this.model!.MonsterSpawns.Add(spawn);
-            this.persistenceContext?.CreateNew<MonsterSpawnArea>(spawn);
-            this.persistenceContext?.SaveChanges();
-            this.StateHasChanged();
+            var newSpawn = this.persistenceContext?.CreateNew<MonsterSpawnArea>(spawn);
+            this.model!.MonsterSpawns.Add(newSpawn!);
+            return this.SaveChanges();
         }
 
         private Task SaveChanges()


### PR DESCRIPTION
This MR is adding a "Create Spawn" button at map editor page to activate a mode to use the MapEditor capabilities to create a new MonsterSpawnArea

- [X] set the map to the current map being edited
- [X] hide the object select when in create mode
- [x] disable object selection when in create mode
- [x] make SaveSpawn work properly

![image](https://user-images.githubusercontent.com/8407904/127756613-d7b5cb5e-6345-42bd-aa90-4f227ba85fef.png)
