### PR TITLE
Fix infinity arrow adding after quest completion

### DIFF
--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -4,7 +4,6 @@
 
 namespace MUnique.OpenMU.GameLogic;
 
-using System.Numerics;
 using System.Threading;
 using MUnique.OpenMU.AttributeSystem;
 using MUnique.OpenMU.DataModel.Attributes;

--- a/src/Persistence/Initialization/GameConfigurationInitializerBase.cs
+++ b/src/Persistence/Initialization/GameConfigurationInitializerBase.cs
@@ -39,6 +39,7 @@ public abstract class GameConfigurationInitializerBase : InitializerBase
     {
         this.GameConfiguration.ExperienceRate = 1.0f;
         this.GameConfiguration.MaximumLevel = 400;
+        this.GameConfiguration.MaximumMasterLevel = 400;
         this.GameConfiguration.InfoRange = 12;
         this.GameConfiguration.AreaSkillHitsPlayer = false;
         this.GameConfiguration.MaximumInventoryMoney = int.MaxValue;

--- a/src/Persistence/Initialization/Updates/InfinityArrowSkillOnQuestCompletionPlugIn.cs
+++ b/src/Persistence/Initialization/Updates/InfinityArrowSkillOnQuestCompletionPlugIn.cs
@@ -62,5 +62,6 @@ public class InfinityArrowSkillOnQuestCompletionPlugIn : UpdatePlugInBase
         skillReward.Value = 1;
         skillReward.SkillReward = gameConfiguration.Skills.First(s => s.Number == (short)SkillNumber.InfinityArrow);
         skillReward.RewardType = QuestRewardType.Skill;
+        quest.Rewards.Add(skillReward);
     }
 }

--- a/src/Persistence/Initialization/Updates/UpdateVersion.cs
+++ b/src/Persistence/Initialization/Updates/UpdateVersion.cs
@@ -83,5 +83,5 @@ public enum UpdateVersion
     /// <summary>
     /// The version of the <see cref="InfinityArrowSkillOnQuestCompletionPlugIn"/>.
     /// </summary>
-    InfinityArrowSkillOnQuestCompletion = 14,
+    InfinityArrowSkillOnQuestCompletion = 15,
 }

--- a/src/Persistence/Initialization/VersionSeasonSix/Quests.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Quests.cs
@@ -249,6 +249,7 @@ internal class Quests : InitializerBase
             skillReward.Value = 1;
             skillReward.SkillReward = this.GameConfiguration.Skills.First(s => s.Number == (short)SkillNumber.InfinityArrow);
             skillReward.RewardType = QuestRewardType.Skill;
+            heroStatus.Rewards.Add(skillReward);
         }
 
         heroStatus.Rewards.Add(pointReward);


### PR DESCRIPTION
Added two fixes for the problem, that the inifinity arrow skill didn't get add to the character after quest completion:
* Generally, stat attributes which are defined in the character class, but not in the character, are added automatically as soon as the player enters the game.
* Fixed initialization code. Since the inifinty arrow quest reward was the last database update, i just fixed that and increased its number.

Another minor fix was defining the maximum master level to the initialization code of season 6.