### PR TITLE
Fixed item set completion bonuses

### DIFF
--- a/src/DataModel/Configuration/Items/ItemSetGroup.cs
+++ b/src/DataModel/Configuration/Items/ItemSetGroup.cs
@@ -5,6 +5,7 @@
 namespace MUnique.OpenMU.DataModel.Configuration.Items;
 
 using MUnique.OpenMU.Annotations;
+using MUnique.OpenMU.DataModel.Entities;
 
 /// <summary>
 /// Defines an item set group. With (partial) completion of the set, additional options are getting applied.
@@ -28,8 +29,9 @@ public partial class ItemSetGroup
     public string Name { get; set; } = string.Empty;
 
     /// <summary>
-    /// Gets or sets a value indicating whether all of the options of this item set always apply.
-    /// If not, the minimum item count and the minimum set levels are respected.
+    /// Gets or sets a value indicating whether the options of this item set always apply to an item,
+    /// even if the group wasn't explicitly added to the <see cref="Item.ItemSetGroups"/>.
+    /// The minimum item count and the minimum set levels are respected.
     /// </summary>
     public bool AlwaysApplies { get; set; }
 
@@ -57,8 +59,7 @@ public partial class ItemSetGroup
     /// <remarks>
     /// The order is defined by <see cref="ItemOption.Number"/>.
     /// </remarks>
-    [MemberOfAggregate]
-    public virtual ICollection<IncreasableItemOption> Options { get; protected set; } = null!;
+    public virtual ItemOptionDefinition? Options { get; set; } = null!;
 
     /// <summary>
     /// Gets or sets the items of this set.

--- a/src/DataModel/GameConfigurationHelper.cs
+++ b/src/DataModel/GameConfigurationHelper.cs
@@ -34,7 +34,6 @@ public static class GameConfigurationHelper
         { typeof(ItemOptionDefinition), c => c.ItemOptions },
         {
             typeof(IncreasableItemOption), c => c.ItemOptions.SelectMany(o => o.PossibleOptions)
-                .Concat(c.ItemSetGroups.SelectMany(o => o.Options))
         },
         { typeof(ItemSetGroup), c => c.ItemSetGroups },
         { typeof(ItemOfItemSet), c => c.ItemSetGroups.SelectMany(o => o.Items) },

--- a/src/GameLogic/DefaultDropGenerator.cs
+++ b/src/GameLogic/DefaultDropGenerator.cs
@@ -42,7 +42,7 @@ public class DefaultDropGenerator : IDropGenerator
     {
         this._randomizer = randomizer;
         this._droppableItems = config.Items.Where(i => i.DropsFromMonsters).ToList();
-        this._ancientItems = this._droppableItems.Where(i => i.PossibleItemSetGroups.Any(o => o.Options.Any(o => o.OptionType == ItemOptionTypes.AncientOption))).ToList();
+        this._ancientItems = this._droppableItems.Where(i => i.PossibleItemSetGroups.Any(o => o.Options?.PossibleOptions.Any(o => o.OptionType == ItemOptionTypes.AncientOption) ?? false)).ToList();
     }
 
     /// <inheritdoc/>
