### PR TITLE
Attribute System extensions

### DIFF
--- a/src/AttributeSystem/AttributeSystem.cs
+++ b/src/AttributeSystem/AttributeSystem.cs
@@ -4,8 +4,6 @@
 
 namespace MUnique.OpenMU.AttributeSystem;
 
-using System.Globalization;
-
 /// <summary>
 /// The attribute system which holds all attributes of a character.
 /// </summary>

--- a/src/DataModel/Configuration/GameMapDefinition.cs
+++ b/src/DataModel/Configuration/GameMapDefinition.cs
@@ -4,6 +4,7 @@
 
 namespace MUnique.OpenMU.DataModel.Configuration;
 
+using MUnique.OpenMU.DataModel.Attributes;
 using MUnique.OpenMU.DataModel.Configuration.Items;
 
 /// <summary>
@@ -97,6 +98,12 @@ public class GameMapDefinition
     /// </summary>
     [MemberOfAggregate]
     public virtual ICollection<AttributeRequirement> MapRequirements { get; protected set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the power ups which are applied to characters which are currently on this map.
+    /// </summary>
+    [MemberOfAggregate]
+    public virtual ICollection<PowerUpDefinition> CharacterPowerUpDefinitions { get; protected set; } = null!;
 
     /// <inheritdoc/>
     public override string ToString()

--- a/src/DataModel/Entities/Account.cs
+++ b/src/DataModel/Entities/Account.cs
@@ -4,6 +4,7 @@
 
 namespace MUnique.OpenMU.DataModel.Entities;
 
+using MUnique.OpenMU.AttributeSystem;
 using MUnique.OpenMU.DataModel.Configuration;
 
 /// <summary>
@@ -122,6 +123,16 @@ public class Account
     [MemberOfAggregate]
     [HiddenAtCreation]
     public virtual ICollection<Character> Characters { get; protected set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the stat attributes which are applied across all characters of the account.
+    /// </summary>
+    /// <remarks>
+    /// Please note, that it's not possible to add stat attribute with the same
+    /// attribute definition to the <see cref="Account.Attributes"/> and the <see cref="Character.Attributes"/>.
+    /// </remarks>
+    [MemberOfAggregate]
+    public virtual ICollection<StatAttribute> Attributes { get; protected set; } = null!;
 
     /// <inheritdoc />
     public override string ToString()

--- a/src/DataModel/Entities/Character.cs
+++ b/src/DataModel/Entities/Character.cs
@@ -217,6 +217,10 @@ public class Character
     /// <summary>
     /// Gets or sets the stat attributes.
     /// </summary>
+    /// <remarks>
+    /// Please note, that it's not possible to add stat attribute with the same
+    /// attribute definition to the <see cref="Account.Attributes"/> and the <see cref="Character.Attributes"/>.
+    /// </remarks>
     [MemberOfAggregate]
     public virtual ICollection<StatAttribute> Attributes { get; protected set; } = null!;
 

--- a/src/GameLogic/Attributes/ItemAwareAttributeSystem.cs
+++ b/src/GameLogic/Attributes/ItemAwareAttributeSystem.cs
@@ -5,7 +5,6 @@
 namespace MUnique.OpenMU.GameLogic.Attributes;
 
 using MUnique.OpenMU.AttributeSystem;
-using System.Globalization;
 
 /// <summary>
 /// An attribute system which considers items of a character.
@@ -13,11 +12,15 @@ using System.Globalization;
 public sealed class ItemAwareAttributeSystem : AttributeSystem, IDisposable
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="ItemAwareAttributeSystem"/> class.
+    /// Initializes a new instance of the <see cref="ItemAwareAttributeSystem" /> class.
     /// </summary>
+    /// <param name="account">The account.</param>
     /// <param name="character">The character.</param>
-    public ItemAwareAttributeSystem(Character character)
-        : base(character.Attributes, character.CharacterClass!.BaseAttributeValues, character.CharacterClass.AttributeCombinations)
+    public ItemAwareAttributeSystem(Account account, Character character)
+        : base(
+            character.Attributes.Concat(account.Attributes),
+            character.CharacterClass!.BaseAttributeValues,
+            character.CharacterClass.AttributeCombinations)
     {
         this.ItemPowerUps = new Dictionary<Item, IReadOnlyList<PowerUpWrapper>>();
     }

--- a/src/GameLogic/Attributes/Stats.cs
+++ b/src/GameLogic/Attributes/Stats.cs
@@ -895,6 +895,11 @@ public class Stats
     public static AttributeDefinition NovaStageDamage { get; } = new(new Guid("9185A46A-4C56-4FF1-A0D2-C0CD58CB17FB"), "Nova Stage Damage", "The currently reached nova stage bonus which depends on the duration of the skill.");
 
     /// <summary>
+    /// Gets the attribute for the VIP flag.
+    /// </summary>
+    public static AttributeDefinition IsVip { get; } = new(new Guid("195474D6-59A2-4033-9C30-8628ECC0097E"), "Is VIP", "The flag, if an account is a VIP.");
+
+    /// <summary>
     /// Gets the attributes which are regenerated in an interval.
     /// </summary>
     public static IEnumerable<Regeneration> IntervalRegenerationAttributes

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -1687,7 +1687,7 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
 
     private async ValueTask OnPlayerEnteredWorldAsync()
     {
-        this.Attributes = new ItemAwareAttributeSystem(this.SelectedCharacter!);
+        this.Attributes = new ItemAwareAttributeSystem(this.Account!, this.SelectedCharacter!);
         this.Inventory = new InventoryStorage(this, this.GameContext);
         this.ShopStorage = new ShopStorage(this);
         this.TemporaryStorage = new Storage(InventoryConstants.TemporaryStorageSize, new TemporaryItemStorage());

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -99,6 +99,16 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
     public event AsyncEventHandler<Player>? PlayerLeftWorld;
 
     /// <summary>
+    /// Occurs when the player entered the map with his selected character.
+    /// </summary>
+    public event EventHandler<(Player, GameMap)>? PlayerEnteredMap;
+
+    /// <summary>
+    /// Occurs when the player left the map with his selected character.
+    /// </summary>
+    public event EventHandler<(Player, GameMap)>? PlayerLeftMap;
+
+    /// <summary>
     /// Occurs when the player picked up an item.
     /// </summary>
     public event AsyncEventHandler<(Player, ILocateable)>? PlayerPickedUpItem;
@@ -237,8 +247,18 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         {
             if (this._currentMap != value)
             {
+                if (this._currentMap is { } oldMap)
+                {
+                    this.RaisePlayerLeftMap(oldMap);
+                }
+
                 this._currentMap = value;
                 this.GameContext.PlugInManager?.GetPlugInPoint<IAttackableMovedPlugIn>()?.AttackableMoved(this);
+
+                if (this._currentMap is { } newMap)
+                {
+                    this.RaisePlayerEnteredMap(newMap);
+                }
             }
         }
     }
@@ -471,6 +491,7 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
             this._comboStateLazy = null;
 
             this._appearanceData.RaiseAppearanceChanged();
+
             await this.PlayerLeftWorld.SafeInvokeAsync(this).ConfigureAwait(false);
             this._selectedCharacter = null;
             (this.SkillList as IDisposable)?.Dispose();
@@ -481,6 +502,7 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
             this._selectedCharacter = character;
             await this.OnPlayerEnteredWorldAsync().ConfigureAwait(false);
             await this.PlayerEnteredWorld.SafeInvokeAsync(this).ConfigureAwait(false);
+
             this._appearanceData.RaiseAppearanceChanged();
         }
     }
