### PR TITLE
Improvements for the connect server ip resolve

### DIFF
--- a/src/ConnectServer/PacketHandler/ServerInfoRequestHandler.cs
+++ b/src/ConnectServer/PacketHandler/ServerInfoRequestHandler.cs
@@ -4,6 +4,7 @@
 
 namespace MUnique.OpenMU.ConnectServer.PacketHandler;
 
+using System.Net;
 using Microsoft.Extensions.Logging;
 using MUnique.OpenMU.Network;
 using MUnique.OpenMU.Network.Packets.ConnectServer;
@@ -15,6 +16,7 @@ internal class ServerInfoRequestHandler : IPacketHandler<Client>
 {
     private readonly IConnectServer _connectServer;
     private readonly ILogger<ServerInfoRequestHandler> _logger;
+    private readonly HashSet<IPAddress> _localIpAddresses;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ServerInfoRequestHandler" /> class.
@@ -25,6 +27,7 @@ internal class ServerInfoRequestHandler : IPacketHandler<Client>
     {
         this._connectServer = connectServer;
         this._logger = logger;
+        this._localIpAddresses = Dns.GetHostAddresses(Dns.GetHostName()).ToHashSet();
     }
 
     /// <inheritdoc/>
@@ -38,8 +41,31 @@ internal class ServerInfoRequestHandler : IPacketHandler<Client>
             await client.Connection.DisconnectAsync().ConfigureAwait(false);
         }
 
-        if (this._connectServer.ConnectInfos.TryGetValue(serverId, out var connectInfo))
+        // First we look, if we can just use the IP address which the client connected to.
+        // If the game server is running on the same ip as the connect server, we can use that.
+        // This way, we can be sure, that the client can connect to it, too.
+        if (this._connectServer.ServerList.GetItem(serverId) is { } serverItem
+            && this._localIpAddresses.Contains(serverItem.EndPoint.Address)
+            && client.Connection.LocalEndPoint is IPEndPoint localIpEndPoint
+            && !object.Equals(client.Address, localIpEndPoint.Address)) // only if we can't use the cached data
         {
+            int WritePacket()
+            {
+                var data = client.Connection.Output.GetSpan(ConnectionInfoRef.Length)[..ConnectionInfoRef.Length];
+                _ = new ConnectionInfoRef(data)
+                {
+                    IpAddress = localIpEndPoint.Address.ToString(),
+                    Port = (ushort)serverItem.EndPoint.Port
+                };
+                return data.Length;
+            }
+
+            await client.Connection.SendAsync(WritePacket).ConfigureAwait(false);
+        }
+        else if (this._connectServer.ConnectInfos.TryGetValue(serverId, out var connectInfo))
+        {
+            // more optimal way, because the serialized data was cached.
+
             int WritePacket()
             {
                 var span = client.Connection.Output.GetSpan(connectInfo.Length)[..connectInfo.Length];

--- a/src/Network/Connection.cs
+++ b/src/Network/Connection.cs
@@ -62,6 +62,7 @@ public sealed class Connection : PacketPipeReaderBase, IConnection
         this._logger = logger;
         this.Source = decryptionPipe?.Reader ?? this._duplexPipe!.Input;
         this._remoteEndPoint = this.SocketConnection?.Socket.RemoteEndPoint ?? new IPEndPoint(IPAddress.Any, 0);
+        this.LocalEndPoint = this.SocketConnection?.Socket.LocalEndPoint;
         this.OutputLock = new();
     }
 
@@ -76,6 +77,9 @@ public sealed class Connection : PacketPipeReaderBase, IConnection
 
     /// <inheritdoc />
     public EndPoint? EndPoint => this._remoteEndPoint;
+
+    /// <inheritdoc />
+    public EndPoint? LocalEndPoint { get; }
 
     /// <inheritdoc />
     public PipeWriter Output => this._outputWriter ??= new ExtendedPipeWriter(this._encryptionPipe?.Writer ?? this._duplexPipe!.Output, OutgoingBytesCounter);

--- a/src/Network/IConnection.cs
+++ b/src/Network/IConnection.cs
@@ -43,6 +43,11 @@ public interface IConnection : IDisposable
     EndPoint? EndPoint { get; }
 
     /// <summary>
+    /// Gets the local endpoint of the connection.
+    /// </summary>
+    EndPoint? LocalEndPoint { get; }
+
+    /// <summary>
     /// Gets the pipe writer to send data.
     /// </summary>
     /// <value>


### PR DESCRIPTION
We always have the issue that the server doesn't magically work after it has been installed. One major thing is that the game client gets disconnected after selecting a server in the server list.
I had the idea that, if the client connects, we can look at the Socket.LocalEndPoint to which IP it initially connected. If the ip address of the connect server is the same as the ip of the choosen game server we can assume that the client has also access to the game server by connecting to the same ip address.

Probably needs some additional tests for the different scenarios, so I leave it as draft for now.