### PR TITLE
Support references to config objects in custom plugin configurations

### DIFF
--- a/src/ChatServer/ExDbConnector/Program.cs
+++ b/src/ChatServer/ExDbConnector/Program.cs
@@ -56,7 +56,7 @@ internal class Program
             // To make the chat server use our configured encryption key, we need to trick a bit. We add an endpoint with a special client version which is defined in the plugin.
             var configuration = new ChatServerSettings();
             configuration.Endpoints.Add(new ChatServerEndpoint { ClientVersion = ConfigurableNetworkEncryptionPlugIn.Version, NetworkPort = chatServerListenerPort });
-            var pluginManager = new PlugInManager(null, loggerFactory, serviceContainer);
+            var pluginManager = new PlugInManager(null, loggerFactory, serviceContainer, null);
             pluginManager.DiscoverAndRegisterPlugInsOf<INetworkEncryptionFactoryPlugIn>();
             var chatServer = new ChatServer(addressResolver, loggerFactory, pluginManager);
             chatServer.Initialize(configuration);

--- a/src/GameLogic/PlayerActions/ItemConsumeActions/BlessJewelConsumeHandlerPlugIn.cs
+++ b/src/GameLogic/PlayerActions/ItemConsumeActions/BlessJewelConsumeHandlerPlugIn.cs
@@ -15,14 +15,26 @@ using MUnique.OpenMU.PlugIns;
 /// </summary>
 [Guid("E95A0292-B3B4-4E8C-AC5A-7F3DB4F01A37")]
 [PlugIn(nameof(BlessJewelConsumeHandlerPlugIn), "Plugin which handles the jewel of bless consumption.")]
-public class BlessJewelConsumeHandlerPlugIn : ItemModifyConsumeHandlerPlugIn
+public class BlessJewelConsumeHandlerPlugIn : ItemModifyConsumeHandlerPlugIn, ISupportCustomConfiguration<BlessJewelConsumeHandlerPlugInConfiguration>
 {
     /// <inheritdoc />
     public override ItemIdentifier Key => ItemConstants.JewelOfBless;
 
+    /// <summary>
+    /// Gets or sets the configuration.
+    /// </summary>
+    public BlessJewelConsumeHandlerPlugInConfiguration? Configuration { get; set; }
+
     /// <inheritdoc/>
     protected override bool ModifyItem(Item item, IContext persistenceContext)
     {
+        if (this.Configuration?.RepairTargetItems.Contains(item.Definition!) is true
+            && item.Durability < item.GetMaximumDurabilityOfOnePiece())
+        {
+            item.Durability = item.GetMaximumDurabilityOfOnePiece();
+            return true;
+        }
+
         if (!item.CanLevelBeUpgraded())
         {
             return false;
@@ -37,6 +49,7 @@ public class BlessJewelConsumeHandlerPlugIn : ItemModifyConsumeHandlerPlugIn
 
         level++;
         item.Level = level;
+        item.Durability = item.GetMaximumDurabilityOfOnePiece();
         return true;
     }
 }

--- a/src/GameLogic/PlayerActions/ItemConsumeActions/BlessJewelConsumeHandlerPlugInConfiguration.cs
+++ b/src/GameLogic/PlayerActions/ItemConsumeActions/BlessJewelConsumeHandlerPlugInConfiguration.cs
@@ -1,0 +1,18 @@
+﻿// <copyright file="BlessJewelConsumeHandlerPlugInConfiguration.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.PlayerActions.ItemConsumeActions;
+
+using MUnique.OpenMU.DataModel.Configuration.Items;
+
+/// <summary>
+/// The configuration for the <see cref="BlessJewelConsumeHandlerPlugIn"/>.
+/// </summary>
+public class BlessJewelConsumeHandlerPlugInConfiguration
+{
+    /// <summary>
+    /// Gets or sets the items which can be repaired by consuming a bless on them.
+    /// </summary>
+    public ICollection<ItemDefinition> RepairTargetItems { get; set; } = new List<ItemDefinition>();
+}

--- a/src/GameLogic/PlayerActions/ItemConsumeActions/SoulJewelConsumeHandlerPlugIn.cs
+++ b/src/GameLogic/PlayerActions/ItemConsumeActions/SoulJewelConsumeHandlerPlugIn.cs
@@ -62,6 +62,7 @@ public class SoulJewelConsumeHandlerPlugIn : ItemModifyConsumeHandlerPlugIn
         if (this._randomizer.NextRandomBool(percent))
         {
             item.Level++;
+            item.Durability = item.GetMaximumDurabilityOfOnePiece();
             return true; // true doesn't mean that it was successful, just that the consumption happened.
         }
 

--- a/src/Network/Analyzer/MainForm.cs
+++ b/src/Network/Analyzer/MainForm.cs
@@ -49,7 +49,7 @@ public partial class MainForm : Form
         this.InitializeComponent();
         var serviceContainer = new ServiceContainer();
         serviceContainer.AddService(typeof(ILoggerFactory), new NullLoggerFactory());
-        this._plugInManager = new PlugInManager(null, new NullLoggerFactory(), serviceContainer);
+        this._plugInManager = new PlugInManager(null, new NullLoggerFactory(), serviceContainer, null);
         this._plugInManager.DiscoverAndRegisterPlugIns();
         this.clientBindingSource.DataSource = this._proxiedConnections;
         this.connectedClientsListBox.DisplayMember = nameof(ICapturedConnection.Name);

--- a/src/Persistence/ByDataSourceReferenceHandler.cs
+++ b/src/Persistence/ByDataSourceReferenceHandler.cs
@@ -1,0 +1,34 @@
+// <copyright file="ByDataSourceReferenceHandler.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Persistence;
+
+using System.Text.Json.Serialization;
+using MUnique.OpenMU.DataModel.Configuration;
+
+/// <summary>
+/// A reference handler which uses a <see cref="IDataSource{T}"/> to resolve references.
+/// </summary>
+public class ByDataSourceReferenceHandler : ReferenceHandler
+{
+    /// <summary>
+    /// The data source.
+    /// </summary>
+    private IDataSource<GameConfiguration> _dataSource;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ByDataSourceReferenceHandler"/> class.
+    /// </summary>
+    /// <param name="dataSource">The data source.</param>
+    public ByDataSourceReferenceHandler(IDataSource<GameConfiguration> dataSource)
+    {
+        this._dataSource = dataSource;
+    }
+
+    /// <inheritdoc />
+    public override ReferenceResolver CreateResolver()
+    {
+        return new ByDataSourceReferenceResolver(this._dataSource);
+    }
+}

--- a/src/Persistence/ByDataSourceReferenceHandler.cs
+++ b/src/Persistence/ByDataSourceReferenceHandler.cs
@@ -15,7 +15,7 @@ public class ByDataSourceReferenceHandler : ReferenceHandler
     /// <summary>
     /// The data source.
     /// </summary>
-    private IDataSource<GameConfiguration> _dataSource;
+    private readonly IDataSource<GameConfiguration> _dataSource;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ByDataSourceReferenceHandler"/> class.

--- a/src/Persistence/ByDataSourceReferenceResolver.cs
+++ b/src/Persistence/ByDataSourceReferenceResolver.cs
@@ -1,0 +1,54 @@
+// <copyright file="ByDataSourceReferenceResolver.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Persistence;
+
+using System.Text.Json.Serialization;
+using MUnique.OpenMU.DataModel.Configuration;
+
+/// <summary>
+/// A reference resolver which uses a <see cref="IDataSource{T}"/> to resolve references.
+/// </summary>
+public class ByDataSourceReferenceResolver : ReferenceResolver
+{
+    /// <summary>
+    /// The data source.
+    /// </summary>
+    private readonly IDataSource<GameConfiguration> _dataSource;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ByDataSourceReferenceResolver"/> class.
+    /// </summary>
+    /// <param name="dataSource">The data source.</param>
+    public ByDataSourceReferenceResolver(IDataSource<GameConfiguration> dataSource)
+    {
+        this._dataSource = dataSource;
+    }
+
+    /// <inheritdoc />
+    public override void AddReference(string referenceId, object value)
+    {
+        //throw new NotImplementedException();
+    }
+
+    /// <inheritdoc />
+    public override string GetReference(object value, out bool alreadyExists)
+    {
+        if (value is IIdentifiable identifiable)
+        {
+            alreadyExists = this._dataSource.Get(identifiable.Id) is { };
+            return identifiable.Id.ToString();
+        }
+
+        alreadyExists = false;
+        return string.Empty;
+    }
+
+    /// <inheritdoc />
+    public override object ResolveReference(string referenceId)
+    {
+        var id = Guid.Parse(referenceId);
+        return this._dataSource.Get(id) ?? throw new KeyNotFoundException($"Reference with id '{referenceId}' not found.");
+    }
+}

--- a/src/Persistence/ByDataSourceReferenceResolver.cs
+++ b/src/Persistence/ByDataSourceReferenceResolver.cs
@@ -29,7 +29,7 @@ public class ByDataSourceReferenceResolver : ReferenceResolver
     /// <inheritdoc />
     public override void AddReference(string referenceId, object value)
     {
-        //throw new NotImplementedException();
+        // do nothing here, because the data source is the source of truth.
     }
 
     /// <inheritdoc />

--- a/src/Persistence/Initialization/DataInitializationBase.cs
+++ b/src/Persistence/Initialization/DataInitializationBase.cs
@@ -120,9 +120,10 @@ public abstract class DataInitializationBase : IDataInitializationPlugIn
             // should never happen, but the access to the GameServer type is a trick to load the assembly into the current domain.
         }
 
