### PR TITLE
Fixed max element jewelry resistance

### DIFF
--- a/src/GameLogic/Attributes/PowerUpWrapper.cs
+++ b/src/GameLogic/Attributes/PowerUpWrapper.cs
@@ -45,6 +45,11 @@ public sealed class PowerUpWrapper : IElement, IDisposable
     public AggregateType AggregateType => this._element.AggregateType;
 
     /// <summary>
+    /// Gets the parent attribute.
+    /// </summary>
+    public ComposableAttribute? ParentAttribute => this._parentAttribute;
+
+    /// <summary>
     /// Creates elements by a <see cref="PowerUpDefinition"/>.
     /// </summary>
     /// <param name="powerUpDef">The power up definition.</param>

--- a/src/GameLogic/Attributes/Stats.cs
+++ b/src/GameLogic/Attributes/Stats.cs
@@ -553,37 +553,37 @@ public class Stats
     public static AttributeDefinition IsStunned { get; } = new (new Guid("22C86BAF-7F27-478D-8075-E4465C2859DD"), "Is stunned", "The player is poisoned and loses health");
 
     /// <summary>
-    /// Gets the ice resistance attribute definition. Value range from 0 to 1.
+    /// Gets the ice resistance attribute definition. Value range from 0 to 0.5.
     /// </summary>
     public static AttributeDefinition IceResistance { get; } = new (new Guid("47235C36-41BB-44B4-8823-6FC415709F59"), "Ice Resistance", string.Empty);
 
     /// <summary>
-    /// Gets the fire resistance attribute definition. Value range from 0 to 1.
+    /// Gets the fire resistance attribute definition. Value range from 0 to 0.5.
     /// </summary>
     public static AttributeDefinition FireResistance { get; } = new (new Guid("9AE4D80D-5706-48B9-AD11-EAC4FE088A81"), "Fire Resistance", string.Empty);
 
     /// <summary>
-    /// Gets the water resistance attribute definition. Value range from 0 to 1.
+    /// Gets the water resistance attribute definition. Value range from 0 to 0.5.
     /// </summary>
     public static AttributeDefinition WaterResistance { get; } = new (new Guid("3AF88672-D8DB-44E1-937A-7E6484134C39"), "Water Resistance", string.Empty);
 
     /// <summary>
-    /// Gets the earth resistance attribute definition. Value range from 0 to 1.
+    /// Gets the earth resistance attribute definition. Value range from 0 to 0.5.
     /// </summary>
     public static AttributeDefinition EarthResistance { get; } = new (new Guid("4470890F-00CE-44A6-BADB-203684B6014D"), "Earth Resistance", string.Empty);
 
     /// <summary>
-    /// Gets the wind resistance attribute definition. Value range from 0 to 1.
+    /// Gets the wind resistance attribute definition. Value range from 0 to 0.5.
     /// </summary>
     public static AttributeDefinition WindResistance { get; } = new (new Guid("03A29C46-7B7E-424D-8325-8390692570C3"), "Wind Resistance", string.Empty);
 
     /// <summary>
-    /// Gets the poison resistance attribute definition. Value range from 0 to 1.
+    /// Gets the poison resistance attribute definition. Value range from 0 to 0.5.
     /// </summary>
     public static AttributeDefinition PoisonResistance { get; } = new (new Guid("3D50D0B7-63A2-4DA9-8855-12173EAE6B39"), "Poison Resistance", string.Empty);
 
     /// <summary>
-    /// Gets the lightning resistance attribute definition. Value range from 0 to 1.
+    /// Gets the lightning resistance attribute definition. Value range from 0 to 0.5.
     /// </summary>
     public static AttributeDefinition LightningResistance { get; } = new (new Guid("3E339393-2D17-452E-81D9-3987947A407F"), "Lightning Resistance", string.Empty);
 

