### PR TITLE
Implemented nullable inputs in the admin panel

### DIFF
--- a/src/PlugIns/TypeExtensions.cs
+++ b/src/PlugIns/TypeExtensions.cs
@@ -35,4 +35,20 @@ public static class TypeExtensions
 
         return null;
     }
+
+    /// <summary>
+    /// Determines whether this type is a <see cref="Nullable{T}"/>.
+    /// </summary>
+    /// <param name="type">The type.</param>
+    /// <returns>
+    ///   <c>true</c> if the specified type is a nullable; otherwise, <c>false</c>.
+    /// </returns>
+    public static bool IsNullable(this Type type) => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(Nullable<>);
+
+    /// <summary>
+    /// Gets the generic type argument of the nullable.
+    /// </summary>
+    /// <param name="type">The nullable type.</param>
+    /// <returns>The generic type argument of the nullable.</returns>
+    public static Type GetTypeOfNullable(this Type type) => type.IsNullable() ? type.GetGenericArguments().First() : type;
 }

--- a/src/Web/AdminPanel/ComponentBuilders/ByteFieldBuilder.cs
+++ b/src/Web/AdminPanel/ComponentBuilders/ByteFieldBuilder.cs
@@ -15,8 +15,16 @@ using MUnique.OpenMU.Web.AdminPanel.Services;
 public class ByteFieldBuilder : BaseComponentBuilder, IComponentBuilder
 {
     /// <inheritdoc/>
-    public int BuildComponent(object model, PropertyInfo propertyInfo, RenderTreeBuilder builder, int currentIndex, IChangeNotificationService notificationService) => this.BuildField<byte, ByteField>(model, propertyInfo, builder, currentIndex, notificationService);
+    public int BuildComponent(object model, PropertyInfo propertyInfo, RenderTreeBuilder builder, int currentIndex, IChangeNotificationService notificationService)
+    {
+        if (propertyInfo.PropertyType == typeof(byte))
+        {
+            return this.BuildField<byte, ByteField>(model, propertyInfo, builder, currentIndex, notificationService);
+        }
+
+        return this.BuildField<byte?, NullableByteField>(model, propertyInfo, builder, currentIndex, notificationService);
+    }
 
     /// <inheritdoc/>
-    public bool CanBuildComponent(PropertyInfo propertyInfo) => propertyInfo.PropertyType == typeof(byte);
+    public bool CanBuildComponent(PropertyInfo propertyInfo) => propertyInfo.PropertyType == typeof(byte) || propertyInfo.PropertyType == typeof(byte?);
 }

--- a/src/Web/AdminPanel/ComponentBuilders/NumberFieldBuilder.cs
+++ b/src/Web/AdminPanel/ComponentBuilders/NumberFieldBuilder.cs
@@ -17,8 +17,16 @@ public class NumberFieldBuilder<TNumber> : BaseComponentBuilder, IComponentBuild
     where TNumber : struct
 {
     /// <inheritdoc/>
-    public int BuildComponent(object model, PropertyInfo propertyInfo, RenderTreeBuilder builder, int currentIndex, IChangeNotificationService notificationService) => this.BuildField<TNumber, NumberField<TNumber>>(model, propertyInfo, builder, currentIndex, notificationService);
+    public int BuildComponent(object model, PropertyInfo propertyInfo, RenderTreeBuilder builder, int currentIndex, IChangeNotificationService notificationService)
+    {
+        if (propertyInfo.PropertyType == typeof(TNumber))
+        {
+            return this.BuildField<TNumber, NumberField<TNumber>>(model, propertyInfo, builder, currentIndex, notificationService);
+        }
+
+        return this.BuildField<TNumber?, NullableNumberField<TNumber>>(model, propertyInfo, builder, currentIndex, notificationService);
+    }
 
     /// <inheritdoc/>
-    public bool CanBuildComponent(PropertyInfo propertyInfo) => propertyInfo.PropertyType == typeof(TNumber);
+    public bool CanBuildComponent(PropertyInfo propertyInfo) => propertyInfo.PropertyType == typeof(TNumber) || propertyInfo.PropertyType == typeof(TNumber?);
 }