@@ -327,7 +327,7 @@ public class DefaultDropGenerator : IDropGenerator
 
     private void ApplyRandomAncientOption(Item item)
     {
-        var ancientSet = item.Definition?.PossibleItemSetGroups.Where(g => g!.Options.Any(o => o.OptionType == ItemOptionTypes.AncientOption)).SelectRandom(this._randomizer);
+        var ancientSet = item.Definition?.PossibleItemSetGroups.Where(g => g!.Options?.PossibleOptions.Any(o => o.OptionType == ItemOptionTypes.AncientOption) ?? false).SelectRandom(this._randomizer);
         if (ancientSet is null)
         {
             return;

--- a/src/GameServer/RemoteView/IItemSerializer.cs
+++ b/src/GameServer/RemoteView/IItemSerializer.cs
@@ -305,7 +305,7 @@ public class ItemSerializer : IItemSerializer
         var bonusLevel = (ancientByte & AncientBonusLevelMask) >> 2;
         var setDiscriminator = ancientByte & AncientDiscriminatorMask;
         var ancientSets = item.Definition!.PossibleItemSetGroups
-            .Where(set => set.Options.Any(o => o.OptionType == ItemOptionTypes.AncientOption))
+            .Where(set => set.Options?.PossibleOptions.Any(o => o.OptionType == ItemOptionTypes.AncientOption) ?? false)
             .SelectMany(i => i.Items).Where(i => i.ItemDefinition == item.Definition)
             .Where(set => set.AncientSetDiscriminator == setDiscriminator).ToList();
         if (ancientSets.Count > 1)

--- a/src/Persistence/BasicModel/ItemSetGroup.Generated.cs
+++ b/src/Persistence/BasicModel/ItemSetGroup.Generated.cs
@@ -26,27 +26,6 @@ public partial class ItemSetGroup : MUnique.OpenMU.DataModel.Configuration.Items
     public Guid Id { get; set; }
     
     /// <summary>
-    /// Gets the raw collection of <see cref="Options" />.
-    /// </summary>
-    [System.Text.Json.Serialization.JsonPropertyName("options")]
-    public ICollection<IncreasableItemOption> RawOptions { get; } = new List<IncreasableItemOption>();
-    
-    /// <inheritdoc/>
-    [System.Text.Json.Serialization.JsonIgnore]
-    public override ICollection<MUnique.OpenMU.DataModel.Configuration.Items.IncreasableItemOption> Options
-    {
-        get => base.Options ??= new CollectionAdapter<MUnique.OpenMU.DataModel.Configuration.Items.IncreasableItemOption, IncreasableItemOption>(this.RawOptions);
-        protected set
-        {
-            this.Options.Clear();
-            foreach (var item in value)
-            {
-                this.Options.Add(item);
-            }
-        }
-    }
-
-    /// <summary>
     /// Gets the raw collection of <see cref="Items" />.
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("items")]
@@ -65,6 +44,24 @@ public partial class ItemSetGroup : MUnique.OpenMU.DataModel.Configuration.Items
                 this.Items.Add(item);
             }
         }
+    }
+
+    /// <summary>
+    /// Gets the raw object of <see cref="Options" />.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonPropertyName("options")]
+    public ItemOptionDefinition RawOptions
+    {
+        get => base.Options as ItemOptionDefinition;
+        set => base.Options = value;
+    }
+
+    /// <inheritdoc/>
+    [System.Text.Json.Serialization.JsonIgnore]
+    public override MUnique.OpenMU.DataModel.Configuration.Items.ItemOptionDefinition Options
+    {
+        get => base.Options;
+        set => base.Options = value;
     }
 
     /// <inheritdoc />

--- a/src/Persistence/EntityFramework/CachingRepositoryProvider.cs
+++ b/src/Persistence/EntityFramework/CachingRepositoryProvider.cs
@@ -59,8 +59,9 @@ internal class CachingRepositoryProvider : RepositoryProvider
 
         this.RegisterRepository(new ConfigurationTypeRepository<ItemOptionDefinition>(this._parent, this.LoggerFactory, config => config.RawItemOptions));
         this.RegisterRepository(new ConfigurationTypeRepository<IncreasableItemOption>(
-            this._parent, this.LoggerFactory,
-            config => config.RawItemOptions.SelectMany(o => o.RawPossibleOptions).Concat(config.RawItemSetGroups.SelectMany(g => g.RawOptions)).Distinct().ToList()));
+            this._parent,
+            this.LoggerFactory,
+            config => config.RawItemOptions.SelectMany(o => o.RawPossibleOptions).Distinct().ToList()));
         this.RegisterRepository(new ConfigurationTypeRepository<AttributeDefinition>(this._parent, this.LoggerFactory, config => config.RawAttributes));
         this.RegisterRepository(new ConfigurationTypeRepository<DropItemGroup>(this._parent, this.LoggerFactory, config => config.RawDropItemGroups));
         this.RegisterRepository(new ConfigurationTypeRepository<CharacterClass>(this._parent, this.LoggerFactory, config => config.RawCharacterClasses));