@@ -848,6 +870,15 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         else
         {
             this.CurrentMap = await this.GameContext.GetMapAsync(this.SelectedCharacter!.CurrentMap.Number.ToUnsigned()).ConfigureAwait(false);
+        }
+
+        if (this.CurrentMap?.Definition.CharacterPowerUpDefinitions is { Count: > 0 } mapPowerUps)
+        {
+            foreach (var mapPowerUp in mapPowerUps)
+            {
+                var powerup = PowerUpWrapper.CreateByPowerUpDefinition(mapPowerUp, this.Attributes!);
+                
+            }
         }
 
         await this.PlayerState.TryAdvanceToAsync(GameLogic.PlayerState.EnteredWorld).ConfigureAwait(false);
@@ -1683,6 +1714,34 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         }
 
         return null;
+    }
+
+    private void RaisePlayerEnteredMap(GameMap map)
+    {
+        this.PlayerEnteredMap?.Invoke(this, (this, map));
+        if (map.Definition.CharacterPowerUpDefinitions is { Count: > 0 } powerUpDefinitions
+            && this.Attributes is { } attributes)
+        {
+            foreach (var powerUpDefinition in powerUpDefinitions)
+            {
+                if (powerUpDefinition.TargetAttribute is not { } targetAttribute)
+                {
+                    continue;
+                }
+
+                var powerUps = PowerUpWrapper.CreateByPowerUpDefinition(powerUpDefinition, attributes);
+                powerUps.ForEach(p =>
+                {
+                    this.Attributes?.AddElement(p, targetAttribute);
+                    this.PlayerLeftMap += (_, _) => attributes.RemoveElement(p, targetAttribute);
+                });
+            }
+        }
+    }
+
+    private void RaisePlayerLeftMap(GameMap map)
+    {
+        this.PlayerLeftMap?.Invoke(this, (this, map));
     }
 
     private async ValueTask OnPlayerEnteredWorldAsync()

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -872,15 +872,6 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
             this.CurrentMap = await this.GameContext.GetMapAsync(this.SelectedCharacter!.CurrentMap.Number.ToUnsigned()).ConfigureAwait(false);
         }
 