+        var referenceHandler = new ByDataSourceReferenceHandler(new GameConfigurationDataSource(this._loggerFactory.CreateLogger<GameConfigurationDataSource>(), this._persistenceContextProvider));
         var serviceContainer = new ServiceContainer();
         serviceContainer.AddService(typeof(IPersistenceContextProvider), this._persistenceContextProvider);
-        var plugInManager = new PlugInManager(null, this._loggerFactory, serviceContainer);
+        var plugInManager = new PlugInManager(null, this._loggerFactory, serviceContainer, referenceHandler);
         plugInManager.DiscoverAndRegisterPlugIns();
         plugInManager.KnownPlugInTypes.ForEach(plugInType =>
         {
@@ -136,32 +137,32 @@ public abstract class DataInitializationBase : IDataInitializationPlugIn
             if (plugInType == typeof(ResetFeaturePlugIn))
             {
                 plugInConfiguration.IsActive = false;
-                plugInConfiguration.SetConfiguration(new ResetConfiguration());
+                plugInConfiguration.SetConfiguration(new ResetConfiguration(), referenceHandler);
             }
 
             if (plugInType == typeof(ChaosCastleStartPlugIn))
             {
-                plugInConfiguration.SetConfiguration(ChaosCastleStartConfiguration.Default);
+                plugInConfiguration.SetConfiguration(ChaosCastleStartConfiguration.Default, referenceHandler);
             }
 
             if (plugInType == typeof(GoldenInvasionPlugIn))
             {
-                plugInConfiguration.SetConfiguration(PeriodicInvasionConfiguration.DefaultGoldenInvasion);
+                plugInConfiguration.SetConfiguration(PeriodicInvasionConfiguration.DefaultGoldenInvasion, referenceHandler);
             }
 
             if (plugInType == typeof(RedDragonInvasionPlugIn))
             {
-                plugInConfiguration.SetConfiguration(PeriodicInvasionConfiguration.DefaultRedDragonInvasion);
+                plugInConfiguration.SetConfiguration(PeriodicInvasionConfiguration.DefaultRedDragonInvasion, referenceHandler);
             }
 
             if (plugInType == typeof(HappyHourPlugIn))
             {
-                plugInConfiguration.SetConfiguration(HappyHourConfiguration.Default);
+                plugInConfiguration.SetConfiguration(HappyHourConfiguration.Default, referenceHandler);
             }
 
             if (plugInType == typeof(MuHelperFeaturePlugIn))
             {
-                plugInConfiguration.SetConfiguration(new MuHelperConfiguration());
+                plugInConfiguration.SetConfiguration(new MuHelperConfiguration(), referenceHandler);
             }
 
             // We don't move the player anymore by his request. This was usually requested after a player performed a skill.

--- a/src/PlugIns/PlugInConfigurationExtensions.cs
+++ b/src/PlugIns/PlugInConfigurationExtensions.cs
@@ -5,6 +5,7 @@
 namespace MUnique.OpenMU.PlugIns;
 
 using System.Text.Json;
+using System.Text.Json.Serialization;
 
 /// <summary>
 /// Extension methods for the plugin configuration.
@@ -16,10 +17,11 @@ public static class PlugInConfigurationExtensions
     /// </summary>
     /// <typeparam name="T">The custom configuration type.</typeparam>
     /// <param name="configuration">The configuration.</param>
+    /// <param name="referenceHandler">The reference handler.</param>
     /// <returns>
     /// The custom configuration as <typeparamref name="T" />.
     /// </returns>
-    public static T? GetConfiguration<T>(this PlugInConfiguration configuration)
+    public static T? GetConfiguration<T>(this PlugInConfiguration configuration, ReferenceHandler? referenceHandler)
         where T : class
     {
         if (string.IsNullOrWhiteSpace(configuration.CustomConfiguration))
@@ -27,7 +29,12 @@ public static class PlugInConfigurationExtensions
             return default;
         }
 
-        return JsonSerializer.Deserialize<T>(configuration.CustomConfiguration);
+        var options = new JsonSerializerOptions
+        {
+            ReferenceHandler = referenceHandler,
+        };
+
+        return JsonSerializer.Deserialize<T>(configuration.CustomConfiguration, options);
     }
 
     /// <summary>
@@ -35,17 +42,23 @@ public static class PlugInConfigurationExtensions
     /// </summary>
     /// <param name="configuration">The configuration.</param>
     /// <param name="configurationType">Type of the configuration.</param>
+    /// <param name="referenceHandler">The reference handler.</param>
     /// <returns>
     /// The custom configuration as the given specified type.
     /// </returns>
-    public static object? GetConfiguration(this PlugInConfiguration configuration, Type configurationType)
+    public static object? GetConfiguration(this PlugInConfiguration configuration, Type configurationType, ReferenceHandler? referenceHandler)
     {
         if (string.IsNullOrWhiteSpace(configuration.CustomConfiguration))
         {
             return default;
         }
 
-        return JsonSerializer.Deserialize(configuration.CustomConfiguration, configurationType);
+        var options = new JsonSerializerOptions
+        {
+            ReferenceHandler = referenceHandler,
+        };
+
+        return JsonSerializer.Deserialize(configuration.CustomConfiguration, configurationType, options);
     }
 
     /// <summary>
@@ -54,9 +67,10 @@ public static class PlugInConfigurationExtensions
     /// <typeparam name="T">The custom configuration type.</typeparam>
     /// <param name="plugInConfiguration">The plug in configuration.</param>
     /// <param name="configuration">The configuration.</param>
-    public static void SetConfiguration<T>(this PlugInConfiguration plugInConfiguration, T configuration)
+    /// <param name="referenceHandler">The reference handler.</param>
+    public static void SetConfiguration<T>(this PlugInConfiguration plugInConfiguration, T configuration, ReferenceHandler? referenceHandler)
     {
-        plugInConfiguration.CustomConfiguration = JsonSerializer.Serialize(configuration, new JsonSerializerOptions { WriteIndented = true });
+        plugInConfiguration.CustomConfiguration = JsonSerializer.Serialize(configuration, new JsonSerializerOptions { WriteIndented = true, ReferenceHandler = referenceHandler });
     }
 
     /// <summary>
@@ -64,8 +78,12 @@ public static class PlugInConfigurationExtensions
     /// </summary>
     /// <param name="plugInConfiguration">The plug in configuration.</param>
     /// <param name="configuration">The configuration.</param>
-    public static void SetConfiguration(this PlugInConfiguration plugInConfiguration, object configuration)
+    /// <param name="referenceHandler">The reference handler.</param>
+    public static void SetConfiguration(this PlugInConfiguration plugInConfiguration, object configuration, ReferenceHandler? referenceHandler)
     {
-        plugInConfiguration.CustomConfiguration = JsonSerializer.Serialize(configuration, configuration.GetType(), new JsonSerializerOptions { WriteIndented = true });
+        plugInConfiguration.CustomConfiguration = JsonSerializer.Serialize(
+            configuration,
+            configuration.GetType(),
+            new JsonSerializerOptions { WriteIndented = true, ReferenceHandler = referenceHandler });
     }
 }

