### PR TITLE
Implemented effects by consuming items

### DIFF
--- a/docs/Packets/C1-2D-EffectItemConsumption_by-server.md
+++ b/docs/Packets/C1-2D-EffectItemConsumption_by-server.md
@@ -1,0 +1,65 @@
+# C1 2D - EffectItemConsumption (by server)
+
+## Is sent when
+
+The player requested to consume an item which gives a magic effect.
+
+## Causes the following actions on the client side
+
+The client updates the user interface, it shows the remaining time at the effect icon.
+
+## Structure
+
+| Index | Length | Data Type | Value | Description |
+|-------|--------|-----------|-------|-------------|
+| 0 | 1 |   Byte   | 0xC1  | [Packet type](PacketTypes.md) |
+| 1 | 1 |    Byte   |   17   | Packet header - length of the packet |
+| 2 | 1 |    Byte   | 0x2D  | Packet header - packet type identifier |
+| 4 | 1 | EffectOrigin |  | Origin |
+| 6 | 1 | EffectType |  | Type |
+| 8 | 1 | EffectAction |  | Action |
+| 12 | 4 | IntegerLittleEndian |  | RemainingSeconds |
+| 16 | 1 | Byte |  | MagicEffectNumber |
+
+### EffectOrigin Enum
+
+Defines the origin of the effect.
+
+| Value | Name | Description |
+|-------|------|-------------|
+| 0 | Undefined | Not defined. |
+| 1 | HalloweenAndCherryBlossomEvent | Options of Halloween and Cherry Blossom Event items. |
+| 2 | CashShopItem | Options of cash shop items, like Seals. |
+
+### EffectAction Enum
+
+Defines the effect option.
+
+| Value | Name | Description |
+|-------|------|-------------|
+| 0 | Add | Effect is added. |
+| 1 | Remove | Effect is removed. |
+| 2 | Replace | Effect is removed, because its getting replaced. |
+
+### EffectType Enum
+
+Defines the kind of effect which was applied.
+
+| Value | Name | Description |
+|-------|------|-------------|
+| 1 | AttackSpeed | Attack speed increase. |
+| 2 | Damage | Damage increase. |
+| 3 | Defense | Defense increase. |
+| 4 | MaximumHealth | Maximum Health increase. |
+| 5 | MaximumMana | Maximum Mana increase. |
+| 6 | ExperienceRate | Experience rate increase. |
+| 7 | DropRate | Drop rate increase. |
+| 8 | Sustenance | Sustenance effect, means no experience is gained during this effect. |
+| 9 | Strength | Strength stat increase. |
+| 10 | Agility | Agility stat increase. |
+| 11 | Vitality | Vitality stat increase. |
+| 12 | Energy | Energy stat increase. |
+| 13 | Leadership | Leadership stat increase. |
+| 14 | PhysicalDamage | Physical damage increase. |
+| 15 | WizardryDamage | Wizardry damage increase. |
+| 16 | Mobility | Mobility increase. |

--- a/docs/Packets/C1-F3-40-ShowSwirl_by-server.md
+++ b/docs/Packets/C1-F3-40-ShowSwirl_by-server.md
@@ -17,4 +17,4 @@ The client shows a swirl effect at the specified object.
 | 2 | 1 |    Byte   | 0xF3  | Packet header - packet type identifier |
 | 3 | 1 |    Byte   | 0x40  | Packet header - sub packet type identifier |
 | 4 | 1 | Byte | 58 | EffectType |
-| 5 | 2 | ShortLittleEndian |  | TargetObjectId |
+| 5 | 2 | ShortBigEndian |  | TargetObjectId |

--- a/docs/Packets/ServerToClient.md
+++ b/docs/Packets/ServerToClient.md
@@ -51,6 +51,7 @@
   * [C3 29 - ConsumeItemWithEffect (by server)](C3-29-ConsumeItemWithEffect_by-server.md)
   * [C1 2A - ItemDurabilityChanged (by server)](C1-2A-ItemDurabilityChanged_by-server.md)
   * [C1 2C - FruitConsumptionResponse (by server)](C1-2C-FruitConsumptionResponse_by-server.md)
+  * [C1 2D - EffectItemConsumption (by server)](C1-2D-EffectItemConsumption_by-server.md)
   * [C3 30 - NpcWindowResponse (by server)](C3-30-NpcWindowResponse_by-server.md)
   * [C2 31 - StoreItemList (by server)](C2-31-StoreItemList_by-server.md)
   * [C1 32 - ItemBought (by server)](C1-32-ItemBought_by-server.md)

--- a/src/DataModel/Configuration/Items/ItemDefinition.cs
+++ b/src/DataModel/Configuration/Items/ItemDefinition.cs
@@ -83,6 +83,12 @@ public class ItemDefinition
     public string? ConsumeHandlerClass { get; set; }
 
     /// <summary>
+    /// Gets or sets the effect which is applied when this item is consumed.
+    /// Setting the <see cref="ConsumeHandlerClass"/> is not required when this effect definition is set.
+    /// </summary>
+    public virtual MagicEffectDefinition? ConsumeEffect { get; set; }
+
+    /// <summary>
     /// Gets or sets the maximum number of sockets an instance of this item can have.
     /// </summary>
     public int MaximumSockets { get; set; }

--- a/src/DataModel/Configuration/MagicEffectDefinition.cs
+++ b/src/DataModel/Configuration/MagicEffectDefinition.cs
@@ -27,7 +27,7 @@ public class MagicEffectDefinition
 
     /// <summary>
     /// Gets or sets the sub type.
