### PR TITLE
Fixed invisible monsters

### DIFF
--- a/src/GameLogic/MapInitializer.cs
+++ b/src/GameLogic/MapInitializer.cs
@@ -138,6 +138,7 @@ public class MapInitializer : IMapInitializer
                 await createdMap.RemoveAsync(o).ConfigureAwait(false);
                 o.Initialize();
                 await createdMap.AddAsync(o).ConfigureAwait(false);
+                o.OnSpawn();
 
                 if (this._spawnedMonsters.TryGetValue(area, out var previousSpawnCount))
                 {
@@ -275,6 +276,7 @@ public class MapInitializer : IMapInitializer
             npc.SpawnIndex = spawnIndex;
             npc.Initialize();
             await createdMap.AddAsync(npc).ConfigureAwait(false);
+            npc.OnSpawn();
             if (spawnArea.SpawnTrigger is SpawnTrigger.Automatic or SpawnTrigger.Wandering)
             {
                 this.RegisterForConfigChanges(createdMap, spawnArea, npc);

--- a/src/GameLogic/NPC/AttackableNpcBase.cs
+++ b/src/GameLogic/NPC/AttackableNpcBase.cs
@@ -237,6 +237,7 @@ public abstract class AttackableNpcBase : NonPlayerCharacter, IAttackable
 
             this.Initialize();
             await this.CurrentMap.RespawnAsync(this).ConfigureAwait(false);
+            this.OnSpawn();
         }
         catch (Exception ex)
         {

--- a/src/GameLogic/NPC/Monster.cs
+++ b/src/GameLogic/NPC/Monster.cs
@@ -41,6 +41,8 @@ public sealed class Monster : AttackableNpcBase, IAttackable, IAttacker, ISuppor
 
     private bool _isCalculatingPath;
 
+    private bool _isReadyToWalk;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="Monster" /> class.
     /// </summary>
@@ -77,7 +79,6 @@ public sealed class Monster : AttackableNpcBase, IAttackable, IAttacker, ISuppor
     /// </summary>
     public Player? SummonedBy => (this._intelligence as SummonedMonsterIntelligence)?.Owner;
 
-    /// <inheritdoc/>
     public Point WalkTarget => this._walker.CurrentTarget;
 
     /// <inheritdoc/>
@@ -104,13 +105,20 @@ public sealed class Monster : AttackableNpcBase, IAttackable, IAttacker, ISuppor
         }
     }
 
+    /// <inheritdoc />
+    public override void OnSpawn()
+    {
+        base.OnSpawn();
+        this._isReadyToWalk = true;
+    }
+
     /// <summary>
     /// Walks to the target coordinates.
     /// </summary>
     /// <param name="target">The target object.</param>
     public async ValueTask<bool> WalkToAsync(Point target)
     {
-        if (this._isCalculatingPath || this.IsWalking)
+        if (this._isCalculatingPath || this.IsWalking || !this._isReadyToWalk)
         {
             return false;
         }
@@ -215,6 +223,11 @@ public sealed class Monster : AttackableNpcBase, IAttackable, IAttacker, ISuppor
     /// </summary>
     internal async ValueTask RandomMoveAsync()
     {
+        if (!this._isReadyToWalk)
+        {
+            return;
+        }
+
         byte randx = (byte)GameLogic.Rand.NextInt(Math.Max(0, this.Position.X - 1), Math.Min(0xFF, this.Position.X + 2));
         byte randy = (byte)GameLogic.Rand.NextInt(Math.Max(0, this.Position.Y - 1), Math.Min(0xFF, this.Position.Y + 2));
         if (this.CurrentMap.Terrain.AIgrid[randx, randy] == 1)

--- a/src/GameLogic/NPC/NonPlayerCharacter.cs
+++ b/src/GameLogic/NPC/NonPlayerCharacter.cs
@@ -96,6 +96,14 @@ public class NonPlayerCharacter : AsyncDisposable, IObservable, IRotatable, ILoc
         this.Rotation = GetSpawnDirection(this.SpawnArea.Direction);
     }
 
+    /// <summary>
+    /// Called when this instance spawned on the map.
+    /// </summary>
+    public virtual void OnSpawn()
+    {
+        // can be overwritten
+    }
+
     /// <inheritdoc/>
     public async ValueTask AddObserverAsync(IWorldObserver observer)
     {

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -901,6 +901,7 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         if (this.Summon?.Item1 is { IsAlive: true } summon)
         {
             await this.CurrentMap.AddAsync(summon).ConfigureAwait(false);
+            summon.OnSpawn();
         }
     }
 
@@ -1321,6 +1322,7 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         this.Summon = (monster, intelligence);
         monster.Initialize();
         await gameMap.AddAsync(monster).ConfigureAwait(false);
+        monster.OnSpawn();
     }
 
     /// <summary>


### PR DESCRIPTION
They occur when a freshly spawned monster starts a walk before it has been added to be observed by the player object.
In this case, `ObserverToWorldViewAdapter.LocateableRemovedAsync` leaves early, because the `NewBucket` is not null and the player is observing this bucket already.
Therefore, we can only start to walk, when the monster was safely added to the observing players before.