### PR TITLE
Quest item fixes

### DIFF
--- a/src/DataModel/Configuration/Items/ItemDefinition.cs
+++ b/src/DataModel/Configuration/Items/ItemDefinition.cs
@@ -48,6 +48,14 @@ public class ItemDefinition
     public bool IsBoundToCharacter { get; set; }
 
     /// <summary>
+    /// Gets or sets the storage limit per character which is checked on pick-up.
+    /// A value of 0 means, that there is no limit.
+    /// A value 'n' above 0 means, that the inventory of the character can store
+    /// at most 'n' items of this kind.
+    /// </summary>
+    public int StorageLimitPerCharacter { get; set; }
+
+    /// <summary>
     /// Gets or sets the name of the item.
     /// </summary>
     public string Name { get; set; } = string.Empty;

--- a/src/GameServer/RemoteView/Character/UpdateCharacterStatsPlugIn.cs
+++ b/src/GameServer/RemoteView/Character/UpdateCharacterStatsPlugIn.cs
@@ -43,7 +43,7 @@ public class UpdateCharacterStatsPlugIn : IUpdateCharacterStatsPlugIn
             this._player.SelectedCharacter!.CurrentMap!.Number.ToUnsigned(),
             (ulong)this._player.SelectedCharacter.Experience,
             (ulong)this._player.GameServerContext.Configuration.ExperienceTable![(int)this._player.Attributes![Stats.Level] + 1],
-            (ushort)this._player.SelectedCharacter.LevelUpPoints,
+            (ushort)Math.Max(0, this._player.SelectedCharacter.LevelUpPoints),
             (ushort)this._player.Attributes[Stats.BaseStrength],
             (ushort)this._player.Attributes[Stats.BaseAgility],
             (ushort)this._player.Attributes[Stats.BaseVitality],

--- a/src/Persistence/EntityFramework/Migrations/20230504172021_StorageLimitPerCharacter.Designer.cs
+++ b/src/Persistence/EntityFramework/Migrations/20230504172021_StorageLimitPerCharacter.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MUnique.OpenMU.Persistence.EntityFramework;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
     [DbContext(typeof(EntityDataContext))]
-    partial class EntityDataContextModelSnapshot : ModelSnapshot
+    [Migration("20230504172021_StorageLimitPerCharacter")]
+    partial class StorageLimitPerCharacter
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Persistence/EntityFramework/Migrations/20230504172021_StorageLimitPerCharacter.cs
+++ b/src/Persistence/EntityFramework/Migrations/20230504172021_StorageLimitPerCharacter.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
+{
+    /// <inheritdoc />
+    public partial class StorageLimitPerCharacter : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "StorageLimitPerCharacter",
+                schema: "config",
+                table: "ItemDefinition",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "StorageLimitPerCharacter",
+                schema: "config",
+                table: "ItemDefinition");
+        }
+    }
+}

--- a/src/Persistence/Initialization/DataInitializationBase.cs
+++ b/src/Persistence/Initialization/DataInitializationBase.cs
@@ -192,7 +192,7 @@ public abstract class DataInitializationBase : IDataInitializationPlugIn
         foreach (var update in updates)
         {
             var entry = this.Context.CreateNew<ConfigurationUpdate>();
-            entry.Version = update.Version;
+            entry.Version = (int)update.Version;
             entry.Name = update.Name;
             entry.Description = update.Description;
             entry.CreatedAt = update.CreatedAt;
@@ -201,7 +201,7 @@ public abstract class DataInitializationBase : IDataInitializationPlugIn
 
         var updateState = this.Context.CreateNew<ConfigurationUpdateState>();
         updateState.InitializationKey = this.Key;
-        updateState.CurrentInstalledVersion = updates.Max(u => u.Version);
+        updateState.CurrentInstalledVersion = updates.Max(u => (int)u.Version);
     }
 
     private async ValueTask CreateConnectServerDefinitionAsync()

