### PR TITLE
Fix monster position bug

### DIFF
--- a/src/GameLogic/NPC/Monster.cs
+++ b/src/GameLogic/NPC/Monster.cs
@@ -188,11 +188,11 @@ public sealed class Monster : NonPlayerCharacter, IAttackable, IAttacker, ISuppo
 
         var targetNode = calculatedPath.Last(); // that's one step before the target coordinates actually are reached.
         Span<WalkingStep> steps = stackalloc WalkingStep[calculatedPath.Count];
-        var i = steps.Length;
+        var i = 0;
         foreach (var step in calculatedPath.Select(GetStep))
         {
-            i--;
             steps[i] = step;
+            i++;
         }
 
         this.WalkTo(new Point(targetNode.X, targetNode.Y), steps);

--- a/src/GameLogic/NPC/Monster.cs
+++ b/src/GameLogic/NPC/Monster.cs
@@ -285,7 +285,6 @@ public sealed class Monster : NonPlayerCharacter, IAttackable, IAttacker, ISuppo
             this._respawnTimer?.Dispose();
             this._walker.Dispose();
             (this._intelligence as IDisposable)?.Dispose();
-            this.CurrentMap?.Remove(this);
             this.IsAlive = false;
         }
 

--- a/src/GameLogic/NPC/NonPlayerCharacter.cs
+++ b/src/GameLogic/NPC/NonPlayerCharacter.cs
@@ -138,6 +138,8 @@ public class NonPlayerCharacter : IObservable, IRotatable, ILocateable, IHasBuck
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Usage", "CA2213:DisposableFieldsShouldBeDisposed", MessageId = "<ObserverLock>k__BackingField", Justification = "Can't access backing field.")]
     protected virtual void Dispose(bool managed)
     {
+        this.CurrentMap?.Remove(this);
+
         this.ObserverLock.Dispose();
     }
 

--- a/src/GameLogic/NPC/NullMonsterIntelligence.cs
+++ b/src/GameLogic/NPC/NullMonsterIntelligence.cs
@@ -1,0 +1,32 @@
+﻿// <copyright file="NullMonsterIntelligence.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.NPC;
+
+/// <summary>
+/// The monster intelligence which does nothing.
+/// </summary>
+public sealed class NullMonsterIntelligence : INpcIntelligence
+{
+    private NonPlayerCharacter? _npc;
+
+    /// <inheritdoc />
+    public NonPlayerCharacter Npc
+    {
+        get => this._npc ?? throw Error.NotInitializedProperty(this);
+        set => this._npc = value;
+    }
+
+    /// <inheritdoc />
+    public void RegisterHit(IAttacker attacker)
+    {
+        // do nothing
+    }
+
+    /// <inheritdoc />
+    public void Start()
+    {
+        // do nothing
+    }
+}

--- a/src/GameLogic/PlugIns/ChatCommands/Arguments/CoordinatesCommandArgs.cs
+++ b/src/GameLogic/PlugIns/ChatCommands/Arguments/CoordinatesCommandArgs.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TeleportChatCommandArgs.cs" company="MUnique">
+﻿// <copyright file="CoordinatesCommandArgs.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
@@ -7,20 +7,20 @@ namespace MUnique.OpenMU.GameLogic.PlugIns.ChatCommands.Arguments;
 using MUnique.OpenMU.Pathfinding;
 
 /// <summary>
-/// Arguments used by TeleportChatCommandPlugIn.
+/// Arguments used by <see cref="TeleportChatCommandPlugIn"/> and others which just require an X and Y coordinate of a game map.
 /// </summary>
