### PR TITLE
Fixed deleting of items (and possibly other objects)

### DIFF
--- a/src/GameLogic/PlayerActions/ItemConsumeActions/BaseConsumeHandler.cs
+++ b/src/GameLogic/PlayerActions/ItemConsumeActions/BaseConsumeHandler.cs
@@ -35,16 +35,6 @@ public class BaseConsumeHandler : IItemConsumeHandler
         {
             item.Durability -= 1;
         }
-
-        if (item.Durability == 0)
-        {
-            if (player.Inventory is { } inventory)
-            {
-                await inventory.RemoveItemAsync(item).ConfigureAwait(false);
-            }
-
-            await player.PersistenceContext.DeleteAsync(item).ConfigureAwait(false);
-        }
     }
 
     /// <summary>

--- a/src/Persistence/EntityFramework/EntityFrameworkContextBase.cs
+++ b/src/Persistence/EntityFramework/EntityFrameworkContextBase.cs
@@ -131,7 +131,19 @@ public class EntityFrameworkContextBase : IContext
         where T : class
     {
         using var l = await this._lock.LockAsync();
-        var result = this.Context.Remove(obj) is { };
+
+        var result = false;
+        if (this.Context.Entry(obj) is { } entry)
+        {
+            if (entry.State == EntityState.Detached)
+            {
+                return true;
+            }
+
+            this.Context.Remove(obj);
+            result = true;
+        }
+
         if (result)
         {
             this.ForEachAggregate(obj, a => this.Context.Remove(a));


### PR DESCRIPTION
When we delete new items twice - by calling DbContext,Remove - something strange happens:
* After the first delete, the entity entry has the state Detached. So far, so good.
* After the second delete, the entity entry has the state Deleted. That's a problem, because then, ef core tries to delete it from the database, where it never existed. This leads to an error, see also #261 