--- a/src/Web/AdminPanel/ComponentBuilders/ShortFieldBuilder.cs
+++ b/src/Web/AdminPanel/ComponentBuilders/ShortFieldBuilder.cs
@@ -15,8 +15,16 @@ using MUnique.OpenMU.Web.AdminPanel.Services;
 public class ShortFieldBuilder : BaseComponentBuilder, IComponentBuilder
 {
     /// <inheritdoc/>
-    public int BuildComponent(object model, PropertyInfo propertyInfo, RenderTreeBuilder builder, int currentIndex, IChangeNotificationService notificationService) => this.BuildField<short, ShortField>(model, propertyInfo, builder, currentIndex, notificationService);
+    public int BuildComponent(object model, PropertyInfo propertyInfo, RenderTreeBuilder builder, int currentIndex, IChangeNotificationService notificationService)
+    {
+        if (propertyInfo.PropertyType == typeof(short))
+        {
+            return this.BuildField<short, ShortField>(model, propertyInfo, builder, currentIndex, notificationService);
+        }
+
+        return this.BuildField<short?, NullableShortField>(model, propertyInfo, builder, currentIndex, notificationService);
+    }
 
     /// <inheritdoc/>
-    public bool CanBuildComponent(PropertyInfo propertyInfo) => propertyInfo.PropertyType == typeof(short);
+    public bool CanBuildComponent(PropertyInfo propertyInfo) => propertyInfo.PropertyType == typeof(short) || propertyInfo.PropertyType == typeof(short?);
 }

--- a/src/Web/AdminPanel/Components/Form/InputByte.cs
+++ b/src/Web/AdminPanel/Components/Form/InputByte.cs
@@ -7,47 +7,13 @@ namespace MUnique.OpenMU.Web.AdminPanel.Components.Form;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Forms;
-using Microsoft.AspNetCore.Components.Rendering;
 
 /// <summary>
 /// An input component for editing numeric byte values.
 /// </summary>
-public class InputByte : InputBase<byte>
+/// <typeparam name="TByte">The type of the byte.</typeparam>
+public class InputByte : InputByteBase<byte>
 {
-    /// <summary>
-    /// Gets or sets the error message used when displaying an a parsing error.
-    /// </summary>
-    [Parameter]
-    public string ParsingErrorMessage { get; set; } = "The {0} field must be a number between 0 and 255.";
-
-    /// <summary>
-    /// Gets or sets the minimum value.
-    /// </summary>
-    [Parameter]
-    public byte Min { get; set; } = byte.MinValue;
-
-    /// <summary>
-    /// Gets or sets the maximum value.
-    /// </summary>
-    [Parameter]
-    public byte Max { get; set; } = byte.MaxValue;
-
-    /// <inheritdoc />
-    protected override void BuildRenderTree(RenderTreeBuilder builder)
-    {
-        builder.OpenElement(0, "input");
-        builder.AddAttribute(1, "step", 1);
-        builder.AddMultipleAttributes(2, this.AdditionalAttributes);
-        builder.AddAttribute(3, "type", "number");
-        builder.AddAttribute(4, "class", this.CssClass);
-        builder.AddAttribute(5, "value", BindConverter.FormatValue(this.CurrentValueAsString));
-        builder.AddAttribute(6, "onchange", EventCallback.Factory.CreateBinder<string>(this, v => this.CurrentValueAsString = v, this.CurrentValueAsString!));
-        builder.AddAttribute(7, "min", this.Min);
-        builder.AddAttribute(8, "max", this.Max);
-        builder.CloseElement();
-    }
-
     /// <inheritdoc />
     protected override bool TryParseValueFromString(string? value, [MaybeNullWhen(false)] out byte result, [NotNullWhen(false)] out string? validationErrorMessage)
     {

--- a/src/Web/AdminPanel/Components/Form/InputByteBase.cs
+++ b/src/Web/AdminPanel/Components/Form/InputByteBase.cs
@@ -1,0 +1,49 @@
+﻿// <copyright file="InputByteBase.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Web.AdminPanel.Components.Form;
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.AspNetCore.Components.Rendering;
+
+/// <summary>
+/// An input component for editing numeric byte values.
+/// </summary>
+/// <typeparam name="TByte">The type of the byte.</typeparam>
+public abstract class InputByteBase<TByte> : InputBase<TByte>
+{
+    /// <summary>
+    /// Gets or sets the error message used when displaying an a parsing error.
+    /// </summary>
+    [Parameter]
+    public string ParsingErrorMessage { get; set; } = "The {0} field must be a number between 0 and 255.";
+
+    /// <summary>
+    /// Gets or sets the minimum value.
+    /// </summary>
+    [Parameter]
+    public byte Min { get; set; } = byte.MinValue;
+
+    /// <summary>
+    /// Gets or sets the maximum value.
+    /// </summary>
+    [Parameter]
+    public byte Max { get; set; } = byte.MaxValue;
+
+    /// <inheritdoc />
+    protected override void BuildRenderTree(RenderTreeBuilder builder)
+    {
+        builder.OpenElement(0, "input");
+        builder.AddAttribute(1, "step", 1);
+        builder.AddMultipleAttributes(2, this.AdditionalAttributes);
+        builder.AddAttribute(3, "type", "number");
+        builder.AddAttribute(4, "class", this.CssClass);
+        builder.AddAttribute(5, "value", BindConverter.FormatValue(this.CurrentValueAsString));
+        builder.AddAttribute(6, "onchange", EventCallback.Factory.CreateBinder<string>(this, v => this.CurrentValueAsString = v, this.CurrentValueAsString!));
+        builder.AddAttribute(7, "min", this.Min);
+        builder.AddAttribute(8, "max", this.Max);
+        builder.CloseElement();
+    }
+}

--- a/src/Web/AdminPanel/Components/Form/InputNullableByte.cs
+++ b/src/Web/AdminPanel/Components/Form/InputNullableByte.cs
@@ -1,0 +1,48 @@
+﻿// <copyright file="InputNullableByte.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Web.AdminPanel.Components.Form;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using Microsoft.AspNetCore.Components;
+
+/// <summary>
+/// An input component for editing numeric byte values.
+/// </summary>
+public class InputNullableByte : InputByteBase<byte?>
+{
+    /// <inheritdoc />
+    protected override bool TryParseValueFromString(string? value, [MaybeNullWhen(false)] out byte? result, [NotNullWhen(false)] out string? validationErrorMessage)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            validationErrorMessage = null;
+            result = null;
+            return true;
+        }
+
+        if (byte.TryParse(value, out var parsed))
+        {
+            result = parsed;
+            validationErrorMessage = null;
+            return true;
+        }
+
+        result = null;
+        validationErrorMessage = string.Format(this.ParsingErrorMessage, this.FieldIdentifier.FieldName);
+        return false;
+    }
+
+    /// <inheritdoc />
+    protected override string FormatValueAsString(byte? value)
+    {
+        if (value is null)
+        {
+            return string.Empty;
+        }
+
+        return BindConverter.FormatValue(value, CultureInfo.InvariantCulture) as string ?? string.Empty;
+    }
+}