--- a/src/PlugIns/PlugInContainerBase.cs
+++ b/src/PlugIns/PlugInContainerBase.cs
@@ -207,7 +207,7 @@ public class PlugInContainerBase<TPlugIn> : IPlugInContainer<TPlugIn>
             is { } configSupportInterface)
         {
             var configType = configSupportInterface.GenericTypeArguments[0];
-            var typedCustomConfiguration = e.Configuration.GetConfiguration(configType);
+            var typedCustomConfiguration = e.Configuration.GetConfiguration(configType, this.Manager.CustomConfigReferenceHandler);
             configSupportInterface
                 .GetProperty(nameof(ISupportCustomConfiguration<object>.Configuration))
                 ?.SetMethod

--- a/src/PlugIns/PlugInManager.cs
+++ b/src/PlugIns/PlugInManager.cs
@@ -8,6 +8,7 @@ using System.Collections.Concurrent;
 using System.ComponentModel.Design;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Text.Json.Serialization;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
@@ -32,7 +33,7 @@ public class PlugInManager
     /// <param name="configurations">The configurations.</param>
     /// <param name="loggerFactory">The logger factory.</param>
     /// <param name="serviceProvider">The service provider.</param>
-    public PlugInManager(ICollection<PlugInConfiguration>? configurations, ILoggerFactory loggerFactory, IServiceProvider? serviceProvider)
+    public PlugInManager(ICollection<PlugInConfiguration>? configurations, ILoggerFactory loggerFactory, IServiceProvider? serviceProvider, ReferenceHandler? customConfigReferenceHandler)
     {
         _ = typeof(Nito.AsyncEx.AsyncReaderWriterLock); // Ensure Nito.AsyncEx.Coordination is loaded so it will be available in proxy generation.
 
@@ -40,6 +41,8 @@ public class PlugInManager
         this._serviceContainer = new ServiceContainer(serviceProvider);
         this._serviceContainer.AddService(typeof(PlugInManager), this);
         this._serviceContainer.AddService(typeof(ILoggerFactory), loggerFactory);
+
+        this.CustomConfigReferenceHandler = customConfigReferenceHandler;
 
         if (configurations is not null)
         {
@@ -74,6 +77,11 @@ public class PlugInManager
     /// The known plug in types.
     /// </value>
     public IEnumerable<Type> KnownPlugInTypes => this._knownPlugIns.Values;
+
+    /// <summary>
+    /// Gets the reference handler for references in custom plugin configurations.
+    /// </summary>
+    public ReferenceHandler? CustomConfigReferenceHandler { get; }
 
     /// <summary>
     /// Discovers and registers all plug ins of all loaded assemblies.

--- a/src/Startup/Program.cs
+++ b/src/Startup/Program.cs
@@ -274,8 +274,8 @@ internal sealed class Program : IDisposable
                 var dataSource = new GameConfigurationDataSource(
                     provider.GetService<ILogger<GameConfigurationDataSource>>()!,
                     persistenceContextProvider!);
-                var configId = persistenceContextProvider!.CreateNewConfigurationContext().GetDefaultGameConfigurationIdAsync(default).GetAwaiter().GetResult();
-                dataSource.GetOwnerAsync(configId!.Value).GetAwaiter().GetResult();
+                var configId = persistenceContextProvider!.CreateNewConfigurationContext().GetDefaultGameConfigurationIdAsync(default).AsTask().WaitAndUnwrapException();
+                dataSource.GetOwnerAsync(configId!.Value).AsTask().WaitAndUnwrapException();
                 var referenceHandler = new ByDataSourceReferenceHandler(dataSource);
                 return referenceHandler;
             })

--- a/src/Startup/Program.cs
+++ b/src/Startup/Program.cs
@@ -4,9 +4,11 @@
 
 namespace MUnique.OpenMU.Startup;
 
+using System;
 using System.ComponentModel.Design;
 using System.Diagnostics;
 using System.IO;
+using System.Text.Json.Serialization;
 using System.Threading;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.Configuration;
@@ -266,6 +268,18 @@ internal sealed class Program : IDisposable
             .AddSingleton<PlugInManager>()
             .AddSingleton<IServerProvider, LocalServerProvider>()
             .AddSingleton<ICollection<PlugInConfiguration>>(this.PlugInConfigurationsFactory)
+            .AddTransient<ReferenceHandler, ByDataSourceReferenceHandler>(provider =>
+            {
+                var persistenceContextProvider = provider.GetService<IPersistenceContextProvider>();
+                var dataSource = new GameConfigurationDataSource(
+                    provider.GetService<ILogger<GameConfigurationDataSource>>()!,
+                    persistenceContextProvider!);
+                var configId = persistenceContextProvider!.CreateNewConfigurationContext().GetDefaultGameConfigurationIdAsync(default).GetAwaiter().GetResult();
+                dataSource.GetOwnerAsync(configId!.Value).GetAwaiter().GetResult();
+                var referenceHandler = new ByDataSourceReferenceHandler(dataSource);
+                return referenceHandler;
+            })
+            .AddTransient<IDataSource<GameConfiguration>, GameConfigurationDataSource>()
             .AddHostedService<ChatServerContainer>()
             .AddHostedService<GameServerContainer>()
             .AddHostedService(provider => provider.GetService<ConnectServerContainer>()!)
@@ -310,8 +324,11 @@ internal sealed class Program : IDisposable
 
         var configs = context.GetAsync<PlugInConfiguration>().AsTask().WaitAndUnwrapException().ToList();
 
+        var referenceHandler = new ByDataSourceReferenceHandler(
+            new GameConfigurationDataSource(serviceProvider.GetService<ILogger<GameConfigurationDataSource>>()!, persistenceContextProvider));
+
         // We check if we miss any plugin configurations in the database. If we do, we try to add them.
-        var pluginManager = new PlugInManager(null, serviceProvider.GetService<ILoggerFactory>()!, serviceProvider);
+        var pluginManager = new PlugInManager(null, serviceProvider.GetService<ILoggerFactory>()!, serviceProvider, referenceHandler);
         pluginManager.DiscoverAndRegisterPlugIns();
 
         var typesWithCustomConfig = pluginManager.KnownPlugInTypes.Where(t => t.GetInterfaces().Contains(typeof(ISupportDefaultCustomConfiguration))).ToDictionary(t => t.GUID, t => t);
@@ -319,7 +336,7 @@ internal sealed class Program : IDisposable
         var typesWithMissingCustomConfigs = configs.Where(c => string.IsNullOrWhiteSpace(c.CustomConfiguration) && typesWithCustomConfig.ContainsKey(c.TypeId)).ToList();
         if (typesWithMissingCustomConfigs.Any())
         {
-            typesWithMissingCustomConfigs.ForEach(c => this.CreateDefaultPlugInConfiguration(typesWithCustomConfig[c.TypeId]!, c));
+            typesWithMissingCustomConfigs.ForEach(c => this.CreateDefaultPlugInConfiguration(typesWithCustomConfig[c.TypeId]!, c, referenceHandler));
             context.SaveChanges();
         }
 
@@ -329,11 +346,11 @@ internal sealed class Program : IDisposable
             return configs;
         }
 
