### PR TITLE
Improvements for the network code

### DIFF
--- a/src/Network/Connection.cs
+++ b/src/Network/Connection.cs
@@ -193,8 +193,8 @@ public sealed class Connection : PacketPipeReaderBase, IConnection
     /// Reads the mu online packet by raising <see cref="PacketReceived" />.
     /// </summary>
     /// <param name="packet">The mu online packet.</param>
-    /// <returns>The async task.</returns>
-    protected override async ValueTask ReadPacketAsync(ReadOnlySequence<byte> packet)
+    /// <returns><see langword="true" />, if the flush was successful or not required.<see langword="false" />, if the pipe reader is completed and no longer reading data.</returns>
+    protected override async ValueTask<bool> ReadPacketAsync(ReadOnlySequence<byte> packet)
     {
         IncomingBytesCounter.Add(packet.Length);
 
@@ -205,6 +205,7 @@ public sealed class Connection : PacketPipeReaderBase, IConnection
         try
         {
             await this.PacketReceived.SafeInvokeAsync(packet).ConfigureAwait(false);
+            return true;
         }
         finally
         {

--- a/src/Network/ExtendedPipeWriter.cs
+++ b/src/Network/ExtendedPipeWriter.cs
@@ -9,7 +9,7 @@ using System.IO.Pipelines;
 using System.Threading;
 
 /// <summary>
-/// A wrapper for an existing <see cref="PipeWriter"/>, which flushes the advanced bytes automatically.
+/// A wrapper for an existing <see cref="PipeWriter"/>, which has metrics about the written bytes.
 /// </summary>
 public class ExtendedPipeWriter : PipeWriter
 {

--- a/src/Network/SimpleModulus/PipelinedSimpleModulusDecryptor.cs
+++ b/src/Network/SimpleModulus/PipelinedSimpleModulusDecryptor.cs
@@ -80,8 +80,8 @@ public class PipelinedSimpleModulusDecryptor : PipelinedSimpleModulusBase, IPipe
     /// Decrypts the packet and writes it into our pipe.
     /// </summary>
     /// <param name="packet">The mu online packet.</param>
-    /// <returns>The async task.</returns>
-    protected override async ValueTask ReadPacketAsync(ReadOnlySequence<byte> packet)
+    /// <returns><see langword="true" />, if the flush was successful or not required.<see langword="false" />, if the pipe reader is completed and no longer reading data.</returns>
+    protected override async ValueTask<bool> ReadPacketAsync(ReadOnlySequence<byte> packet)
     {
         // The next line is getting a span from the writer which is at least as big as the packet.
         // As I found out, it's initially about 2 kb in size and gets smaller within further
@@ -92,7 +92,7 @@ public class PipelinedSimpleModulusDecryptor : PipelinedSimpleModulusBase, IPipe
         {
             // we just have to write-through
             this.CopyDataIntoWriter(this.Pipe.Writer, packet);
-            await this.Pipe.Writer.FlushAsync().ConfigureAwait(false);
+            return await this.TryFlushWriterAsync(this.Pipe.Writer).ConfigureAwait(false);
         }
         else
         {
@@ -105,7 +105,7 @@ public class PipelinedSimpleModulusDecryptor : PipelinedSimpleModulusBase, IPipe
             }
 
             this.DecryptAndWrite(packet);
-            await this.Pipe.Writer.FlushAsync().ConfigureAwait(false);
+            return await this.TryFlushWriterAsync(this.Pipe.Writer).ConfigureAwait(false);
         }
     }
 

--- a/src/Network/SimpleModulus/PipelinedSimpleModulusEncryptor.cs
+++ b/src/Network/SimpleModulus/PipelinedSimpleModulusEncryptor.cs
@@ -73,7 +73,7 @@ public class PipelinedSimpleModulusEncryptor : PipelinedSimpleModulusBase, IPipe
     }
 
     /// <inheritdoc />
-    protected override async ValueTask ReadPacketAsync(ReadOnlySequence<byte> packet)
+    protected override async ValueTask<bool> ReadPacketAsync(ReadOnlySequence<byte> packet)
     {
         packet.Slice(0, this.HeaderBuffer.Length).CopyTo(this.HeaderBuffer);
 
@@ -81,12 +81,11 @@ public class PipelinedSimpleModulusEncryptor : PipelinedSimpleModulusBase, IPipe
         {
             // we just have to write-through
             this.CopyDataIntoWriter(this._target, packet);
-            await this._target.FlushAsync().ConfigureAwait(false);
-            return;
+            return await this.TryFlushWriterAsync(this._target).ConfigureAwait(false);
         }
 
         this.EncryptAndWrite(packet);
-        await this._target.FlushAsync().ConfigureAwait(false);
+        return await this.TryFlushWriterAsync(this._target).ConfigureAwait(false);
     }
 
     /// <summary>

--- a/src/Network/Xor/PipelinedXor32Decryptor.cs
+++ b/src/Network/Xor/PipelinedXor32Decryptor.cs
@@ -56,11 +56,11 @@ public class PipelinedXor32Decryptor : PacketPipeReaderBase, IPipelinedDecryptor
     /// Decrypts the packet and writes it into our pipe.
     /// </summary>
     /// <param name="packet">The mu online packet.</param>
-    /// <returns>The async task.</returns>
-    protected override async ValueTask ReadPacketAsync(ReadOnlySequence<byte> packet)
+    /// <returns><see langword="true" />, if the flush was successful or not required.<see langword="false" />, if the pipe reader is completed and no longer reading data.</returns>
+    protected override async ValueTask<bool> ReadPacketAsync(ReadOnlySequence<byte> packet)
     {
         this.DecryptAndWrite(packet);
-        await this._pipe.Writer.FlushAsync().ConfigureAwait(false);
+        return await this.TryFlushWriterAsync(this._pipe.Writer).ConfigureAwait(false);
     }
 
     private void DecryptAndWrite(ReadOnlySequence<byte> packet)

--- a/src/Network/Xor/PipelinedXor32Encryptor.cs
+++ b/src/Network/Xor/PipelinedXor32Encryptor.cs
@@ -58,11 +58,11 @@ public class PipelinedXor32Encryptor : PacketPipeReaderBase, IPipelinedEncryptor
     /// Encrypts the packet and writes it into the target.
     /// </summary>
     /// <param name="packet">The mu online packet.</param>
-    /// <returns>The async task.</returns>
-    protected override async ValueTask ReadPacketAsync(ReadOnlySequence<byte> packet)
+    /// <returns><see langword="true" />, if the flush was successful or not required.<see langword="false" />, if the pipe reader is completed and no longer reading data.</returns>
+    protected override async ValueTask<bool> ReadPacketAsync(ReadOnlySequence<byte> packet)
     {
         this.EncryptAndWrite(packet);
-        await this._target.FlushAsync().ConfigureAwait(false);
+        return await this.TryFlushWriterAsync(this._target).ConfigureAwait(false);
     }
 
     private void EncryptAndWrite(ReadOnlySequence<byte> packet)


### PR DESCRIPTION
Consider result of PipeWriter.FlushAsync before flushing the next time.
This should prevent possible deadlocks.

See also https://learn.microsoft.com/en-us/dotnet/standard/io/pipelines#tips-for-using-pipereader-and-pipewriter

>* Periodically await [PipeWriter.FlushAsync](https://learn.microsoft.com/en-us/dotnet/api/system.io.pipelines.pipewriter.flushasync) while writing, and always check [FlushResult.IsCompleted](https://learn.microsoft.com/en-us/dotnet/api/system.io.pipelines.flushresult.iscompleted#system-io-pipelines-flushresult-iscompleted). Abort writing if IsCompleted is true, as that indicates the reader is completed and no longer cares about what is written.
>* Do not call FlushAsync if the reader can't start until FlushAsync finishes, as that may cause a deadlock.