### PR TITLE
Added PVP option to GameServerDefinition and AdminPanel

### DIFF
--- a/src/Dapr/GameServer.Host/Pages/Index.razor
+++ b/src/Dapr/GameServer.Host/Pages/Index.razor
@@ -21,6 +21,9 @@
         <span class="badge badge-primary">
             Experience Rate: <span class="badge badge-light">@_gameServerContext.ExperienceRate</span>
         </span>
+        <span class="badge badge-primary">
+            PVP Enabled: <span class="badge badge-light">@_gameServerContext.PvpEnabled</span>
+        </span>
     </h3>
 </p>
 

--- a/src/DataModel/Configuration/GameServerDefinition.cs
+++ b/src/DataModel/Configuration/GameServerDefinition.cs
@@ -33,7 +33,7 @@ public partial class GameServerDefinition
     /// <summary>
     /// Gets or sets a value indicating whether PVP is enabled on this server.
     /// </summary>
-    public bool PvpEnabled { get; set; }
+    public bool PvpEnabled { get; set; } = true;
 
     /// <summary>
     /// Gets or sets the server configuration.

--- a/src/DataModel/Configuration/GameServerDefinition.cs
+++ b/src/DataModel/Configuration/GameServerDefinition.cs
@@ -31,6 +31,11 @@ public partial class GameServerDefinition
     public float ExperienceRate { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether PVP is enabled on this server.
+    /// </summary>
+    public bool PvpEnabled { get; set; }
+
+    /// <summary>
     /// Gets or sets the server configuration.
     /// </summary>
     [Required]

--- a/src/GameLogic/GameContext.cs
+++ b/src/GameLogic/GameContext.cs
@@ -110,6 +110,8 @@ public class GameContext : AsyncDisposable, IGameContext
     /// <inheritdoc />
     public virtual float ExperienceRate => this.Configuration.ExperienceRate;
 
+    public virtual bool PvpEnabled { get; }
+
     /// <inheritdoc/>
     public GameConfiguration Configuration { get; }
 

--- a/src/GameLogic/GameContext.cs
+++ b/src/GameLogic/GameContext.cs
@@ -110,6 +110,7 @@ public class GameContext : AsyncDisposable, IGameContext
     /// <inheritdoc />
     public virtual float ExperienceRate => this.Configuration.ExperienceRate;
 
+    /// <inheritdoc />
     public virtual bool PvpEnabled { get; }
 
     /// <inheritdoc/>

--- a/src/GameLogic/IGameContext.cs
+++ b/src/GameLogic/IGameContext.cs
@@ -31,6 +31,11 @@ public interface IGameContext
     /// Gets the global experience rate.
     /// </summary>
     float ExperienceRate { get; }
+    
+    /// <summary>
+    /// Gets a value indicating whether PVP is enabled.
+    /// </summary>
+    bool PvpEnabled { get; }
 
     /// <summary>
     /// Gets the repository provider. Used to retrieve data, e.g. from a database.

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -595,6 +595,12 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
             throw new InvalidOperationException("AttributeSystem not set.");
         }
 
+        if (!this.GameContext.PvpEnabled && this.CurrentMap?.Definition.BattleZone == null &&
+            this.CurrentMiniGame?.AllowPlayerKilling is false)
+        {
+            return null;
+        }
+
         var hitInfo = await attacker.CalculateDamageAsync(this, skill, isCombo, damageFactor).ConfigureAwait(false);
 
         if (hitInfo.HealthDamage == 0)

--- a/src/GameServer/GameServerContext.cs
+++ b/src/GameServer/GameServerContext.cs
@@ -92,6 +92,9 @@ public class GameServerContext : GameContext, IGameServerContext
     public override float ExperienceRate => base.ExperienceRate * this._gameServerDefinition.ExperienceRate;
 
     /// <inheritdoc />
+    public override bool PvpEnabled => this._gameServerDefinition.PvpEnabled;
+
+    /// <inheritdoc />
     public override string ToString()
     {
         return $"Game Server {this.Id}";

--- a/src/Persistence/EntityFramework/EntityDataContext.cs
+++ b/src/Persistence/EntityFramework/EntityDataContext.cs
@@ -44,7 +44,10 @@ public class EntityDataContext : ExtendedTypeContext
         modelBuilder.Entity<ConnectServerDefinition>();
         modelBuilder.Entity<ChatServerDefinition>();
         modelBuilder.Entity<MiniGameRankingEntry>();
-        modelBuilder.Entity<GameServerDefinition>();
+        modelBuilder.Entity<GameServerDefinition>(entity =>
+        {
+            entity.Property(e => e.PvpEnabled).HasDefaultValue(true);
+        });
         modelBuilder.Entity<ConfigurationUpdate>();
         modelBuilder.Entity<ConfigurationUpdateState>();
         modelBuilder.Entity<SystemConfiguration>();

--- a/src/Persistence/EntityFramework/Migrations/20240902181002_AddPvpOptionToGameServer.Designer.cs
+++ b/src/Persistence/EntityFramework/Migrations/20240902181002_AddPvpOptionToGameServer.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MUnique.OpenMU.Persistence.EntityFramework;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
     [DbContext(typeof(EntityDataContext))]
-    partial class EntityDataContextModelSnapshot : ModelSnapshot
+    [Migration("20240902181002_AddPvpOptionToGameServer")]
+    partial class AddPvpOptionToGameServer
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Persistence/EntityFramework/Migrations/20240902181002_AddPvpOptionToGameServer.cs
+++ b/src/Persistence/EntityFramework/Migrations/20240902181002_AddPvpOptionToGameServer.cs
@@ -1,0 +1,31 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPvpOptionToGameServer : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "PvpEnabled",
+                schema: "config",
+                table: "GameServerDefinition",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "PvpEnabled",
+                schema: "config",
+                table: "GameServerDefinition");
+        }
+    }
+}


### PR DESCRIPTION
This adds the ability to toggle PVP on individual game servers.
PVP is enabled by default as that's the default behavior of OpenMU before this change.

I'm not sure how battle zones should be handled.
This PR allows them on non-PVP servers, let me know if this shouldn't be the case.

This is my first PR for this project, and this is also my first time using C#, so please let me know if I'm doing something wrong here.

It also adds a checkbox in the admin panel:
![image](https://github.com/user-attachments/assets/fd3c29c3-0990-4fcf-961f-8b8d477e76a2)