-        configs.AddRange(this.CreateMissingPlugInConfigurations(typesWithMissingConfigs, persistenceContextProvider));
+        configs.AddRange(this.CreateMissingPlugInConfigurations(typesWithMissingConfigs, persistenceContextProvider, referenceHandler));
         return configs;
     }
 
-    private IEnumerable<PlugInConfiguration> CreateMissingPlugInConfigurations(IEnumerable<Type> plugInTypes, IPersistenceContextProvider persistenceContextProvider)
+    private IEnumerable<PlugInConfiguration> CreateMissingPlugInConfigurations(IEnumerable<Type> plugInTypes, IPersistenceContextProvider persistenceContextProvider, ReferenceHandler referenceHandler)
     {
         GameConfiguration gameConfiguration;
 
@@ -352,7 +369,7 @@ internal sealed class Program : IDisposable
             gameConfiguration.PlugInConfigurations.Add(plugInConfiguration);
             if (plugInType.GetInterfaces().Contains(typeof(ISupportDefaultCustomConfiguration)))
             {
-                this.CreateDefaultPlugInConfiguration(plugInType, plugInConfiguration);
+                this.CreateDefaultPlugInConfiguration(plugInType, plugInConfiguration, referenceHandler);
             }
 
             yield return plugInConfiguration;
@@ -361,13 +378,13 @@ internal sealed class Program : IDisposable
         saveContext.SaveChanges();
     }
 
-    private void CreateDefaultPlugInConfiguration(Type plugInType, PlugInConfiguration plugInConfiguration)
+    private void CreateDefaultPlugInConfiguration(Type plugInType, PlugInConfiguration plugInConfiguration, ReferenceHandler referenceHandler)
     {
         try
         {
             var plugin = (ISupportDefaultCustomConfiguration)Activator.CreateInstance(plugInType)!;
             var defaultConfig = plugin.CreateDefaultConfig();
-            plugInConfiguration.SetConfiguration(defaultConfig);
+            plugInConfiguration.SetConfiguration(defaultConfig, referenceHandler);
         }
         catch (Exception ex)
         {
@@ -490,7 +507,10 @@ internal sealed class Program : IDisposable
         serviceContainer.AddService(typeof(ILoggerFactory), loggerFactory);
         serviceContainer.AddService(typeof(IPersistenceContextProvider), contextProvider);
 
-        var plugInManager = new PlugInManager(null, loggerFactory, serviceContainer);
+        var referenceHandler = new ByDataSourceReferenceHandler(
+            new GameConfigurationDataSource(serviceContainer.GetService<ILogger<GameConfigurationDataSource>>()!, contextProvider));
+
+        var plugInManager = new PlugInManager(null, loggerFactory, serviceContainer, referenceHandler);
         plugInManager.DiscoverAndRegisterPlugInsOf<IDataInitializationPlugIn>();
         var initialization = plugInManager.GetStrategy<IDataInitializationPlugIn>(version) ?? throw new Exception("Data initialization plugin not found");
         await initialization.CreateInitialDataAsync(3, true).ConfigureAwait(false);

--- a/src/Web/AdminPanel/ComponentBuilders/EmbeddedFormFieldBuilder.cs
+++ b/src/Web/AdminPanel/ComponentBuilders/EmbeddedFormFieldBuilder.cs
@@ -16,7 +16,10 @@ using MUnique.OpenMU.Web.AdminPanel.Services;
 public class EmbeddedFormFieldBuilder : BaseComponentBuilder, IComponentBuilder
 {
     /// <inheritdoc/>
-    public int BuildComponent(object model, PropertyInfo propertyInfo, RenderTreeBuilder builder, int currentIndex, IChangeNotificationService notificationService) => this.BuildGenericField(model, typeof(MemberOfAggregateField<>), builder, propertyInfo, currentIndex, notificationService);
+    public int BuildComponent(object model, PropertyInfo propertyInfo, RenderTreeBuilder builder, int currentIndex, IChangeNotificationService notificationService)
+    {
+        return this.BuildGenericField(model, typeof(MemberOfAggregateField<>), builder, propertyInfo, currentIndex, notificationService);
+    }
 
     /// <inheritdoc/>
     public bool CanBuildComponent(PropertyInfo propertyInfo) =>

--- a/src/Web/AdminPanel/Components/Form/MemberOfAggregateField.razor
+++ b/src/Web/AdminPanel/Components/Form/MemberOfAggregateField.razor
@@ -9,7 +9,7 @@
             <FieldLabel Text="@Label" ValueExpression="@this.ValueExpression" />
         </h5>
         <div class="card-body card-text">
-            @if (this.Value is null)
+            @if (this.CurrentValue is null)
             {
                 <button type="button" class="btn-primary" @onclick="this.OnCreateClick">Create</button>
             }
@@ -46,6 +46,6 @@
 
     private void OnCreateClick()
     {
-        this.Value = this.PersistentContext.CreateNew<TObject>();
+        this.CurrentValue = this.PersistentContext.CreateNew<TObject>();
     }
 }

--- a/src/Web/AdminPanel/Services/PersistentObjectsLookupController.cs
+++ b/src/Web/AdminPanel/Services/PersistentObjectsLookupController.cs
@@ -47,6 +47,7 @@ public class PersistentObjectsLookupController : ILookupController
                 return Enumerable.Empty<T>();
             }
 
+            var owner = await this._gameConfigurationSource.GetOwnerAsync();
             IEnumerable<T> values;
             if (this._gameConfigurationSource.IsSupporting(typeof(T)))
             {
@@ -55,7 +56,7 @@ public class PersistentObjectsLookupController : ILookupController
             else
             {
                 using var context = persistenceContext is null
-                    ? this._contextProvider.CreateNewContext(await this._gameConfigurationSource.GetOwnerAsync(Guid.Empty))
+                    ? this._contextProvider.CreateNewContext(owner)
                     : null;
                 var effectiveContext = persistenceContext ?? context;
                 if (effectiveContext is null)

--- a/tests/MUnique.OpenMU.PlugIns.Tests/CustomPlugInContainerTest.cs
+++ b/tests/MUnique.OpenMU.PlugIns.Tests/CustomPlugInContainerTest.cs
@@ -20,7 +20,7 @@ public class CustomPlugInContainerTest
     [Test]
     public void CreatingContainerWithNonMarkedTypeThrowsException()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), null);
+        var manager = new PlugInManager(null, new NullLoggerFactory(), null, null);
         var mock = new Mock<CustomPlugInContainerBase<ITestCustomPlugIn>>(manager);
         var exception = Assert.Throws<TargetInvocationException>(() =>
         {
@@ -36,7 +36,7 @@ public class CustomPlugInContainerTest
     [Test]
     public void GetPlugInFromCustomContainerWithRegisteredPlugInAfterRegistration()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), null);
+        var manager = new PlugInManager(null, new NullLoggerFactory(), null, null);
         var container = new CustomTestPlugInContainer(manager);
         manager.RegisterPlugIn<ITestCustomPlugIn, TestCustomPlugIn>();
 
@@ -50,7 +50,7 @@ public class CustomPlugInContainerTest
     [Test]
     public void GetPlugInFromCustomContainerWithInitiallyRegisteredPlugIn()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), null);
