### PR TITLE
Separated move and walk plugins

### DIFF
--- a/src/GameServer/MessageHandler/CharacterMoveBaseHandlerPlugIn.cs
+++ b/src/GameServer/MessageHandler/CharacterMoveBaseHandlerPlugIn.cs
@@ -5,9 +5,7 @@
 namespace MUnique.OpenMU.GameServer.MessageHandler
 {
     using System;
-    using MUnique.OpenMU.DataModel.Configuration;
     using MUnique.OpenMU.GameLogic;
-    using MUnique.OpenMU.GameLogic.Views.World;
     using MUnique.OpenMU.Network.Packets.ClientToServer;
     using MUnique.OpenMU.Pathfinding;
 
@@ -22,114 +20,20 @@ namespace MUnique.OpenMU.GameServer.MessageHandler
         /// <inheritdoc/>
         public abstract byte Key { get; }
 
-        /// <summary>
-        /// Gets the type of the move.
-        /// </summary>
-        /// <value>
-        /// The type of the move.
-        /// </value>
-        public abstract MoveType MoveType { get; }
-
         /// <inheritdoc/>
         public void HandlePacket(Player player, Span<byte> packet)
         {
-            if (packet.Length <= 4)
+            if (packet.Length < InstantMoveRequest.Length)
             {
                 return;
             }
 
-            if (this.MoveType == MoveType.Walk)
-            {
-                WalkRequest request = packet;
-                this.Walk(player, request, new Point(request.SourceX, request.SourceY));
-            }
-            else
-            {
-                // We don't move the player anymore by his request. This was usually requested after a player performed a skill.
-                // However, it adds way for cheaters to move through the map.
-                // So, we just allow it for developers when the debugger is attached.
-                // When handling a skill which moves to the target, we'll handle the move on server-side, instead.
-#if DEBUG
-                if (System.Diagnostics.Debugger.IsAttached)
-                {
-                    InstantMoveRequest moveRequest = packet;
-                    player.Move(new Point(moveRequest.TargetX, moveRequest.TargetY));
-                }
-#endif
-            }
-        }
-
-        private void Walk(Player player, WalkRequest request, Point sourcePoint)
-        {
-            if (request.Header.Length > 6)
-            {
-                // in a walk packet, x and y are the current coordinates and the steps are leading us to the target
-                var steps = this.GetSteps(sourcePoint, this.DecodePayload(request, out _));
-                Point target = this.GetTarget(steps, sourcePoint);
-
-                player.WalkTo(target, steps);
-            }
-            else
-            {
-                player.Rotation = request.TargetRotation.ParseAsDirection();
-            }
-        }
-
-        private Point GetTarget(Span<WalkingStep> steps, Point source)
-        {
-            if (steps.Length > 0)
-            {
-                var step = steps[steps.Length - 1];
-                return step.To;
-            }
-
-            return source;
-        }
-
-        private Span<WalkingStep> GetSteps(Point start, Span<Direction> directions)
-        {
-            var result = new WalkingStep[directions.Length];
-            Point previousTarget = start;
-            int i = 0;
-            foreach (var direction in directions)
-            {
-                var currentTarget = previousTarget.CalculateTargetPoint(direction);
-                result[i] = new WalkingStep { Direction = direction, To = currentTarget, From = previousTarget };
-                i++;
-                previousTarget = currentTarget;
-            }
-
-            return result;
-        }
-
-        /// <summary>
-        /// Gets the walking directions from the walk packet and the final rotation of the character.
-        /// </summary>
-        /// <param name="walkRequest">
-        /// The walk request, received from the client.
-        /// </param>
-        /// <param name="rotation">
-        /// The rotation of the character once the walking is done.
-        /// </param>
-        /// <returns>The walking directions and the final rotation of the character.</returns>
-        /// <remarks>
-        /// We return here the directions left-rotated; I don't know yet if that's an error in our Direction-enum
-        /// or just the client uses another enumeration for it.
-        /// </remarks>
-        private Span<Direction> DecodePayload(WalkRequest walkRequest, out Direction rotation)
-        {
-            var stepsCount = walkRequest.StepCount;
-            rotation = walkRequest.TargetRotation.ParseAsDirection();
-            var directions = new Direction[stepsCount];
-            var payload = walkRequest.Directions;
-            for (int i = 0; i < stepsCount; i++)
-            {
-                var val = payload[i / 2];
-                val = (byte)(i % 2 == 0 ? val >> 4 : val & 0x0F);
-                directions[i] = val.ParseAsDirection();
-            }
-
-            return directions.AsSpan(0, directions.Length);
+            // We don't move the player anymore by his request. This was usually requested after a player performed a skill.
+            // However, it adds way for cheaters to move through the map.
+            // So, we just allow it for developers when the debugger is attached.
+            // When handling a skill which moves to the target, we'll handle the move on server-side, instead.
+            InstantMoveRequest moveRequest = packet;
+            player.Move(new Point(moveRequest.TargetX, moveRequest.TargetY));
         }
     }
 }