-    /// Same sub type = cant stack. adding a magic effect with the same sub type will cause the existing magic effect to disappear.
+    /// Same sub type = cant stack. Adding a magic effect with the same sub type will cause the existing magic effect to disappear.
     /// </summary>
     public byte SubType { get; set; }
 

--- a/src/GameLogic/MagicEffectsList.cs
+++ b/src/GameLogic/MagicEffectsList.cs
@@ -5,6 +5,7 @@
 namespace MUnique.OpenMU.GameLogic;
 
 using System.Collections;
+using System.Diagnostics.CodeAnalysis;
 using MUnique.OpenMU.GameLogic.Views.World;
 
 /// <summary>
@@ -85,6 +86,28 @@ public class MagicEffectsList
         {
             this.ActiveEffects.Values.First().Dispose();
         }
+    }
+
+    /// <summary>
+    /// Tries to get the currently active effect of the specified <see cref="MagicEffectDefinition.SubType"/>.
+    /// </summary>
+    /// <param name="subType">The <see cref="MagicEffectDefinition.SubType"/>.</param>
+    /// <param name="effect">The effect, if found.</param>
+    /// <returns><see langword="true"/>, if found.</returns>
+    public bool TryGetActiveEffectOfSubType(byte subType, [MaybeNullWhen(false)] out MagicEffect effect)
+    {
+        lock (this._addLock)
+        {
+            effect = this.ActiveEffects.Values.FirstOrDefault(e => e.Definition.SubType == subType);
+            return effect is not null;
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        base.Dispose(disposing);
+        this.ClearAllEffects();
     }
 
     private void OnEffectTimeOut(object? sender, EventArgs args)

--- a/src/GameLogic/MagicEffectsList.cs
+++ b/src/GameLogic/MagicEffectsList.cs
@@ -11,7 +11,7 @@ using MUnique.OpenMU.GameLogic.Views.World;
 /// <summary>
 /// The list of magic effects of a player instance. Automatically applies the power-ups of the effects to the player.
 /// </summary>
-public class MagicEffectsList
+public class MagicEffectsList : Disposable
 {
     private readonly BitArray _contains = new (0x100);
     private readonly IAttackable _owner;

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -1167,6 +1167,7 @@ public class Player : IBucketMapObserver, IAttackable, IAttacker, ITrader, IPart
             this._observerToWorldViewAdapter.Dispose();
             this._walker.Dispose();
             this.ObserverLock.Dispose();
+            this.MagicEffectList.Dispose();
         }
     }
 

--- a/src/GameLogic/PlayerActions/ItemConsumeActions/ApplyMagicEffectConsumeHandler.cs
+++ b/src/GameLogic/PlayerActions/ItemConsumeActions/ApplyMagicEffectConsumeHandler.cs
@@ -1,0 +1,41 @@
+﻿// <copyright file="ApplyMagicEffectConsumeHandler.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.PlayerActions.ItemConsumeActions;
+
+using MUnique.OpenMU.DataModel.Configuration.Items;
+using MUnique.OpenMU.GameLogic.Attributes;
+
+/// <summary>
+/// <see cref="IItemConsumeHandler"/> for <see cref="Item"/>s which have a defined <see cref="ItemDefinition.ConsumeEffect"/>.
+/// </summary>
+public class ApplyMagicEffectConsumeHandler : BaseConsumeHandler
+{
+    /// <inheritdoc />
+    public override bool ConsumeItem(Player player, Item item, Item? targetItem, FruitUsage fruitUsage)
+    {
+        if (!base.ConsumeItem(player, item, targetItem, fruitUsage))
+        {
+            return false;
+        }
+
+        if (item.Definition?.ConsumeEffect is not { } effectDefinition
+            || effectDefinition.PowerUpDefinition?.Boost is not { } boostDefinition
+            || effectDefinition.PowerUpDefinition.Duration?.ConstantValue?.Value is not { } durationInSeconds)
+        {
+            return false;
+        }
+
+        if (player.MagicEffectList.TryGetActiveEffectOfSubType(effectDefinition.SubType, out var existingEffect))
+        {
+            existingEffect.Dispose();
+        }
+
+        var boost = player.Attributes!.CreateElement(boostDefinition);
+
+        var effect = new MagicEffect(boost, effectDefinition, TimeSpan.FromSeconds(durationInSeconds));
+        player.MagicEffectList.AddEffect(effect);
+        return true;
+    }
+}

--- a/src/GameLogic/PlayerActions/ItemConsumeActions/FruitConsumeHandler.cs
+++ b/src/GameLogic/PlayerActions/ItemConsumeActions/FruitConsumeHandler.cs
@@ -178,7 +178,7 @@ public class FruitConsumeHandler : BaseConsumeHandler
             2 => Stats.BaseAgility,
             3 => Stats.BaseStrength,
             4 => Stats.BaseLeadership,
-            _ => throw new ArgumentException("Invalid item level {item.Level}"),
+            _ => throw new ArgumentException($"Invalid item level {item.Level}"),
         };
     }
 }

--- a/src/GameLogic/PlayerActions/ItemConsumeActions/ItemConsumeAction.cs
+++ b/src/GameLogic/PlayerActions/ItemConsumeActions/ItemConsumeAction.cs
@@ -91,6 +91,13 @@ public class ItemConsumeAction
             var consumeHandler = this.CreateConsumeHandler(gameContext, item.ConsumeHandlerClass!);
             this._consumeHandlers.Add(item, consumeHandler);
         }
+
+        IItemConsumeHandler effectHandler = new ApplyMagicEffectConsumeHandler();
+        var effectItems = gameContext.Configuration.Items.Where(def => def.ConsumeEffect is not null);
+        foreach (var item in effectItems)
+        {
+            this._consumeHandlers.Add(item, effectHandler);
+        }
     }
 
     private IItemConsumeHandler CreateConsumeHandler(IGameContext gameContext, string handlerTypeName)