+        var manager = new PlugInManager(null, new NullLoggerFactory(), null, null);
         manager.RegisterPlugIn<ITestCustomPlugIn, TestCustomPlugIn>();
         var container = new CustomTestPlugInContainer(manager);
         var plugIn = container.GetPlugIn<ITestCustomPlugIn>();
@@ -63,7 +63,7 @@ public class CustomPlugInContainerTest
     [Test]
     public void DontGetPlugInFromCustomContainerAfterDeactivation()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), null);
+        var manager = new PlugInManager(null, new NullLoggerFactory(), null, null);
         manager.RegisterPlugIn<ITestCustomPlugIn, TestCustomPlugIn>();
         var container = new CustomTestPlugInContainer(manager);
         manager.DeactivatePlugIn<TestCustomPlugIn>();
@@ -77,7 +77,7 @@ public class CustomPlugInContainerTest
     [Test]
     public void DontGetPlugInFromCustomContainerIfItDoesntSuit()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), null);
+        var manager = new PlugInManager(null, new NullLoggerFactory(), null, null);
         var container = new CustomTestPlugInContainer(manager) { CreateNewPlugIns = false };
         manager.RegisterPlugIn<ITestCustomPlugIn, TestCustomPlugIn>();
         var plugIn = container.GetPlugIn<ITestCustomPlugIn>();
@@ -90,7 +90,7 @@ public class CustomPlugInContainerTest
     [Test]
     public void ReplacePlugInAtCustomContainer()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), null);
+        var manager = new PlugInManager(null, new NullLoggerFactory(), null, null);
         manager.RegisterPlugIn<ITestCustomPlugIn, TestCustomPlugIn>();
         var container = new CustomTestPlugInContainer(manager);
         manager.RegisterPlugIn<ITestCustomPlugIn, TestCustomPlugIn2>();
@@ -104,7 +104,7 @@ public class CustomPlugInContainerTest
     [Test]
     public void ReactivatePlugInAtCustomContainer()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), null);
+        var manager = new PlugInManager(null, new NullLoggerFactory(), null, null);
         manager.RegisterPlugIn<ITestCustomPlugIn, TestCustomPlugIn>();
         var container = new CustomTestPlugInContainer(manager);
         manager.RegisterPlugIn<ITestCustomPlugIn, TestCustomPlugIn2>();
@@ -119,7 +119,7 @@ public class CustomPlugInContainerTest
     [Test]
     public void GetPlugInFromCustomContainerWithAllImplementedInterfaces()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), null);
+        var manager = new PlugInManager(null, new NullLoggerFactory(), null, null);
         var container = new CustomTestPlugInContainer(manager);
         container.AddPlugIn(new TestCustomPlugIn2(), true);
         Assert.That(container.GetPlugIn<ITestCustomPlugIn>(), Is.Not.Null);

--- a/tests/MUnique.OpenMU.PlugIns.Tests/PlugInManagerTest.cs
+++ b/tests/MUnique.OpenMU.PlugIns.Tests/PlugInManagerTest.cs
@@ -21,7 +21,7 @@ public class PlugInManagerTest
     [Test]
     public void RegisteringPlugInCreatesProxy()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider());
+        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider(), null);
         manager.RegisterPlugIn<IExamplePlugIn, ExamplePlugIn>();
 
         var point = manager.GetPlugInPoint<IExamplePlugIn>();
@@ -35,7 +35,7 @@ public class PlugInManagerTest
     [Test]
     public async ValueTask RegisteredPlugInsActiveByDefaultAsync()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider());
+        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider(), null);
         var plugIn = new ExamplePlugIn();
         manager.RegisterPlugInAtPlugInPoint<IExamplePlugIn>(plugIn);
 
@@ -54,7 +54,7 @@ public class PlugInManagerTest
     [Test]
     public async ValueTask DeactivatingPlugInsAsync()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider());
+        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider(), null);
         var plugIn = new ExamplePlugIn();
         manager.RegisterPlugInAtPlugInPoint<IExamplePlugIn>(plugIn);
         manager.DeactivatePlugIn<ExamplePlugIn>();
@@ -74,7 +74,7 @@ public class PlugInManagerTest
     [Test]
     public async ValueTask DeactivatingDeactivatedPlugInAsync()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider());
+        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider(), null);
         var plugIn = new ExamplePlugIn();
         manager.RegisterPlugInAtPlugInPoint<IExamplePlugIn>(plugIn);
         manager.DeactivatePlugIn<ExamplePlugIn>();
@@ -95,7 +95,7 @@ public class PlugInManagerTest
     [Test]
     public async ValueTask ActivatingActivatedPlugInAsync()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider());
+        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider(), null);
         var plugIn = new ExamplePlugIn();
         manager.RegisterPlugInAtPlugInPoint<IExamplePlugIn>(plugIn);
         manager.ActivatePlugIn<ExamplePlugIn>();
@@ -116,7 +116,7 @@ public class PlugInManagerTest
     [Test]
     public async ValueTask DeactivatingOnePlugInDoesntAffectOthersAsync()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider());
+        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider(), null);
         var plugIn = new ExamplePlugIn();
         manager.RegisterPlugInAtPlugInPoint<IExamplePlugIn>(plugIn);
         manager.RegisterPlugIn<IExamplePlugIn, ExamplePlugIn.NestedPlugIn>();
@@ -146,7 +146,7 @@ public class PlugInManagerTest
             TypeId = typeof(ExamplePlugIn).GUID,
             IsActive = active,
         };
-        var manager = new PlugInManager(new List<PlugInConfiguration> { configuration }, new NullLoggerFactory(), this.CreateServiceProvider());
+        var manager = new PlugInManager(new List<PlugInConfiguration> { configuration }, new NullLoggerFactory(), this.CreateServiceProvider(), null);
         var player = await TestHelper.CreatePlayerAsync().ConfigureAwait(false);
         var command = "test";
         var args = new MyEventArgs();
@@ -191,7 +191,7 @@ public class PlugInManagerTest
                         }
                     }",
         };