--- a/src/Persistence/EntityFramework/Migrations/20240602060055_FixItemOptions.Designer.cs
+++ b/src/Persistence/EntityFramework/Migrations/20240602060055_FixItemOptions.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MUnique.OpenMU.Persistence.EntityFramework;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
     [DbContext(typeof(EntityDataContext))]
-    partial class EntityDataContextModelSnapshot : ModelSnapshot
+    [Migration("20240602060055_FixItemOptions")]
+    partial class FixItemOptions
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -1138,6 +1141,9 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     b.Property<Guid?>("ItemOptionDefinitionId")
                         .HasColumnType("uuid");
 
+                    b.Property<Guid?>("ItemSetGroupId")
+                        .HasColumnType("uuid");
+
                     b.Property<int>("LevelType")
                         .HasColumnType("integer");
 
@@ -1156,6 +1162,8 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     b.HasKey("Id");
 
                     b.HasIndex("ItemOptionDefinitionId");
+
+                    b.HasIndex("ItemSetGroupId");
 
                     b.HasIndex("OptionTypeId");
 
@@ -1876,17 +1884,12 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                         .IsRequired()
                         .HasColumnType("text");
 
-                    b.Property<Guid?>("OptionsId")
-                        .HasColumnType("uuid");
-
                     b.Property<int>("SetLevel")
                         .HasColumnType("integer");
 
                     b.HasKey("Id");
 
                     b.HasIndex("GameConfigurationId");
-
-                    b.HasIndex("OptionsId");
 
                     b.ToTable("ItemSetGroup", "config");
                 });
@@ -3654,6 +3657,10 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                         .HasForeignKey("ItemOptionDefinitionId")
                         .OnDelete(DeleteBehavior.Cascade);
 
+                    b.HasOne("MUnique.OpenMU.Persistence.EntityFramework.Model.ItemSetGroup", null)
+                        .WithMany("RawOptions")
+                        .HasForeignKey("ItemSetGroupId");
+
                     b.HasOne("MUnique.OpenMU.Persistence.EntityFramework.Model.ItemOptionType", "RawOptionType")
                         .WithMany()
                         .HasForeignKey("OptionTypeId");
@@ -4059,12 +4066,6 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                         .WithMany("RawItemSetGroups")
                         .HasForeignKey("GameConfigurationId")
                         .OnDelete(DeleteBehavior.Cascade);