--- a/src/GameServer/MessageHandler/CharacterMoveHandlerPlugIn.cs
+++ b/src/GameServer/MessageHandler/CharacterMoveHandlerPlugIn.cs
@@ -5,7 +5,6 @@
 namespace MUnique.OpenMU.GameServer.MessageHandler
 {
     using System.Runtime.InteropServices;
-    using MUnique.OpenMU.GameLogic.Views.World;
     using MUnique.OpenMU.Network.Packets.ClientToServer;
     using MUnique.OpenMU.Network.PlugIns;
     using MUnique.OpenMU.PlugIns;
@@ -20,8 +19,5 @@ namespace MUnique.OpenMU.GameServer.MessageHandler
     {
         /// <inheritdoc/>
         public override byte Key => InstantMoveRequest.Code;
-
-        /// <inheritdoc/>
-        public override MoveType MoveType => MoveType.Instant;
     }
 }

--- a/src/GameServer/MessageHandler/CharacterMoveHandlerPlugIn075.cs
+++ b/src/GameServer/MessageHandler/CharacterMoveHandlerPlugIn075.cs
@@ -5,7 +5,6 @@
 namespace MUnique.OpenMU.GameServer.MessageHandler
 {
     using System.Runtime.InteropServices;
-    using MUnique.OpenMU.GameLogic.Views.World;
     using MUnique.OpenMU.Network.PlugIns;
     using MUnique.OpenMU.PlugIns;
 
@@ -20,8 +19,5 @@ namespace MUnique.OpenMU.GameServer.MessageHandler
     {
         /// <inheritdoc/>
         public override byte Key => 0x11;
-
-        /// <inheritdoc/>
-        public override MoveType MoveType => MoveType.Instant;
     }
 }

