### PR TITLE
fix: Adds conditions to avoid equipping two-handed item when all slots are occupied

### DIFF
--- a/src/GameLogic/PlayerActions/Items/MoveItemAction.cs
+++ b/src/GameLogic/PlayerActions/Items/MoveItemAction.cs
@@ -238,9 +238,16 @@ public class MoveItemAction
                 static bool IsOneHandedOrShield(ItemDefinition definition) =>
                     (definition.ItemSlot!.ItemSlots.Contains(RightHandSlot) && definition.ItemSlot.ItemSlots.Contains(LeftHandSlot)) || definition.Group == 6;
 
+                static bool RightHandOccupied(ItemDefinition definition) => definition != null;
+
+                // Bolts = 7, Arrows = 15
+                static bool IsArrowOrBolt(ItemDefinition definition) =>
+                    definition.Group == 4 && (definition.Number == 7 || definition.Number == 15);
+
                 if ((toSlot == LeftHandSlot
                     && itemDefinition.Width >= 2
-                    && storage.GetItem(RightHandSlot)?.Definition!.Group == 6)
+                    && RightHandOccupied(storage.GetItem(RightHandSlot)?.Definition!)
+                    && !IsArrowOrBolt(storage.GetItem(RightHandSlot)?.Definition!))
                     || (toSlot == RightHandSlot
                     && IsOneHandedOrShield(itemDefinition)
                     && storage.GetItem(LeftHandSlot)?.Definition!.Width >= 2))

--- a/src/GameLogic/PlayerActions/Items/MoveItemAction.cs
+++ b/src/GameLogic/PlayerActions/Items/MoveItemAction.cs
@@ -238,16 +238,12 @@ public class MoveItemAction
                 static bool IsOneHandedOrShield(ItemDefinition definition) =>
                     (definition.ItemSlot!.ItemSlots.Contains(RightHandSlot) && definition.ItemSlot.ItemSlots.Contains(LeftHandSlot)) || definition.Group == 6;
 
-                static bool RightHandOccupied(ItemDefinition definition) => definition != null;
-
-                // Bolts = 7, Arrows = 15
-                static bool IsArrowOrBolt(ItemDefinition definition) =>
-                    definition.Group == 4 && (definition.Number == 7 || definition.Number == 15);
+                var rightHandItemDefinition = storage.GetItem(RightHandSlot)?.Definition!;
 
                 if ((toSlot == LeftHandSlot
                     && itemDefinition.Width >= 2
-                    && RightHandOccupied(storage.GetItem(RightHandSlot)?.Definition!)
-                    && !IsArrowOrBolt(storage.GetItem(RightHandSlot)?.Definition!))
+                    && rightHandItemDefinition != null
+                    && !rightHandItemDefinition.IsAmmunition)
                     || (toSlot == RightHandSlot
                     && IsOneHandedOrShield(itemDefinition)
                     && storage.GetItem(LeftHandSlot)?.Definition!.Width >= 2))


### PR DESCRIPTION
Closes https://github.com/MUnique/OpenMU/issues/392

This PR goes one step further after https://github.com/MUnique/OpenMU/pull/393 and solves the case for one-handed items (such as shields and swords) being able to be equipped in the second slot.

This doesn't change the already working behavior for elves (bolts and arrows)

