### PR TITLE
fix arrows and bolts consumption issue

### DIFF
--- a/src/GameLogic/IStorage.cs
+++ b/src/GameLogic/IStorage.cs
@@ -193,6 +193,11 @@ public interface IInventoryStorage : IStorage
     /// Gets all items which are in the wearable slots.
     /// </summary>
     IEnumerable<Item> EquippedItems { get; }
+
+    /// <summary>
+    /// Gets equipped ammunition item.
+    /// </summary>
+    Item? EquippedAmmunitionItem { get; }
 }
 
 /// <summary>

--- a/src/GameLogic/InventoryStorage.cs
+++ b/src/GameLogic/InventoryStorage.cs
@@ -4,6 +4,7 @@
 
 namespace MUnique.OpenMU.GameLogic;
 
+using MUnique.OpenMU.GameLogic.Attributes;
 using MUnique.OpenMU.GameLogic.Views.World;
 using MUnique.OpenMU.PlugIns;
 using static OpenMU.DataModel.InventoryConstants;
@@ -50,6 +51,26 @@ public class InventoryStorage : Storage, IInventoryStorage
                     yield return this.ItemArray[i]!;
                 }
             }
+        }
+    }
+
+
+    /// <inheritdoc/>
+    public Item? EquippedAmmunitionItem
+    {
+        get
+        {
+            if (this.ItemArray[LeftHandSlot] is { } leftItem && (leftItem.Definition?.IsAmmunition ?? false))
+            {
+                return leftItem;
+            }
+
+            if (this.ItemArray[RightHandSlot] is { } rightItem && (rightItem.Definition?.IsAmmunition ?? false))
+            {
+                return rightItem;
+            }
+
+            return null;
         }
     }
 
@@ -128,6 +149,11 @@ public class InventoryStorage : Storage, IInventoryStorage
         {
             var factory = this._gameContext.ItemPowerUpFactory;
             this._player.Attributes.ItemPowerUps.Add(item, factory.GetPowerUps(item, this._player.Attributes).ToList());
+
+            // reset player equipped ammunition amount
+            if (this.EquippedAmmunitionItem is { } ammoItem) {
+                this._player.Attributes[Stats.AmmunitionAmount] = (float) ammoItem.Durability;
+            }
         }
     }
 

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -1653,23 +1653,6 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         await this.ForEachWorldObserverAsync<IUpdateCharacterHeroStatePlugIn>(o => o.UpdateCharacterHeroStateAsync(this), true).ConfigureAwait(false);
     }
 
-    private Item? GetAmmunitionItem()
-    {
-        if (this.Inventory?.GetItem(InventoryConstants.LeftHandSlot) is { } leftItem
-            && (leftItem.Definition?.IsAmmunition ?? false))
-        {
-            return leftItem;
-        }
-
-        if (this.Inventory?.GetItem(InventoryConstants.RightHandSlot) is { } rightItem
-            && (rightItem.Definition?.IsAmmunition ?? false))
-        {
-            return rightItem;
-        }
-
-        return null;
-    }
-
     private SkillComboDefinition? DetermineComboDefinition()
     {
         var characterClass = this.SelectedCharacter!.CharacterClass;
@@ -1716,7 +1699,7 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         this.Attributes.GetOrCreateAttribute(Stats.TransformationSkin).ValueChanged += this.OnTransformationSkinChanged;
 
         var ammoAttribute = this.Attributes.GetOrCreateAttribute(Stats.AmmunitionAmount);
-        this.Attributes[Stats.AmmunitionAmount] = (float)(this.GetAmmunitionItem()?.Durability ?? 0);
+        this.Attributes[Stats.AmmunitionAmount] = (float)(this.Inventory?.EquippedAmmunitionItem?.Durability ?? 0);
         ammoAttribute.ValueChanged += this.OnAmmunitionAmountChanged;
 
         await this.ClientReadyAfterMapChangeAsync().ConfigureAwait(false);
@@ -1790,7 +1773,7 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         try
         {
             var value = Math.Max((byte)this.Attributes![Stats.AmmunitionAmount], (byte)0);
-            if (this.GetAmmunitionItem() is { } ammoItem
+            if (this.Inventory?.EquippedAmmunitionItem is { } ammoItem
                 && (int)ammoItem.Durability != value)
             {
                 ammoItem.Durability = value;


### PR DESCRIPTION
When an elf player logs in to the game, only the arrows or bolts equipped at the beginning will be consumed with the attack, and will no longer be consumed after replacing it with a new one.