### PR TITLE
Fixed selection of the packet handlers for a specific game version

### DIFF
--- a/src/GameServer/MessageHandler/PacketHandlerPlugInContainer.cs
+++ b/src/GameServer/MessageHandler/PacketHandlerPlugInContainer.cs
@@ -176,7 +176,7 @@ namespace MUnique.OpenMU.GameServer.MessageHandler
             // find available replacement if the plugin was effective before
             var replacement = this.ActivePlugIns
                 .Where(p => p.Key == plugIn.Key)
-                .OrderByDescending(p => p.GetType().GetCustomAttribute(typeof(MinimumClientAttribute)))
+                .OrderByDescending(p => p.GetType().GetCustomAttribute(typeof(MinimumClientAttribute), inherit: false))
                 .FirstOrDefault();
             if (replacement != null)
             {

--- a/src/GameServer/MessageHandler/PacketHandlerPlugInExtensions.cs
+++ b/src/GameServer/MessageHandler/PacketHandlerPlugInExtensions.cs
@@ -21,8 +21,8 @@ namespace MUnique.OpenMU.GameServer.MessageHandler
         /// </returns>
         public static bool IsPreferedTo(this IPacketHandlerPlugInBase packetHandler, IPacketHandlerPlugInBase otherPacketHandlerPlugIn)
         {
-            var currentPlugInClient = packetHandler.GetType().GetCustomAttribute<MinimumClientAttribute>()?.Client ?? default;
-            var activatedPluginClient = otherPacketHandlerPlugIn.GetType().GetCustomAttribute<MinimumClientAttribute>()?.Client ?? default;
+            var currentPlugInClient = packetHandler.GetType().GetCustomAttribute<MinimumClientAttribute>(inherit: false)?.Client ?? default;
+            var activatedPluginClient = otherPacketHandlerPlugIn.GetType().GetCustomAttribute<MinimumClientAttribute>(inherit: false)?.Client ?? default;
             return currentPlugInClient.CompareTo(activatedPluginClient) > 0;
         }
     }


### PR DESCRIPTION
When searching for the MinimumClientAttribute, inherited classes should not be considered