### PR TITLE
Fix for masterlevel level report on client

### DIFF
--- a/src/GameLogic/Party.cs
+++ b/src/GameLogic/Party.cs
@@ -232,10 +232,13 @@ public sealed class Party : Disposable
         var randomizedTotalExperiencePerLevel = randomizedTotalExperience / totalLevel;
         foreach (var player in this._distributionList)
         {
-            if (player.SelectedCharacter?.CharacterClass?.IsMasterClass ?? false)
+            if ((short)player.Attributes![Stats.Level] == player.GameContext.Configuration.MaximumLevel)
             {
-                var exp = (int)(randomizedTotalExperiencePerLevel * (player.Attributes![Stats.MasterLevel] + player.Attributes![Stats.Level]) * player.Attributes[Stats.MasterExperienceRate]);
-                await player.AddMasterExperienceAsync(exp, killedObject).ConfigureAwait(false);
+                if (player.SelectedCharacter?.CharacterClass?.IsMasterClass ?? false)
+                {
+                    var expMaster = (int)(randomizedTotalExperiencePerLevel * (player.Attributes![Stats.MasterLevel] + player.Attributes![Stats.Level]) * player.Attributes[Stats.MasterExperienceRate]);
+                    await player.AddMasterExperienceAsync(expMaster, killedObject).ConfigureAwait(false);
+                }
             }
             else
             {


### PR DESCRIPTION
I noticed that a fix was implemented on `Player` for this issue, but it wasn't until I added this in `Party` that I started to get the regular level to show up while leveling up; the client wasn't reporting the level up without this fix, it was staying at the level the character had when I logged in.

Example:
I login with MG level 200; I level up to 300 but character screen still shows level 200. I log out, log back in, now it shows level 300 but it stays there.

New:
I login with MG level 200; I level up to 300 and level keeps showing up with experience as I kill monsters.