--- a/src/Web/AdminPanel/Components/Form/InputNullableShort.cs
+++ b/src/Web/AdminPanel/Components/Form/InputNullableShort.cs
@@ -1,0 +1,48 @@
+﻿// <copyright file="InputNullableShort.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Web.AdminPanel.Components.Form;
+
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using Microsoft.AspNetCore.Components;
+
+/// <summary>
+/// An input component for editing numeric short values.
+/// </summary>
+public class InputNullableShort : InputShortBase<short?>
+{
+    /// <inheritdoc />
+    protected override bool TryParseValueFromString(string? value, out short? result, [NotNullWhen(false)] out string? validationErrorMessage)
+    {
+        if (string.IsNullOrEmpty(value))
+        {
+            validationErrorMessage = null;
+            result = null;
+            return true;
+        }
+
+        if (short.TryParse(value, out var parsed))
+        {
+            validationErrorMessage = null;
+            result = parsed;
+            return true;
+        }
+
+        result = null;
+        validationErrorMessage = string.Format(this.ParsingErrorMessage, this.FieldIdentifier.FieldName);
+        return false;
+    }
+
+    /// <inheritdoc />
+    protected override string FormatValueAsString(short? value)
+    {
+        if (value is null)
+        {
+            return string.Empty;
+        }
+
+        return BindConverter.FormatValue(value, CultureInfo.InvariantCulture) ?? string.Empty;
+    }
+}

--- a/src/Web/AdminPanel/Components/Form/InputShort.cs
+++ b/src/Web/AdminPanel/Components/Form/InputShort.cs
@@ -7,37 +7,14 @@ namespace MUnique.OpenMU.Web.AdminPanel.Components.Form;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using Microsoft.AspNetCore.Components;
-using Microsoft.AspNetCore.Components.Forms;
-using Microsoft.AspNetCore.Components.Rendering;
 
 /// <summary>
 /// An input component for editing numeric short values.
 /// </summary>
