### PR TITLE
Fixed jewelery option level multipliers for max Ability and Mana increase

### DIFF
--- a/src/Persistence/Initialization/InitializerBase.cs
+++ b/src/Persistence/Initialization/InitializerBase.cs
@@ -180,6 +180,7 @@ public abstract class InitializerBase : IInitializer
         itemOption.Number = number;
 
         itemOption.PowerUpDefinition = this.CreatePowerUpDefinition(attributeDefinition, value, aggregateType);
+        float baseValue = aggregateType == AggregateType.Multiplicate ? 1.0f : 0.0f;
 
         for (int level = 1; level <= this.MaximumOptionLevel; level++)
         {
@@ -187,7 +188,7 @@ public abstract class InitializerBase : IInitializer
             optionOfLevel.Level = level;
             optionOfLevel.PowerUpDefinition = this.CreatePowerUpDefinition(
                 itemOption.PowerUpDefinition.TargetAttribute!,
-                level * valueIncrementPerLevel,
+                baseValue + (level * valueIncrementPerLevel),
                 aggregateType);
             itemOption.LevelDependentOptions.Add(optionOfLevel);
         }

--- a/src/Persistence/Initialization/Updates/FixMaxManaAndAbilityJewelryOptionsUpdateSeason6.cs
+++ b/src/Persistence/Initialization/Updates/FixMaxManaAndAbilityJewelryOptionsUpdateSeason6.cs
@@ -1,0 +1,72 @@
+﻿// <copyright file="FixMaxManaAndAbilityJewelryOptionsUpdateSeason6.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Persistence.Initialization.Updates;
+
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using MUnique.OpenMU.AttributeSystem;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// This update fixes the calculation for max mana/AG % increase provided by Ring of Magic/Pendant of Ability options.
+/// </summary>
+[PlugIn(PlugInName, PlugInDescription)]
+[Guid("EAC7C809-D4B8-443F-BE52-E56560003483")]
+public class FixMaxManaAndAbilityJewelryOptionsUpdateSeason6 : UpdatePlugInBase
+{
+    /// <summary>
+    /// The plug in name.
+    /// </summary>
+    internal const string PlugInName = "Fix max mana/AG % increase jewelry options";
+
+    /// <summary>
+    /// The plug in description.
+    /// </summary>
+    internal const string PlugInDescription = "This update fixes the calculation for max mana/AG % increase provided by Ring of Magic/Pendant of Ability options";
+
+    /// <inheritdoc />
+    public override string Name => PlugInName;
+
+    /// <inheritdoc />
+    public override string Description => PlugInDescription;
+
+    /// <inheritdoc />
+    public override UpdateVersion Version => UpdateVersion.FixMaxManaAndAbilityJewelryOptionsSeason6;
+
+    /// <inheritdoc />
+    public override string DataInitializationKey => VersionSeasonSix.DataInitialization.Id;
+
+    /// <inheritdoc />
+    public override bool IsMandatory => true;
+
+    /// <inheritdoc />
+    public override DateTime CreatedAt => new(2024, 09, 26, 10, 00, 0, DateTimeKind.Utc);
+
+    /// <inheritdoc />
+    protected override async ValueTask ApplyAsync(IContext context, GameConfiguration gameConfiguration)
+    {
+        var itemOptions = gameConfiguration.ItemOptions
+            .Where(io => io.Name == "Jewelery option Maximum Mana" || io.Name == "Jewelery option Maximum Ability");
+
+        foreach (var itemOption in itemOptions)
+        {
+            var optionsOfLevel = itemOption?.PossibleOptions.FirstOrDefault()?.LevelDependentOptions
+                .Where(opt => opt.Level > 1)
+                .OrderBy(opt => opt.Level);
+
+            if (optionsOfLevel is not null)
+            {
+                for (int i = 0; i < optionsOfLevel.Count(); i++)
+                {
+                    if (optionsOfLevel.ElementAt(i).PowerUpDefinition?.Boost?.ConstantValue is SimpleElement elmt && elmt.Value > i + 2)
+                    {
+                        elmt.Value -= i + 1;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/src/Persistence/Initialization/Updates/FixMaxManaAndAbilityJewelryOptionsUpdateSeason6.cs
+++ b/src/Persistence/Initialization/Updates/FixMaxManaAndAbilityJewelryOptionsUpdateSeason6.cs
@@ -48,8 +48,8 @@ public class FixMaxManaAndAbilityJewelryOptionsUpdateSeason6 : UpdatePlugInBase
     /// <inheritdoc />
     protected override async ValueTask ApplyAsync(IContext context, GameConfiguration gameConfiguration)
     {
-        var itemOptions = gameConfiguration.ItemOptions
-            .Where(io => io.Name == "Jewelery option Maximum Mana" || io.Name == "Jewelery option Maximum Ability");
+        var itemOptionGuids = new List<Guid> { new("00000083-d018-8826-0000-000000000000"), new("00000083-d01c-bbba-0000-000000000000") };
+        var itemOptions = gameConfiguration.ItemOptions.Where(io => itemOptionGuids.Contains(io.GetId()));
 
         foreach (var itemOption in itemOptions)
         {

--- a/src/Persistence/Initialization/Updates/UpdateVersion.cs
+++ b/src/Persistence/Initialization/Updates/UpdateVersion.cs
@@ -159,4 +159,9 @@ public enum UpdateVersion
     /// The version of the <see cref="AddItemDropGroupForJewelsUpdateSeason6"/>.
     /// </summary>
     AddItemDropGroupForJewelsSeason6 = 30,
+
+    /// <summary>
+    /// The version of the <see cref="FixMaxManaAndAbilityJewelryOptionsUpdateSeason6"/>.
+    /// </summary>
+    FixMaxManaAndAbilityJewelryOptionsSeason6 = 31,
 }

--- a/src/Persistence/Initialization/VersionSeasonSix/Items/Jewelery.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Items/Jewelery.cs
@@ -206,7 +206,7 @@ internal class Jewelery : Version095d.Items.Jewelery
         if (optionTargetAttribute != Stats.HealthRecoveryMultiplier && optionTargetAttribute is not null)
         {
             // Then it's either maximum mana or ability increase by 1% for each option level
-            var option = this.CreateOption("Jewelery option " + optionTargetAttribute.Designation, optionTargetAttribute, 1.01f, item.GetItemId(), AggregateType.Multiplicate);
+            var option = this.CreateOption("Jewelery option " + optionTargetAttribute.Designation, optionTargetAttribute, 0.01f, item.GetItemId(), AggregateType.Multiplicate);
 
             item.PossibleItemOptions.Add(option);
         }


### PR DESCRIPTION
Calculations of Max Ability and Mana increase for jewelery was multiplying by values 1.01/2.02/3.03/4.04 (respectively for +1%/2%/3%/4% level options). Evidence:
[Screencast from 12-09-2024 11:03:33.webm](https://github.com/user-attachments/assets/89eb865d-5b9a-44fe-b342-f5d3abab0900)
[Screencast from 12-09-2024 11:17:22.webm](https://github.com/user-attachments/assets/5ba49e6c-2022-4932-a28e-6e0262ed82d8)

After fix:
[Screencast from 13-09-2024 21:09:03.webm](https://github.com/user-attachments/assets/87ab967b-6995-4044-a8c0-66fb88ef0b08)