--- a/src/Persistence/Initialization/Updates/AddQuestItemLimitPlugIn.cs
+++ b/src/Persistence/Initialization/Updates/AddQuestItemLimitPlugIn.cs
@@ -48,7 +48,7 @@ public abstract class AddQuestItemLimitPlugIn : UpdatePlugInBase
     /// <inheritdoc />
     protected override async ValueTask ApplyAsync(IContext context, GameConfiguration gameConfiguration)
     {
-        var hashSet = new HashSet<short>()
+        var hashSet = new HashSet<short>
         {
             Quest.BrokenSwordNumber,
             Quest.EyeOfAbyssalNumber,

--- a/src/Persistence/Initialization/Updates/AddQuestItemLimitPlugIn.cs
+++ b/src/Persistence/Initialization/Updates/AddQuestItemLimitPlugIn.cs
@@ -1,0 +1,68 @@
+﻿// <copyright file="AddQuestItemLimitPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Persistence.Initialization.Updates;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.DataModel.Configuration.Items;
+using MUnique.OpenMU.Persistence.Initialization.VersionSeasonSix.Items;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// This updates adds the new <see cref="ItemDefinition.StorageLimitPerCharacter"/> for quest items.
+/// </summary>
+[PlugIn(PlugInName, PlugInDescription)]
+[Guid("48D40F2E-2844-4058-B1FA-710EEE55157B")]
+public abstract class AddQuestItemLimitPlugIn : UpdatePlugInBase
+{
+    /// <summary>
+    /// The plug in name.
+    /// </summary>
+    internal const string PlugInName = "Add quest item limits";
+
+    /// <summary>
+    /// The plug in description.
+    /// </summary>
+    internal const string PlugInDescription = "This update adds limits to quest items, so that only one item can be picked up.";
+
+    /// <inheritdoc />
+    public override string Name => PlugInName;
+
+    /// <inheritdoc />
+    public override string Description => PlugInDescription;
+
+    /// <inheritdoc />
+    public override UpdateVersion Version => UpdateVersion.AddQuestItemLimit;
+
+    /// <inheritdoc />
+    public override string DataInitializationKey => VersionSeasonSix.DataInitialization.Id;
+
+    /// <inheritdoc />
+    public override bool IsMandatory => true;
+
+    /// <inheritdoc />
+    public override DateTime CreatedAt => new(2023, 05, 04, 20, 0, 0, DateTimeKind.Utc);
+
+    /// <inheritdoc />
+    protected override async ValueTask ApplyAsync(IContext context, GameConfiguration gameConfiguration)
+    {
+        var hashSet = new HashSet<short>()
+        {
+            Quest.BrokenSwordNumber,
+            Quest.EyeOfAbyssalNumber,
+            Quest.FeatherOfDarkPhoenixNumber,
+            Quest.FlameOfDeathBeamKnightNumber,
+            Quest.HornOfHellMaineNumber,
+            Quest.ScrollOfEmperorNumber,
+            Quest.SoulShardOfWizardNumber,
+            Quest.TearOfElfNumber,
+        };
+        var questItems = gameConfiguration.Items.Where(item => item.Group == 14 && hashSet.Contains(item.Number));
+        foreach (var item in questItems)
+        {
+            item.StorageLimitPerCharacter = 1;
+        }
+    }
+}

--- a/src/Persistence/Initialization/Updates/ChaosCastleDataUpdatePlugIn.cs
+++ b/src/Persistence/Initialization/Updates/ChaosCastleDataUpdatePlugIn.cs
@@ -27,7 +27,7 @@ public class ChaosCastleDataUpdatePlugIn : UpdatePlugInBase
     internal const string PlugInDescription = "This update creates the configuration data for the chaos castle event.";
 
     /// <inheritdoc />
-    public override int Version => 1;
+    public override UpdateVersion Version => UpdateVersion.ChaosCastleDataUpdate;
 
     /// <inheritdoc />
     public override string DataInitializationKey => VersionSeasonSix.DataInitialization.Id;

--- a/src/Persistence/Initialization/Updates/FixLevelDiv20ExcOptionUpdatePlugIn.cs
+++ b/src/Persistence/Initialization/Updates/FixLevelDiv20ExcOptionUpdatePlugIn.cs
@@ -29,7 +29,7 @@ public class FixLevelDiv20ExcOptionUpdatePlugIn : UpdatePlugInBase
     internal const string PlugInDescription = "This update fixes the excellent option which adds level / 20 as wizardry damage";
 
     /// <inheritdoc />
-    public override int Version => 6;
+    public override UpdateVersion Version => UpdateVersion.FixLevelDiv20ExcOptionUpdate;
 
     /// <inheritdoc />
     public override string DataInitializationKey => VersionSeasonSix.DataInitialization.Id;

--- a/src/Persistence/Initialization/Updates/FixSetBonusesPlugIn.cs
+++ b/src/Persistence/Initialization/Updates/FixSetBonusesPlugIn.cs
@@ -55,7 +55,7 @@ public abstract class FixSetBonusesPlugIn : UpdatePlugInBase
     public class Season6 : FixSetBonusesPlugIn
     {
         /// <inheritdoc />
-        public override int Version => 7;
+        public override UpdateVersion Version => UpdateVersion.FixSetBonusesSeason6;
 
         /// <inheritdoc />
         public override string DataInitializationKey => VersionSeasonSix.DataInitialization.Id;
@@ -69,7 +69,7 @@ public abstract class FixSetBonusesPlugIn : UpdatePlugInBase
     public class V095d : FixSetBonusesPlugIn
     {
         /// <inheritdoc />
-        public override int Version => 8;
+        public override UpdateVersion Version => UpdateVersion.FixSetBonuses095d;
 
         /// <inheritdoc />
         public override string DataInitializationKey => Version095d.DataInitialization.Id;
@@ -83,7 +83,7 @@ public abstract class FixSetBonusesPlugIn : UpdatePlugInBase
     public class V075 : FixSetBonusesPlugIn
     {
         /// <inheritdoc />
-        public override int Version => 9;
+        public override UpdateVersion Version => UpdateVersion.FixSetBonuses075;
 
         /// <inheritdoc />
         public override string DataInitializationKey => Version075.DataInitialization.Id;

--- a/src/Persistence/Initialization/Updates/FixWarpLevelUpdatePlugIn.cs
+++ b/src/Persistence/Initialization/Updates/FixWarpLevelUpdatePlugIn.cs
@@ -6,7 +6,6 @@ namespace MUnique.OpenMU.Persistence.Initialization.Updates;
 
 using System.Runtime.InteropServices;
 using MUnique.OpenMU.DataModel.Configuration;
-using MUnique.OpenMU.DataModel.Configuration.Items;
 using MUnique.OpenMU.PlugIns;
 
 /// <summary>
@@ -27,7 +26,7 @@ public class FixWarpLevelUpdatePlugIn : UpdatePlugInBase
     internal const string PlugInDescription = "This plugin updates the LevelWarpRequirementReductionPercent for MG, DL, and RF.";
 
     /// <inheritdoc />
-    public override int Version => 10;
+    public override UpdateVersion Version => UpdateVersion.FixWarpLevelUpdate;
 
     /// <inheritdoc />
     public override string DataInitializationKey => VersionSeasonSix.DataInitialization.Id;
@@ -70,7 +69,7 @@ public class FixWarpLevelUpdatePlugIn : UpdatePlugInBase
         };
         foreach (var (name, newName, costs, level) in warps)
         {
-            var warpInfo = gameConfiguration.WarpList.Where(w => w.Name == name).FirstOrDefault();
+            var warpInfo = gameConfiguration.WarpList.FirstOrDefault(w => w.Name == name);
             if (warpInfo is not null)
             {
                 if (newName is not null)
@@ -91,7 +90,7 @@ public class FixWarpLevelUpdatePlugIn : UpdatePlugInBase
         }
 
         // add LaCleon
-        var laCleon = gameConfiguration.WarpList.Where(w => w.Name == "LaCleon").FirstOrDefault();
+        var laCleon = gameConfiguration.WarpList.FirstOrDefault(w => w.Name == "LaCleon");
         if (laCleon is null)
         {
             laCleon = context.CreateNew<WarpInfo>();
@@ -100,8 +99,8 @@ public class FixWarpLevelUpdatePlugIn : UpdatePlugInBase
             laCleon.Costs = 15000;
             laCleon.LevelRequirement = 280;
             laCleon.Gate = gameConfiguration.Maps
-                    .Where(m => m.Name == "LaCleon").FirstOrDefault()?
-                    .ExitGates.Where(g => g.X1 == 222).FirstOrDefault();
+                .FirstOrDefault(m => m.Name == "LaCleon")
+                ?.ExitGates.FirstOrDefault(g => g.X1 == 222);
             gameConfiguration.WarpList.Add(laCleon);
         }
     }

--- a/src/Persistence/Initialization/Updates/IConfigurationUpdatePlugIn.cs
+++ b/src/Persistence/Initialization/Updates/IConfigurationUpdatePlugIn.cs
@@ -18,7 +18,7 @@ public interface IConfigurationUpdatePlugIn : IStrategyPlugIn<int>
     /// <summary>
     /// Gets the version number of the update. This must be unique over all <see cref="DataInitializationKey"/>s.
     /// </summary>
-    int Version { get; }
+    UpdateVersion Version { get; }
 
     /// <summary>
     /// Gets the <see cref="IDataInitializationPlugIn.Key"/> to which this update belongs to.

--- a/src/Persistence/Initialization/Updates/SpawnFixesUpdatePlugIn.cs
+++ b/src/Persistence/Initialization/Updates/SpawnFixesUpdatePlugIn.cs
@@ -31,7 +31,7 @@ public class SpawnFixesUpdatePlugIn : UpdatePlugInBase
     private const short ZyroNumber = 568;
 
     /// <inheritdoc />
-    public override int Version => 5;
+    public override UpdateVersion Version => UpdateVersion.SpawnFixesUpdate;
 
     /// <inheritdoc />
     public override string DataInitializationKey => VersionSeasonSix.DataInitialization.Id;

--- a/src/Persistence/Initialization/Updates/SystemConfigurationAddedPlugIn075.cs
+++ b/src/Persistence/Initialization/Updates/SystemConfigurationAddedPlugIn075.cs
@@ -20,5 +20,5 @@ public class SystemConfigurationAddedPlugIn075 : SystemConfigurationAddedPlugInB
     public override string DataInitializationKey => Version075.DataInitialization.Id;
 
     /// <inheritdoc />
-    public override int Version => 4;
+    public override UpdateVersion Version => UpdateVersion.SystemConfigurationAdded075;
 }

--- a/src/Persistence/Initialization/Updates/SystemConfigurationAddedPlugIn095d.cs
+++ b/src/Persistence/Initialization/Updates/SystemConfigurationAddedPlugIn095d.cs
@@ -18,7 +18,7 @@ public class SystemConfigurationAddedPlugIn095d : SystemConfigurationAddedPlugIn
 {
     /// <inheritdoc />
     public override string DataInitializationKey => Version095d.DataInitialization.Id;
-    
+
     /// <inheritdoc />
-    public override int Version => 3;
+    public override UpdateVersion Version => UpdateVersion.SystemConfigurationAdded095d;
 }

--- a/src/Persistence/Initialization/Updates/SystemConfigurationAddedPlugInSeason6.cs
+++ b/src/Persistence/Initialization/Updates/SystemConfigurationAddedPlugInSeason6.cs
@@ -20,5 +20,5 @@ public class SystemConfigurationAddedPlugInSeason6 : SystemConfigurationAddedPlu
     public override string DataInitializationKey => VersionSeasonSix.DataInitialization.Id;
 
     /// <inheritdoc />
-    public override int Version => 2;
+    public override UpdateVersion Version => UpdateVersion.SystemConfigurationAddedSeason6;
 }

--- a/src/Persistence/Initialization/Updates/UpdatePlugInBase.cs
+++ b/src/Persistence/Initialization/Updates/UpdatePlugInBase.cs
@@ -12,10 +12,10 @@ using MUnique.OpenMU.DataModel.Configuration;
 public abstract class UpdatePlugInBase : IConfigurationUpdatePlugIn
 {
     /// <inheritdoc />
-    public int Key => this.Version;
+    public int Key => (int)this.Version;
 
     /// <inheritdoc />
-    public abstract int Version { get; }
+    public abstract UpdateVersion Version { get; }
 
     /// <inheritdoc />
     public abstract string DataInitializationKey { get; }
@@ -53,7 +53,7 @@ public abstract class UpdatePlugInBase : IConfigurationUpdatePlugIn
     private void AddUpdateEntry(IContext context)
     {
         var entry = context.CreateNew<ConfigurationUpdate>();
-        entry.Version = this.Version;
+        entry.Version = (int)this.Version;
         entry.Name = this.Name;
         entry.Description = this.Description;
         entry.CreatedAt = this.CreatedAt;

--- a/src/Persistence/Initialization/Updates/UpdateVersion.cs
+++ b/src/Persistence/Initialization/Updates/UpdateVersion.cs
@@ -1,0 +1,72 @@
+// <copyright file="UpdateVersion.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Persistence.Initialization.Updates;
+
+/// <summary>
+/// Enum which keeps track of the <see cref="IConfigurationUpdatePlugIn.Version"/>,
+/// so that it's easier to know which number is next.
+/// </summary>
+public enum UpdateVersion
+{
+    /// <summary>
+    /// Undefined version.
+    /// </summary>
+    Undefined = 0,
+
+    /// <summary>
+    /// The version of the <see cref="ChaosCastleDataUpdatePlugIn"/>.
+    /// </summary>
+    ChaosCastleDataUpdate = 1,
+
+    /// <summary>
+    /// The version of the <see cref="SystemConfigurationAddedPlugInSeason6"/>.
+    /// </summary>
+    SystemConfigurationAddedSeason6 = 2,
+
+    /// <summary>
+    /// The version of the <see cref="SystemConfigurationAddedPlugIn095d"/>.
+    /// </summary>
+    SystemConfigurationAdded095d = 3,
+
+    /// <summary>
+    /// The version of the <see cref="SystemConfigurationAddedPlugIn075"/>.
+    /// </summary>
+    SystemConfigurationAdded075 = 4,
+
+    /// <summary>
+    /// The version of the <see cref="SpawnFixesUpdatePlugIn"/>.
+    /// </summary>
+    SpawnFixesUpdate = 5,
+
+    /// <summary>
+    /// The version of the <see cref="FixLevelDiv20ExcOptionUpdatePlugIn"/>.
+    /// </summary>
+    FixLevelDiv20ExcOptionUpdate = 6,
+
+    /// <summary>
+    /// The version of the <see cref="FixSetBonusesPlugIn.Season6"/>.
+    /// </summary>
+    FixSetBonusesSeason6 = 7,
+
+    /// <summary>
+    /// The version of the <see cref="FixSetBonusesPlugIn.V095d"/>.
+    /// </summary>
+    FixSetBonuses095d = 8,
+
+    /// <summary>
+    /// The version of the <see cref="FixSetBonusesPlugIn.V075"/>.
+    /// </summary>
+    FixSetBonuses075 = 9,
+
+    /// <summary>
+    /// The version of the <see cref="FixWarpLevelUpdatePlugIn"/>.
+    /// </summary>
+    FixWarpLevelUpdate = 10,
+
+    /// <summary>
+    /// The version of the <see cref="AddQuestItemLimitPlugIn"/>.
+    /// </summary>
+    AddQuestItemLimit = 11,
+}

--- a/src/Persistence/Initialization/VersionSeasonSix/Items/Quest.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Items/Quest.cs
@@ -86,6 +86,7 @@ public class Quest : InitializerBase
         item.Name = name;
         item.DropLevel = dropLevel;
         item.IsBoundToCharacter = true;
+        item.StorageLimitPerCharacter = 1;
         item.DropsFromMonsters = false; // it'll be added explicitly to a DropItemGroup
         item.Durability = 1;
         item.MaximumItemLevel = maximumLevel;


### PR DESCRIPTION
* Added a limit for quest items: After one item got picked up, the player can't pick another one.
* Improved drop generation: When there are items with a high chance, which are in sum greater than 1, it was possible that the DropItemGroups with the greatest chance did never drop.