### PR TITLE
Use persistence context for lookups where possible

### DIFF
--- a/src/Persistence/EntityFramework/EntityFrameworkContextBase.cs
+++ b/src/Persistence/EntityFramework/EntityFrameworkContextBase.cs
@@ -220,6 +220,34 @@ internal class EntityFrameworkContextBase : IContext
     }
 
     /// <inheritdoc/>
+    public bool IsSupporting(Type type)
+    {
+        var currentSearchType = type;
+        do
+        {
+            if (currentSearchType is null)
+            {
+                break;
+            }
+
+            if (this.Context.Model.FindLeastDerivedEntityTypes(currentSearchType).FirstOrDefault() is not null)
+            {
+                return true;
+            }
+
+            if (currentSearchType.Name != currentSearchType.BaseType?.Name)
+            {
+                break;
+            }
+
+            currentSearchType = currentSearchType.BaseType;
+        }
+        while (currentSearchType != typeof(object));
+
+        return false;
+    }
+
+    /// <inheritdoc/>
     public void Dispose()
     {
         if (!this._isDisposed)

--- a/src/Persistence/IContext.cs
+++ b/src/Persistence/IContext.cs
@@ -112,4 +112,14 @@ public interface IContext : IDisposable
     /// <param name="type">The type.</param>
     /// <returns>All objects of the specified type.</returns>
     ValueTask<IEnumerable> GetAsync(Type type);
+
+    /// <summary>
+    /// Determines whether the specified type is supported by this instance.
+    /// This is usually the case for a type of the object tree of the owner.
+    /// </summary>
+    /// <param name="type">The type.</param>
+    /// <returns>
+    ///   <c>true</c> if the specified type is supported; otherwise, <c>false</c>.
+    /// </returns>
+    bool IsSupporting(Type type);
 }

--- a/src/Persistence/InMemory/InMemoryContext.cs
+++ b/src/Persistence/InMemory/InMemoryContext.cs
@@ -157,4 +157,10 @@ public class InMemoryContext : IContext
     {
         return this.Provider.GetRepository(type).GetAllAsync();
     }
+
+    /// <inheritdoc/>
+    public bool IsSupporting(Type type)
+    {
+        return true;
+    }
 }

--- a/src/Web/AdminPanel/Components/Form/ItemTable.razor.cs
+++ b/src/Web/AdminPanel/Components/Form/ItemTable.razor.cs
@@ -68,7 +68,9 @@ public partial class ItemTable<TItem>
 
     private async Task OnAddClickAsync()
     {
-        var modal = this._modal.Show<ModalObjectSelection<TItem>>($"Select {typeof(TItem).Name}");
+        var parameters = new ModalParameters();
+        parameters.Add(nameof(ModalCreateNew<TItem>.PersistenceContext), this.PersistenceContext);
+        var modal = this._modal.Show<ModalObjectSelection<TItem>>($"Select {typeof(TItem).Name}", parameters);
         var result = await modal.Result.ConfigureAwait(false);
         if (!result.Cancelled && result.Data is TItem item)
         {

--- a/src/Web/AdminPanel/Components/Form/LookupField.razor
+++ b/src/Web/AdminPanel/Components/Form/LookupField.razor
@@ -10,7 +10,7 @@
     <FieldLabel Text="@Label" ValueExpression="@this.ValueExpression" />
     <BlazoredTypeahead TItem="TObject" TValue="TObject"
                        @bind-Value="@this.CurrentValue"
-                       SearchMethod="@(text => this.EffectiveLookupController.GetSuggestionsAsync<TObject>(text, null))"
+                       SearchMethod="@(text => this.EffectiveLookupController.GetSuggestionsAsync<TObject>(text, this.PersistenceContext))"
                        EnableDropDown="true"
                        MaximumSuggestions="20"
                        placeholder="Search ..."

--- a/src/Web/AdminPanel/Components/Form/ModalObjectSelection.razor
+++ b/src/Web/AdminPanel/Components/Form/ModalObjectSelection.razor
@@ -3,8 +3,10 @@
 @inject IModalService _modalService;
 
 <EditForm Model="@this">
+  <CascadingValue Value="@this.PersistenceContext">
     <LookupField TObject="TItem" @bind-Value="@Item" Label="@typeof(TItem).Name"/>
+  </CascadingValue>
 
-    <button type="submit" @onclick="@SubmitAsync" class="btn-primary">OK</button>
-    <button @onclick="@CancelAsync" class="btn-secondary">Cancel</button>
+  <button type="submit" @onclick="@SubmitAsync" class="btn-primary">OK</button>
+  <button @onclick="@CancelAsync" class="btn-secondary">Cancel</button>
 </EditForm>

--- a/src/Web/AdminPanel/Components/Form/ModalObjectSelection.razor.cs
+++ b/src/Web/AdminPanel/Components/Form/ModalObjectSelection.razor.cs
@@ -8,6 +8,7 @@ using System.ComponentModel.DataAnnotations;
 using Blazored.Modal;
 using Blazored.Modal.Services;
 using Microsoft.AspNetCore.Components;
+using MUnique.OpenMU.Persistence;
 using MUnique.OpenMU.Web.AdminPanel.Services;
 
 /// <summary>
@@ -29,6 +30,12 @@ public partial class ModalObjectSelection<TItem>
     /// </summary>
     [CascadingParameter]
     public BlazoredModalInstance BlazoredModal { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the persistence context which should be used. It's required for lookups.
+    /// </summary>
+    [Parameter]
+    public IContext PersistenceContext { get; set; } = null!;
 
     private Task SubmitAsync()
     {

--- a/src/Web/AdminPanel/Components/ItemEdit/ItemEdit.razor
+++ b/src/Web/AdminPanel/Components/ItemEdit/ItemEdit.razor
@@ -158,7 +158,7 @@
                 <LookupField
                     Label="@socket.Caption"
                 @bind-Value="@socket.Option"
-                ExplicitLookupController="new EnumerableLookupController(this._viewModel.PossibleSocketOptions)"></LookupField>
+                ExplicitLookupController=@(new EnumerableLookupController(this._viewModel.PossibleSocketOptions))></LookupField>
             @if (socket.Option is { } socketOption)
             {
                 <NumberField

--- a/src/Web/AdminPanel/Services/PersistentObjectsLookupController.cs
+++ b/src/Web/AdminPanel/Services/PersistentObjectsLookupController.cs
@@ -49,7 +49,8 @@ public class PersistentObjectsLookupController : ILookupController
 
             var owner = await this._gameConfigurationSource.GetOwnerAsync();
             IEnumerable<T> values;
-            if (this._gameConfigurationSource.IsSupporting(typeof(T)))
+            if (this._gameConfigurationSource.IsSupporting(typeof(T))
+                && persistenceContext?.IsSupporting(typeof(T)) is not true)
             {
                 values = this._gameConfigurationSource.GetAll<T>();
             }


### PR DESCRIPTION
Fixes this issue, reported by the community:
`when trying to add jewel of chaos do another drop item group`:
![grafik](https://github.com/MUnique/OpenMU/assets/5238610/d8285c75-f51f-4ca0-923c-cd18d2b70b55)
