### PR TITLE
fixed warp issues

### DIFF
--- a/src/GameLogic/CharacterExtensions.cs
+++ b/src/GameLogic/CharacterExtensions.cs
@@ -96,7 +96,7 @@ public static class CharacterExtensions
 
         if (character.CharacterClass?.LevelWarpRequirementReductionPercent is { } reduction and > 0)
         {
-            levelRequirement -= levelRequirement * 100 / reduction;
+            levelRequirement = levelRequirement * (100 - reduction) / 100;
         }
 
         return levelRequirement;

--- a/src/GameLogic/PlayerActions/WarpAction.cs
+++ b/src/GameLogic/PlayerActions/WarpAction.cs
@@ -34,9 +34,11 @@ public class WarpAction
     private bool CheckRequirements(Player player, WarpInfo warpInfo, [MaybeNullWhen(true)] out string errorMessage)
     {
         errorMessage = null;
-        if (!this.CheckLevelRequirement(player, warpInfo))
+
+        var requirement = player.SelectedCharacter?.GetEffectiveMoveLevelRequirement(warpInfo.LevelRequirement);
+        if (requirement > player.Attributes?[Stats.Level])
         {
-            errorMessage = $"You need to be level {warpInfo.LevelRequirement} in order to warp";
+            errorMessage = $"You need to be level {requirement} in order to warp";
             return false;
         }
 
@@ -65,18 +67,6 @@ public class WarpAction
     private bool CheckMoneyRequirement(Player player, WarpInfo warpInfo)
     {
         if (player.TryRemoveMoney(warpInfo.Costs))
-        {
-            return true;
-        }
-
-        return false;
-    }
-
-    private bool CheckLevelRequirement(Player player, WarpInfo warpInfo)
-    {
-        var requirement = player.SelectedCharacter?.GetEffectiveMoveLevelRequirement(warpInfo.LevelRequirement);
-        
-        if (requirement <= player.Attributes?[Stats.Level])
         {
             return true;
         }

--- a/src/Persistence/Initialization/CharacterClasses/ClassDarkLord.cs
+++ b/src/Persistence/Initialization/CharacterClasses/ClassDarkLord.cs
@@ -36,7 +36,7 @@ internal partial class CharacterClassInitialization
         result.LevelRequirementByCreation = 250;
         result.IsMasterClass = isMaster;
         result.NextGenerationClass = nextGenerationClass;
-        result.LevelWarpRequirementReductionPercent = 100 / 3;
+        result.LevelWarpRequirementReductionPercent = (int) Math.Ceiling(100.0 / 3);
         result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.Level, 1, false));
         result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.PointsPerLevelUp, 7, false));
         result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.BaseStrength, 26, true));

--- a/src/Persistence/Initialization/CharacterClasses/ClassMagicGladiator.cs
+++ b/src/Persistence/Initialization/CharacterClasses/ClassMagicGladiator.cs
@@ -35,7 +35,7 @@ internal partial class CharacterClassInitialization
         result.SetGuid((byte)number);
         this.GameConfiguration.CharacterClasses.Add(result);
         result.CanGetCreated = canGetCreated;
-        result.LevelWarpRequirementReductionPercent = 100 / 3;
+        result.LevelWarpRequirementReductionPercent = (int) Math.Ceiling(100.0 / 3);
         result.HomeMap = this.GameConfiguration.Maps.FirstOrDefault(map => map.Number == LorenciaMapId);
         result.Number = (byte)number;
         result.Name = name;

--- a/src/Persistence/Initialization/CharacterClasses/ClassRageFighter.cs
+++ b/src/Persistence/Initialization/CharacterClasses/ClassRageFighter.cs
@@ -33,7 +33,7 @@ internal partial class CharacterClassInitialization
         result.IsMasterClass = isMaster;
         result.LevelRequirementByCreation = 150;
         result.NextGenerationClass = nextGenerationClass;
-        result.LevelWarpRequirementReductionPercent = 100 / 3;
+        result.LevelWarpRequirementReductionPercent = (int) Math.Ceiling(100.0 / 3);
         result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.Level, 1, false));
         result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.PointsPerLevelUp, 7, false));
         result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.BaseStrength, 32, true));

