### PR TITLE
fix: remove deprecated custom plugin test

### DIFF
--- a/tests/MUnique.OpenMU.PlugIns.Tests/PlugInManagerTest.cs
+++ b/tests/MUnique.OpenMU.PlugIns.Tests/PlugInManagerTest.cs
@@ -157,51 +157,6 @@ public class PlugInManagerTest
     }
 
     /// <summary>
-    /// Tests if a custom plugin gets created and executed.
-    /// </summary>
-    [Test]
-    public async ValueTask CustomPlugInByConfigurationAsync()
-    {
-        var configuration = new PlugInConfiguration
-        {
-            TypeId = new Guid("4EC93343-DE05-4449-B312-04005547266C"),
-            IsActive = true,
-            CustomPlugInSource = @"
-                    namespace test
-                    {
-                        using System.Runtime.InteropServices;
-                        using MUnique.OpenMU.GameLogic;
-                        using MUnique.OpenMU.PlugIns;
-                        using MUnique.OpenMU.PlugIns.Tests;
-
-                        [Guid(""4EC93343-DE05-4449-B312-04005547266C"")]
-                        [PlugIn(""foo"", ""Just an example example plugin."")]
-                        internal class ExamplePlugIn : IExamplePlugIn
-                        {
-                            /// <summary>
-                            /// Gets a value indicating whether the plugin instance was executed in the test.
-                            /// </summary>
-                            public bool WasExecuted { get; private set; }
-
-                            public void DoStuff(Player player, string text, MyEventArgs args)
-                            {
-                                this.WasExecuted = true;
-                                args.Text = ""CustomPlugIn"";
-                            }
-                        }
-                    }",
-        };
-        var manager = new PlugInManager(new List<PlugInConfiguration> { configuration }, new NullLoggerFactory(), this.CreateServiceProvider(), null);
-        var player = await TestHelper.CreatePlayerAsync().ConfigureAwait(false);
-        var command = "test";
-        var args = new MyEventArgs();
-
-        var point = manager.GetPlugInPoint<IExamplePlugIn>();
-        point!.DoStuff(player, command, args);
-        Assert.That(args.Text, Is.EqualTo("CustomPlugIn"));
-    }
-
-    /// <summary>
     /// Tests if a custom plugin in a non-existing assembly is not created and throws no errors.
     /// </summary>
     [Test]


### PR DESCRIPTION
Currently has a test failing, the test related to the loading of a custom plugin using CustomPlugInSource in PlugInConfiguration.
Searching better about the problem, I identified that this plugin charging functionality from CustomPlugInSource was disabled in Commit: [c56b989f7dd5f6b2a43558f280345a99ad05ef09](https://github.com/MUnique/OpenMU/commit/c56b989f7dd5f6b2a43558f280345a99ad05ef09)
But the test continued in the code, this PR removes the test that contains depreciated code, causing all the project tests to pass during the execution of the tests.

Currently: 
![image](https://github.com/user-attachments/assets/c11b315c-47b3-447f-b109-ade2f0e8dd17)

Expected:
![image](https://github.com/user-attachments/assets/451fb5cd-e75e-4fa2-944a-40321e5b6616)

