### PR TITLE
Fix wizardry dmg calc

### DIFF
--- a/src/GameLogic/AttackableExtensions.cs
+++ b/src/GameLogic/AttackableExtensions.cs
@@ -127,7 +127,7 @@ public static class AttackableExtensions
     /// <param name="attributes">The attributes.</param>
     /// <param name="attacker">The attacker.</param>
     /// <returns>The calculated hit info.</returns>
-    public static HitInfo GetHitInfo(this IAttackable defender, uint damage, DamageAttributes attributes,  IAttacker attacker)
+    public static HitInfo GetHitInfo(this IAttackable defender, uint damage, DamageAttributes attributes, IAttacker attacker)
     {
         var shieldBypass = Rand.NextRandomBool(attacker.Attributes[Stats.ShieldBypassChance]);
         if (shieldBypass || defender.Attributes[Stats.CurrentShield] < 1)
@@ -486,7 +486,7 @@ public static class AttackableExtensions
 
             var skillDamage = skill.GetDamage();
             minimumBaseDamage += skillDamage;
-            maximumBaseDamage += skillDamage;
+            maximumBaseDamage += skillDamage + (skillDamage / 2);
 
             if (skill.Skill.SkillType == SkillType.Nova)
             {
@@ -561,7 +561,7 @@ public static class AttackableExtensions
             // coordinates, we simply update the position on the client side.
             if (walkSupporter is IObservable observable)
             {
-                await observable.ForEachWorldObserverAsync<IObjectMovedPlugIn> (p => p.ObjectMovedAsync(walkSupporter, MoveType.Instant), true).ConfigureAwait(false);
+                await observable.ForEachWorldObserverAsync<IObjectMovedPlugIn>(p => p.ObjectMovedAsync(walkSupporter, MoveType.Instant), true).ConfigureAwait(false);
             }
         }
     }


### PR DESCRIPTION
Based on the files opened in the sven client, I have been able to confirm that the "maximumBaseDamage" value should also be equal to half of the "skillDamage" value.

client info:
![image](https://github.com/user-attachments/assets/5c851a42-57c6-4ee7-99e3-e91003433958)

server info:
![image](https://github.com/user-attachments/assets/de77ae48-b30f-46e3-9548-f4de425b6499)

