### PR TITLE
catch exceptions when sending network packets

### DIFF
--- a/src/Network/Packets/ChatServer/ConnectionExtensions.cs
+++ b/src/Network/Packets/ChatServer/ConnectionExtensions.cs
@@ -209,8 +209,7 @@ namespace MUnique.OpenMU.Network.Packets.ChatServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(Authenticate.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(Authenticate.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -262,8 +261,7 @@ namespace MUnique.OpenMU.Network.Packets.ChatServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ChatRoomClientJoined.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ChatRoomClientJoined.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -315,8 +313,7 @@ namespace MUnique.OpenMU.Network.Packets.ChatServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ChatRoomClientLeft.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ChatRoomClientLeft.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -368,8 +365,7 @@ namespace MUnique.OpenMU.Network.Packets.ChatServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(KeepAlive.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(KeepAlive.Length).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Network/Packets/ClientToServer/ConnectionExtensions.cs
+++ b/src/Network/Packets/ClientToServer/ConnectionExtensions.cs
@@ -3021,8 +3021,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(Ping.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(Ping.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -3074,8 +3073,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(LoginLongPassword.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(LoginLongPassword.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -3127,8 +3125,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(LoginShortPassword.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(LoginShortPassword.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -3180,8 +3177,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(Login075.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(Login075.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -3233,8 +3229,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(LogOut.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(LogOut.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -3286,8 +3281,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(PlayerShopSetItemPrice.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(PlayerShopSetItemPrice.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -3339,8 +3333,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(PlayerShopOpen.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(PlayerShopOpen.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -3392,8 +3385,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(PlayerShopClose.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(PlayerShopClose.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -3445,8 +3437,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(PlayerShopItemListRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(PlayerShopItemListRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -3498,8 +3489,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(PlayerShopItemBuyRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(PlayerShopItemBuyRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -3551,8 +3541,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(PickupItemRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(PickupItemRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -3604,8 +3593,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(PickupItemRequest075.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(PickupItemRequest075.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -3657,8 +3645,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(DropItemRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(DropItemRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -3710,8 +3697,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ItemMoveRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ItemMoveRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -3763,8 +3749,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ConsumeItemRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ConsumeItemRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -3816,8 +3801,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ConsumeItemRequest075.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ConsumeItemRequest075.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -3869,8 +3853,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(TalkToNpcRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(TalkToNpcRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -3922,8 +3905,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(CloseNpcRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(CloseNpcRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -3975,8 +3957,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(BuyItemFromNpcRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(BuyItemFromNpcRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4028,8 +4009,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(SellItemToNpcRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(SellItemToNpcRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4081,8 +4061,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(RepairItemRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(RepairItemRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4134,8 +4113,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(WarpCommandRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(WarpCommandRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4187,8 +4165,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(EnterGateRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(EnterGateRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4240,8 +4217,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(EnterGateRequest075.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(EnterGateRequest075.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4293,8 +4269,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(UnlockVault.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(UnlockVault.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4346,8 +4321,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(SetVaultPin.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(SetVaultPin.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4399,8 +4373,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(RemoveVaultPin.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(RemoveVaultPin.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4452,8 +4425,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(VaultClosed.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(VaultClosed.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4505,8 +4477,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(VaultMoveMoneyRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(VaultMoveMoneyRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4558,8 +4529,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(LahapJewelMixRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(LahapJewelMixRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4611,8 +4581,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(PartyListRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(PartyListRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4664,8 +4633,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(PartyPlayerKickRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(PartyPlayerKickRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4717,8 +4685,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(PartyInviteRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(PartyInviteRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4770,8 +4737,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(PartyInviteResponse.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(PartyInviteResponse.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4823,8 +4789,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(InstantMoveRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(InstantMoveRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4876,8 +4841,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(AnimationRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(AnimationRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4929,8 +4893,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(RequestCharacterList.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(RequestCharacterList.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4982,8 +4945,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(CreateCharacter.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(CreateCharacter.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5035,8 +4997,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(DeleteCharacter.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(DeleteCharacter.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5088,8 +5049,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(SelectCharacter.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(SelectCharacter.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5141,8 +5101,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(FocusCharacter.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(FocusCharacter.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5194,8 +5153,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(IncreaseCharacterStatPoint.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(IncreaseCharacterStatPoint.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5247,8 +5205,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ClientReadyAfterMapChange.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ClientReadyAfterMapChange.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5300,8 +5257,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(AddMasterSkillPoint.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(AddMasterSkillPoint.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5353,8 +5309,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(HitRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(HitRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5406,8 +5361,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(TargetedSkill.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(TargetedSkill.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5459,8 +5413,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(TargetedSkill075.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(TargetedSkill075.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5512,8 +5465,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(MagicEffectCancelRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(MagicEffectCancelRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5565,8 +5517,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(AreaSkill.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(AreaSkill.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5618,8 +5569,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(AreaSkillHit.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(AreaSkillHit.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5671,8 +5621,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(AreaSkill075.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(AreaSkill075.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5724,8 +5673,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(TradeCancel.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(TradeCancel.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5777,8 +5725,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(TradeButtonStateChange.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(TradeButtonStateChange.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5830,8 +5777,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(TradeRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(TradeRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5883,8 +5829,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(TradeRequestResponse.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(TradeRequestResponse.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5936,8 +5881,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(SetTradeMoney.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(SetTradeMoney.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5989,8 +5933,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(LetterDeleteRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(LetterDeleteRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6042,8 +5985,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(LetterReadRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(LetterReadRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6095,8 +6037,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(GuildJoinRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(GuildJoinRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6148,8 +6089,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(GuildJoinResponse.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(GuildJoinResponse.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6201,8 +6141,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(GuildListRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(GuildListRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6254,8 +6193,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(GuildCreateRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(GuildCreateRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6307,8 +6245,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(GuildCreateRequest075.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(GuildCreateRequest075.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6360,8 +6297,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(GuildMasterAnswer.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(GuildMasterAnswer.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6413,8 +6349,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(CancelGuildCreation.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(CancelGuildCreation.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6466,8 +6401,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(GuildWarResponse.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(GuildWarResponse.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6519,8 +6453,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(GuildInfoRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(GuildInfoRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6572,8 +6505,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ItemRepair.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ItemRepair.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6625,8 +6557,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ChaosMachineMixRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ChaosMachineMixRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6678,8 +6609,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(CraftingDialogCloseRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(CraftingDialogCloseRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6731,8 +6661,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(FriendAddRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(FriendAddRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6784,8 +6713,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(FriendDelete.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(FriendDelete.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6837,8 +6765,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ChatRoomCreateRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ChatRoomCreateRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6890,8 +6817,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(FriendAddResponse.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(FriendAddResponse.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6943,8 +6869,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(SetFriendOnlineState.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(SetFriendOnlineState.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6996,8 +6921,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ChatRoomInvitationRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ChatRoomInvitationRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7049,8 +6973,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(LegacyQuestStateRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(LegacyQuestStateRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7102,8 +7025,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(LegacyQuestStateSetRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(LegacyQuestStateSetRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7155,8 +7077,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(PetCommandRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(PetCommandRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7208,8 +7129,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(PetInfoRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(PetInfoRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7261,8 +7181,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(QuestSelectRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(QuestSelectRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7314,8 +7233,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(QuestProceedRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(QuestProceedRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7367,8 +7285,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(QuestCompletionRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(QuestCompletionRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7420,8 +7337,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(QuestCancelRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(QuestCancelRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7473,8 +7389,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(QuestClientActionRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(QuestClientActionRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7526,8 +7441,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ActiveQuestListRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ActiveQuestListRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7579,8 +7493,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(QuestStateRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(QuestStateRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7632,8 +7545,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(EventQuestStateListRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(EventQuestStateListRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7685,8 +7597,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(AvailableQuestsRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(AvailableQuestsRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7738,8 +7649,7 @@ namespace MUnique.OpenMU.Network.Packets.ClientToServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(NpcBuffRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(NpcBuffRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Network/Packets/ConnectServer/ConnectionExtensions.cs
+++ b/src/Network/Packets/ConnectServer/ConnectionExtensions.cs
@@ -301,8 +301,7 @@ namespace MUnique.OpenMU.Network.Packets.ConnectServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ConnectionInfoRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ConnectionInfoRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -354,8 +353,7 @@ namespace MUnique.OpenMU.Network.Packets.ConnectServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ConnectionInfo.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ConnectionInfo.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -407,8 +405,7 @@ namespace MUnique.OpenMU.Network.Packets.ConnectServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ServerListRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ServerListRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -460,8 +457,7 @@ namespace MUnique.OpenMU.Network.Packets.ConnectServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ServerListRequestOld.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ServerListRequestOld.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -513,8 +509,7 @@ namespace MUnique.OpenMU.Network.Packets.ConnectServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(Hello.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(Hello.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -566,8 +561,7 @@ namespace MUnique.OpenMU.Network.Packets.ConnectServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(PatchCheckRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(PatchCheckRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -619,8 +613,7 @@ namespace MUnique.OpenMU.Network.Packets.ConnectServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(PatchVersionOkay.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(PatchVersionOkay.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -672,8 +665,7 @@ namespace MUnique.OpenMU.Network.Packets.ConnectServer
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ClientNeedsPatch.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ClientNeedsPatch.Length).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Network/Packets/GenerateExtensions.xslt
+++ b/src/Network/Packets/GenerateExtensions.xslt
@@ -92,8 +92,7 @@ namespace MUnique.OpenMU.Network.Packets</xsl:text>
         /// &lt;/summary&gt;
         public void Commit()
         {
-            this.connection.Output.Advance(%NAME%.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(%NAME%.Length).ConfigureAwait(false);
         }
 
         /// &lt;summary&gt;

--- a/src/Network/Packets/ServerToClient/ConnectionExtensions.cs
+++ b/src/Network/Packets/ServerToClient/ConnectionExtensions.cs
@@ -4042,8 +4042,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(GameServerEntered.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(GameServerEntered.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4095,8 +4094,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(MagicEffectStatus.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(MagicEffectStatus.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4148,8 +4146,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(WeatherStatusUpdate.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(WeatherStatusUpdate.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4201,8 +4198,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ObjectGotKilled.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ObjectGotKilled.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4254,8 +4250,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ObjectAnimation.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ObjectAnimation.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4307,8 +4302,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(AreaSkillAnimation.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(AreaSkillAnimation.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4360,8 +4354,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(SkillAnimation.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(SkillAnimation.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4413,8 +4406,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(AreaSkillAnimation075.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(AreaSkillAnimation075.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4466,8 +4458,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(SkillAnimation075.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(SkillAnimation075.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4519,8 +4510,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(MagicEffectCancelled.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(MagicEffectCancelled.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4572,8 +4562,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(MagicEffectCancelled075.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(MagicEffectCancelled075.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4625,8 +4614,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(PartyRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(PartyRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4678,8 +4666,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(RemovePartyMember.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(RemovePartyMember.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4731,8 +4718,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(PlayerShopOpenSuccessful.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(PlayerShopOpenSuccessful.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4784,8 +4770,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(TradeButtonStateChanged.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(TradeButtonStateChanged.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4837,8 +4822,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(TradeMoneySetResponse.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(TradeMoneySetResponse.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4890,8 +4874,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(TradeMoneyUpdate.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(TradeMoneyUpdate.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4943,8 +4926,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(TradeRequestAnswer.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(TradeRequestAnswer.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -4996,8 +4978,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(TradeRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(TradeRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5049,8 +5030,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(TradeFinished.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(TradeFinished.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5102,8 +5082,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(TradeItemRemoved.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(TradeItemRemoved.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5155,8 +5134,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(LoginResponse.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(LoginResponse.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5208,8 +5186,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(LogoutResponse.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(LogoutResponse.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5261,8 +5238,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ObjectHit.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ObjectHit.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5314,8 +5290,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ObjectMoved.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ObjectMoved.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5367,8 +5342,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ObjectWalked075.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ObjectWalked075.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5420,8 +5394,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ExperienceGained.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ExperienceGained.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5473,8 +5446,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(MapChanged.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(MapChanged.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5526,8 +5498,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(MapChanged075.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(MapChanged075.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5579,8 +5550,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(MoneyDropped.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(MoneyDropped.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5632,8 +5602,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(MoneyDropped075.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(MoneyDropped075.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5685,8 +5654,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ItemDropResponse.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ItemDropResponse.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5738,8 +5706,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ItemPickUpRequestFailed.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ItemPickUpRequestFailed.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5791,8 +5758,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(InventoryMoneyUpdate.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(InventoryMoneyUpdate.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5844,8 +5810,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(CurrentHealthAndShield.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(CurrentHealthAndShield.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5897,8 +5862,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(MaximumHealthAndShield.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(MaximumHealthAndShield.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -5950,8 +5914,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ItemConsumptionFailed.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ItemConsumptionFailed.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6003,8 +5966,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(CurrentManaAndAbility.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(CurrentManaAndAbility.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6056,8 +6018,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(MaximumManaAndAbility.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(MaximumManaAndAbility.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6109,8 +6070,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ItemRemoved.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ItemRemoved.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6162,8 +6122,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ConsumeItemWithEffect.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ConsumeItemWithEffect.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6215,8 +6174,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ItemDurabilityChanged.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ItemDurabilityChanged.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6268,8 +6226,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(FruitConsumptionResponse.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(FruitConsumptionResponse.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6321,8 +6278,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(NpcWindowResponse.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(NpcWindowResponse.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6374,8 +6330,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(NpcItemBuyFailed.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(NpcItemBuyFailed.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6427,8 +6382,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(NpcItemSellResult.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(NpcItemSellResult.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6480,8 +6434,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(PlayerShopSetItemPriceResponse.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(PlayerShopSetItemPriceResponse.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6533,8 +6486,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(PlayerShopClosed.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(PlayerShopClosed.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6586,8 +6538,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(PlayerShopItemSoldToPlayer.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(PlayerShopItemSoldToPlayer.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6639,8 +6590,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ClosePlayerShopDialog.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ClosePlayerShopDialog.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6692,8 +6642,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(CharacterCreationSuccessful.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(CharacterCreationSuccessful.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6745,8 +6694,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(CharacterCreationFailed.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(CharacterCreationFailed.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6798,8 +6746,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(RespawnAfterDeath075.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(RespawnAfterDeath075.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6851,8 +6798,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(PoisonDamage.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(PoisonDamage.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6904,8 +6850,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(HeroStateChanged.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(HeroStateChanged.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -6957,8 +6902,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(SkillAdded.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(SkillAdded.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7010,8 +6954,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(SkillRemoved.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(SkillRemoved.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7063,8 +7006,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(SkillAdded075.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(SkillAdded075.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7116,8 +7058,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(SkillRemoved075.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(SkillRemoved075.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7169,8 +7110,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(CharacterFocused.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(CharacterFocused.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7222,8 +7162,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(CharacterStatIncreaseResponse.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(CharacterStatIncreaseResponse.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7275,8 +7214,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(CharacterDeleteResponse.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(CharacterDeleteResponse.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7328,8 +7266,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(CharacterLevelUpdate.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(CharacterLevelUpdate.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7381,8 +7318,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(CharacterInformation.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(CharacterInformation.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7434,8 +7370,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(CharacterInformation075.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(CharacterInformation075.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7487,8 +7422,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(SummonHealthUpdate.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(SummonHealthUpdate.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7540,8 +7474,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(GuildSoccerTimeUpdate.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(GuildSoccerTimeUpdate.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7593,8 +7526,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(GuildSoccerScoreUpdate.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(GuildSoccerScoreUpdate.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7646,8 +7578,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(MasterStatsUpdate.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(MasterStatsUpdate.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7699,8 +7630,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(MasterSkillLevelUpdate.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(MasterSkillLevelUpdate.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7752,8 +7682,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(GuildJoinRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(GuildJoinRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7805,8 +7734,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(GuildJoinResponse.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(GuildJoinResponse.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7858,8 +7786,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(GuildKickResponse.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(GuildKickResponse.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7911,8 +7838,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ShowGuildMasterDialog.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ShowGuildMasterDialog.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -7964,8 +7890,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ShowGuildCreationDialog.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ShowGuildCreationDialog.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -8017,8 +7942,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(GuildCreationResult.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(GuildCreationResult.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -8070,8 +7994,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(GuildMemberLeftGuild.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(GuildMemberLeftGuild.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -8123,8 +8046,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(GuildWarRequestResult.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(GuildWarRequestResult.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -8176,8 +8098,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(GuildWarRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(GuildWarRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -8229,8 +8150,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(GuildWarDeclared.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(GuildWarDeclared.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -8282,8 +8202,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(GuildWarEnded.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(GuildWarEnded.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -8335,8 +8254,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(GuildWarScoreUpdate.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(GuildWarScoreUpdate.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -8388,8 +8306,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(GuildInformation.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(GuildInformation.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -8441,8 +8358,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(SingleGuildInformation075.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(SingleGuildInformation075.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -8494,8 +8410,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(VaultMoneyUpdate.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(VaultMoneyUpdate.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -8547,8 +8462,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(VaultClosed.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(VaultClosed.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -8600,8 +8514,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(VaultProtectionInformation.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(VaultProtectionInformation.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -8653,8 +8566,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(CraftingDialogClosed075.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(CraftingDialogClosed075.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -8706,8 +8618,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(LegacyQuestStateDialog.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(LegacyQuestStateDialog.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -8759,8 +8670,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(LegacySetQuestStateResponse.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(LegacySetQuestStateResponse.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -8812,8 +8722,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(LegacyQuestReward.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(LegacyQuestReward.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -8865,8 +8774,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(LegacyQuestMonsterKillInfo.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(LegacyQuestMonsterKillInfo.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -8918,8 +8826,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(PetMode.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(PetMode.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -8971,8 +8878,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(PetAttack.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(PetAttack.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -9024,8 +8930,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(PetInfoResponse.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(PetInfoResponse.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -9077,8 +8982,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(FriendAdded.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(FriendAdded.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -9130,8 +9034,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(FriendRequest.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(FriendRequest.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -9183,8 +9086,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(FriendDeleted.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(FriendDeleted.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -9236,8 +9138,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(FriendOnlineStateUpdate.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(FriendOnlineStateUpdate.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -9289,8 +9190,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(LetterSendResponse.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(LetterSendResponse.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -9342,8 +9242,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(AddLetter.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(AddLetter.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -9395,8 +9294,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(RemoveLetter.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(RemoveLetter.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -9448,8 +9346,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(ChatRoomConnectionInfo.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(ChatRoomConnectionInfo.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -9501,8 +9398,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(FriendInvitationResult.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(FriendInvitationResult.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -9554,8 +9450,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(QuestEventResponse.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(QuestEventResponse.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -9607,8 +9502,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(QuestStepInfo.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(QuestStepInfo.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -9660,8 +9554,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(QuestProgress.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(QuestProgress.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -9713,8 +9606,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(QuestCompletionResponse.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(QuestCompletionResponse.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -9766,8 +9658,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(QuestCancelled.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(QuestCancelled.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -9819,8 +9710,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(QuestState.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(QuestState.Length).ConfigureAwait(false);
         }
 
         /// <summary>
@@ -9872,8 +9762,7 @@ namespace MUnique.OpenMU.Network.Packets.ServerToClient
         /// </summary>
         public void Commit()
         {
-            this.connection.Output.Advance(OpenNpcDialog.Length);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(OpenNpcDialog.Length).ConfigureAwait(false);
         }
 
         /// <summary>

--- a/src/Network/PipeWriterExtension.cs
+++ b/src/Network/PipeWriterExtension.cs
@@ -1,0 +1,42 @@
+﻿// <copyright file="PipeWriterExtension.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Network
+{
+    using System;
+    using System.Diagnostics;
+    using System.IO.Pipelines;
+    using System.Threading.Tasks;
+
+    /// <summary>
+    /// Extensions for <see cref="PipeWriter"/>.
+    /// </summary>
+    public static class PipeWriterExtension
+    {
+        /// <summary>
+        /// Tries to advance and to flush the <see cref="PipeWriter"/>.
+        /// </summary>
+        /// <param name="pipeWriter">The <see cref="PipeWriter"/>.</param>
+        /// <param name="bytes">The number of data items written to the <see cref="T:System.Span`1" /> or <see cref="T:System.Memory`1" />.</param>
+        /// <returns><see langword="true"/>, if it was successful; Otherwise, <see langword="false"/>.</returns>
+        public static async ValueTask<bool> TryAdvanceAndFlushAsync(this PipeWriter pipeWriter, int bytes)
+        {
+            try
+            {
+                pipeWriter.Advance(bytes);
+                await pipeWriter.FlushAsync().ConfigureAwait(false);
+                return true;
+            }
+            catch (Exception ex)
+            {
+                if (Debugger.IsLogging())
+                {
+                    Debug.Fail(ex.ToString());
+                }
+
+                return false;
+            }
+        }
+    }
+}

--- a/src/Network/ThreadSafeWriter.cs
+++ b/src/Network/ThreadSafeWriter.cs
@@ -6,6 +6,7 @@ namespace MUnique.OpenMU.Network
 {
     using System;
     using System.Threading;
+    using System.Threading.Tasks;
 
     /// <summary>
     /// A helper struct to write safely to a <see cref="IConnection.Output" />.
@@ -59,8 +60,23 @@ namespace MUnique.OpenMU.Network
         /// <param name="packetSize">Size of the packet.</param>
         public void Commit(int packetSize)
         {
-            this.connection.Output.Advance(packetSize);
-            this.connection.Output.FlushAsync().ConfigureAwait(false);
+            this.connection.Output.TryAdvanceAndFlushAsync(packetSize).ConfigureAwait(false);
+        }
+
+        /// <summary>
+        /// Commits the data of the <see cref="Span"/> with the expected packet size.
+        /// </summary>
+        /// <returns><see langword="true"/>, if it was successful; Otherwise, <see langword="false"/>.</returns>
+        public ValueTask<bool> CommitAsync() => this.CommitAsync(this.expectedPacketSize);
+
+        /// <summary>
+        /// Commits the data of the <see cref="Span"/> with specified packet size.
+        /// </summary>
+        /// <param name="packetSize">Size of the packet.</param>
+        /// <returns><see langword="true"/>, if it was successful; Otherwise, <see langword="false"/>.</returns>
+        public ValueTask<bool> CommitAsync(int packetSize)
+        {
+            return this.connection.Output.TryAdvanceAndFlushAsync(packetSize);
         }
 
         /// <summary>


### PR DESCRIPTION
Logging the exceptions is all we can do.
They should not bubble up to the game logic, because the logic might send packets to many clients in a loop - one erroneous connection should not lead to effects on others.
Alternatively, we would have to catch them in the view plugins - with a lot of repeating boilerplate code.