### PR TITLE
Fixed ancient drops from chaos castle.

### DIFF
--- a/src/GameLogic/DefaultDropGenerator.cs
+++ b/src/GameLogic/DefaultDropGenerator.cs
@@ -135,17 +135,9 @@ public class DefaultDropGenerator : IDropGenerator
 
         item.Level = Math.Min(item.Level, item.Definition!.MaximumItemLevel);
 
-        if (selectedGroup.ItemType == SpecialItemType.Ancient)
-        {
-            this.ApplyRandomAncientOption(item);
-        }
-        else if (selectedGroup.ItemType == SpecialItemType.Excellent)
+        if (selectedGroup.ItemType == SpecialItemType.Excellent)
         {
             this.AddRandomExcOptions(item);
-        }
-        else
-        {
-            // nothing to add, others make no sense here.
         }
 
         return item;


### PR DESCRIPTION
The ancient option should only be added once, not twice.