### PR TITLE
Fixed exc options being added to non-exc dropped items and item drops durability

### DIFF
--- a/src/GameLogic/DefaultDropGenerator.cs
+++ b/src/GameLogic/DefaultDropGenerator.cs
@@ -304,6 +304,8 @@ public class DefaultDropGenerator : IDropGenerator
         {
             if (this._randomizer.NextRandomBool(option.AddChance))
             {
+                if (option.AddChance == 0.001)
+                    Console.WriteLine("Uh-oh! Exc option applied!");
                 var remainingOptions = option.PossibleOptions.Where(possibleOption => item.ItemOptions.All(link => link.ItemOption != possibleOption));
                 var newOption = remainingOptions.SelectRandom(this._randomizer);
                 if (newOption is null)
@@ -429,7 +431,7 @@ public class DefaultDropGenerator : IDropGenerator
             case SpecialItemType.Excellent:
                 return this.GenerateRandomExcellentItem((int)monster[Stats.Level]);
             case SpecialItemType.RandomItem:
-                return this.GenerateRandomItem((int)monster[Stats.Level], false);
+                return this.GenerateRandomItem((int)monster[Stats.Level], false); // to-do. Exc options are being applied via this route
             case SpecialItemType.SocketItem:
                 return this.GenerateRandomItem((int)monster[Stats.Level], true);
             case SpecialItemType.Money:

--- a/src/GameLogic/ItemExtensions.cs
+++ b/src/GameLogic/ItemExtensions.cs
@@ -64,7 +64,7 @@ public static class ItemExtensions
         {
             result += 20;
         }
-        else if (item.IsExcellent())
+        else if (item.IsExcellent()) // To-do: no Exc options added at this point
         {
             // TODO: archangel weapons, but I guess it's not a big issue if we don't, because of their already high durability
             result += 15;

--- a/src/GameLogic/ItemExtensions.cs
+++ b/src/GameLogic/ItemExtensions.cs
@@ -64,7 +64,7 @@ public static class ItemExtensions
         {
             result += 20;
         }
-        else if (item.IsExcellent()) // To-do: no Exc options added at this point
+        else if (item.IsExcellent())
         {
             // TODO: archangel weapons, but I guess it's not a big issue if we don't, because of their already high durability
             result += 15;


### PR DESCRIPTION
Two fixes:
1. Excellent options being added to regular, non-excellent drops (because only `AddsRandomly = true` was being checked for the options group). Example of a regular Nikea Axe without skill:
![Screenshot from 2024-10-02 10-47-30](https://github.com/user-attachments/assets/3310f319-a361-4526-a618-3a089855fa60)

2. Items dropping without full durability (due to excellent options/ancient options/item level being assigned after `GetMaximumDurabilityOfOnePiece()` was invoked).