--- a/src/GameServer/RemoteView/Character/UpdateMaximumHealthPlugIn.cs
+++ b/src/GameServer/RemoteView/Character/UpdateMaximumHealthPlugIn.cs
@@ -28,7 +28,8 @@ public class UpdateMaximumHealthPlugIn : IUpdateMaximumHealthPlugIn
     /// <inheritdoc/>
     public void UpdateMaximumHealth()
     {
-        if (this._player.Attributes is null)
+        if (this._player.Attributes is null
+            || !(this._player.Connection?.Connected ?? false))
         {
             return;
         }

--- a/src/GameServer/RemoteView/Character/UpdateMaximumManaPlugIn.cs
+++ b/src/GameServer/RemoteView/Character/UpdateMaximumManaPlugIn.cs
@@ -28,7 +28,8 @@ public class UpdateMaximumManaPlugIn : IUpdateMaximumManaPlugIn
     /// <inheritdoc/>
     public void UpdateMaximumMana()
     {
-        if (this._player.Attributes is null)
+        if (this._player.Attributes is null
+            || !(this._player.Connection?.Connected ?? false))
         {
             return;
         }

--- a/src/Network/Packets/ServerToClient/ServerToClientPackets.cs
+++ b/src/Network/Packets/ServerToClient/ServerToClientPackets.cs
@@ -8638,6 +8638,249 @@ public readonly ref struct FruitConsumptionResponse
 
 
 /// <summary>
+/// Is sent by the server when: The player requested to consume an item which gives a magic effect.
+/// Causes reaction on client side: The client updates the user interface, it shows the remaining time at the effect icon.
+/// </summary>
+public readonly ref struct EffectItemConsumption
+{
+    /// <summary>
+    /// Defines the origin of the effect.
+    /// </summary>
+    public enum EffectOrigin
+    {
+        /// <summary>
+        /// Not defined.
+        /// </summary>
+            Undefined = 0,
+
+        /// <summary>
+        /// Options of Halloween and Cherry Blossom Event items.
+        /// </summary>
+            HalloweenAndCherryBlossomEvent = 1,
+
+        /// <summary>
+        /// Options of cash shop items, like Seals.
+        /// </summary>
+            CashShopItem = 2,
+    }
+
+    /// <summary>
+    /// Defines the effect option.
+    /// </summary>
+    public enum EffectAction
+    {
+        /// <summary>
+        /// Effect is added.
+        /// </summary>
+            Add = 0,
+
+        /// <summary>
+        /// Effect is removed.
+        /// </summary>
+            Remove = 1,
+
+        /// <summary>
+        /// Effect is removed, because its getting replaced.
+        /// </summary>
+            Replace = 2,
+    }
+
+    /// <summary>
+    /// Defines the kind of effect which was applied.
+    /// </summary>
+    public enum EffectType
+    {
+        /// <summary>
+        /// Attack speed increase.
+        /// </summary>
+            AttackSpeed = 1,
+
+        /// <summary>
+        /// Damage increase.
+        /// </summary>
+            Damage = 2,
+
+        /// <summary>
+        /// Defense increase.
+        /// </summary>
+            Defense = 3,
+
+        /// <summary>
+        /// Maximum Health increase.
+        /// </summary>
+            MaximumHealth = 4,
+
+        /// <summary>
+        /// Maximum Mana increase.
+        /// </summary>
+            MaximumMana = 5,
+
+        /// <summary>
+        /// Experience rate increase.
+        /// </summary>
+            ExperienceRate = 6,
+
+        /// <summary>
+        /// Drop rate increase.
+        /// </summary>
+            DropRate = 7,
+
+        /// <summary>
+        /// Sustenance effect, means no experience is gained during this effect.
+        /// </summary>
+            Sustenance = 8,
+
+        /// <summary>
+        /// Strength stat increase.
+        /// </summary>
+            Strength = 9,
+
+        /// <summary>
+        /// Agility stat increase.
+        /// </summary>
+            Agility = 10,
+
+        /// <summary>
+        /// Vitality stat increase.
+        /// </summary>
+            Vitality = 11,
+
+        /// <summary>
+        /// Energy stat increase.
+        /// </summary>
+            Energy = 12,
+
+        /// <summary>
+        /// Leadership stat increase.
+        /// </summary>
+            Leadership = 13,
+
+        /// <summary>
+        /// Physical damage increase.
+        /// </summary>
+            PhysicalDamage = 14,
+
+        /// <summary>
+        /// Wizardry damage increase.
+        /// </summary>
+            WizardryDamage = 15,
+
+        /// <summary>
+        /// Mobility increase.
+        /// </summary>
+            Mobility = 16,
+    }
+
+    private readonly Span<byte> _data;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EffectItemConsumption"/> struct.
+    /// </summary>
+    /// <param name="data">The underlying data.</param>
+    public EffectItemConsumption(Span<byte> data)
+        : this(data, true)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="EffectItemConsumption"/> struct.
+    /// </summary>
+    /// <param name="data">The underlying data.</param>
+    /// <param name="initialize">If set to <c>true</c>, the header data is automatically initialized and written to the underlying span.</param>
+    private EffectItemConsumption(Span<byte> data, bool initialize)
+    {
+        this._data = data;
+        if (initialize)
+        {
+            var header = this.Header;
+            header.Type = HeaderType;
+            header.Code = Code;
+            header.Length = (byte)Math.Min(data.Length, Length);
+        }
+    }
+
+    /// <summary>
+    /// Gets the header type of this data packet.
+    /// </summary>
+    public static byte HeaderType => 0xC1;
+
+    /// <summary>
+    /// Gets the operation code of this data packet.
+    /// </summary>
+    public static byte Code => 0x2D;
+
+    /// <summary>
+    /// Gets the initial length of this data packet. When the size is dynamic, this value may be bigger than actually needed.
+    /// </summary>
+    public static int Length => 17;
+
+    /// <summary>
+    /// Gets the header of this packet.
+    /// </summary>
+    public C1Header Header => new (this._data);
+
+    /// <summary>
+    /// Gets or sets the origin.
+    /// </summary>
+    public EffectItemConsumption.EffectOrigin Origin
+    {
+        get => (EffectOrigin)this._data[4];
+        set => this._data[4] = (byte)value;
+    }
+
+    /// <summary>
+    /// Gets or sets the type.
+    /// </summary>
+    public EffectItemConsumption.EffectType Type
+    {
+        get => (EffectType)this._data[6];
+        set => this._data[6] = (byte)value;
+    }
+
+    /// <summary>
+    /// Gets or sets the action.
+    /// </summary>
+    public EffectItemConsumption.EffectAction Action
+    {
+        get => (EffectAction)this._data[8];
+        set => this._data[8] = (byte)value;
+    }
+
+    /// <summary>
+    /// Gets or sets the remaining seconds.
+    /// </summary>
+    public uint RemainingSeconds
+    {
+        get => ReadUInt32LittleEndian(this._data[12..]);
+        set => WriteUInt32LittleEndian(this._data[12..], value);
+    }
+
+    /// <summary>
+    /// Gets or sets the magic effect number.
+    /// </summary>
+    public byte MagicEffectNumber
+    {
+        get => this._data[16];
+        set => this._data[16] = value;
+    }
+
+    /// <summary>
+    /// Performs an implicit conversion from a Span of bytes to a <see cref="EffectItemConsumption"/>.
+    /// </summary>
+    /// <param name="packet">The packet as span.</param>
+    /// <returns>The packet as struct.</returns>
+    public static implicit operator EffectItemConsumption(Span<byte> packet) => new (packet, false);
+
+    /// <summary>
+    /// Performs an implicit conversion from <see cref="EffectItemConsumption"/> to a Span of bytes.
+    /// </summary>
+    /// <param name="packet">The packet as struct.</param>
+    /// <returns>The packet as byte span.</returns>
+    public static implicit operator Span<byte>(EffectItemConsumption packet) => packet._data; 
+}
+
+
+/// <summary>
 /// Is sent by the server when: After the client talked to an NPC which should cause a dialog to open on the client side.
 /// Causes reaction on client side: The client opens the specified dialog.
 /// </summary>
@@ -14958,8 +15201,8 @@ public readonly ref struct ShowSwirl
     /// </summary>
     public ushort TargetObjectId
     {
-        get => ReadUInt16LittleEndian(this._data[5..]);
-        set => WriteUInt16LittleEndian(this._data[5..], value);
+        get => ReadUInt16BigEndian(this._data[5..]);
+        set => WriteUInt16BigEndian(this._data[5..], value);
     }
 
     /// <summary>

--- a/src/Network/Packets/ServerToClient/ServerToClientPackets.xml
+++ b/src/Network/Packets/ServerToClient/ServerToClientPackets.xml
@@ -3063,6 +3063,175 @@
       </Enums>
     </Packet>
     <Packet>
+      <HeaderType>C1Header</HeaderType>
+      <Code>2D</Code>
+      <Name>EffectItemConsumption</Name>
+      <Length>17</Length>
+      <Direction>ServerToClient</Direction>
+      <SentWhen>The player requested to consume an item which gives a magic effect.</SentWhen>
+      <CausedReaction>The client updates the user interface, it shows the remaining time at the effect icon.</CausedReaction>
+      <Fields>
+        <Field>
+          <Index>4</Index>
+          <Type>Enum</Type>
+          <TypeName>EffectOrigin</TypeName>
+          <Name>Origin</Name>
+        </Field>
+        <Field>
+          <Index>6</Index>
+          <Type>Enum</Type>
+          <TypeName>EffectType</TypeName>
+          <Name>Type</Name>
+        </Field>
+        <Field>
+          <Index>8</Index>
+          <Type>Enum</Type>
+          <TypeName>EffectAction</TypeName>
+          <Name>Action</Name>
+        </Field>
+        <Field>
+          <Index>12</Index>
+          <Type>IntegerLittleEndian</Type>
+          <Name>RemainingSeconds</Name>
+        </Field>
+        <Field>
+          <Index>16</Index>
+          <Type>Byte</Type>
+          <Name>MagicEffectNumber</Name>
+        </Field>
+      </Fields>
+      <Enums>
+        <Enum>
+          <Name>EffectOrigin</Name>
+          <Description>Defines the origin of the effect.</Description>
+          <Values>
+            <EnumValue>
+              <Name>Undefined</Name>
+              <Description>Not defined.</Description>
+              <Value>0</Value>
+            </EnumValue>
+            <EnumValue>
+              <Name>HalloweenAndCherryBlossomEvent</Name>
+              <Description>Options of Halloween and Cherry Blossom Event items.</Description>
+              <Value>1</Value>
+            </EnumValue>
+            <EnumValue>
+              <Name>CashShopItem</Name>
+              <Description>Options of cash shop items, like Seals.</Description>
+              <Value>2</Value>
+            </EnumValue>
+          </Values>
+        </Enum>
+        <Enum>
+          <Name>EffectAction</Name>
+          <Description>Defines the effect option.</Description>
+          <Values>
+            <EnumValue>
+              <Name>Add</Name>
+              <Description>Effect is added.</Description>
+              <Value>0</Value>
+            </EnumValue>
+            <EnumValue>
+              <Name>Remove</Name>
+              <Description>Effect is removed.</Description>
+              <Value>1</Value>
+            </EnumValue>
+            <EnumValue>
+              <Name>Replace</Name>
+              <Description>Effect is removed, because its getting replaced.</Description>
+              <Value>2</Value>
+            </EnumValue>
+          </Values>
+        </Enum>
+        <Enum>
+          <Name>EffectType</Name>
+          <Description>Defines the kind of effect which was applied.</Description>
+          <Values>
+            <EnumValue>
+              <Name>AttackSpeed</Name>
+              <Description>Attack speed increase.</Description>
+              <Value>1</Value>
+            </EnumValue>
+            <EnumValue>
+              <Name>Damage</Name>
+              <Description>Damage increase.</Description>
+              <Value>2</Value>
+            </EnumValue>
+            <EnumValue>
+              <Name>Defense</Name>
+              <Description>Defense increase.</Description>
+              <Value>3</Value>
+            </EnumValue>
+            <EnumValue>
+              <Name>MaximumHealth</Name>
+              <Description>Maximum Health increase.</Description>
+              <Value>4</Value>
+            </EnumValue>
+            <EnumValue>
+              <Name>MaximumMana</Name>
+              <Description>Maximum Mana increase.</Description>
+              <Value>5</Value>
+            </EnumValue>
+            <EnumValue>
+              <Name>ExperienceRate</Name>
+              <Description>Experience rate increase.</Description>
+              <Value>6</Value>
+            </EnumValue>
+            <EnumValue>
+              <Name>DropRate</Name>
+              <Description>Drop rate increase.</Description>
+              <Value>7</Value>
+            </EnumValue>
+            <EnumValue>
+              <Name>Sustenance</Name>
+              <Description>Sustenance effect, means no experience is gained during this effect.</Description>
+              <Value>8</Value>
+            </EnumValue>
+            <EnumValue>
+              <Name>Strength</Name>
+              <Description>Strength stat increase.</Description>
+              <Value>9</Value>
+            </EnumValue>
+            <EnumValue>
+              <Name>Agility</Name>
+              <Description>Agility stat increase.</Description>
+              <Value>10</Value>
+            </EnumValue>
+            <EnumValue>
+              <Name>Vitality</Name>
+              <Description>Vitality stat increase.</Description>
+              <Value>11</Value>
+            </EnumValue>
+            <EnumValue>
+              <Name>Energy</Name>
+              <Description>Energy stat increase.</Description>
+              <Value>12</Value>
+            </EnumValue>
+            <EnumValue>
+              <Name>Leadership</Name>
+              <Description>Leadership stat increase.</Description>
+              <Value>13</Value>
+            </EnumValue>
+            <EnumValue>
+              <Name>PhysicalDamage</Name>
+              <Description>Physical damage increase.</Description>
+              <Value>14</Value>
+            </EnumValue>
+            <EnumValue>
+              <Name>WizardryDamage</Name>
+              <Description>Wizardry damage increase.</Description>
+              <Value>15</Value>
+            </EnumValue>
+            <EnumValue>
+              <Name>Mobility</Name>
+              <Description>Mobility increase.</Description>
+              <Value>16</Value>
+            </EnumValue>
+          </Values>
+        </Enum>
+      </Enums>
+    </Packet>
+    <Packet>
       <HeaderType>C3Header</HeaderType>
       <Code>30</Code>
       <Name>NpcWindowResponse</Name>
@@ -5301,7 +5470,7 @@
         </Field>
         <Field>
           <Index>5</Index>
-          <Type>ShortLittleEndian</Type>
+          <Type>ShortBigEndian</Type>
           <Name>TargetObjectId</Name>
         </Field>
       </Fields>

--- a/src/Persistence/BasicModel/ItemDefinition.Generated.cs
+++ b/src/Persistence/BasicModel/ItemDefinition.Generated.cs
@@ -184,6 +184,26 @@ public partial class ItemDefinition : MUnique.OpenMU.DataModel.Configuration.Ite
     }
 
     /// <summary>
+    /// Gets the raw object of <see cref="ConsumeEffect" />.
+    /// </summary>
+    [Newtonsoft.Json.JsonProperty("consumeEffect")]
+    [System.Text.Json.Serialization.JsonPropertyName("consumeEffect")]
+    public MagicEffectDefinition RawConsumeEffect
+    {
+        get => base.ConsumeEffect as MagicEffectDefinition;
+        set => base.ConsumeEffect = value;
+    }
+
+    /// <inheritdoc/>
+    [Newtonsoft.Json.JsonIgnore]
+    [System.Text.Json.Serialization.JsonIgnore]
+    public override MUnique.OpenMU.DataModel.Configuration.MagicEffectDefinition ConsumeEffect
+    {
+        get => base.ConsumeEffect;
+        set => base.ConsumeEffect = value;
+    }
+
+    /// <summary>
     /// Gets the raw object of <see cref="Skill" />.
     /// </summary>
     [Newtonsoft.Json.JsonProperty("skill")]

--- a/src/Persistence/EntityFramework/Migrations/00000000000000_Initial.cs
+++ b/src/Persistence/EntityFramework/Migrations/00000000000000_Initial.cs
@@ -1703,6 +1703,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 {
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     ItemSlotId = table.Column<Guid>(type: "uuid", nullable: true),
+                    ConsumeEffectId = table.Column<Guid>(type: "uuid", nullable: true),
                     SkillId = table.Column<Guid>(type: "uuid", nullable: true),
                     GameConfigurationId = table.Column<Guid>(type: "uuid", nullable: true),
                     Number = table.Column<short>(type: "smallint", nullable: false),
@@ -1734,6 +1735,12 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                         column: x => x.ItemSlotId,
                         principalSchema: "config",
                         principalTable: "ItemSlotType",
+                        principalColumn: "Id");
+                    table.ForeignKey(
+                        name: "FK_ItemDefinition_MagicEffectDefinition_ConsumeEffectId",
+                        column: x => x.ConsumeEffectId,
+                        principalSchema: "config",
+                        principalTable: "MagicEffectDefinition",
                         principalColumn: "Id");
                 });
 