--- a/src/Persistence/Initialization/Updates/FixWarpLevelUpdatePlugIn.cs
+++ b/src/Persistence/Initialization/Updates/FixWarpLevelUpdatePlugIn.cs
@@ -1,0 +1,58 @@
+// <copyright file="FixWarpLevelUpdatePlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Persistence.Initialization.Updates;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.DataModel.Configuration.Items;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// updating LevelWarpRequirementReductionPercent plugin.
+/// </summary>
+[PlugIn(PlugInName, PlugInDescription)]
+[Guid("F4342D86-7042-477A-BC3B-475C1F2A79FF")]
+public class FixWarpLevelUpdatePlugIn : UpdatePlugInBase
+{
+    /// <summary>
+    /// The plug in name.
+    /// </summary>
+    internal const string PlugInName = "Fix Warp Level Reduction";
+
+    /// <summary>
+    /// The plug in description.
+    /// </summary>
+    internal const string PlugInDescription = "This plugin updates the LevelWarpRequirementReductionPercent for MG, DL, and RF.";
+
+    /// <inheritdoc />
+    public override int Version => 10;
+
+    /// <inheritdoc />
+    public override string DataInitializationKey => VersionSeasonSix.DataInitialization.Id;
+
+    /// <inheritdoc />
+    public override string Name => PlugInName;
+
+    /// <inheritdoc />
+    public override string Description => PlugInDescription;
+
+    /// <inheritdoc />
+    public override bool IsMandatory => true;
+
+    /// <inheritdoc />
+    public override DateTime CreatedAt => new(2023, 04, 24, 02, 05, 0, DateTimeKind.Utc);
+
+    /// <inheritdoc />
+    protected override async ValueTask ApplyAsync(IContext context, GameConfiguration gameConfiguration)
+    {
+        var characterClasses = gameConfiguration.CharacterClasses
+            .Where(cc => cc.LevelWarpRequirementReductionPercent == 33)
+            .ToList();
+        foreach (var cc in characterClasses)
+        {
+            cc.LevelWarpRequirementReductionPercent = 34;
+        }
+    }
+}

--- a/src/Persistence/Initialization/Updates/FixWarpLevelUpdatePlugIn.cs
+++ b/src/Persistence/Initialization/Updates/FixWarpLevelUpdatePlugIn.cs
@@ -47,12 +47,62 @@ public class FixWarpLevelUpdatePlugIn : UpdatePlugInBase
     /// <inheritdoc />
     protected override async ValueTask ApplyAsync(IContext context, GameConfiguration gameConfiguration)
     {
+        // warp requirement reduction
         var characterClasses = gameConfiguration.CharacterClasses
             .Where(cc => cc.LevelWarpRequirementReductionPercent == 33)
             .ToList();
         foreach (var cc in characterClasses)
         {
             cc.LevelWarpRequirementReductionPercent = 34;
+        }
+
+        // warp list
+        (string Name, string? NewName, int Costs, int Level)[] warps =
+        {
+            ("KanturuRuins", "KanturuRuins1", -1, 160),
+            ("KanturuRelics", null, 12000, -1),
+            ("Elbeland", "Elveland", -1, -1),
+            ("Elbeland2", "Elveland2", -1, -1),
+            ("Elbeland3", "Elveland3", -1, -1),
+            ("Vulcan", "Vulcanus", -1, -1),
+            ("KanturuRuins3", null, 15000, -1),
+            ("Karutan2", null, -1, 170),
+        };
+        foreach (var (name, newName, costs, level) in warps)
+        {
+            var warpInfo = gameConfiguration.WarpList.Where(w => w.Name == name).FirstOrDefault();
+            if (warpInfo is not null)
+            {
+                if (newName is not null)
+                {
+                    warpInfo.Name = newName;
+                }
+
+                if (costs > 0)
+                {
+                    warpInfo.Costs = costs;
+                }
+
+                if (level > 0)
+                {
+                    warpInfo.LevelRequirement = level;
+                }
+            }
+        }
+
+        // add LaCleon
+        var laCleon = gameConfiguration.WarpList.Where(w => w.Name == "LaCleon").FirstOrDefault();
+        if (laCleon is null)
+        {
+            laCleon = context.CreateNew<WarpInfo>();
+            laCleon.Index = 48;
+            laCleon.Name = "LaCleon";
+            laCleon.Costs = 15000;
+            laCleon.LevelRequirement = 280;
+            laCleon.Gate = gameConfiguration.Maps
+                    .Where(m => m.Name == "LaCleon").FirstOrDefault()?
+                    .ExitGates.Where(g => g.X1 == 222).FirstOrDefault();
+            gameConfiguration.WarpList.Add(laCleon);
         }
     }
 }