-public class TeleportChatCommandArgs : ArgumentsBase
+public class CoordinatesCommandArgs : ArgumentsBase
 {
     /// <summary>
     /// Gets or sets the coordinate X.
     /// </summary>
-    [Argument("x", false)]
+    [Argument("x", true)]
     public byte X { get; set; }
 
     /// <summary>
     /// Gets or sets the coordinate Y.
     /// </summary>
-    [Argument("y", false)]
+    [Argument("y", true)]
     public byte Y { get; set; }
 
     /// <summary>

--- a/src/GameLogic/PlugIns/ChatCommands/Arguments/CreateMonsterChatCommandArgs.cs
+++ b/src/GameLogic/PlugIns/ChatCommands/Arguments/CreateMonsterChatCommandArgs.cs
@@ -1,0 +1,23 @@
+﻿// <copyright file="CreateMonsterChatCommandArgs.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.PlugIns.ChatCommands.Arguments;
+
+/// <summary>
+/// Arguments used by <see cref="CreateMonsterChatCommand"/>.
+/// </summary>
+public class CreateMonsterChatCommandArgs : ArgumentsBase
+{
+    /// <summary>
+    /// Gets or sets the character name.
+    /// </summary>
+    [Argument("number")]
+    public short MonsterNumber { get; set; }
+
+    /// <summary>
+    /// Gets or sets a flag, if the created monster should be intelligent (walking, attacking), or should do nothing at all.
+    /// </summary>
+    [Argument("intelligence", false)]
+    public bool IsIntelligent { get; set; }
+}

--- a/src/GameLogic/PlugIns/ChatCommands/Arguments/IdCommandArgs.cs
+++ b/src/GameLogic/PlugIns/ChatCommands/Arguments/IdCommandArgs.cs
@@ -1,0 +1,17 @@
+﻿// <copyright file="IdCommandArgs.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.PlugIns.ChatCommands.Arguments;
+
+/// <summary>
+/// Arguments used by <see cref="RemoveNpcChatCommand"/> and others which just require an id of an object.
+/// </summary>
+public class IdCommandArgs : ArgumentsBase
+{
+    /// <summary>
+    /// Gets or sets the npc id.
+    /// </summary>
+    [Argument("id", true)]
+    public short Id { get; set; }
+}

--- a/src/GameLogic/PlugIns/ChatCommands/Arguments/MoveMonsterCommandArgs.cs
+++ b/src/GameLogic/PlugIns/ChatCommands/Arguments/MoveMonsterCommandArgs.cs
@@ -1,0 +1,17 @@
+﻿// <copyright file="MoveMonsterCommandArgs.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.PlugIns.ChatCommands.Arguments;
+
+/// <summary>
+/// Arguments used by <see cref="MoveMonsterChatCommand"/> and others which just require an X and Y coordinate of a game map.
+/// </summary>
+public class MoveMonsterCommandArgs : CoordinatesCommandArgs
+{
+    /// <summary>
+    /// Gets or sets the monster id.
+    /// </summary>
+    [Argument("id", true)]
+    public short Id { get; set; }
+}

--- a/src/GameLogic/PlugIns/ChatCommands/CommandExtensions.cs
+++ b/src/GameLogic/PlugIns/ChatCommands/CommandExtensions.cs
@@ -39,7 +39,7 @@ public static class CommandExtensions
         }
 
         var attributedArguments = properties
-            .Select(p => p.GetCustomAttribute<ArgumentAttribute>())
+            .Select(p => p.GetCustomAttribute<ArgumentAttribute>(inherit: true))
             .Where(a => a is { })
             .Select(a => a!)
             .ToList();

