### PR TITLE
Optimization for the monster/npc intelligence

### DIFF
--- a/src/GameLogic/INpcIntelligence.cs
+++ b/src/GameLogic/INpcIntelligence.cs
@@ -26,4 +26,9 @@ public interface INpcIntelligence
     /// Starts the actions.
     /// </summary>
     void Start();
+
+    /// <summary>
+    /// Pauses the actions.
+    /// </summary>
+    void Pause();
 }

--- a/src/GameLogic/NPC/Monster.cs
+++ b/src/GameLogic/NPC/Monster.cs
@@ -62,7 +62,6 @@ public sealed class Monster : AttackableNpcBase, IAttackable, IAttacker, ISuppor
         (this._skillPowerUp, this._skillPowerUpDuration, this._skillPowerUpTarget) = this.CreateMagicEffectPowerUp();
 
         this._intelligence.Npc = this;
-        this._intelligence.Start();
     }
 
     /// <summary>
@@ -232,6 +231,20 @@ public sealed class Monster : AttackableNpcBase, IAttackable, IAttacker, ISuppor
             };
             await this.WalkToAsync(target, steps).ConfigureAwait(false);
         }
+    }
+
+    /// <inheritdoc/>
+    protected override void OnFirstObserverAdded()
+    {
+        base.OnFirstObserverAdded();
+        this._intelligence.Start();
+    }
+
+    /// <inheritdoc/>
+    protected override void OnLastObserverRemoved()
+    {
+        base.OnLastObserverRemoved();
+        this._intelligence.Pause();
     }
 
     /// <inheritdoc/>

--- a/src/GameLogic/NPC/NonPlayerCharacter.cs
+++ b/src/GameLogic/NPC/NonPlayerCharacter.cs
@@ -96,6 +96,12 @@ public class NonPlayerCharacter : AsyncDisposable, IObservable, IRotatable, ILoc
     {
         using var writerLock = await this.ObserverLock.WriterLockAsync();
         this.Observers.Add(observer);
+        if (this.Observers.Count == 1)
+        {
+            this.OnFirstObserverAdded();
+        }
+
+        this.OnObserverAdded();
     }
 
     /// <inheritdoc/>
@@ -103,12 +109,50 @@ public class NonPlayerCharacter : AsyncDisposable, IObservable, IRotatable, ILoc
     {
         using var writerLock = await this.ObserverLock.WriterLockAsync();
         this.Observers.Remove(observer);
+        if (this.Observers.Count == 0)
+        {
+            this.OnLastObserverRemoved();
+        }
+
+        this.OnObserverRemoved();
     }
 
     /// <inheritdoc/>
     public override string ToString()
     {
         return $"{this.Definition.Designation} - Id: {this.Id} - Position: {this.Position}";
+    }
+
+    /// <summary>
+    /// Called when an observer has been added.
+    /// </summary>
+    protected virtual void OnObserverAdded()
+    {
+        // can be overwritten.
+    }
+
+    /// <summary>
+    /// Called when an observer has been removed.
+    /// </summary>
+    protected virtual void OnObserverRemoved()
+    {
+        // can be overwritten.
+    }
+
+    /// <summary>
+    /// Called when the first observer has been added.
+    /// </summary>
+    protected virtual void OnFirstObserverAdded()
+    {
+        // can be overwritten.
+    }
+
+    /// <summary>
+    /// Called when the last observer has been removed.
+    /// </summary>
+    protected virtual void OnLastObserverRemoved()
+    {
+        // can be overwritten.
     }
 
     /// <inheritdoc />

--- a/src/GameLogic/NPC/NullMonsterIntelligence.cs
+++ b/src/GameLogic/NPC/NullMonsterIntelligence.cs
@@ -29,4 +29,10 @@ public sealed class NullMonsterIntelligence : INpcIntelligence
     {
         // do nothing
     }
+
+    /// <inheritdoc />
+    public void Pause()
+    {
+        // do nothing
+    }
 }

--- a/src/GameLogic/NPC/Trap.cs
+++ b/src/GameLogic/NPC/Trap.cs
@@ -29,7 +29,6 @@ public sealed class Trap : NonPlayerCharacter, IAttacker
         this.Attributes = new TrapAttributeHolder(this);
         this._intelligence = trapIntelligence;
         this._intelligence.Npc = this;
-        this._intelligence.Start();
     }
 
     /// <inheritdoc/>
@@ -49,6 +48,20 @@ public sealed class Trap : NonPlayerCharacter, IAttacker
         // Maybe add SpecificAnimation and AttackWhenPlayerOn properties to MonsterDefinition?? or create new TrapDefinition?
         await player.AttackByAsync(this, null, false).ConfigureAwait(false);
         await this.ForEachWorldObserverAsync<IShowAnimationPlugIn>(p => p.ShowAnimationAsync(this, TrapAttackAnimation, player, this.Rotation), true).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc/>
+    protected override void OnFirstObserverAdded()
+    {
+        base.OnFirstObserverAdded();
+        this._intelligence.Start();
+    }
+
+    /// <inheritdoc/>
+    protected override void OnLastObserverRemoved()
+    {
+        base.OnLastObserverRemoved();
+        this._intelligence.Pause();
     }
 
     /// <inheritdoc/>

--- a/src/GameLogic/NPC/TrapIntelligenceBase.cs
+++ b/src/GameLogic/NPC/TrapIntelligenceBase.cs
@@ -71,7 +71,15 @@ public abstract class TrapIntelligenceBase : INpcIntelligence, IDisposable
     /// <inheritdoc/>
     public void Start()
     {
-        this._aiTimer = new Timer(state => this.SafeTick(), null, this.Trap.Definition.AttackDelay, this.Trap.Definition.AttackDelay);
+        var startDelay = this.Npc.Definition.AttackDelay + TimeSpan.FromMilliseconds(Rand.NextInt(0, 1000));
+        this._aiTimer ??= new Timer(_ => this.SafeTick(), null, startDelay, this.Npc.Definition.AttackDelay);
+    }
+
+    /// <inheritdoc/>
+    public void Pause()
+    {
+        this._aiTimer?.Dispose();
+        this._aiTimer = null;
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
We can turn the timer off, when there is no observer around.
In my debugger, the memory consumption increased a lot (when using the server GC), because a lot of small Tasks were created. If we can prevent them from being created, it also saves some CPU.