-        var manager = new PlugInManager(new List<PlugInConfiguration> { configuration }, new NullLoggerFactory(), this.CreateServiceProvider());
+        var manager = new PlugInManager(new List<PlugInConfiguration> { configuration }, new NullLoggerFactory(), this.CreateServiceProvider(), null);
         var player = await TestHelper.CreatePlayerAsync().ConfigureAwait(false);
         var command = "test";
         var args = new MyEventArgs();
@@ -213,7 +213,7 @@ public class PlugInManagerTest
             IsActive = true,
             ExternalAssemblyName = "DoesNotExist.dll",
         };
-        _ = new PlugInManager(new List<PlugInConfiguration> { configuration }, new NullLoggerFactory(), this.CreateServiceProvider());
+        _ = new PlugInManager(new List<PlugInConfiguration> { configuration }, new NullLoggerFactory(), this.CreateServiceProvider(), null);
     }
 
     /// <summary>
@@ -227,7 +227,7 @@ public class PlugInManagerTest
             TypeId = new Guid("A9BDA3E2-4EB6-45C3-B234-37C1819C0CB6"),
             IsActive = true,
         };
-        _ = new PlugInManager(new List<PlugInConfiguration> { configuration }, new NullLoggerFactory(), this.CreateServiceProvider());
+        _ = new PlugInManager(new List<PlugInConfiguration> { configuration }, new NullLoggerFactory(), this.CreateServiceProvider(), null);
     }
 
     /// <summary>
@@ -236,7 +236,7 @@ public class PlugInManagerTest
     [Test]
     public void ActivatingUnknownPlugInDoesNotThrowError()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider());
+        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider(), null);
         manager.ActivatePlugIn(new Guid("4C38A813-F9BF-428A-8EA1-A6C90A87E583"));
     }
 
@@ -246,7 +246,7 @@ public class PlugInManagerTest
     [Test]
     public void DeactivatingUnknownPlugInDoesNotThrowError()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider());
+        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider(), null);
         manager.ActivatePlugIn(new Guid("4C38A813-F9BF-428A-8EA1-A6C90A87E583"));
     }
 
@@ -256,7 +256,7 @@ public class PlugInManagerTest
     [Test]
     public async ValueTask ActivatingPlugInsAsync()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider());
+        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider(), null);
         var plugIn = new ExamplePlugIn();
         manager.RegisterPlugInAtPlugInPoint<IExamplePlugIn>(plugIn);
         manager.DeactivatePlugIn<ExamplePlugIn>();
@@ -277,7 +277,7 @@ public class PlugInManagerTest
     [Test]
     public void AutoDiscovery()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider());
+        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider(), null);
         manager.DiscoverAndRegisterPlugIns();
         var examplePlugInPoint = manager.GetPlugInPoint<IExamplePlugIn>();
         Assert.That(examplePlugInPoint, Is.InstanceOf<IExamplePlugIn>());
@@ -289,7 +289,7 @@ public class PlugInManagerTest
     [Test]
     public void RegisteringPlugInWithoutGuidThrowsError()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider());
+        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider(), null);
         Assert.Throws<ArgumentException>(() => manager.RegisterPlugIn<IExamplePlugIn, ExamplePlugIn.NestedWithoutGuid>());
     }
 
@@ -299,7 +299,7 @@ public class PlugInManagerTest
     [Test]
     public void StrategyProviderCreatedForRegisteredStrategyPlugIn()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider());
+        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider(), null);
         manager.RegisterPlugIn<IExampleStrategyPlugIn, ExampleStrategyPlugIn>();
 
         var strategyProvider = manager.GetStrategyProvider<string, IExampleStrategyPlugIn>();
@@ -312,7 +312,7 @@ public class PlugInManagerTest
     [Test]
     public void StrategyProviderNotCreatedWithoutRegisteredStrategyPlugIn()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider());
+        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider(), null);
 
         var strategyProvider = manager.GetStrategyProvider<string, IExampleStrategyPlugIn>();
         Assert.That(strategyProvider, Is.Null);
@@ -324,7 +324,7 @@ public class PlugInManagerTest
     [Test]
     public void RegisteredStrategyPlugInAvailable()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider());
+        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider(), null);
         manager.RegisterPlugIn<IExampleStrategyPlugIn, ExampleStrategyPlugIn>();
 
         var strategy = manager.GetStrategy<IExampleStrategyPlugIn>(ExampleStrategyPlugIn.CommandKey);
@@ -338,7 +338,7 @@ public class PlugInManagerTest
     [Test]
     public void DeactivatedStrategyPlugInNotAvailable()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider());
+        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider(), null);
         manager.RegisterPlugIn<IExampleStrategyPlugIn, ExampleStrategyPlugIn>();
         manager.DeactivatePlugIn<ExampleStrategyPlugIn>();
         var strategy = manager.GetStrategy<IExampleStrategyPlugIn>(ExampleStrategyPlugIn.CommandKey);
@@ -351,7 +351,7 @@ public class PlugInManagerTest
     [Test]
     public void RegisteringRegisteredStrategyPlugInDoesntThrowError()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider());
+        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider(), null);
         manager.RegisterPlugIn<IExampleStrategyPlugIn, ExampleStrategyPlugIn>();
         manager.RegisterPlugIn<IExampleStrategyPlugIn, ExampleStrategyPlugIn>();
     }
@@ -362,7 +362,7 @@ public class PlugInManagerTest
     [Test]
     public void NoPlugInPointForStrategyPlugIn()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider());
+        var manager = new PlugInManager(null, new NullLoggerFactory(), this.CreateServiceProvider(), null);
         manager.RegisterPlugIn<IExampleStrategyPlugIn, ExampleStrategyPlugIn>();
         Assert.That(manager.GetPlugInPoint<IExampleStrategyPlugIn>(), Is.Null);
     }

--- a/tests/MUnique.OpenMU.PlugIns.Tests/PlugInProxyTypeGeneratorTest.cs
+++ b/tests/MUnique.OpenMU.PlugIns.Tests/PlugInProxyTypeGeneratorTest.cs
@@ -48,7 +48,7 @@ public class PlugInProxyTypeGeneratorTest
     public void ProxyIsCreated()
     {
         var generator = new PlugInProxyTypeGenerator();
-        var proxy = generator.GenerateProxy<IExamplePlugIn>(new PlugInManager(null, new NullLoggerFactory(), null));
+        var proxy = generator.GenerateProxy<IExamplePlugIn>(new PlugInManager(null, new NullLoggerFactory(), null, null));
 
         Assert.That(proxy, Is.Not.Null);
     }