--- a/src/GameServer/MessageHandler/CharacterWalkBaseHandlerPlugIn.cs
+++ b/src/GameServer/MessageHandler/CharacterWalkBaseHandlerPlugIn.cs
@@ -1,0 +1,109 @@
+﻿// <copyright file="CharacterWalkBaseHandlerPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.MessageHandler
+{
+    using System;
+    using MUnique.OpenMU.DataModel.Configuration;
+    using MUnique.OpenMU.GameLogic;
+    using MUnique.OpenMU.Network.Packets.ClientToServer;
+    using MUnique.OpenMU.Pathfinding;
+
+    /// <summary>
+    /// Abstract packet handler for walk packets.
+    /// </summary>
+    internal abstract class CharacterWalkBaseHandlerPlugIn : IPacketHandlerPlugIn
+    {
+        /// <inheritdoc/>
+        public bool IsEncryptionExpected => false;
+
+        /// <inheritdoc/>
+        public abstract byte Key { get; }
+
+        /// <inheritdoc/>
+        public void HandlePacket(Player player, Span<byte> packet)
+        {
+            if (packet.Length < 6)
+            {
+                return;
+            }
+
+            WalkRequest request = packet;
+            this.Walk(player, request, new Point(request.SourceX, request.SourceY));
+        }
+
+        private void Walk(Player player, WalkRequest request, Point sourcePoint)
+        {
+            if (request.Header.Length > 6)
+            {
+                // in a walk packet, x and y are the current coordinates and the steps are leading us to the target
+                var steps = this.GetSteps(sourcePoint, this.DecodePayload(request, out _));
+                var target = this.GetTarget(steps, sourcePoint);
+
+                player.WalkTo(target, steps);
+            }
+            else
+            {
+                player.Rotation = request.TargetRotation.ParseAsDirection();
+            }
+        }
+
+        private Point GetTarget(Span<WalkingStep> steps, Point source)
+        {
+            if (steps.Length > 0)
+            {
+                var step = steps[steps.Length - 1];
+                return step.To;
+            }
+
+            return source;
+        }
+
+        private Span<WalkingStep> GetSteps(Point start, Span<Direction> directions)
+        {
+            var result = new WalkingStep[directions.Length];
+            var previousTarget = start;
+            int i = 0;
+            foreach (var direction in directions)
+            {
+                var currentTarget = previousTarget.CalculateTargetPoint(direction);
+                result[i] = new WalkingStep { Direction = direction, To = currentTarget, From = previousTarget };
+                i++;
+                previousTarget = currentTarget;
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Gets the walking directions from the walk packet and the final rotation of the character.
+        /// </summary>
+        /// <param name="walkRequest">
+        /// The walk request, received from the client.
+        /// </param>
+        /// <param name="rotation">
+        /// The rotation of the character once the walking is done.
+        /// </param>
+        /// <returns>The walking directions and the final rotation of the character.</returns>
+        /// <remarks>
+        /// We return here the directions left-rotated; I don't know yet if that's an error in our Direction-enum
+        /// or just the client uses another enumeration for it.
+        /// </remarks>
+        private Span<Direction> DecodePayload(WalkRequest walkRequest, out Direction rotation)
+        {
+            var stepsCount = walkRequest.StepCount;
+            rotation = walkRequest.TargetRotation.ParseAsDirection();
+            var directions = new Direction[stepsCount];
+            var payload = walkRequest.Directions;
+            for (int i = 0; i < stepsCount; i++)
+            {
+                var val = payload[i / 2];
+                val = (byte)(i % 2 == 0 ? val >> 4 : val & 0x0F);
+                directions[i] = val.ParseAsDirection();
+            }
+
+            return directions.AsSpan(0, directions.Length);
+        }
+    }
+}

--- a/src/GameServer/MessageHandler/CharacterWalkHandlerPlugIn.cs
+++ b/src/GameServer/MessageHandler/CharacterWalkHandlerPlugIn.cs
@@ -16,12 +16,9 @@ namespace MUnique.OpenMU.GameServer.MessageHandler
     [PlugIn("Character walk handler", "Packet handler for walk packets.")]
     [Guid("19056DEB-4321-4D25-8615-EE49A453DF03")]
     [MinimumClient(0, 97, ClientLanguage.Invariant)]
-    internal class CharacterWalkHandlerPlugIn : CharacterMoveBaseHandlerPlugIn
+    internal class CharacterWalkHandlerPlugIn : CharacterWalkBaseHandlerPlugIn
     {
         /// <inheritdoc/>
         public override byte Key => WalkRequest.Code;
-
-        /// <inheritdoc/>
-        public override MoveType MoveType => MoveType.Walk;
     }
 }

--- a/src/GameServer/MessageHandler/CharacterWalkHandlerPlugIn075.cs
+++ b/src/GameServer/MessageHandler/CharacterWalkHandlerPlugIn075.cs
@@ -5,7 +5,6 @@
 namespace MUnique.OpenMU.GameServer.MessageHandler
 {
     using System.Runtime.InteropServices;
-    using MUnique.OpenMU.GameLogic.Views.World;
     using MUnique.OpenMU.Network.Packets.ClientToServer;
     using MUnique.OpenMU.Network.PlugIns;
     using MUnique.OpenMU.PlugIns;
@@ -17,12 +16,9 @@ namespace MUnique.OpenMU.GameServer.MessageHandler
     [Guid("9FD41038-39D9-4D3D-A1DD-A87DB6388248")]
     [MinimumClient(0, 75, ClientLanguage.Invariant)]
     [MaximumClient(0, 89, ClientLanguage.Invariant)]
-    internal class CharacterWalkHandlerPlugIn075 : CharacterMoveBaseHandlerPlugIn
+    internal class CharacterWalkHandlerPlugIn075 : CharacterWalkBaseHandlerPlugIn
     {
         /// <inheritdoc/>
         public override byte Key => WalkRequest075.Code;
-
-        /// <inheritdoc/>
-        public override MoveType MoveType => MoveType.Walk;
     }
 }

--- a/src/Persistence/Initialization/DataInitializationBase.cs
+++ b/src/Persistence/Initialization/DataInitializationBase.cs
@@ -12,6 +12,7 @@ namespace MUnique.OpenMU.Persistence.Initialization
     using MUnique.OpenMU.DataModel.Configuration;
     using MUnique.OpenMU.GameLogic;
     using MUnique.OpenMU.GameLogic.Resets;
+    using MUnique.OpenMU.GameServer.MessageHandler;
     using MUnique.OpenMU.Network.PlugIns;
     using MUnique.OpenMU.PlugIns;
 
@@ -128,6 +129,14 @@ namespace MUnique.OpenMU.Persistence.Initialization
                 {
                     plugInConfiguration.IsActive = false;
                     plugInConfiguration.SetConfiguration(new ResetConfiguration());
+                }
+
+                // We don't move the player anymore by his request. This was usually requested after a player performed a skill.
+                // However, it adds way for cheaters to move through the map.
+                // The plugin is therefore deactivated by default.
+                if (plugInType.IsAssignableTo(typeof(CharacterMoveBaseHandlerPlugIn)))
+                {
+                    plugInConfiguration.IsActive = false;
                 }
             });
 


### PR DESCRIPTION
One base class for all move and walk handlers violates the single-responsibility principle (SRP).

While I was at it, I also removed the debugger-conditional in the CharacterMoveBaseHandlerPlugIn. Instead, these handlers are deactivated by default.