--- a/src/GameLogic/IItemPowerUpFactory.cs
+++ b/src/GameLogic/IItemPowerUpFactory.cs
@@ -19,8 +19,10 @@ public interface IItemPowerUpFactory
     /// </summary>
     /// <param name="item">The item.</param>
     /// <param name="attributeSystem">The attribute system of the player who equipped the item.</param>
+    /// <param name="skipBasePowerUps">If only the item base power ups should be built.</param>
+    /// <param name="skipOptionPowerUps">If only the item option power ups should be built.</param>
     /// <returns>The created power ups.</returns>
-    IEnumerable<PowerUpWrapper> GetPowerUps(Item item, AttributeSystem attributeSystem);
+    IEnumerable<PowerUpWrapper> GetPowerUps(Item item, AttributeSystem attributeSystem, bool skipBasePowerUps = false, bool skipOptionPowerUps = false);
 
     /// <summary>
     /// Gets the set power ups, which are created for existing <see cref="ItemSetGroup"/>s in the equipped items.

--- a/src/GameLogic/ItemExtensions.cs
+++ b/src/GameLogic/ItemExtensions.cs
@@ -125,12 +125,24 @@ public static class ItemExtensions
     }
 
     /// <summary>
+    /// Determines whether this item is a jewelry (pendant or ring) item.
+    /// </summary>
+    /// <param name="item">The item.</param>
+    /// <returns>
+    ///   <c>true</c> if the specified item is jewelry; otherwise, <c>false</c>.
+    /// </returns>
+    public static bool IsJewelry(this Item item)
+    {
+        return item.ItemSlot >= InventoryConstants.PendantSlot && item.ItemSlot <= InventoryConstants.Ring2Slot;
+    }
+
+    /// <summary>
     /// Determines whether this instance is a is weapon which deals physical damage.
     /// </summary>
     /// <param name="item">The item.</param>
     /// <param name="minimumDmg">The minimum physical damage of the weapon.</param>
     /// <returns>