-        if (this.CurrentMap?.Definition.CharacterPowerUpDefinitions is { Count: > 0 } mapPowerUps)
-        {
-            foreach (var mapPowerUp in mapPowerUps)
-            {
-                var powerup = PowerUpWrapper.CreateByPowerUpDefinition(mapPowerUp, this.Attributes!);
-                
-            }
-        }
-
         await this.PlayerState.TryAdvanceToAsync(GameLogic.PlayerState.EnteredWorld).ConfigureAwait(false);
         this.IsAlive = true;
 

--- a/src/Persistence/BasicModel/Account.Generated.cs
+++ b/src/Persistence/BasicModel/Account.Generated.cs
@@ -68,6 +68,27 @@ public partial class Account : MUnique.OpenMU.DataModel.Entities.Account, IIdent
     }
 
     /// <summary>
+    /// Gets the raw collection of <see cref="Attributes" />.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonPropertyName("attributes")]
+    public ICollection<StatAttribute> RawAttributes { get; } = new List<StatAttribute>();
+    
+    /// <inheritdoc/>
+    [System.Text.Json.Serialization.JsonIgnore]
+    public override ICollection<MUnique.OpenMU.AttributeSystem.StatAttribute> Attributes
+    {
+        get => base.Attributes ??= new CollectionAdapter<MUnique.OpenMU.AttributeSystem.StatAttribute, StatAttribute>(this.RawAttributes);
+        protected set
+        {
+            this.Attributes.Clear();
+            foreach (var item in value)
+            {
+                this.Attributes.Add(item);
+            }
+        }
+    }
+
+    /// <summary>
     /// Gets the raw object of <see cref="Vault" />.
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("vault")]

--- a/src/Persistence/BasicModel/GameMapDefinition.Generated.cs
+++ b/src/Persistence/BasicModel/GameMapDefinition.Generated.cs
@@ -131,6 +131,27 @@ public partial class GameMapDefinition : MUnique.OpenMU.DataModel.Configuration.
     }
 
     /// <summary>
+    /// Gets the raw collection of <see cref="CharacterPowerUpDefinitions" />.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonPropertyName("characterPowerUpDefinitions")]
+    public ICollection<PowerUpDefinition> RawCharacterPowerUpDefinitions { get; } = new List<PowerUpDefinition>();
+    
+    /// <inheritdoc/>
+    [System.Text.Json.Serialization.JsonIgnore]
+    public override ICollection<MUnique.OpenMU.DataModel.Attributes.PowerUpDefinition> CharacterPowerUpDefinitions
+    {
+        get => base.CharacterPowerUpDefinitions ??= new CollectionAdapter<MUnique.OpenMU.DataModel.Attributes.PowerUpDefinition, PowerUpDefinition>(this.RawCharacterPowerUpDefinitions);
+        protected set
+        {
+            this.CharacterPowerUpDefinitions.Clear();
+            foreach (var item in value)
+            {
+                this.CharacterPowerUpDefinitions.Add(item);
+            }
+        }
+    }
+
+    /// <summary>
     /// Gets the raw object of <see cref="SafezoneMap" />.
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("safezoneMap")]

