### PR TITLE
[Feature] Make gm logo visible to other players

### DIFF
--- a/src/GameServer/RemoteView/World/NewPlayersInScopePlugIn.cs
+++ b/src/GameServer/RemoteView/World/NewPlayersInScopePlugIn.cs
@@ -35,7 +35,7 @@ public class NewPlayersInScopePlugIn : INewPlayersInScopePlugIn
     /// <param name="player">The player.</param>
     public NewPlayersInScopePlugIn(RemotePlayer player) => this._player = player;
 
-    private static readonly MagicEffectDefinition GMEffect = new GMMagicEffectDefinition()
+    private static readonly MagicEffectDefinition GMEffect = new GMMagicEffectDefinition
     {
         InformObservers = true,
         Name = "GM MARK",


### PR DESCRIPTION
This pull request makes the GM (Game Master) logo visible to all players, instead of being limited to just the GM player.
This is done by applying the GM Buff (0x1c or 28), ensuring consistent visibility across all players.