-
-                    b.HasOne("MUnique.OpenMU.Persistence.EntityFramework.Model.ItemOptionDefinition", "RawOptions")
-                        .WithMany()
-                        .HasForeignKey("OptionsId");
-
-                    b.Navigation("RawOptions");
                 });
 
             modelBuilder.Entity("MUnique.OpenMU.Persistence.EntityFramework.Model.ItemSlotType", b =>
@@ -4793,6 +4794,8 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
             modelBuilder.Entity("MUnique.OpenMU.Persistence.EntityFramework.Model.ItemSetGroup", b =>
                 {
                     b.Navigation("RawItems");
+
+                    b.Navigation("RawOptions");
                 });
 
             modelBuilder.Entity("MUnique.OpenMU.Persistence.EntityFramework.Model.ItemStorage", b =>

--- a/src/Persistence/EntityFramework/Migrations/20240602060055_FixItemOptions.cs
+++ b/src/Persistence/EntityFramework/Migrations/20240602060055_FixItemOptions.cs
@@ -1,0 +1,106 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixItemOptions : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_IncreasableItemOption_ItemSetGroup_ItemSetGroupId",
+                schema: "config",
+                table: "IncreasableItemOption");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_IncreasableItemOption_ItemSetGroup_ItemSetGroupId",
+                schema: "config",
+                table: "IncreasableItemOption",
+                column: "ItemSetGroupId",
+                principalSchema: "config",
+                principalTable: "ItemSetGroup",
+                principalColumn: "Id");
+
+            // First, we need to create the new item option definitions for the ancient sets
+            migrationBuilder.Sql(
+                """
+                INSERT INTO config."ItemOptionDefinition" ("Id", "GameConfigurationId", "Name", "AddsRandomly", "AddChance", "MaximumOptionsPerItem")
+                SELECT UUID(REPLACE(sets.setId, '00000092-','00000083-')), '00000001-0001-0000-0000-000000000000', sets.setName || ' (Ancient Set)', false, 0, 0
+                FROM
+                (
+                    SELECT COUNT(o."Id") c, text(o."ItemSetGroupId") setId, g."Name" setName
+                    FROM config."IncreasableItemOption" o, config."ItemSetGroup" g
+                    WHERE "ItemSetGroupId" is not null
+                      AND "ItemOptionDefinitionId" is null
+                      AND g."Id" = o."ItemSetGroupId"
+                    GROUP BY o."ItemSetGroupId", g."Name"
+                    ORDER BY c
+                ) sets
+                WHERE sets.c > 1
+                """);
+
+            // Then we need to update the item option definitions of the ancient sets,
+            // so that they belong to the previously created item option defintions
+            migrationBuilder.Sql(
+                """
+                UPDATE config."IncreasableItemOption" o
+                SET "ItemOptionDefinitionId" = UUID(REPLACE(TEXT(o."ItemSetGroupId"), '00000092-','00000083-'))
+                    WHERE o."ItemSetGroupId" is not null
+                      AND o."ItemOptionDefinitionId" is null
+                      AND o."OptionTypeId" is not null
+                """);
+
+            // Then what's left are the options for set completion of normal sets.
+            migrationBuilder.Sql(
+                """
+                INSERT INTO config."ItemOptionDefinition" ("Id", "GameConfigurationId", "Name", "AddsRandomly", "AddChance", "MaximumOptionsPerItem")
+                SELECT UUID(REPLACE(sets.optionId, '00000088-','00000083-')),
+                        '00000001-0001-0000-0000-000000000000',
+                        CASE WHEN sets.setLevel=0 THEN 'Complete Set Bonus (any level)'
+                            ELSE 'Complete Set Bonus (Level ' || sets.setLevel || ')'
+                        END,
+                        false, 0, 0
+                FROM
+                (
+                    SELECT text(o."Id") optionId, text(o."ItemSetGroupId") setId, g."Name" setName, g."SetLevel" setLevel
+                    FROM config."IncreasableItemOption" o, config."ItemSetGroup" g
+                    WHERE "ItemSetGroupId" is not null
+                      AND "ItemOptionDefinitionId" is null
+                      AND g."Id" = o."ItemSetGroupId"
+                    ORDER BY setLevel
+                ) sets
+                """);
+
+            // Then we need to update the item option definitions of the normal sets
+            // so that they belong to the previously created item option defintions
+            migrationBuilder.Sql(
+                """
+                UPDATE config."IncreasableItemOption" o
+                SET "ItemOptionDefinitionId" = UUID(REPLACE(TEXT(o."Id"), '00000088-','00000083-'))
+                    WHERE o."ItemOptionDefinitionId" is null
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_IncreasableItemOption_ItemSetGroup_ItemSetGroupId",
+                schema: "config",
+                table: "IncreasableItemOption");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_IncreasableItemOption_ItemSetGroup_ItemSetGroupId",
+                schema: "config",
+                table: "IncreasableItemOption",
+                column: "ItemSetGroupId",
+                principalSchema: "config",
+                principalTable: "ItemSetGroup",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/src/Persistence/EntityFramework/Migrations/20240602085237_FixItemOptions2.Designer.cs
+++ b/src/Persistence/EntityFramework/Migrations/20240602085237_FixItemOptions2.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MUnique.OpenMU.Persistence.EntityFramework;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
     [DbContext(typeof(EntityDataContext))]
-    partial class EntityDataContextModelSnapshot : ModelSnapshot
+    [Migration("20240602085237_FixItemOptions2")]
+    partial class FixItemOptions2
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Persistence/EntityFramework/Migrations/20240602085237_FixItemOptions2.cs
+++ b/src/Persistence/EntityFramework/Migrations/20240602085237_FixItemOptions2.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixItemOptions2 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_IncreasableItemOption_ItemSetGroup_ItemSetGroupId",
+                schema: "config",
+                table: "IncreasableItemOption");
+
+            migrationBuilder.DropIndex(
+                name: "IX_IncreasableItemOption_ItemSetGroupId",
+                schema: "config",
+                table: "IncreasableItemOption");
+
+            migrationBuilder.DropColumn(
+                name: "ItemSetGroupId",
+                schema: "config",
+                table: "IncreasableItemOption");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "OptionsId",
+                schema: "config",
+                table: "ItemSetGroup",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ItemSetGroup_OptionsId",
+                schema: "config",
+                table: "ItemSetGroup",
+                column: "OptionsId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_ItemSetGroup_ItemOptionDefinition_OptionsId",
+                schema: "config",
+                table: "ItemSetGroup",
+                column: "OptionsId",
+                principalSchema: "config",
+                principalTable: "ItemOptionDefinition",
+                principalColumn: "Id");
+
+            // Now we are left with ItemSetGroups which have no options assigned.
+            // Luckily, we can identify them by their UUIDs, they share the same pattern.
+            // First we care about ancient sets, which have the same id as the option definition,
+            // except in their prefix.
+            migrationBuilder.Sql(
+                """
+                UPDATE config."ItemSetGroup" s
+                  SET "OptionsId" = UUID(REPLACE(TEXT(s."Id"), '00000092-','00000083-'))
+                WHERE EXISTS(SELECT "Id" FROM config."ItemOptionDefinition" WHERE "Id" = UUID(REPLACE(TEXT(s."Id"), '00000092-','00000083-')) )
+                """);
+
+            // Then we look at the non-ancient sets.
+            migrationBuilder.Sql(
+                """
+                UPDATE config."ItemSetGroup" s SET
+                  "AlwaysApplies" = true,
+                  "OptionsId" = 
+                    CASE
+                      WHEN "SetLevel"=0 THEN uuid('00000083-0021-0000-0000-000000000000')
+                      ELSE uuid('00000083-0020-000' || to_hex("SetLevel") || '-0000-000000000000')
+                    END
+                WHERE "OptionsId" is null
+                """);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_ItemSetGroup_ItemOptionDefinition_OptionsId",
+                schema: "config",
+                table: "ItemSetGroup");
+
+            migrationBuilder.DropIndex(
+                name: "IX_ItemSetGroup_OptionsId",
+                schema: "config",
+                table: "ItemSetGroup");
+
+            migrationBuilder.DropColumn(
+                name: "OptionsId",
+                schema: "config",
+                table: "ItemSetGroup");
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "ItemSetGroupId",
+                schema: "config",
+                table: "IncreasableItemOption",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_IncreasableItemOption_ItemSetGroupId",
+                schema: "config",
+                table: "IncreasableItemOption",
+                column: "ItemSetGroupId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_IncreasableItemOption_ItemSetGroup_ItemSetGroupId",
+                schema: "config",
+                table: "IncreasableItemOption",
+                column: "ItemSetGroupId",
+                principalSchema: "config",
+                principalTable: "ItemSetGroup",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/src/Persistence/EntityFramework/Model/ExtendedTypeContext.Generated.cs
+++ b/src/Persistence/EntityFramework/Model/ExtendedTypeContext.Generated.cs
@@ -187,7 +187,6 @@ public class ExtendedTypeContext : Microsoft.EntityFrameworkCore.DbContext
         modelBuilder.Entity<ItemOptionCombinationBonus>().HasOne(entity => entity.RawBonus).WithOne().OnDelete(DeleteBehavior.Cascade);
         modelBuilder.Entity<ItemOptionDefinition>().HasMany(entity => entity.RawPossibleOptions).WithOne().OnDelete(DeleteBehavior.Cascade);
         modelBuilder.Entity<ItemOptionOfLevel>().HasOne(entity => entity.RawPowerUpDefinition).WithOne().OnDelete(DeleteBehavior.Cascade);
-        modelBuilder.Entity<ItemSetGroup>().HasMany(entity => entity.RawOptions).WithOne().OnDelete(DeleteBehavior.Cascade);
         modelBuilder.Entity<ItemSetGroup>().HasMany(entity => entity.RawItems).WithOne().OnDelete(DeleteBehavior.Cascade);
         modelBuilder.Entity<ItemCrafting>().HasOne(entity => entity.RawSimpleCraftingSettings).WithOne().OnDelete(DeleteBehavior.Cascade);
         modelBuilder.Entity<SimpleCraftingSettings>().HasMany(entity => entity.RawRequiredItems).WithOne().OnDelete(DeleteBehavior.Cascade);

--- a/src/Persistence/EntityFramework/Model/ItemSetGroup.Generated.cs
+++ b/src/Persistence/EntityFramework/Model/ItemSetGroup.Generated.cs
@@ -29,15 +29,6 @@ internal partial class ItemSetGroup : MUnique.OpenMU.DataModel.Configuration.Ite
     public Guid Id { get; set; }
     
     /// <summary>
-    /// Gets the raw collection of <see cref="Options" />.
-    /// </summary>
-    public ICollection<IncreasableItemOption> RawOptions { get; } = new EntityFramework.List<IncreasableItemOption>();
-    
-    /// <inheritdoc/>
-    [NotMapped]
-    public override ICollection<MUnique.OpenMU.DataModel.Configuration.Items.IncreasableItemOption> Options => base.Options ??= new CollectionAdapter<MUnique.OpenMU.DataModel.Configuration.Items.IncreasableItemOption, IncreasableItemOption>(this.RawOptions);
-
-    /// <summary>
     /// Gets the raw collection of <see cref="Items" />.
     /// </summary>
     public ICollection<ItemOfItemSet> RawItems { get; } = new EntityFramework.List<ItemOfItemSet>();
@@ -45,6 +36,32 @@ internal partial class ItemSetGroup : MUnique.OpenMU.DataModel.Configuration.Ite
     /// <inheritdoc/>
     [NotMapped]
     public override ICollection<MUnique.OpenMU.DataModel.Configuration.Items.ItemOfItemSet> Items => base.Items ??= new CollectionAdapter<MUnique.OpenMU.DataModel.Configuration.Items.ItemOfItemSet, ItemOfItemSet>(this.RawItems);
+
+    /// <summary>
+    /// Gets or sets the identifier of <see cref="Options"/>.
+    /// </summary>
+    public Guid? OptionsId { get; set; }
+
+    /// <summary>
+    /// Gets the raw object of <see cref="Options" />.
+    /// </summary>
+    [ForeignKey(nameof(OptionsId))]
+    public ItemOptionDefinition RawOptions
+    {
+        get => base.Options as ItemOptionDefinition;
+        set => base.Options = value;
+    }
+
+    /// <inheritdoc/>
+    [NotMapped]
+    public override MUnique.OpenMU.DataModel.Configuration.Items.ItemOptionDefinition Options
+    {
+        get => base.Options;set
+        {
+            base.Options = value;
+            this.OptionsId = this.RawOptions?.Id;
+        }
+    }
 
     /// <inheritdoc />
     public override MUnique.OpenMU.DataModel.Configuration.Items.ItemSetGroup Clone(MUnique.OpenMU.DataModel.Configuration.GameConfiguration gameConfiguration)

--- a/src/Persistence/Initialization/VersionSeasonSix/Items/AncientSets.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Items/AncientSets.cs
@@ -674,6 +674,10 @@ public class AncientSets : InitializerBase
         set.CountDistinct = true;
         set.MinimumItemCount = 2;
         int number = 1;
+        var options = this.Context.CreateNew<ItemOptionDefinition>();
+        options.SetGuid(ItemOptionDefinitionNumbers.AncientOption, setNumber, (byte)number);
+        options.Name = $"{name} (Ancient Set)";
+        set.Options = options;
         foreach (var optionTuple in ancientOptions)
         {
             var option = this.Context.CreateNew<IncreasableItemOption>();
@@ -684,7 +688,7 @@ public class AncientSets : InitializerBase
             option.PowerUpDefinition.TargetAttribute = optionTuple.Attribute.GetPersistent(this.GameConfiguration);
             option.PowerUpDefinition.Boost = this.Context.CreateNew<PowerUpDefinitionValue>();
             option.PowerUpDefinition.Boost.ConstantValue.Value = optionTuple.Value;
-            set.Options.Add(option);
+            options.PossibleOptions.Add(option);
         }
 
         this.GameConfiguration.ItemSetGroups.Add(set);

--- a/tests/MUnique.OpenMU.Tests/PowerUpFactoryTest.cs
+++ b/tests/MUnique.OpenMU.Tests/PowerUpFactoryTest.cs
@@ -318,12 +318,16 @@ public class PowerUpFactoryTest
 
     private IEnumerable<Item> GetDefenseBonusSet(float setBonusDefense, byte minimumLevel, params byte[] levels)
     {
+        var itemOptionDef = new Mock<ItemOptionDefinition>();
+        itemOptionDef.Setup(a => a.PossibleOptions).Returns(new List<IncreasableItemOption>());
+        itemOptionDef.Object.PossibleOptions.Add(this.GetOption(Stats.DefenseBase, setBonusDefense).ItemOption!);
+
         var armorSet = new Mock<ItemSetGroup>();
         armorSet.Setup(a => a.Items).Returns(new List<ItemOfItemSet>());
-        armorSet.Setup(a => a.Options).Returns(new List<IncreasableItemOption>());
+        armorSet.Object.Options = itemOptionDef.Object;
         armorSet.Object.MinimumItemCount = levels.Length;
         armorSet.Object.SetLevel = minimumLevel;
-        armorSet.Object.Options.Add(this.GetOption(Stats.DefenseBase, setBonusDefense).ItemOption!);
+        
         foreach (var level in levels)
         {
             var item = this.GetItem();
@@ -338,15 +342,18 @@ public class PowerUpFactoryTest
 
     private IEnumerable<Item> GetAncientSet(int ancientOptionCount, int itemCount)
     {
+        var itemOptionDef = new Mock<ItemOptionDefinition>();
+        itemOptionDef.Setup(a => a.PossibleOptions).Returns(new List<IncreasableItemOption>());
         var ancientSet = new Mock<ItemSetGroup>();
         ancientSet.Setup(a => a.Items).Returns(new List<ItemOfItemSet>());
-        ancientSet.Setup(a => a.Options).Returns(new List<IncreasableItemOption>());
+
+        ancientSet.Object.Options = itemOptionDef.Object;
         ancientSet.Object.MinimumItemCount = 2;
         for (int i = 0; i < ancientOptionCount; i++)
         {
             var setOption = this.GetOption(Stats.DefenseBase, i + 10).ItemOption;
             setOption!.Number = i + 1;
-            ancientSet.Object.Options.Add(setOption);
+            itemOptionDef.Object.PossibleOptions.Add(setOption);
         }
 
         var bonusOption = this.GetOption(Stats.TotalStrength, 5).ItemOption;


### PR DESCRIPTION
This fixes a major design flaw in the data model.
ItemSets now have a reference to a ItemOptionDefinition instead of a collection of options. This way, we have a clean way to define set options without many-to-many references to IncreasableItemOption. This also solves the multiple foreign keys in the IncreasableItemOption table and different options for the composition root.

Had to introduce some sql at the ef migrations to fix existing data.