--- a/src/Persistence/EntityFramework/Migrations/20230724154747_AccountAndMapAttributes.Designer.cs
+++ b/src/Persistence/EntityFramework/Migrations/20230724154747_AccountAndMapAttributes.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MUnique.OpenMU.Persistence.EntityFramework;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
     [DbContext(typeof(EntityDataContext))]
-    partial class EntityDataContextModelSnapshot : ModelSnapshot
+    [Migration("20230724154747_AccountAndMapAttributes")]
+    partial class AccountAndMapAttributes
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Persistence/EntityFramework/Migrations/20230724154747_AccountAndMapAttributes.cs
+++ b/src/Persistence/EntityFramework/Migrations/20230724154747_AccountAndMapAttributes.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
+{
+    /// <inheritdoc />
+    public partial class AccountAndMapAttributes : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "AccountId",
+                schema: "data",
+                table: "StatAttribute",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "GameMapDefinitionId",
+                schema: "config",
+                table: "PowerUpDefinition",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_StatAttribute_AccountId",
+                schema: "data",
+                table: "StatAttribute",
+                column: "AccountId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PowerUpDefinition_GameMapDefinitionId",
+                schema: "config",
+                table: "PowerUpDefinition",
+                column: "GameMapDefinitionId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_PowerUpDefinition_GameMapDefinition_GameMapDefinitionId",
+                schema: "config",
+                table: "PowerUpDefinition",
+                column: "GameMapDefinitionId",
+                principalSchema: "config",
+                principalTable: "GameMapDefinition",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_StatAttribute_Account_AccountId",
+                schema: "data",
+                table: "StatAttribute",
+                column: "AccountId",
+                principalSchema: "data",
+                principalTable: "Account",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_PowerUpDefinition_GameMapDefinition_GameMapDefinitionId",
+                schema: "config",
+                table: "PowerUpDefinition");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_StatAttribute_Account_AccountId",
+                schema: "data",
+                table: "StatAttribute");
+
+            migrationBuilder.DropIndex(
+                name: "IX_StatAttribute_AccountId",
+                schema: "data",
+                table: "StatAttribute");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PowerUpDefinition_GameMapDefinitionId",
+                schema: "config",
+                table: "PowerUpDefinition");
+
+            migrationBuilder.DropColumn(
+                name: "AccountId",
+                schema: "data",
+                table: "StatAttribute");
+
+            migrationBuilder.DropColumn(
+                name: "GameMapDefinitionId",
+                schema: "config",
+                table: "PowerUpDefinition");
+        }
+    }
+}

--- a/src/Persistence/EntityFramework/Model/Account.Generated.cs
+++ b/src/Persistence/EntityFramework/Model/Account.Generated.cs
@@ -43,6 +43,15 @@ internal partial class Account : MUnique.OpenMU.DataModel.Entities.Account, IIde
     public override ICollection<MUnique.OpenMU.DataModel.Entities.Character> Characters => base.Characters ??= new CollectionAdapter<MUnique.OpenMU.DataModel.Entities.Character, Character>(this.RawCharacters);
 
     /// <summary>
+    /// Gets the raw collection of <see cref="Attributes" />.
+    /// </summary>
+    public ICollection<StatAttribute> RawAttributes { get; } = new EntityFramework.List<StatAttribute>();
+    
+    /// <inheritdoc/>
+    [NotMapped]
+    public override ICollection<MUnique.OpenMU.AttributeSystem.StatAttribute> Attributes => base.Attributes ??= new CollectionAdapter<MUnique.OpenMU.AttributeSystem.StatAttribute, StatAttribute>(this.RawAttributes);
+
+    /// <summary>
     /// Gets or sets the identifier of <see cref="Vault"/>.
     /// </summary>
     public Guid? VaultId { get; set; }