@@ -60,7 +60,7 @@ public class PlugInProxyTypeGeneratorTest
     public async ValueTask MultiplePlugInsAreExecutedAsync()
     {
         var generator = new PlugInProxyTypeGenerator();
-        var proxy = generator.GenerateProxy<IExamplePlugIn>(new PlugInManager(null, NullLoggerFactory.Instance, null));
+        var proxy = generator.GenerateProxy<IExamplePlugIn>(new PlugInManager(null, NullLoggerFactory.Instance, null, null));
 
         var player = await TestHelper.CreatePlayerAsync().ConfigureAwait(false);
         var command = "test";
@@ -86,7 +86,7 @@ public class PlugInProxyTypeGeneratorTest
     public async ValueTask MultipleAsyncPlugInsAreExecutedAsync()
     {
         var generator = new PlugInProxyTypeGenerator();
-        var proxy = generator.GenerateProxy<IAsyncPlugIn>(new PlugInManager(null, NullLoggerFactory.Instance, null));
+        var proxy = generator.GenerateProxy<IAsyncPlugIn>(new PlugInManager(null, NullLoggerFactory.Instance, null, null));
 
         // Forcing to load NitoEx
         _ = new AsyncReaderWriterLock();
@@ -113,7 +113,7 @@ public class PlugInProxyTypeGeneratorTest
     public async ValueTask InactivePlugInsAreNotExecutedAsync()
     {
         var generator = new PlugInProxyTypeGenerator();
-        var proxy = generator.GenerateProxy<IExamplePlugIn>(new PlugInManager(null, NullLoggerFactory.Instance, null));
+        var proxy = generator.GenerateProxy<IExamplePlugIn>(new PlugInManager(null, NullLoggerFactory.Instance, null, null));
 
         var player = await TestHelper.CreatePlayerAsync().ConfigureAwait(false);
         var command = "test";
@@ -140,7 +140,7 @@ public class PlugInProxyTypeGeneratorTest
     public async ValueTask CancelEventArgsAreRespectedAsync()
     {
         var generator = new PlugInProxyTypeGenerator();
-        var proxy = generator.GenerateProxy<IExamplePlugIn>(new PlugInManager(null, NullLoggerFactory.Instance, null));
+        var proxy = generator.GenerateProxy<IExamplePlugIn>(new PlugInManager(null, NullLoggerFactory.Instance, null, null));
 
         var player = await TestHelper.CreatePlayerAsync().ConfigureAwait(false);
         var command = "test";
@@ -165,7 +165,7 @@ public class PlugInProxyTypeGeneratorTest
     public void ErrorForClasses()
     {
         var generator = new PlugInProxyTypeGenerator();
-        Assert.Throws<ArgumentException>(() => generator.GenerateProxy<ExamplePlugIn>(new PlugInManager(null, new NullLoggerFactory(), null)));
+        Assert.Throws<ArgumentException>(() => generator.GenerateProxy<ExamplePlugIn>(new PlugInManager(null, new NullLoggerFactory(), null, null)));
     }
 
     /// <summary>
@@ -175,7 +175,7 @@ public class PlugInProxyTypeGeneratorTest
     public void ErrorForInterfaceWithoutAttribute()
     {
         var generator = new PlugInProxyTypeGenerator();
-        Assert.Throws<ArgumentException>(() => generator.GenerateProxy<ICloneable>(new PlugInManager(null, new NullLoggerFactory(), null)));
+        Assert.Throws<ArgumentException>(() => generator.GenerateProxy<ICloneable>(new PlugInManager(null, new NullLoggerFactory(), null, null)));
     }
 
     /// <summary>
@@ -185,6 +185,6 @@ public class PlugInProxyTypeGeneratorTest
     public void ErrorForInterfaceWithUnsupportedMethodSignature()
     {
         var generator = new PlugInProxyTypeGenerator();
-        Assert.Throws<ArgumentException>(() => generator.GenerateProxy<IUnsupportedPlugIn>(new PlugInManager(null, new NullLoggerFactory(), null)));
+        Assert.Throws<ArgumentException>(() => generator.GenerateProxy<IUnsupportedPlugIn>(new PlugInManager(null, new NullLoggerFactory(), null, null)));
     }
 }

--- a/tests/MUnique.OpenMU.Tests/GuildActionTest.cs
+++ b/tests/MUnique.OpenMU.Tests/GuildActionTest.cs
@@ -164,7 +164,7 @@ public class GuildActionTest : GuildTestBase
             new InMemoryPersistenceContextProvider(),
             mapInitializer,
             new NullLoggerFactory(),
-            new PlugInManager(new List<PlugIns.PlugInConfiguration>(), new NullLoggerFactory(), null),
+            new PlugInManager(new List<PlugIns.PlugInConfiguration>(), new NullLoggerFactory(), null, null),
             NullDropGenerator.Instance,
             new ConfigurationChangeMediator());
         mapInitializer.PlugInManager = gameServer.PlugInManager;

--- a/tests/MUnique.OpenMU.Tests/PacketHandlerPlugInContainerTest.cs
+++ b/tests/MUnique.OpenMU.Tests/PacketHandlerPlugInContainerTest.cs
@@ -30,7 +30,7 @@ public class PacketHandlerPlugInContainerTest
     [Test]
     public void SelectPlugInOfCorrectVersionWhenExactVersionIsAvailable()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), null);
+        var manager = new PlugInManager(null, new NullLoggerFactory(), null, null);
         manager.RegisterPlugIn<IPacketHandlerPlugIn, PacketHandlerSeason1>();
         manager.RegisterPlugIn<IPacketHandlerPlugIn, PacketHandlerSeason6>();
         manager.RegisterPlugIn<IPacketHandlerPlugIn, PacketHandlerSeason9>();
@@ -48,7 +48,7 @@ public class PacketHandlerPlugInContainerTest
     [Test]
     public void SelectPlugInOfCorrectVersionWhenLowerVersionsAreAvailable()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), null);
+        var manager = new PlugInManager(null, new NullLoggerFactory(), null, null);
         manager.RegisterPlugIn<IPacketHandlerPlugIn, PacketHandlerSeason1>();
         manager.RegisterPlugIn<IPacketHandlerPlugIn, PacketHandlerSeason6>();
         var clientVersionProvider = new Mock<IClientVersionProvider>();
@@ -65,7 +65,7 @@ public class PacketHandlerPlugInContainerTest
     [Test]
     public void SelectPlugInOfCorrectLanguage()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), null);
+        var manager = new PlugInManager(null, new NullLoggerFactory(), null, null);
         manager.RegisterPlugIn<IPacketHandlerPlugIn, PacketHandlerSeason6Chinese>();
         manager.RegisterPlugIn<IPacketHandlerPlugIn, PacketHandlerSeason6>();
         var clientVersionProvider = new Mock<IClientVersionProvider>();
@@ -82,7 +82,7 @@ public class PacketHandlerPlugInContainerTest
     [Test]
     public void SelectInvariantPlugIn()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), null);
+        var manager = new PlugInManager(null, new NullLoggerFactory(), null, null);
         manager.RegisterPlugIn<IPacketHandlerPlugIn, PacketHandlerInvariant>();
         var clientVersionProvider = new Mock<IClientVersionProvider>();
         clientVersionProvider.Setup(p => p.ClientVersion).Returns(Season6E3English);
@@ -98,7 +98,7 @@ public class PacketHandlerPlugInContainerTest
     [Test]
     public void SelectPlugInAfterDeactivation()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), null);
+        var manager = new PlugInManager(null, new NullLoggerFactory(), null, null);
         manager.RegisterPlugIn<IPacketHandlerPlugIn, PacketHandlerSeason1>();
         manager.RegisterPlugIn<IPacketHandlerPlugIn, PacketHandlerSeason6>();
         var clientVersionProvider = new Mock<IClientVersionProvider>();
@@ -118,7 +118,7 @@ public class PacketHandlerPlugInContainerTest
     [Test]
     public void SelectLanguageSpecificOverInvariant()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), null);
+        var manager = new PlugInManager(null, new NullLoggerFactory(), null, null);
         manager.RegisterPlugIn<IPacketHandlerPlugIn, PacketHandlerSeason6>();
         manager.RegisterPlugIn<IPacketHandlerPlugIn, PacketHandlerSeason6Chinese>();
         manager.RegisterPlugIn<IPacketHandlerPlugIn, PacketHandlerSeason6English>();

