### PR TITLE
Fix GuildName length on GuildCreateRequest packet

### DIFF
--- a/src/Network/Packets/ClientToServer/ClientToServerPackets.cs
+++ b/src/Network/Packets/ClientToServer/ClientToServerPackets.cs
@@ -6828,8 +6828,8 @@ public readonly ref struct GuildCreateRequest
     /// </summary>
     public string GuildName
     {
-        get => this._data.ExtractString(4, 9, System.Text.Encoding.UTF8);
-        set => this._data.Slice(4, 9).WriteString(value, System.Text.Encoding.UTF8);
+        get => this._data.ExtractString(4, 8, System.Text.Encoding.UTF8);
+        set => this._data.Slice(4, 8).WriteString(value, System.Text.Encoding.UTF8);
     }
 
     /// <summary>

--- a/src/Network/Packets/ClientToServer/ClientToServerPackets.xml
+++ b/src/Network/Packets/ClientToServer/ClientToServerPackets.xml
@@ -1840,7 +1840,7 @@
           <Index>4</Index>
           <Type>String</Type>
           <Name>GuildName</Name>
-          <Length>9</Length>
+          <Length>8</Length>
         </Field>
         <Field>
           <Index>12</Index>


### PR DESCRIPTION
It's breaking the guild creation for names with 8 characters since it's adding an extra noise character