-public class InputShort : InputBase<short>
+public class InputShort : InputShortBase<short>
 {
-    /// <summary>
-    /// Gets or sets the error message used when displaying an a parsing error.
-    /// </summary>
-    [Parameter]
-    public string ParsingErrorMessage { get; set; } = $"The {0} field must be a number between {short.MinValue} and {short.MaxValue}.";
-
     /// <inheritdoc />
-    protected override void BuildRenderTree(RenderTreeBuilder builder)
-    {
-        builder.OpenElement(0, "input");
-        builder.AddAttribute(1, "step", 1);
-        builder.AddMultipleAttributes(2, this.AdditionalAttributes);
-        builder.AddAttribute(3, "type", "number");
-        builder.AddAttribute(4, "class", this.CssClass);
-        builder.AddAttribute(5, "value", BindConverter.FormatValue(this.CurrentValueAsString));
-        builder.AddAttribute(6, "onchange", EventCallback.Factory.CreateBinder<string>(this, v => this.CurrentValueAsString = v, this.CurrentValueAsString!));
-        builder.AddAttribute(7, "min", short.MinValue.ToString(CultureInfo.InvariantCulture));
-        builder.AddAttribute(8, "max", short.MaxValue.ToString(CultureInfo.InvariantCulture));
-        builder.CloseElement();
-    }
-
-    /// <inheritdoc />
-    protected override bool TryParseValueFromString(string? value, [MaybeNullWhen(false)] out short result, [NotNullWhen(false)] out string? validationErrorMessage)
+    protected override bool TryParseValueFromString(string? value, out short result, [NotNullWhen(false)] out string? validationErrorMessage)
     {
         if (short.TryParse(value, out result))
         {

--- a/src/Web/AdminPanel/Components/Form/InputShortBase.cs
+++ b/src/Web/AdminPanel/Components/Form/InputShortBase.cs
@@ -1,0 +1,38 @@
+﻿// <copyright file="InputShortBase.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Web.AdminPanel.Components.Form;
+
+using System.Globalization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.AspNetCore.Components.Forms;
+using Microsoft.AspNetCore.Components.Rendering;
+
+/// <summary>
+/// An input component for editing numeric short values.
+/// </summary>
+/// <typeparam name="TShort">The type of the short.</typeparam>
+public abstract class InputShortBase<TShort> : InputBase<TShort>
+{
+    /// <summary>
+    /// Gets or sets the error message used when displaying an a parsing error.
+    /// </summary>
+    [Parameter]
+    public string ParsingErrorMessage { get; set; } = $"The {0} field must be a number between {short.MinValue} and {short.MaxValue}.";
+
+    /// <inheritdoc />
+    protected override void BuildRenderTree(RenderTreeBuilder builder)
+    {
+        builder.OpenElement(0, "input");
+        builder.AddAttribute(1, "step", 1);
+        builder.AddMultipleAttributes(2, this.AdditionalAttributes);
+        builder.AddAttribute(3, "type", "number");
+        builder.AddAttribute(4, "class", this.CssClass);
+        builder.AddAttribute(5, "value", BindConverter.FormatValue(this.CurrentValueAsString));
+        builder.AddAttribute(6, "onchange", EventCallback.Factory.CreateBinder<string>(this, v => this.CurrentValueAsString = v, this.CurrentValueAsString!));
+        builder.AddAttribute(7, "min", short.MinValue.ToString(CultureInfo.InvariantCulture));
+        builder.AddAttribute(8, "max", short.MaxValue.ToString(CultureInfo.InvariantCulture));
+        builder.CloseElement();
+    }
+}

--- a/src/Web/AdminPanel/Components/Form/NullableByteField.razor
+++ b/src/Web/AdminPanel/Components/Form/NullableByteField.razor
@@ -1,0 +1,35 @@
+﻿@using System.Diagnostics.CodeAnalysis
+@inherits NotifyableInputBase<byte?>
+
+<div>
+    <FieldLabel Text="@Label" ValueExpression="@this.ValueExpression" />
+    <InputNullableByte id="@this.FieldIdentifier.FieldName" @bind-Value="@CurrentValue" Min="@Min" Max="@(Max ?? byte.MaxValue)"/>
+    <ValidationMessage For=@this.ValueExpression />
+</div>
+
+@code {
+
+    /// <summary>
+    /// Gets or sets the label.
+    /// </summary>
+    [Parameter]
+    public string? Label { get; set; }
+
+    /// <summary>
+    /// Gets or sets the minimum value.
+    /// </summary>
+    [Parameter]
+    public byte Min { get; set; } = byte.MinValue;
+
+    /// <summary>
+    /// Gets or sets the maximum value.
+    /// </summary>
+    [Parameter]
+    public byte? Max { get; set; }
+
+    /// <inheritdoc />
+    protected override bool TryParseValueFromString(string? value, [MaybeNullWhen(false)] out byte? result, [NotNullWhen(false)] out string? validationErrorMessage)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Web/AdminPanel/Components/Form/NullableNumberField.razor
+++ b/src/Web/AdminPanel/Components/Form/NullableNumberField.razor
@@ -1,0 +1,72 @@
+﻿@typeparam TNumber where TNumber : struct
+
+@using System.Diagnostics.CodeAnalysis
+@using MUnique.OpenMU.PlugIns
+@inherits NotifyableInputBase<TNumber?>
+
+<div>
+    <FieldLabel Text="@Label" ValueExpression="@this.ValueExpression" />
+    <InputNumber TValue="TNumber?" id="@this.FieldIdentifier.FieldName" @bind-Value="@CurrentValue" min=@(Min ?? MinOfType) max=@(Max ?? MaxOfType) />
+    <ValidationMessage For=@this.ValueExpression />
+</div>
+
+@code {
+
+    /// <summary>
+    /// Gets or sets the label.
+    /// </summary>
+    [Parameter]
+    public string? Label { get; set; }
+
+    /// <summary>
+    /// Gets or sets the minimum value.
+    /// </summary>
+    [Parameter]
+    public TNumber? Min { get; set; }
+
+    /// <summary>
+    /// Gets or sets the maximum value.
+    /// </summary>
+    [Parameter]
+    public TNumber? Max { get; set; }
+
+    /// <inheritdoc />
+    protected override bool TryParseValueFromString(string? value, [MaybeNullWhen(false)] out TNumber? result, [NotNullWhen(false)] out string? validationErrorMessage)
+    {
+        throw new NotImplementedException();
+    }
+
+    private TNumber? MinOfType
+    {
+        get
+        {
+            return typeof(TNumber).GetTypeOfNullable() switch
+            {
+                var t when t == typeof(int) => (TNumber)(object)int.MinValue,
+                var t when t == typeof(long) => (TNumber)(object)long.MinValue,
+                var t when t == typeof(short) => (TNumber)(object)int.MinValue,
+                var t when t == typeof(float) => (TNumber)(object)float.MinValue,
+                var t when t == typeof(double) => (TNumber)(object)double.MinValue,
+                var t when t == typeof(decimal) => (TNumber)(object)decimal.MinValue,
+                _ => default,
+                };
+        }
+    }
+
+    private TNumber? MaxOfType
+    {
+        get
+        {
+            return typeof(TNumber).GetTypeOfNullable() switch
+            {
+                var t when t == typeof(int) => (TNumber)(object)int.MaxValue,
+                var t when t == typeof(long) => (TNumber)(object)long.MaxValue,
+                var t when t == typeof(short) => (TNumber)(object)int.MaxValue,
+                var t when t == typeof(float) => (TNumber)(object)float.MaxValue,
+                var t when t == typeof(double) => (TNumber)(object)double.MaxValue,
+                var t when t == typeof(decimal) => (TNumber)(object)decimal.MaxValue,
+                _ => default,
+            };
+        }
+    }
+}

--- a/src/Web/AdminPanel/Components/Form/NullableShortField.razor
+++ b/src/Web/AdminPanel/Components/Form/NullableShortField.razor
@@ -1,0 +1,23 @@
+﻿@using System.Diagnostics.CodeAnalysis
+@inherits NotifyableInputBase<short?>
+
+<div>
+    <FieldLabel Text="@Label" ValueExpression="@this.ValueExpression" />
+    <InputNullableShort id="@this.FieldIdentifier.FieldName" @bind-Value="@CurrentValue" />
+    <ValidationMessage For=@this.ValueExpression />
+</div>
+
+@code {
+
+    /// <summary>
+    /// Gets or sets the label.
+    /// </summary>
+    [Parameter]
+    public string? Label { get; set; }
+
+    /// <inheritdoc />
+    protected override bool TryParseValueFromString(string? value, [MaybeNullWhen(false)] out short? result, [NotNullWhen(false)] out string? validationErrorMessage)
+    {
+        throw new NotImplementedException();
+    }
+}


### PR DESCRIPTION
The nullable properties were not rendered in the admin panel.
However, some types use them, for example the DropItemGroup.