--- a/tests/MUnique.OpenMU.Tests/PartyTest.cs
+++ b/tests/MUnique.OpenMU.Tests/PartyTest.cs
@@ -204,7 +204,7 @@ public class PartyTest
         gameConfig.Maps.Add(contextProvider.CreateNewContext().CreateNew<GameMapDefinition>());
 
         var mapInitializer = new MapInitializer(gameConfig, new NullLogger<MapInitializer>(), NullDropGenerator.Instance, null);
-        var gameContext = new GameContext(gameConfig, contextProvider, mapInitializer, new NullLoggerFactory(), new PlugInManager(new List<PlugInConfiguration>(), new NullLoggerFactory(), null), NullDropGenerator.Instance, new ConfigurationChangeMediator());
+        var gameContext = new GameContext(gameConfig, contextProvider, mapInitializer, new NullLoggerFactory(), new PlugInManager(new List<PlugInConfiguration>(), new NullLoggerFactory(), null, null), NullDropGenerator.Instance, new ConfigurationChangeMediator());
         gameContext.Configuration.MaximumPartySize = 5;
         mapInitializer.PlugInManager = gameContext.PlugInManager;
         mapInitializer.PathFinderPool = gameContext.PathFinderPool;

--- a/tests/MUnique.OpenMU.Tests/TestHelper.cs
+++ b/tests/MUnique.OpenMU.Tests/TestHelper.cs
@@ -43,7 +43,7 @@ public static class TestHelper
         gameConfig.Object.Maps.Add(map.Object);
 
         var mapInitializer = new MapInitializer(gameConfig.Object, new NullLogger<MapInitializer>(), NullDropGenerator.Instance, null);
-        var gameContext = new GameContext(gameConfig.Object, new InMemoryPersistenceContextProvider(), mapInitializer, new NullLoggerFactory(), new PlugInManager(null, new NullLoggerFactory(), null), NullDropGenerator.Instance, new ConfigurationChangeMediator());
+        var gameContext = new GameContext(gameConfig.Object, new InMemoryPersistenceContextProvider(), mapInitializer, new NullLoggerFactory(), new PlugInManager(null, new NullLoggerFactory(), null, null), NullDropGenerator.Instance, new ConfigurationChangeMediator());
         mapInitializer.PlugInManager = gameContext.PlugInManager;
         mapInitializer.PathFinderPool = gameContext.PathFinderPool;
         return await CreatePlayerAsync(gameContext).ConfigureAwait(false);

--- a/tests/MUnique.OpenMU.Tests/TradeTest.cs
+++ b/tests/MUnique.OpenMU.Tests/TradeTest.cs
@@ -90,7 +90,7 @@ public class TradeTest
         trader2.TradingPartner = trader1;
 
         var gameContext = new Mock<IGameContext>();
-        gameContext.Setup(c => c.PlugInManager).Returns(new PlugInManager(null, new NullLoggerFactory(), null));
+        gameContext.Setup(c => c.PlugInManager).Returns(new PlugInManager(null, new NullLoggerFactory(), null, null));
         gameContext.Setup(c => c.PersistenceContextProvider).Returns(new InMemoryPersistenceContextProvider());
 
         Mock.Get(trader1).Setup(m => m.GameContext).Returns(gameContext.Object);

--- a/tests/MUnique.OpenMU.Tests/ViewPlugInContainerTest.cs
+++ b/tests/MUnique.OpenMU.Tests/ViewPlugInContainerTest.cs
@@ -40,7 +40,7 @@ public class ViewPlugInContainerTest
     [Test]
     public void SelectPlugInOfCorrectVersionWhenExactVersionIsAvailable()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), null);
+        var manager = new PlugInManager(null, new NullLoggerFactory(), null, null);
         manager.RegisterPlugIn<ISomeViewPlugIn, Season1PlugIn>();
         manager.RegisterPlugIn<ISomeViewPlugIn, Season6PlugIn>();
         manager.RegisterPlugIn<ISomeViewPlugIn, Season9PlugIn>();
@@ -54,7 +54,7 @@ public class ViewPlugInContainerTest
     [Test]
     public void SelectPlugInOfCorrectVersionWhenLowerVersionsAreAvailable()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), null);
+        var manager = new PlugInManager(null, new NullLoggerFactory(), null, null);
         manager.RegisterPlugIn<ISomeViewPlugIn, InvariantSeasonPlugIn>();
         manager.RegisterPlugIn<ISomeViewPlugIn, Season1PlugIn>();
         manager.RegisterPlugIn<ISomeViewPlugIn, Season6PlugIn>();
@@ -68,7 +68,7 @@ public class ViewPlugInContainerTest
     [Test]
     public void SelectPlugInOfCorrectLanguage()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), null);
+        var manager = new PlugInManager(null, new NullLoggerFactory(), null, null);
         manager.RegisterPlugIn<ISomeViewPlugIn, Season6PlugInOfSomeOtherLanguage>();
         manager.RegisterPlugIn<ISomeViewPlugIn, Season6PlugIn>();
         var containerForSeason6English = new ViewPlugInContainer(this.CreatePlayer(manager), Season6E3English, manager);
@@ -81,7 +81,7 @@ public class ViewPlugInContainerTest
     [Test]
     public void SelectInvariantPlugIn()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), null);
+        var manager = new PlugInManager(null, new NullLoggerFactory(), null, null);
         manager.RegisterPlugIn<ISomeViewPlugIn, InvariantSeasonPlugIn>();
         var containerForSeason6English = new ViewPlugInContainer(this.CreatePlayer(manager), Season6E3English, manager);
         Assert.That(containerForSeason6English.GetPlugIn<ISomeViewPlugIn>()!.GetType(), Is.EqualTo(typeof(InvariantSeasonPlugIn)));
@@ -93,7 +93,7 @@ public class ViewPlugInContainerTest
     [Test]
     public void SelectPlugInAfterDeactivation()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), null);
+        var manager = new PlugInManager(null, new NullLoggerFactory(), null, null);
         manager.RegisterPlugIn<ISomeViewPlugIn, InvariantSeasonPlugIn>();
         manager.RegisterPlugIn<ISomeViewPlugIn, Season1PlugIn>();
         manager.RegisterPlugIn<ISomeViewPlugIn, Season6PlugIn>();
@@ -109,7 +109,7 @@ public class ViewPlugInContainerTest
     [Test]
     public void SelectLanguageSpecificOverInvariant()
     {
-        var manager = new PlugInManager(null, new NullLoggerFactory(), null);
+        var manager = new PlugInManager(null, new NullLoggerFactory(), null, null);
         manager.RegisterPlugIn<ISomeViewPlugIn, Season6PlugIn>();
         manager.RegisterPlugIn<ISomeViewPlugIn, Season6PlugInInvariant>();
         var containerForSeason9 = new ViewPlugInContainer(this.CreatePlayer(manager), Season9E2English, manager);


### PR DESCRIPTION
With #403 we noticed that it wasn't possible to add references to configration objects, such as `ItemDefinition` to custom plugin configurations. So, I added some infrastructure to support that.
It's working, but I don't like one thing about it yet: In the DI setup, we call some async code and wait for that to finish. So I keep this PR as Draft until I found a solution.
For a test I implemented a simple plugin config to fix #400.