-    ///   <c>true</c> if this instance is a is weapon which deals physical damage; otherwise, <c>false</c>.
+    ///   <c>true</c> if this instance is a weapon which deals physical damage; otherwise, <c>false</c>.
     /// </returns>
     public static bool IsPhysicalWeapon(this Item item, [NotNullWhen(true)] out float? minimumDmg)
     {
@@ -144,7 +156,7 @@ public static class ItemExtensions
     /// <param name="item">The item.</param>
     /// <param name="staffRise">The staff rise percentage of the weapon.</param>
     /// <returns>
-    ///   <c>true</c> if this instance is a is weapon which deals wizardry damage; otherwise, <c>false</c>.
+    ///   <c>true</c> if this instance is a weapon which deals wizardry damage; otherwise, <c>false</c>.
     /// </returns>
     public static bool IsWizardryWeapon(this Item item, [NotNullWhen(true)] out float? staffRise)
     {

--- a/src/GameLogic/ItemPowerUpFactory.cs
+++ b/src/GameLogic/ItemPowerUpFactory.cs
@@ -27,7 +27,7 @@ public class ItemPowerUpFactory : IItemPowerUpFactory
     }
 
     /// <inheritdoc/>
-    public IEnumerable<PowerUpWrapper> GetPowerUps(Item item, AttributeSystem attributeHolder)
+    public IEnumerable<PowerUpWrapper> GetPowerUps(Item item, AttributeSystem attributeHolder, bool skipBasePowerUps = false, bool skipOptionPowerUps = false)
     {
         if (item.Definition is null)
         {
@@ -45,17 +45,23 @@ public class ItemPowerUpFactory : IItemPowerUpFactory
             yield break;
         }
 
-        foreach (var attribute in item.Definition.BasePowerUpAttributes)
+        if (!skipBasePowerUps)
         {
-            foreach (var powerUp in this.GetBasePowerUpWrappers(item, attributeHolder, attribute))
+            foreach (var attribute in item.Definition.BasePowerUpAttributes)
             {
-                yield return powerUp;
+                foreach (var powerUp in this.GetBasePowerUpWrappers(item, attributeHolder, attribute))
+                {
+                    yield return powerUp;
+                }
             }
         }
 
-        foreach (var powerUp in this.GetPowerUpsOfItemOptions(item, attributeHolder))
+        if (!skipOptionPowerUps)
         {
-            yield return powerUp;
+            foreach (var powerUp in this.GetPowerUpsOfItemOptions(item, attributeHolder))
+            {
+                yield return powerUp;
+            }
         }
 
         if (this.GetPetLevel(item, attributeHolder) is { } petLevel)
@@ -253,7 +259,7 @@ public class ItemPowerUpFactory : IItemPowerUpFactory
         var baseDropLevel = item.Definition!.DropLevel;
         var ancientDropLevel = item.Definition!.CalculateDropLevel(true, false, 0);
 
-        if (InventoryConstants.IsDefenseItemSlot(item.ItemSlot))
+        if (InventoryConstants.IsDefenseItemSlot(item.ItemSlot) && !item.IsJewelry())
         {
             var baseDefense = (int)(item.Definition?.BasePowerUpAttributes.FirstOrDefault(a => a.TargetAttribute == Stats.DefenseBase)?.BaseValue ?? 0);
             var additionalDefense = (baseDefense * 12 / baseDropLevel) + (baseDropLevel / 5) + 4;

--- a/src/Persistence/Initialization/Items/OptionExtensions.cs
+++ b/src/Persistence/Initialization/Items/OptionExtensions.cs
@@ -80,6 +80,6 @@ public static class OptionExtensions
     /// <returns>The excellent wizardry attack options.</returns>
     public static ItemOptionDefinition ExcellentWizardryAttackOptions(this GameConfiguration gameConfiguration)
     {
-        return gameConfiguration.ItemOptions.First(o => o.Name == ExcellentOptions.PhysicalAttackOptionsName);
+        return gameConfiguration.ItemOptions.First(o => o.Name == ExcellentOptions.WizardryAttackOptionsName);
     }
 }

--- a/src/Persistence/Initialization/Version075/Items/Jewelery.cs
+++ b/src/Persistence/Initialization/Version075/Items/Jewelery.cs
@@ -5,7 +5,6 @@
 namespace MUnique.OpenMU.Persistence.Initialization.Version075.Items;
 
 using MUnique.OpenMU.AttributeSystem;
-using MUnique.OpenMU.DataModel.Attributes;
 using MUnique.OpenMU.DataModel.Configuration;
 using MUnique.OpenMU.DataModel.Configuration.Items;
 using MUnique.OpenMU.GameLogic.Attributes;
@@ -28,6 +27,9 @@ internal class Jewelery : InitializerBase
         : base(context, gameConfiguration)
     {
     }
+
+    /// <inheritdoc/>
+    protected override int MaximumOptionLevel => 3;
 
     /// <inheritdoc/>
     public sealed override void Initialize()
@@ -164,6 +166,7 @@ internal class Jewelery : InitializerBase
         {
             var powerUp = this.CreateItemBasePowerUpDefinition(resistanceAttribute, 0.1f, AggregateType.AddRaw);
             powerUp.BonusPerLevelTable = this._resistancesBonusTable;
+            item.BasePowerUpAttributes.Add(powerUp);
         }
 
         foreach (var characterClass in this.GameConfiguration.CharacterClasses)


### PR DESCRIPTION
Fixes:

- Resistance base power ups missing from jewelry items
- Max element resistance given by jewelry - only the highest level pendant or ring applies => max element resistance = 0.5, which implies an equipped pendant or ring level +4 (upon investigation)
- Jewelry items max option level from +4% to +3% (upon investigation)
- Excellent and ancient ring items giving additional base defense
- Excellent wizardry attack options giving excellent physical damage options