--- a/src/GameLogic/PlugIns/ChatCommands/CreateMonsterChatCommand.cs
+++ b/src/GameLogic/PlugIns/ChatCommands/CreateMonsterChatCommand.cs
@@ -1,0 +1,60 @@
+﻿// <copyright file="CreateMonsterChatCommand.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.PlugIns.ChatCommands;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic.NPC;
+using MUnique.OpenMU.GameLogic.PlugIns.ChatCommands.Arguments;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// A chat command to create a new monster which can be remote controlled.
+/// </summary>
+[Guid("BF4DA282-8CFE-4110-B1C5-A01D3F224FAB")]
+[PlugIn("Create monster chat command", "Handles the chat command '/createmonster <number> <intelligent>'. Creates a monster which can be remote controlled by the GM.")]
+[ChatCommandHelp(Command, typeof(CreateMonsterChatCommandArgs), CharacterStatus.GameMaster)]
+internal class CreateMonsterChatCommand : ChatCommandPlugInBase<CreateMonsterChatCommandArgs>
+{
+    private const string Command = "/createmonster";
+
+    /// <inheritdoc />
+    public override string Key => Command;
+
+    /// <inheritdoc/>
+    public override CharacterStatus MinCharacterStatusRequirement => CharacterStatus.GameMaster;
+
+    /// <inheritdoc />
+    protected override void DoHandleCommand(Player gameMaster, CreateMonsterChatCommandArgs arguments)
+    {
+        var monsterDef = gameMaster.GameContext.Configuration.Monsters.FirstOrDefault(m => m.Number == arguments.MonsterNumber);
+        if (monsterDef is null)
+        {
+            this.ShowMessageTo(gameMaster, $"Monster with number {arguments.MonsterNumber} not found.");
+            return;
+        }
+
+        var gameMap = gameMaster.CurrentMap;
+        var area = new MonsterSpawnArea
+        {
+            GameMap = gameMap!.Definition,
+            MonsterDefinition = monsterDef,
+            SpawnTrigger = SpawnTrigger.Automatic,
+            Quantity = 1,
+            X1 = (byte)Math.Max(gameMaster.Position.X - 3, byte.MinValue),
+            X2 = (byte)Math.Min(gameMaster.Position.X + 3, byte.MaxValue),
+            Y1 = (byte)Math.Max(gameMaster.Position.Y - 3, byte.MinValue),
+            Y2 = (byte)Math.Min(gameMaster.Position.Y + 3, byte.MaxValue),
+        };
+
+        INpcIntelligence intelligence = arguments.IsIntelligent ? new BasicMonsterIntelligence() : new NullMonsterIntelligence();
+        var monster = new Monster(area, monsterDef, gameMap, NullDropGenerator.Instance, intelligence, gameMaster.GameContext.PlugInManager);
+        intelligence.Npc = monster;
+        monster.Initialize();
+        gameMap.Add(monster);
+        gameMaster.PlayerDisconnected += (_, _) => monster.Dispose();
+
+        this.ShowMessageTo(gameMaster, $"Monster with number {arguments.MonsterNumber} created, id: {monster.Id}.");
+    }
+}

--- a/src/GameLogic/PlugIns/ChatCommands/MoveMonsterChatCommand.cs
+++ b/src/GameLogic/PlugIns/ChatCommands/MoveMonsterChatCommand.cs
@@ -1,0 +1,40 @@
+﻿// <copyright file="MoveMonsterChatCommand.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.PlugIns.ChatCommands;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic.NPC;
+using MUnique.OpenMU.GameLogic.PlugIns.ChatCommands.Arguments;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Chat command to instantly move a monster to specific coordinates.
+/// </summary>
+[Guid("B3DE58F3-B604-4F59-9122-E686AD90BE7B")]
+[PlugIn("Move remote monster chat command", "Handles the chat command '/movemonster <id> <x> <y>'. Moves a previously created monster which can be remote controlled by the GM.")]
+[ChatCommandHelp(Command, typeof(MoveMonsterCommandArgs), CharacterStatus.GameMaster)]
+internal class MoveMonsterChatCommand : ChatCommandPlugInBase<MoveMonsterCommandArgs>
+{
+    private const string Command = "/movemonster";
+
+    /// <inheritdoc />
+    public override string Key => Command;
+
+    /// <inheritdoc/>
+    public override CharacterStatus MinCharacterStatusRequirement => CharacterStatus.GameMaster;
+
+    /// <inheritdoc />
+    protected override void DoHandleCommand(Player gameMaster, MoveMonsterCommandArgs arguments)
+    {
+        var monster = gameMaster.ObservingBuckets.SelectMany(b => b).OfType<Monster>().FirstOrDefault(m => m.Id == arguments.Id);
+        if (monster is null)
+        {
+            this.ShowMessageTo(gameMaster, $"Monster with id {arguments.Id} not found.");
+            return;
+        }
+
+        monster.Move(arguments.Coordinates);
+    }
+}

