### PR TITLE
Fixed random moves

### DIFF
--- a/src/GameLogic/NPC/Monster.cs
+++ b/src/GameLogic/NPC/Monster.cs
@@ -237,16 +237,7 @@ public sealed class Monster : AttackableNpcBase, IAttackable, IAttacker, ISuppor
         var target = new Point(randx, randy);
         if (this._intelligence.CanWalkOn(target))
         {
-            var current = this.Position;
-            using var stepsRent = MemoryPool<WalkingStep>.Shared.Rent(1);
-            var steps = stepsRent.Memory.Slice(0, 1);
-            steps.Span[0] = new WalkingStep
-            {
-                From = current,
-                To = target,
-                Direction = current.GetDirectionTo(target),
-            };
-            await this.WalkToAsync(target, steps).ConfigureAwait(false);
+            await this.WalkToAsync(target).ConfigureAwait(false);
         }
     }
 


### PR DESCRIPTION
After some recent changes, we have to calculate the path. Otherwise, monsters with a big WalkRange can "teleport" to other places of the map.