@@ -3017,6 +3024,12 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 schema: "config",
                 table: "ItemCraftingResultItem",
                 column: "SimpleCraftingSettingsId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ItemDefinition_ConsumeEffectId",
+                schema: "config",
+                table: "ItemDefinition",
+                column: "ConsumeEffectId");
 
             migrationBuilder.CreateIndex(
                 name: "IX_ItemDefinition_GameConfigurationId",

--- a/src/Persistence/EntityFramework/Migrations/00000000000000_Initial.designer.cs
+++ b/src/Persistence/EntityFramework/Migrations/00000000000000_Initial.designer.cs
@@ -1346,6 +1346,9 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uuid");
 
+                    b.Property<Guid?>("ConsumeEffectId")
+                        .HasColumnType("uuid");
+
                     b.Property<string>("ConsumeHandlerClass")
                         .HasColumnType("text");
 
@@ -1399,6 +1402,8 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                         .HasColumnType("smallint");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("ConsumeEffectId");
 
                     b.HasIndex("GameConfigurationId");
 
@@ -3444,6 +3449,10 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 
             modelBuilder.Entity("MUnique.OpenMU.Persistence.EntityFramework.Model.ItemDefinition", b =>
                 {
+                    b.HasOne("MUnique.OpenMU.Persistence.EntityFramework.Model.MagicEffectDefinition", "RawConsumeEffect")
+                        .WithMany()
+                        .HasForeignKey("ConsumeEffectId");
+
                     b.HasOne("MUnique.OpenMU.Persistence.EntityFramework.Model.GameConfiguration", null)
                         .WithMany("RawItems")
                         .HasForeignKey("GameConfigurationId");
@@ -3455,6 +3464,8 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     b.HasOne("MUnique.OpenMU.Persistence.EntityFramework.Model.Skill", "RawSkill")
                         .WithMany()
                         .HasForeignKey("SkillId");
+
+                    b.Navigation("RawConsumeEffect");
 
                     b.Navigation("RawItemSlot");
 

--- a/src/Persistence/EntityFramework/Migrations/EntityDataContextModelSnapshot.cs
+++ b/src/Persistence/EntityFramework/Migrations/EntityDataContextModelSnapshot.cs
@@ -1344,6 +1344,9 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                         .ValueGeneratedOnAdd()
                         .HasColumnType("uuid");
 
+                    b.Property<Guid?>("ConsumeEffectId")
+                        .HasColumnType("uuid");
+
                     b.Property<string>("ConsumeHandlerClass")
                         .HasColumnType("text");
 
@@ -1397,6 +1400,8 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                         .HasColumnType("smallint");
 
                     b.HasKey("Id");
+
+                    b.HasIndex("ConsumeEffectId");
 
                     b.HasIndex("GameConfigurationId");
 
@@ -3442,6 +3447,10 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 
             modelBuilder.Entity("MUnique.OpenMU.Persistence.EntityFramework.Model.ItemDefinition", b =>
                 {
+                    b.HasOne("MUnique.OpenMU.Persistence.EntityFramework.Model.MagicEffectDefinition", "RawConsumeEffect")
+                        .WithMany()
+                        .HasForeignKey("ConsumeEffectId");
+
                     b.HasOne("MUnique.OpenMU.Persistence.EntityFramework.Model.GameConfiguration", null)
                         .WithMany("RawItems")
                         .HasForeignKey("GameConfigurationId");
@@ -3453,6 +3462,8 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     b.HasOne("MUnique.OpenMU.Persistence.EntityFramework.Model.Skill", "RawSkill")
                         .WithMany()
                         .HasForeignKey("SkillId");
+
+                    b.Navigation("RawConsumeEffect");
 
                     b.Navigation("RawItemSlot");
 

--- a/src/Persistence/EntityFramework/Model/ItemDefinition.Generated.cs
+++ b/src/Persistence/EntityFramework/Model/ItemDefinition.Generated.cs
@@ -87,6 +87,32 @@ internal partial class ItemDefinition : MUnique.OpenMU.DataModel.Configuration.I
     }
 
     /// <summary>
+    /// Gets or sets the identifier of <see cref="ConsumeEffect"/>.
+    /// </summary>
+    public Guid? ConsumeEffectId { get; set; }
+
+    /// <summary>
+    /// Gets the raw object of <see cref="ConsumeEffect" />.
+    /// </summary>
+    [ForeignKey(nameof(ConsumeEffectId))]
+    public MagicEffectDefinition RawConsumeEffect
+    {
+        get => base.ConsumeEffect as MagicEffectDefinition;
+        set => base.ConsumeEffect = value;
+    }
+
+    /// <inheritdoc/>
+    [NotMapped]
+    public override MUnique.OpenMU.DataModel.Configuration.MagicEffectDefinition ConsumeEffect
+    {
+        get => base.ConsumeEffect;set
+        {
+            base.ConsumeEffect = value;
+            this.ConsumeEffectId = this.RawConsumeEffect?.Id;
+        }
+    }
+
+    /// <summary>
     /// Gets or sets the identifier of <see cref="Skill"/>.
     /// </summary>
     public Guid? SkillId { get; set; }

--- a/src/Persistence/Initialization/Skills/MagicEffectNumber.cs
+++ b/src/Persistence/Initialization/Skills/MagicEffectNumber.cs
@@ -175,6 +175,26 @@ internal enum MagicEffectNumber : short
     ScrollOfDefense = 0x2D,
 
     /// <summary>
+    /// The scroll of wrath effect.
+    /// </summary>
+    ScrollOfWrath = 0x2E,
+
+    /// <summary>
+    /// The scroll of wizardry effect.
+    /// </summary>
+    ScrollOfWizardry = 0x2F,
+
+    /// <summary>
+    /// The scroll of health effect.
+    /// </summary>
+    ScrollOfHealth = 0x30,
+
+    /// <summary>
+    /// The scroll of mana effect.
+    /// </summary>
+    ScrollOfMana = 0x31,
+
+    /// <summary>
     /// The poisoned effect.
     /// </summary>
     Poisoned = 0x37,
@@ -218,6 +238,21 @@ internal enum MagicEffectNumber : short
     /// The blind effect.
     /// </summary>
     Blind = 0x49,
+
+    /// <summary>
+    /// The cherry blossom wine effect (+ 700 Mana).
+    /// </summary>
+    CherryBlossomWine = 0x4E,
+
+    /// <summary>
+    /// The cherry blossom rice cake effect (+ 700 Health).
+    /// </summary>
+    CherryBlossomRiceCake = 0x4F,
+
+    /// <summary>
+    /// The cherry blossom flower petal effect (+ 40 dmg).
+    /// </summary>
+    CherryBlossomFlowerPetal = 0x50,
 
     /// <summary>
     /// The wiz enhance effect.

--- a/src/Persistence/Initialization/VersionSeasonSix/Items/BoxOfLuck.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Items/BoxOfLuck.cs
@@ -1054,7 +1054,7 @@ internal class BoxOfLuck : InitializerBase
     {
         var box = this.CreateBox("Pumpkin of Luck", 14, 45);
         box.Value = 1;
-        /* TODO: add the scrolls below as consumables
+
         var pumpkinBox = this.Context.CreateNew<ItemDropItemGroup>();
         pumpkinBox.ItemType = SpecialItemType.RandomItem;
         pumpkinBox.Chance = 1.0;
@@ -1066,7 +1066,6 @@ internal class BoxOfLuck : InitializerBase
         this.AddDropItem(pumpkinBox, 14, 48); // Jack O'Lantern Scream Scroll
         this.AddDropItem(pumpkinBox, 14, 49); // Jack O'Lantern Food Scroll
         this.AddDropItem(pumpkinBox, 14, 50); // Jack O'Lantern Drink Scroll
-        */
     }
 
     private void CreateRedRibbonBox()
@@ -1251,12 +1250,11 @@ internal class BoxOfLuck : InitializerBase
         playBox.Description = "Cherry Blossom Play-Box";
         playBox.DropEffect = ItemDropEffect.Swirl;
         box.DropItems.Add(playBox);
-        /* TODO: Add these items
+
         this.AddDropItem(playBox, 14, 85); // Cherry Blossom Wine
         this.AddDropItem(playBox, 14, 86); // Cherry Blossom Rice Cake
         this.AddDropItem(playBox, 14, 87); // Cherry Blossom Flower Petal
         this.AddDropItem(playBox, 14, 90); // Golden Cherry Blossom Branch
-        */
     }
 
     // season 4

--- a/src/Persistence/Initialization/VersionSeasonSix/Items/Potions.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Items/Potions.cs
@@ -4,8 +4,12 @@
 
 namespace MUnique.OpenMU.Persistence.Initialization.VersionSeasonSix.Items;
 
+using MUnique.OpenMU.AttributeSystem;
+using MUnique.OpenMU.DataModel.Attributes;
 using MUnique.OpenMU.DataModel.Configuration;
 using MUnique.OpenMU.DataModel.Configuration.Items;
+using MUnique.OpenMU.GameLogic.Attributes;
+using MUnique.OpenMU.Persistence.Initialization.Skills;
 
 /// <summary>
 /// Class which contains item definitions for jewels.
@@ -45,6 +49,16 @@ public class Potions : InitializerBase
         this.GameConfiguration.Items.Add(this.CreateTownPortalScroll());
         this.GameConfiguration.Items.Add(this.CreateFruits());
         this.GameConfiguration.Items.Add(this.CreateSiegePotion());
+
+        this.GameConfiguration.Items.Add(this.CreateJackOLanternBlessings());
+        this.GameConfiguration.Items.Add(this.CreateJackOLanternWrath());
+        this.GameConfiguration.Items.Add(this.CreateJackOLanternCry());
+        this.GameConfiguration.Items.Add(this.CreateJackOLanternFood());
+        this.GameConfiguration.Items.Add(this.CreateJackOLanternDrink());
+
+        this.GameConfiguration.Items.Add(this.CreateCherryBlossomWine());
+        this.GameConfiguration.Items.Add(this.CreateCherryBlossomRiceCake());
+        this.GameConfiguration.Items.Add(this.CreateCherryBlossomFlowerPetal());
     }
 
     private ItemDefinition CreateAlcohol()
@@ -394,5 +408,129 @@ public class Potions : InitializerBase
         fruits.Width = 1;
         fruits.Height = 1;
         return fruits;
+    }
+
+    private ItemDefinition CreateJackOLanternBlessings()
+    {
+        var item = this.Context.CreateNew<ItemDefinition>();
+        item.Name = "Jack O'Lantern Blessings";
+        item.Number = 46;
+        item.Group = 14;
+        item.Durability = 10;
+        item.Width = 1;
+        item.Height = 2;
+        this.CreateConsumeEffect(item, 16, MagicEffectNumber.JackOlanternBlessing, Stats.AttackSpeed, 10, TimeSpan.FromMinutes(32));
+        return item;
+    }
+
+    private ItemDefinition CreateJackOLanternWrath()
+    {
+        var item = this.Context.CreateNew<ItemDefinition>();
+        item.Name = "Jack O'Lantern Wrath";
+        item.Number = 47;
+        item.Group = 14;
+        item.Durability = 10;
+        item.Width = 1;
+        item.Height = 2;
+        this.CreateConsumeEffect(item, 16, MagicEffectNumber.JackOlanternWrath, Stats.BaseDamageBonus, 25, TimeSpan.FromMinutes(30));
+        return item;
+    }
+
+    private ItemDefinition CreateJackOLanternCry()
+    {
+        var item = this.Context.CreateNew<ItemDefinition>();
+        item.Name = "Jack O'Lantern Cry";
+        item.Number = 48;
+        item.Group = 14;
+        item.Durability = 10;
+        item.Width = 1;
+        item.Height = 2;
+        this.CreateConsumeEffect(item, 16, MagicEffectNumber.JackOlanternCry, Stats.DefenseBase, 100, TimeSpan.FromMinutes(30));
+        return item;
+    }
+
+    private ItemDefinition CreateJackOLanternFood()
+    {
+        var item = this.Context.CreateNew<ItemDefinition>();
+        item.Name = "Jack O'Lantern Food";
+        item.Number = 49;
+        item.Group = 14;
+        item.Durability = 10;
+        item.Width = 1;
+        item.Height = 1;
+        this.CreateConsumeEffect(item, 16, MagicEffectNumber.JackOlanternFood, Stats.MaximumHealth, 500, TimeSpan.FromMinutes(30));
+        return item;
+    }
+
+    private ItemDefinition CreateJackOLanternDrink()
+    {
+        var item = this.Context.CreateNew<ItemDefinition>();
+        item.Name = "Jack O'Lantern Drink";
+        item.Number = 50;
+        item.Group = 14;
+        item.Durability = 10;
+        item.Width = 1;
+        item.Height = 1;
+        this.CreateConsumeEffect(item, 16, MagicEffectNumber.JackOlanternDrink, Stats.MaximumMana, 500, TimeSpan.FromMinutes(30));
+        return item;
+    }
+
+    private ItemDefinition CreateCherryBlossomWine()
+    {
+        var item = this.Context.CreateNew<ItemDefinition>();
+        item.Name = "Cherry Blossom Wine";
+        item.Number = 85;
+        item.Group = 14;
+        item.Durability = 10;
+        item.Width = 1;
+        item.Height = 2;
+        this.CreateConsumeEffect(item, 16, MagicEffectNumber.CherryBlossomWine, Stats.MaximumMana, 700, TimeSpan.FromMinutes(30));
+        return item;
+    }
+
+    private ItemDefinition CreateCherryBlossomRiceCake()
+    {
+        var item = this.Context.CreateNew<ItemDefinition>();
+        item.Name = "Cherry Blossom Rice Cake";
+        item.Number = 86;
+        item.Group = 14;
+        item.Durability = 10;
+        item.Width = 1;
+        item.Height = 1;
+        this.CreateConsumeEffect(item, 16, MagicEffectNumber.CherryBlossomRiceCake, Stats.MaximumHealth, 700, TimeSpan.FromMinutes(30));
+        return item;
+    }
+
+    private ItemDefinition CreateCherryBlossomFlowerPetal()
+    {
+        var item = this.Context.CreateNew<ItemDefinition>();
+        item.Name = "Cherry Blossom Flower Petal";
+        item.Number = 87;
+        item.Group = 14;
+        item.Durability = 10;
+        item.Width = 1;
+        item.Height = 1;
+        this.CreateConsumeEffect(item, 16, MagicEffectNumber.CherryBlossomFlowerPetal, Stats.BaseDamageBonus, 40, TimeSpan.FromMinutes(30));
+        return item;
+    }
+
+    private MagicEffectDefinition CreateConsumeEffect(ItemDefinition item, byte subType, MagicEffectNumber effectNumber, AttributeDefinition targetAttribute, float boostValue, TimeSpan duration)
+    {
+        var effect = this.Context.CreateNew<MagicEffectDefinition>();
+        this.GameConfiguration.MagicEffects.Add(effect);
+        item.ConsumeEffect = effect;
+        effect.Name = item.Name;
+        effect.InformObservers = false;
+        effect.Number = (short)effectNumber;
+        effect.StopByDeath = true;
+        effect.SubType = subType;
+        effect.SendDuration = true;
+        effect.PowerUpDefinition = this.Context.CreateNew<PowerUpDefinitionWithDuration>();
+        effect.PowerUpDefinition.Duration = this.Context.CreateNew<PowerUpDefinitionValue>();
+        effect.PowerUpDefinition.Duration.ConstantValue.Value = (float)duration.TotalSeconds;
+        effect.PowerUpDefinition.Boost = this.Context.CreateNew<PowerUpDefinitionValue>();
+        effect.PowerUpDefinition.Boost.ConstantValue.Value = boostValue;
+        effect.PowerUpDefinition.TargetAttribute = targetAttribute.GetPersistent(this.GameConfiguration);
+        return effect;
     }
 }


### PR DESCRIPTION
There are some items which apply time-limited effects when they're consumed by the player, e.g. Cherry Blossom or Jack O'Lantern event items.
I extended the ItemDefinition by a MagicEffectDefinition, named ConsumeEffect. When the ConsumeEffect is set for a consumed item, a corresponding MagicEffect is created when consuming it.

See also #231 and #236.