--- a/src/Persistence/Initialization/VersionSeasonSix/Gates.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Gates.cs
@@ -68,19 +68,20 @@ public class Gates : InitializerBase
         this.GameConfiguration.WarpList.Add(this.CreateWarpInfo(23, "Icarus", 10000, 170, gates[63]));
         this.GameConfiguration.WarpList.Add(this.CreateWarpInfo(25, "Aida1", 8500, 150, gates[119]));
         this.GameConfiguration.WarpList.Add(this.CreateWarpInfo(27, "Aida2", 8500, 150, gates[140]));
-        this.GameConfiguration.WarpList.Add(this.CreateWarpInfo(28, "KanturuRuins", 9000, 150, gates[138]));
+        this.GameConfiguration.WarpList.Add(this.CreateWarpInfo(28, "KanturuRuins1", 9000, 160, gates[138]));
         this.GameConfiguration.WarpList.Add(this.CreateWarpInfo(29, "KanturuRuins2", 9000, 160, gates[141]));
-        this.GameConfiguration.WarpList.Add(this.CreateWarpInfo(30, "KanturuRelics", 15000, 230, gates[139]));
-        this.GameConfiguration.WarpList.Add(this.CreateWarpInfo(31, "Elbeland", 2000, 10, gates[267]));
-        this.GameConfiguration.WarpList.Add(this.CreateWarpInfo(32, "Elbeland2", 2500, 10, gates[268]));
+        this.GameConfiguration.WarpList.Add(this.CreateWarpInfo(30, "KanturuRelics", 12000, 230, gates[139]));
+        this.GameConfiguration.WarpList.Add(this.CreateWarpInfo(31, "Elveland", 2000, 10, gates[267]));
+        this.GameConfiguration.WarpList.Add(this.CreateWarpInfo(32, "Elveland2", 2500, 10, gates[268]));
         this.GameConfiguration.WarpList.Add(this.CreateWarpInfo(33, "PeaceSwamp", 15000, 400, gates[273]));
         this.GameConfiguration.WarpList.Add(this.CreateWarpInfo(34, "Raklion", 15000, 280, gates[287]));
-        this.GameConfiguration.WarpList.Add(this.CreateWarpInfo(37, "Vulcan", 15000, 30, gates[294]));
+        this.GameConfiguration.WarpList.Add(this.CreateWarpInfo(37, "Vulcanus", 15000, 30, gates[294]));
         this.GameConfiguration.WarpList.Add(this.CreateWarpInfo(44, "LorenMarket", 18000, 200, gates[333]));
-        this.GameConfiguration.WarpList.Add(this.CreateWarpInfo(43, "Elbeland3", 3000, 10, gates[269]));
-        this.GameConfiguration.WarpList.Add(this.CreateWarpInfo(45, "KanturuRuins3", 9000, 160, gates[334]));
+        this.GameConfiguration.WarpList.Add(this.CreateWarpInfo(43, "Elveland3", 3000, 10, gates[269]));
+        this.GameConfiguration.WarpList.Add(this.CreateWarpInfo(45, "KanturuRuins3", 15000, 160, gates[334]));
         this.GameConfiguration.WarpList.Add(this.CreateWarpInfo(46, "Karutan1", 13000, 170, gates[335]));
-        this.GameConfiguration.WarpList.Add(this.CreateWarpInfo(47, "Karutan2", 14000, 180, gates[344]));
+        this.GameConfiguration.WarpList.Add(this.CreateWarpInfo(47, "Karutan2", 14000, 170, gates[344]));
+        this.GameConfiguration.WarpList.Add(this.CreateWarpInfo(48, "LaCleon", 15000, 280, gates[287]));
     }
 
     private WarpInfo CreateWarpInfo(ushort index, string name, int costs, int levelRequirement, ExitGate gate)


### PR DESCRIPTION
This PR fixed following issues:

1. Fixed a bug in calculating level. It should be `levelRequirement * reduction / 100`, not `levelRequirement * 100 / reduction`.
2. Optimized the calculation for levels. (Compared with the previous code, the result might differ by 1~2 levels now.)

The motivation for this modification is:

As an example, in the case of map Tarkan, according to the previous calculation, a MG player should reach level 94 to enter the map using the /move command or warp menu. But when the player was supposed to be able to enter the map at level 93 (which the original server required), he was told that level 94 is required, which will make the player feel confused.

Therefore, for the above reason, I modified the calculation method so that the required level is the same as the original server, or 1~2 levels lower, so that the player's experience may be better.

3. Fixed the description of the required level in the error message when a player's level was lower than requirement.
4. Fixed some incorrect definitions of name, level, and money in Gates.cs.