--- a/src/GameLogic/PlugIns/ChatCommands/RemoveNpcChatCommand.cs
+++ b/src/GameLogic/PlugIns/ChatCommands/RemoveNpcChatCommand.cs
@@ -1,0 +1,41 @@
+﻿// <copyright file="RemoveNpcChatCommand.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.PlugIns.ChatCommands;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic.NPC;
+using MUnique.OpenMU.GameLogic.PlugIns.ChatCommands.Arguments;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Chat command to remove a npc with a specific id.
+/// </summary>
+[Guid("34FAAD0A-FCA4-42E2-8F37-CEF48783BD78")]
+[PlugIn("Remove npc chat command", "Handles the chat command '/removenpc <id>'.")]
+[ChatCommandHelp(Command, typeof(IdCommandArgs), CharacterStatus.GameMaster)]
+internal class RemoveNpcChatCommand : ChatCommandPlugInBase<IdCommandArgs>
+{
+    private const string Command = "/removenpc";
+
+    /// <inheritdoc />
+    public override string Key => Command;
+
+    /// <inheritdoc/>
+    public override CharacterStatus MinCharacterStatusRequirement => CharacterStatus.GameMaster;
+
+    /// <inheritdoc />
+    protected override void DoHandleCommand(Player gameMaster, IdCommandArgs arguments)
+    {
+        var monster = gameMaster.ObservingBuckets.SelectMany(b => b).OfType<NonPlayerCharacter>().FirstOrDefault(m => m.Id == arguments.Id);
+        if (monster is null)
+        {
+            this.ShowMessageTo(gameMaster, $"NPC with id {arguments.Id} not found.");
+            return;
+        }
+
+        monster.Dispose();
+        this.ShowMessageTo(gameMaster, $"NPC with id {arguments.Id} removed.");
+    }
+}

--- a/src/GameLogic/PlugIns/ChatCommands/ShowNpcIdsChatCommand.cs
+++ b/src/GameLogic/PlugIns/ChatCommands/ShowNpcIdsChatCommand.cs
@@ -1,0 +1,37 @@
+﻿// <copyright file="ShowNpcIdsChatCommand.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.PlugIns.ChatCommands;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic.NPC;
+using MUnique.OpenMU.GameLogic.Views.NPC;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Chat command to request the ids of all NPCs in the range of the player.
+/// </summary>
+[Guid("498D0205-388F-410A-A7C7-49069A64D3A9")]
+[PlugIn("Show NPC ids chat command", "Handles the chat command '/showids'.")]
+[ChatCommandHelp(Command, CharacterStatus.GameMaster)]
+internal sealed class ShowNpcIdsChatCommand : IChatCommandPlugIn
+{
+    private const string Command = "/showids";
+
+    /// <inheritdoc />
+    public string Key => Command;
+
+    /// <inheritdoc/>
+    public CharacterStatus MinCharacterStatusRequirement => CharacterStatus.GameMaster;
+
+    /// <inheritdoc/>
+    public void HandleCommand(Player player, string command)
+    {
+        var monsters = player.ObservingBuckets.SelectMany(b => b).OfType<NonPlayerCharacter>().ToList();
+        foreach (var monster in monsters)
+        {
+            player.ViewPlugIns.GetPlugIn<IShowMessageOfObjectPlugIn>()?.ShowMessageOfObject($"{monster.Id}", monster);
+        }
+    }
+}

--- a/src/GameLogic/PlugIns/ChatCommands/TeleportChatCommandPlugIn.cs
+++ b/src/GameLogic/PlugIns/ChatCommands/TeleportChatCommandPlugIn.cs
@@ -13,8 +13,8 @@ using MUnique.OpenMU.PlugIns;
 /// </summary>
 [Guid("ABFE2440-E765-4F17-A588-BD9AE3799886")]
 [PlugIn("Teleport chat command", "Handles the chat command '/teleport <x> <y>'. Teleports the game master to the specified coordinate.")]
