### PR TITLE
fix drop chance generation

### DIFF
--- a/src/GameLogic/DefaultDropGenerator.cs
+++ b/src/GameLogic/DefaultDropGenerator.cs
@@ -402,7 +402,7 @@ public class DefaultDropGenerator : IDropGenerator
 
     private DropItemGroup? SelectRandomGroup(IEnumerable<DropItemGroup> dropGroups)
     {
-        var sum = dropGroups.Sum(group => group.Chance);
+        var sum = Math.Max(1.0, dropGroups.Sum(group => group.Chance));
         double lot = this._randomizer.NextDouble() * sum;
 
         foreach (var group in dropGroups)

--- a/src/GameLogic/DefaultDropGenerator.cs
+++ b/src/GameLogic/DefaultDropGenerator.cs
@@ -402,7 +402,9 @@ public class DefaultDropGenerator : IDropGenerator
 
     private DropItemGroup? SelectRandomGroup(IEnumerable<DropItemGroup> dropGroups)
     {
-        double lot = this._randomizer.NextDouble();
+        var sum = dropGroups.Sum(group => group.Chance);
+        double lot = this._randomizer.NextDouble() * sum;
+
         foreach (var group in dropGroups)
         {
             if (lot > group.Chance)


### PR DESCRIPTION
If we have two or more groups with 1.0 chance, all except first will never be selected.

```csharp
double lot = 1; //or 0

for(group of groups) {
  // ALWAYS BE FALSE when lot = 0..1 !!!
  if(lot > group.Chance) {
    lot -= group.Chance;
  } else {
    return group;
  }
}
```