--- a/src/Persistence/EntityFramework/Model/ExtendedTypeContext.Generated.cs
+++ b/src/Persistence/EntityFramework/Model/ExtendedTypeContext.Generated.cs
@@ -155,6 +155,7 @@ public class ExtendedTypeContext : Microsoft.EntityFrameworkCore.DbContext
         modelBuilder.Entity<GameMapDefinition>().HasOne(entity => entity.RawBattleZone).WithOne().OnDelete(DeleteBehavior.Cascade);
         modelBuilder.Entity<GameMapDefinition>().HasMany(entity => entity.RawExitGates).WithOne().OnDelete(DeleteBehavior.Cascade);
         modelBuilder.Entity<GameMapDefinition>().HasMany(entity => entity.RawMapRequirements).WithOne().OnDelete(DeleteBehavior.Cascade);
+        modelBuilder.Entity<GameMapDefinition>().HasMany(entity => entity.RawCharacterPowerUpDefinitions).WithOne().OnDelete(DeleteBehavior.Cascade);
         modelBuilder.Entity<GameServerDefinition>().HasMany(entity => entity.RawEndpoints).WithOne().OnDelete(DeleteBehavior.Cascade);
         modelBuilder.Entity<MagicEffectDefinition>().HasOne(entity => entity.RawDuration).WithOne().OnDelete(DeleteBehavior.Cascade);
         modelBuilder.Entity<MagicEffectDefinition>().HasMany(entity => entity.RawPowerUpDefinitions).WithOne().OnDelete(DeleteBehavior.Cascade);

--- a/src/Persistence/EntityFramework/Model/ExtendedTypeContext.Generated.cs
+++ b/src/Persistence/EntityFramework/Model/ExtendedTypeContext.Generated.cs
@@ -112,6 +112,7 @@ public class ExtendedTypeContext : Microsoft.EntityFrameworkCore.DbContext
         // All members which are marked with the MemberOfAggregateAttribute, should be defined with ON DELETE CASCADE.
         modelBuilder.Entity<Account>().HasOne(entity => entity.RawVault).WithOne().OnDelete(DeleteBehavior.Cascade);
         modelBuilder.Entity<Account>().HasMany(entity => entity.RawCharacters).WithOne().OnDelete(DeleteBehavior.Cascade);
+        modelBuilder.Entity<Account>().HasMany(entity => entity.RawAttributes).WithOne().OnDelete(DeleteBehavior.Cascade);
         modelBuilder.Entity<AppearanceData>().HasMany(entity => entity.RawEquippedItems).WithOne().OnDelete(DeleteBehavior.Cascade);
         modelBuilder.Entity<Character>().HasMany(entity => entity.RawAttributes).WithOne().OnDelete(DeleteBehavior.Cascade);
         modelBuilder.Entity<Character>().HasMany(entity => entity.RawLetters).WithOne().OnDelete(DeleteBehavior.Cascade);

--- a/src/Persistence/EntityFramework/Model/GameMapDefinition.Generated.cs
+++ b/src/Persistence/EntityFramework/Model/GameMapDefinition.Generated.cs
@@ -70,6 +70,15 @@ internal partial class GameMapDefinition : MUnique.OpenMU.DataModel.Configuratio
     public override ICollection<MUnique.OpenMU.DataModel.Configuration.Items.AttributeRequirement> MapRequirements => base.MapRequirements ??= new CollectionAdapter<MUnique.OpenMU.DataModel.Configuration.Items.AttributeRequirement, AttributeRequirement>(this.RawMapRequirements);
 
     /// <summary>
+    /// Gets the raw collection of <see cref="CharacterPowerUpDefinitions" />.
+    /// </summary>
+    public ICollection<PowerUpDefinition> RawCharacterPowerUpDefinitions { get; } = new EntityFramework.List<PowerUpDefinition>();
+    
+    /// <inheritdoc/>
+    [NotMapped]
+    public override ICollection<MUnique.OpenMU.DataModel.Attributes.PowerUpDefinition> CharacterPowerUpDefinitions => base.CharacterPowerUpDefinitions ??= new CollectionAdapter<MUnique.OpenMU.DataModel.Attributes.PowerUpDefinition, PowerUpDefinition>(this.RawCharacterPowerUpDefinitions);
+
+    /// <summary>
     /// Gets or sets the identifier of <see cref="SafezoneMap"/>.
     /// </summary>
     public Guid? SafezoneMapId { get; set; }


### PR DESCRIPTION
1. Added the possibility to define account-wide StatAttributes. One example usage: VIP-Flag for accounts.
2. Added the possibility to define power ups which apply only to players on a certain map. With this, you could make players weaker or stronger on a per-map basis.