-[ChatCommandHelp(Command, typeof(TeleportChatCommandArgs), CharacterStatus.GameMaster)]
-public class TeleportChatCommandPlugIn : ChatCommandPlugInBase<TeleportChatCommandArgs>
+[ChatCommandHelp(Command, typeof(CoordinatesCommandArgs), CharacterStatus.GameMaster)]
+public class TeleportChatCommandPlugIn : ChatCommandPlugInBase<CoordinatesCommandArgs>
 {
     private const string Command = "/teleport";
 
@@ -25,7 +25,7 @@ public class TeleportChatCommandPlugIn : ChatCommandPlugInBase<TeleportChatComma
     public override CharacterStatus MinCharacterStatusRequirement => CharacterStatus.GameMaster;
 
     /// <inheritdoc/>
-    protected override void DoHandleCommand(Player gameMaster, TeleportChatCommandArgs arguments)
+    protected override void DoHandleCommand(Player gameMaster, CoordinatesCommandArgs arguments)
     {
         gameMaster.Move(arguments.Coordinates);
     }

--- a/src/GameLogic/PlugIns/ChatCommands/WalkMonsterChatCommand.cs
+++ b/src/GameLogic/PlugIns/ChatCommands/WalkMonsterChatCommand.cs
@@ -1,0 +1,40 @@
+﻿// <copyright file="WalkMonsterChatCommand.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.PlugIns.ChatCommands;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic.NPC;
+using MUnique.OpenMU.GameLogic.PlugIns.ChatCommands.Arguments;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Chat command to let a monster walk to specific coordinates.
+/// </summary>
+[Guid("1852FED5-8184-431E-8C5F-5131356D348F")]
+[PlugIn("Walk remote monster chat command", "Handles the chat command '/walkmonster <id> <x> <y>'. Walks a previously created monster which can be remote controlled by the GM.")]
+[ChatCommandHelp(Command, typeof(MoveMonsterCommandArgs), CharacterStatus.GameMaster)]
+internal class WalkMonsterChatCommand : ChatCommandPlugInBase<MoveMonsterCommandArgs>
+{
+    private const string Command = "/walkmonster";
+
+    /// <inheritdoc />
+    public override string Key => Command;
+
+    /// <inheritdoc/>
+    public override CharacterStatus MinCharacterStatusRequirement => CharacterStatus.GameMaster;
+
+    /// <inheritdoc />
+    protected override void DoHandleCommand(Player gameMaster, MoveMonsterCommandArgs arguments)
+    {
+        var monster = gameMaster.ObservingBuckets.SelectMany(b => b).OfType<Monster>().FirstOrDefault(m => m.Id == arguments.Id);
+        if (monster is null)
+        {
+            this.ShowMessageTo(gameMaster, $"Monster with id {arguments.Id} not found.");
+            return;
+        }
+
+        monster.WalkTo(arguments.Coordinates);
+    }
+}

--- a/src/GameLogic/Walker.cs
+++ b/src/GameLogic/Walker.cs
@@ -235,15 +235,17 @@ public sealed class Walker : IDisposable
 
     private void WalkNextStepIfStepAvailable()
     {
-        if (!this.ShouldWalkerStop())
+        if (this.ShouldWalkerStop())
         {
-            var nextStep = this._nextSteps.Dequeue();
-            this._walkSupporter.Position = nextStep.To;
+            return;
+        }
 
-            if (this._walkSupporter is IRotatable rotatable)
-            {
-                rotatable.Rotation = nextStep.Direction;
-            }
+        var nextStep = this._nextSteps.Dequeue();
+        this._walkSupporter.Position = nextStep.To;
+
+        if (this._walkSupporter is IRotatable rotatable)
+        {
+            rotatable.Rotation = nextStep.Direction;
         }
     }
 


### PR DESCRIPTION
This should fix issue #226.

The steps which were calculated by the path finder got reverted when passed to `Monster.WalkTo(target, steps)`. This is wrong - the order must be maintained.