### PR TITLE
Bugfix/joh upgrade

### DIFF
--- a/src/DataModel/Configuration/GameConfiguration.cs
+++ b/src/DataModel/Configuration/GameConfiguration.cs
@@ -121,6 +121,11 @@ public partial class GameConfiguration
     public TimeSpan ItemDropDuration { get; set; }
 
     /// <summary>
+    /// Gets or sets the maximum droppable item option level.
+    /// </summary>
+    public byte MaximumItemOptionLevelDrop { get; set; }
+
+    /// <summary>
     /// Gets or sets the accumulated damage which needs to be done to decrease <see cref="Item.Durability"/> of a defending item by 1.
     /// </summary>
     public double DamagePerOneItemDurability { get; set; }

--- a/src/DataModel/Configuration/GameConfiguration.cs
+++ b/src/DataModel/Configuration/GameConfiguration.cs
@@ -121,11 +121,6 @@ public partial class GameConfiguration
     public TimeSpan ItemDropDuration { get; set; }
 
     /// <summary>
-    /// Gets or sets the maximum droppable item option level.
-    /// </summary>
-    public byte MaximumItemOptionLevelDrop { get; set; }
-
-    /// <summary>
     /// Gets or sets the accumulated damage which needs to be done to decrease <see cref="Item.Durability"/> of a defending item by 1.
     /// </summary>
     public double DamagePerOneItemDurability { get; set; }

--- a/src/GameLogic/ItemPowerUpFactory.cs
+++ b/src/GameLogic/ItemPowerUpFactory.cs
@@ -219,6 +219,12 @@ public class ItemPowerUpFactory : IItemPowerUpFactory
                 continue;
             }
 
+            if (optionOfLevel?.RequiredItemLevel > item.Level)
+            {
+                // Some options (like harmony) although on the item can be inactive.
+                continue;
+            }
+
             var powerUp = optionOfLevel?.PowerUpDefinition ?? option.PowerUpDefinition;
 
             if (powerUp?.Boost is null)

--- a/src/GameLogic/PlayerActions/Craftings/RefineStoneCrafting.cs
+++ b/src/GameLogic/PlayerActions/Craftings/RefineStoneCrafting.cs
@@ -114,7 +114,7 @@ public class RefineStoneCrafting : SimpleItemCraftingHandler
     protected override bool RequiredItemMatches(Item item, ItemCraftingRequiredItem requiredItem)
     {
         return base.RequiredItemMatches(item, requiredItem)
-               && (item.IsWearable() && !this._excludedItems.Contains((item.Definition!.Group, item.Definition.Number)));
+               && item.IsWearable() && !this._excludedItems.Contains((item.Definition!.Group, item.Definition.Number));
     }
 
     /// <inheritdoc />
@@ -129,12 +129,12 @@ public class RefineStoneCrafting : SimpleItemCraftingHandler
         var result = new List<Item>();
         if (higherRefineStoneItems > 0)
         {
-            result.AddRange(await this.CreateRefineStonesAsync(higherRefineStoneItems, 20, 44, player).ConfigureAwait(false));
+            result.AddRange(await this.CreateRefineStonesAsync(higherRefineStoneItems, 50, 44, player).ConfigureAwait(false));
         }
 
         if (lowerRefineStoneItems > 0)
         {
-            result.AddRange(await this.CreateRefineStonesAsync(lowerRefineStoneItems, 50, 43, player).ConfigureAwait(false));
+            result.AddRange(await this.CreateRefineStonesAsync(lowerRefineStoneItems, 20, 43, player).ConfigureAwait(false));
         }
 
         return result;

--- a/src/GameLogic/PlayerActions/Craftings/RefineStoneCrafting.cs
+++ b/src/GameLogic/PlayerActions/Craftings/RefineStoneCrafting.cs
@@ -5,6 +5,7 @@
 namespace MUnique.OpenMU.GameLogic.PlayerActions.Craftings;
 
 using MUnique.OpenMU.DataModel.Configuration.ItemCrafting;
+using MUnique.OpenMU.DataModel.Configuration.Items;
 using MUnique.OpenMU.GameLogic.PlayerActions.Items;
 
 /// <summary>
@@ -12,27 +13,35 @@ using MUnique.OpenMU.GameLogic.PlayerActions.Items;
 /// </summary>
 public class RefineStoneCrafting : SimpleItemCraftingHandler
 {
-    #region List of excluded Items
+    #region List of excluded Items (if item level < 4)
 
     private readonly ISet<(byte Group, short Number)> _excludedItems = new HashSet<(byte, short)>
     {
         (0, 0), // Kris
         (0, 1), // Short Sword
         (0, 2), // Rapier
+        (0, 4), // Sword of Assassin
         (1, 0), // Small Axe
         (1, 1), // Hand Axe
         (1, 2), // Double Axe
         (2, 0), // Mace
         (2, 1), // Morning Star
+        (2, 2), // Flail
+        (3, 1), // Spear
+        (3, 2), // Dragon Lance
+        (3, 3), // Giant Trident
+        (3, 5), // Double Poleaxe
         (4, 0), // Short Bow
         (4, 1), // Bow
         (4, 2), // Elven Bow
         (4, 3), // Battle Bow
+        (4, 8), // Crossbow
         (4, 9), // Golden Crossbow
         (4, 10), // Arquebus
-        (5, 1), // Skull Staff
-        (5, 2), // Angelic Staff
-        (5, 3), // Serpent Staff
+        (4, 11), // Light Crossbow
+        (5, 0), // Skull Staff
+        (5, 1), // Angelic Staff
+        (5, 2), // Serpent Staff
         (6, 0), // Small Shield
         (6, 1), // Horn Shield
         (6, 2), // Kite Shield
@@ -41,13 +50,14 @@ public class RefineStoneCrafting : SimpleItemCraftingHandler
         (6, 6), // Skull Shield
         (6, 7), // Spiked Shield
         (6, 9), // Plate Shield
-        (6, 10), // Large Round Shield
+        (6, 10), // Big Round Shield
         (7, 0), // Bronze Helm
         (7, 2), // Pad Helm
         (7, 4), // Bone Helm
         (7, 5), // Leather Helm
         (7, 6), // Scale Helm
-        (7, 7), // Sphinx Helm
+        (7, 7), // Sphinx Mask
+        (7, 8), // Brass Helm
         (7, 10), // Vine Helm
         (7, 11), // Silk Helm
         (7, 12), // Wind Helm
@@ -57,6 +67,7 @@ public class RefineStoneCrafting : SimpleItemCraftingHandler
         (8, 5), // Leather Armor
         (8, 6), // Scale Armor
         (8, 7), // Sphinx Armor
+        (8, 8), // Brass Armor
         (8, 10), // Vine Armor
         (8, 11), // Silk Armor
         (8, 12), // Wind Armor
@@ -66,6 +77,7 @@ public class RefineStoneCrafting : SimpleItemCraftingHandler
         (9, 5), // Leather Pants
         (9, 6), // Scale Pants
         (9, 7), // Sphinx Pants
+        (9, 8), // Brass Pants
         (9, 10), // Vine Pants
         (9, 11), // Silk Pants
         (9, 12), // Wind Pants
@@ -75,6 +87,7 @@ public class RefineStoneCrafting : SimpleItemCraftingHandler
         (10, 5), // Leather Gloves
         (10, 6), // Scale Gloves
         (10, 7), // Sphinx Gloves
+        (10, 8), // Brass Gloves
         (10, 10), // Vine Gloves
         (10, 11), // Silk Gloves
         (10, 12), // Wind Gloves
@@ -84,6 +97,7 @@ public class RefineStoneCrafting : SimpleItemCraftingHandler
         (11, 5), // Leather Boots
         (11, 6), // Scale Boots
         (11, 7), // Sphinx Boots
+        (11, 8), // Brass Boots
         (11, 10), // Vine Boots
         (11, 11), // Silk Boots
         (11, 12), // Wind Boots
@@ -114,7 +128,10 @@ public class RefineStoneCrafting : SimpleItemCraftingHandler
     protected override bool RequiredItemMatches(Item item, ItemCraftingRequiredItem requiredItem)
     {
         return base.RequiredItemMatches(item, requiredItem)
-               && item.IsWearable() && !this._excludedItems.Contains((item.Definition!.Group, item.Definition.Number));
+               && item.IsWearable()
+               && !item.IsAncient()
+               && !item.ItemOptions.Any(o => o.ItemOption?.OptionType == ItemOptionTypes.HarmonyOption)
+               && (!this._excludedItems.Contains((item.Definition!.Group, item.Definition.Number)) || item.Level > 3);
     }
 
     /// <inheritdoc />

--- a/src/GameLogic/PlayerActions/ItemConsumeActions/HarmonyJewelConsumeHandlerPlugIn.cs
+++ b/src/GameLogic/PlayerActions/ItemConsumeActions/HarmonyJewelConsumeHandlerPlugIn.cs
@@ -25,4 +25,16 @@ public class HarmonyJewelConsumeHandlerPlugIn : ItemUpgradeConsumeHandlerPlugIn
 
     /// <inheritdoc />
     public override ItemIdentifier Key => ItemConstants.JewelOfHarmony;
+
+    /// <inheritdoc />
+    protected override bool ItemCanHaveOption(Item item)
+    {
+        if (item.IsAncient())
+        {
+            // Until S16E2 ancient and socket items couldn't have harmony options: https://muonline.webzen.com/en/gameinfo/guide/detail/117
+            return false;
+        }
+
+        return base.ItemCanHaveOption(item);
+    }
 }

--- a/src/GameLogic/PlayerActions/ItemConsumeActions/HarmonyJewelConsumeHandlerPlugIn.cs
+++ b/src/GameLogic/PlayerActions/ItemConsumeActions/HarmonyJewelConsumeHandlerPlugIn.cs
@@ -19,7 +19,7 @@ public class HarmonyJewelConsumeHandlerPlugIn : ItemUpgradeConsumeHandlerPlugIn
     /// Initializes a new instance of the <see cref="HarmonyJewelConsumeHandlerPlugIn" /> class.
     /// </summary>
     public HarmonyJewelConsumeHandlerPlugIn()
-        : base(new ItemUpgradeConfiguration(ItemOptionTypes.HarmonyOption, true, false, 0.5, ItemFailResult.None))
+        : base(new ItemUpgradeConfiguration(ItemOptionTypes.HarmonyOption, true, false, 0.6, ItemFailResult.None))
     {
     }
 

--- a/src/GameLogic/PlayerActions/ItemConsumeActions/HigherRefineStoneConsumeHandlerPlugIn.cs
+++ b/src/GameLogic/PlayerActions/ItemConsumeActions/HigherRefineStoneConsumeHandlerPlugIn.cs
@@ -9,11 +9,11 @@ using MUnique.OpenMU.DataModel.Configuration.Items;
 using MUnique.OpenMU.PlugIns;
 
 /// <summary>
-/// Consume handler for the Lower Refine Stone which increases the item option of <see cref="ItemOptionTypes.HarmonyOption"/>.
+/// Consume handler for the Higher Refine Stone which increases the item option of <see cref="ItemOptionTypes.HarmonyOption"/>.
 /// </summary>
 [Guid("A9F58DF6-06DB-4187-B386-9F00382333EE")]
 [PlugIn(nameof(HigherRefineStoneConsumeHandlerPlugIn), "Plugin which handles the higher refine stone consumption.")]
-public class HigherRefineStoneConsumeHandlerPlugIn : ItemUpgradeConsumeHandlerPlugIn
+public class HigherRefineStoneConsumeHandlerPlugIn : RefineStoneUpgradeConsumeHandlerPlugIn
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="HigherRefineStoneConsumeHandlerPlugIn" /> class.

--- a/src/GameLogic/PlayerActions/ItemConsumeActions/HigherRefineStoneConsumeHandlerPlugIn.cs
+++ b/src/GameLogic/PlayerActions/ItemConsumeActions/HigherRefineStoneConsumeHandlerPlugIn.cs
@@ -19,7 +19,7 @@ public class HigherRefineStoneConsumeHandlerPlugIn : ItemUpgradeConsumeHandlerPl
     /// Initializes a new instance of the <see cref="HigherRefineStoneConsumeHandlerPlugIn" /> class.
     /// </summary>
     public HigherRefineStoneConsumeHandlerPlugIn()
-        : base(new ItemUpgradeConfiguration(ItemOptionTypes.HarmonyOption, false, true, 0.5, ItemFailResult.SetOptionToLevelOne))
+        : base(new ItemUpgradeConfiguration(ItemOptionTypes.HarmonyOption, false, true, 0.8, ItemFailResult.SetOptionToBaseLevel))
     {
     }
 

--- a/src/GameLogic/PlayerActions/ItemConsumeActions/ItemUpgradeConsumeHandlerPlugIn.cs
+++ b/src/GameLogic/PlayerActions/ItemConsumeActions/ItemUpgradeConsumeHandlerPlugIn.cs
@@ -34,14 +34,9 @@ public abstract class ItemUpgradeConsumeHandlerPlugIn : ItemModifyConsumeHandler
         None,
 
         /// <summary>
-        /// Sets the option to level one.
+        /// Sets the option to the base level.
         /// </summary>
-        SetOptionToLevelOne,
-
-        /// <summary>
-        /// Decreases the option by one level.
-        /// </summary>
-        DecreaseOptionByOne,
+        SetOptionToBaseLevel,
 
         /// <summary>
         /// Removes the option.
@@ -101,14 +96,11 @@ public abstract class ItemUpgradeConsumeHandlerPlugIn : ItemModifyConsumeHandler
     {
         switch (this.Configuration.FailResult)
         {
-            case ItemFailResult.DecreaseOptionByOne:
-                itemOption.Level = Math.Max(itemOption.Level - 1, 1);
-                break;
             case ItemFailResult.RemoveOption:
                 item.ItemOptions.Remove(itemOption);
                 break;
-            case ItemFailResult.SetOptionToLevelOne:
-                itemOption.Level = 1;
+            case ItemFailResult.SetOptionToBaseLevel:
+                itemOption.Level = itemOption.ItemOption?.LevelDependentOptions.Min(ldo => ldo.Level) ?? itemOption.Level;
                 break;
             default:
                 // do nothing

--- a/src/GameLogic/PlayerActions/ItemConsumeActions/ItemUpgradeConsumeHandlerPlugIn.cs
+++ b/src/GameLogic/PlayerActions/ItemConsumeActions/ItemUpgradeConsumeHandlerPlugIn.cs
@@ -65,7 +65,12 @@ public abstract class ItemUpgradeConsumeHandlerPlugIn : ItemModifyConsumeHandler
         return this.TryAddItemOption(item, persistenceContext);
     }
 
-    private bool TryUpgradeItemOption(Item item)
+    /// <summary>
+    /// Tries to upgrade the item option.
+    /// </summary>
+    /// <param name="item">The item to upgrade.</param>
+    /// <returns>Flag indicating whether the item option was upgraded.</returns>
+    protected virtual bool TryUpgradeItemOption(Item item)
     {
         if (!this.Configuration.IncreasesOption)
         {
@@ -74,7 +79,7 @@ public abstract class ItemUpgradeConsumeHandlerPlugIn : ItemModifyConsumeHandler
 
         var itemOption = item.ItemOptions.First(o => o.ItemOption?.OptionType == this.Configuration.OptionType);
         var increasableOption = itemOption.ItemOption;
-        var higherOptionPossible = increasableOption?.LevelDependentOptions.Any(o => o.Level > itemOption.Level) ?? false;
+        var higherOptionPossible = increasableOption?.LevelDependentOptions.Any(o => o.Level > itemOption.Level && o.RequiredItemLevel <= item.Level) ?? false;
         if (!higherOptionPossible)
         {
             return false;

--- a/src/GameLogic/PlayerActions/ItemConsumeActions/ItemUpgradeConsumeHandlerPlugIn.cs
+++ b/src/GameLogic/PlayerActions/ItemConsumeActions/ItemUpgradeConsumeHandlerPlugIn.cs
@@ -66,6 +66,16 @@ public abstract class ItemUpgradeConsumeHandlerPlugIn : ItemModifyConsumeHandler
     }
 
     /// <summary>
+    /// Checks if an item can have the configured option.
+    /// </summary>
+    /// <param name="item">The item.</param>
+    /// <returns>Flag indicating whether the item can have the option.</returns>
+    protected virtual bool ItemCanHaveOption(Item item)
+    {
+        return item.Definition?.PossibleItemOptions.Any(o => o.PossibleOptions.Any(p => p.OptionType == this.Configuration.OptionType)) ?? false;
+    }
+
+    /// <summary>
     /// Tries to upgrade the item option.
     /// </summary>
     /// <param name="item">The item to upgrade.</param>
@@ -147,11 +157,6 @@ public abstract class ItemUpgradeConsumeHandlerPlugIn : ItemModifyConsumeHandler
     private bool ItemHasOptionAlready(Item item)
     {
         return item.ItemOptions.Any(o => o.ItemOption?.OptionType == this.Configuration.OptionType);
-    }
-
-    private bool ItemCanHaveOption(Item item)
-    {
-        return item.Definition?.PossibleItemOptions.Any(o => o.PossibleOptions.Any(p => p.OptionType == this.Configuration.OptionType)) ?? false;
     }
 
     /// <summary>

--- a/src/GameLogic/PlayerActions/ItemConsumeActions/LowerRefineStoneConsumeHandlerPlugIn.cs
+++ b/src/GameLogic/PlayerActions/ItemConsumeActions/LowerRefineStoneConsumeHandlerPlugIn.cs
@@ -13,7 +13,7 @@ using MUnique.OpenMU.PlugIns;
 /// </summary>
 [Guid("71380E37-7AA9-447A-8A83-D08B676E55E1")]
 [PlugIn(nameof(LowerRefineStoneConsumeHandlerPlugIn), "Plugin which handles the lower refine stone consumption.")]
-public class LowerRefineStoneConsumeHandlerPlugIn : ItemUpgradeConsumeHandlerPlugIn
+public class LowerRefineStoneConsumeHandlerPlugIn : RefineStoneUpgradeConsumeHandlerPlugIn
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="LowerRefineStoneConsumeHandlerPlugIn" /> class.

--- a/src/GameLogic/PlayerActions/ItemConsumeActions/LowerRefineStoneConsumeHandlerPlugIn.cs
+++ b/src/GameLogic/PlayerActions/ItemConsumeActions/LowerRefineStoneConsumeHandlerPlugIn.cs
@@ -19,7 +19,7 @@ public class LowerRefineStoneConsumeHandlerPlugIn : ItemUpgradeConsumeHandlerPlu
     /// Initializes a new instance of the <see cref="LowerRefineStoneConsumeHandlerPlugIn" /> class.
     /// </summary>
     public LowerRefineStoneConsumeHandlerPlugIn()
-        : base(new ItemUpgradeConfiguration(ItemOptionTypes.HarmonyOption, false, true, 0.2, ItemFailResult.SetOptionToLevelOne))
+        : base(new ItemUpgradeConfiguration(ItemOptionTypes.HarmonyOption, false, true, 0.2, ItemFailResult.SetOptionToBaseLevel))
     {
     }
 

--- a/src/GameLogic/PlayerActions/ItemConsumeActions/RefineStoneUpgradeConsumeHandlerPlugIn.cs
+++ b/src/GameLogic/PlayerActions/ItemConsumeActions/RefineStoneUpgradeConsumeHandlerPlugIn.cs
@@ -1,0 +1,45 @@
+﻿// -----------------------------------------------------------------------
+// <copyright file="RefineStoneUpgradeConsumeHandlerPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+// -----------------------------------------------------------------------
+
+namespace MUnique.OpenMU.GameLogic.PlayerActions.ItemConsumeActions;
+
+using MUnique.OpenMU.DataModel.Configuration.Items;
+using MUnique.OpenMU.GameLogic.Attributes;
+
+/// <summary>
+/// Consume handler for a Refine Stone which increases the item option of <see cref="ItemOptionTypes.HarmonyOption"/>.
+/// </summary>
+public abstract class RefineStoneUpgradeConsumeHandlerPlugIn : ItemUpgradeConsumeHandlerPlugIn
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RefineStoneUpgradeConsumeHandlerPlugIn"/> class.
+    /// </summary>
+    /// <param name="configuration">The configuration.</param>
+    internal RefineStoneUpgradeConsumeHandlerPlugIn(ItemUpgradeConfiguration configuration)
+        : base(configuration)
+    {
+    }
+
+    /// <inheritdoc/>
+    protected override bool TryUpgradeItemOption(Item item)
+    {
+        var harmonyOption = item.ItemOptions.First(o => o.ItemOption?.OptionType == this.Configuration.OptionType);
+        var levelOptions = harmonyOption.ItemOption?.LevelDependentOptions;
+
+        if (levelOptions?.FirstOrDefault()?.PowerUpDefinition?.TargetAttribute == Stats.MinimumPhysBaseDmg)
+        { // The difference betwen the max and min dmg of a weapon must be at least 1
+            var weaponMinDmg = item.Definition!.BasePowerUpAttributes.First(bpu => bpu.TargetAttribute == Stats.MinimumPhysBaseDmgByWeapon).BaseValue;
+            var weaponMaxDmg = item.Definition!.BasePowerUpAttributes.First(bpu => bpu.TargetAttribute == Stats.MaximumPhysBaseDmgByWeapon).BaseValue;
+            var nextMinDmgBoost = levelOptions.FirstOrDefault(o => o.Level == harmonyOption.Level + 1)?.PowerUpDefinition?.Boost?.ConstantValue.Value;
+            if (nextMinDmgBoost is float boost && weaponMaxDmg - (weaponMinDmg + boost) < 1)
+            {
+                return false;
+            }
+        }
+
+        return base.TryUpgradeItemOption(item);
+    }
+}

--- a/src/GameLogic/PlayerActions/PlayerStore/OpenStoreAction.cs
+++ b/src/GameLogic/PlayerActions/PlayerStore/OpenStoreAction.cs
@@ -28,7 +28,7 @@ public class OpenStoreAction
 
         if (player.ShopStorage?.Items.Any(i => i.ItemOptions.Any(o => o.ItemOption?.OptionType == ItemOptionTypes.HarmonyOption)) ?? true)
         {
-            player.Logger.LogWarning("OpenStore request failed: There are store items with harmony option. Player: [{0}], StoreName: [{1}]", player.SelectedCharacter?.Name, player.ShopStorage?.StoreName);
+            player.Logger.LogWarning("OpenStore request failed: Items with an harmony option can't be traded. Player: [{0}], StoreName: [{1}]", player.SelectedCharacter?.Name, player.ShopStorage?.StoreName);
             return;
         }
 

--- a/src/GameLogic/PlayerActions/PlayerStore/OpenStoreAction.cs
+++ b/src/GameLogic/PlayerActions/PlayerStore/OpenStoreAction.cs
@@ -4,6 +4,7 @@
 
 namespace MUnique.OpenMU.GameLogic.PlayerActions.PlayerStore;
 
+using MUnique.OpenMU.DataModel.Configuration.Items;
 using MUnique.OpenMU.GameLogic.Views.PlayerShop;
 
 /// <summary>
@@ -22,6 +23,12 @@ public class OpenStoreAction
         if (player.ShopStorage?.Items.Any(i => !i.StorePrice.HasValue) ?? true)
         {
             player.Logger.LogWarning("OpenStore request failed: Not all store items have a price assigned. Player: [{0}], StoreName: [{1}]", player.SelectedCharacter?.Name, player.ShopStorage?.StoreName);
+            return;
+        }
+
+        if (player.ShopStorage?.Items.Any(i => i.ItemOptions.Any(o => o.ItemOption?.OptionType == ItemOptionTypes.HarmonyOption)) ?? true)
+        {
+            player.Logger.LogWarning("OpenStore request failed: There are store items with harmony option. Player: [{0}], StoreName: [{1}]", player.SelectedCharacter?.Name, player.ShopStorage?.StoreName);
             return;
         }
 

--- a/src/Persistence/Initialization/VersionSeasonSix/ChaosMixes.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/ChaosMixes.cs
@@ -90,7 +90,7 @@ public class ChaosMixes : InitializerBase
 
         crafting.SimpleCraftingSettings = craftingSettings;
         craftingSettings.Money = money;
-        craftingSettings.SuccessPercent = (byte)(60 - (((targetLevel - 10) / 2) * 5));
+        craftingSettings.SuccessPercent = (byte)(60 - ((targetLevel - 10) / 2 * 5));
         craftingSettings.SuccessPercentageAdditionForExcellentItem = -10;
         craftingSettings.SuccessPercentageAdditionForAncientItem = -15;
         craftingSettings.SuccessPercentageAdditionForSocketItem = -20;
@@ -1186,7 +1186,8 @@ public class ChaosMixes : InitializerBase
 
         var randomItem = this.Context.CreateNew<ItemCraftingRequiredItem>();
         randomItem.MinimumAmount = 1;
-        randomItem.MinimumAmount = 1;
+        randomItem.MaximumAmount = 1;
+        randomItem.MaximumItemLevel = 15;
         randomItem.RequiredItemOptions.Add(this.GameConfiguration.ItemOptionTypes.First(o => o == ItemOptionTypes.HarmonyOption));
         randomItem.FailResult = MixResult.StaysAsIs; // It's never failing, but we set it just in case.
         randomItem.SuccessResult = MixResult.StaysAsIs;

--- a/src/Persistence/Initialization/VersionSeasonSix/Items/HarmonyOptions.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Items/HarmonyOptions.cs
@@ -86,7 +86,7 @@ public class HarmonyOptions : InitializerBase
         definition.PossibleOptions.Add(this.CreateHarmonyOptions(6, ItemOptionDefinitionNumbers.HarmonyWizardry, Stats.ShieldDecreaseRateIncrease, AggregateType.AddRaw, 9, 4, 6, 8, 10, 13));
         definition.PossibleOptions.Add(this.CreateHarmonyOptions(7, ItemOptionDefinitionNumbers.HarmonyWizardry, Stats.AttackRatePvp, AggregateType.AddRaw, 9, 5, 7, 9, 11, 14));
         definition.PossibleOptions.Add(this.CreateHarmonyOptions(8, ItemOptionDefinitionNumbers.HarmonyWizardry, Stats.ShieldBypassChance, AggregateType.AddRaw, 13, 0.15f));
-    }   
+    }
 
     private void CreatePhysicalAttackOptions()
     {

--- a/src/Persistence/Initialization/VersionSeasonSix/Items/HarmonyOptions.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Items/HarmonyOptions.cs
@@ -66,7 +66,7 @@ public class HarmonyOptions : InitializerBase
         definition.PossibleOptions.Add(this.CreateHarmonyOptions(3, ItemOptionDefinitionNumbers.HarmonyCurse, Stats.RequiredAgilityReduction, AggregateType.AddRaw, 0, 6, 8, 10, 12, 14, 16, 20, 23, 26, 29, 32, 35, 37, 40));
         definition.PossibleOptions.Add(this.CreateHarmonyOptions(4, ItemOptionDefinitionNumbers.HarmonyCurse, Stats.SkillDamageBonus, AggregateType.AddRaw, 6, 7, 10, 13, 16, 19, 22, 25, 30));
         definition.PossibleOptions.Add(this.CreateHarmonyOptions(5, ItemOptionDefinitionNumbers.HarmonyCurse, Stats.CriticalDamageBonus, AggregateType.AddRaw, 6, 10, 12, 14, 16, 18, 20, 22, 28));
-        definition.PossibleOptions.Add(this.CreateHarmonyOptions(6, ItemOptionDefinitionNumbers.HarmonyCurse, Stats.ShieldDecreaseRateIncrease, AggregateType.AddRaw, 9, 3, 5, 7, 9, 10));
+        definition.PossibleOptions.Add(this.CreateHarmonyOptions(6, ItemOptionDefinitionNumbers.HarmonyCurse, Stats.ShieldDecreaseRateIncrease, AggregateType.AddRaw, 9, 4, 6, 8, 10, 13));
         definition.PossibleOptions.Add(this.CreateHarmonyOptions(7, ItemOptionDefinitionNumbers.HarmonyCurse, Stats.AttackRatePvp, AggregateType.AddRaw, 9, 5, 7, 9, 11, 14));
         definition.PossibleOptions.Add(this.CreateHarmonyOptions(8, ItemOptionDefinitionNumbers.HarmonyCurse, Stats.ShieldBypassChance, AggregateType.AddRaw, 13, 0.15f));
     }
@@ -83,8 +83,8 @@ public class HarmonyOptions : InitializerBase
         definition.PossibleOptions.Add(this.CreateHarmonyOptions(3, ItemOptionDefinitionNumbers.HarmonyWizardry, Stats.RequiredAgilityReduction, AggregateType.AddRaw, 0, 6, 8, 10, 12, 14, 16, 20, 23, 26, 29, 32, 35, 37, 40));
         definition.PossibleOptions.Add(this.CreateHarmonyOptions(4, ItemOptionDefinitionNumbers.HarmonyWizardry, Stats.SkillDamageBonus, AggregateType.AddRaw, 6, 7, 10, 13, 16, 19, 22, 25, 30));
         definition.PossibleOptions.Add(this.CreateHarmonyOptions(5, ItemOptionDefinitionNumbers.HarmonyWizardry, Stats.CriticalDamageBonus, AggregateType.AddRaw, 6, 10, 12, 14, 16, 18, 20, 22, 28));
-        definition.PossibleOptions.Add(this.CreateHarmonyOptions(6, ItemOptionDefinitionNumbers.HarmonyWizardry, Stats.ShieldDecreaseRateIncrease, AggregateType.AddRaw, 9, 3, 5, 7, 9, 10));
-        definition.PossibleOptions.Add(this.CreateHarmonyOptions(7, ItemOptionDefinitionNumbers.HarmonyWizardry, Stats.AttackRatePvp, AggregateType.AddRaw, 11, 5, 7, 9, 11, 14));
+        definition.PossibleOptions.Add(this.CreateHarmonyOptions(6, ItemOptionDefinitionNumbers.HarmonyWizardry, Stats.ShieldDecreaseRateIncrease, AggregateType.AddRaw, 9, 4, 6, 8, 10, 13));
+        definition.PossibleOptions.Add(this.CreateHarmonyOptions(7, ItemOptionDefinitionNumbers.HarmonyWizardry, Stats.AttackRatePvp, AggregateType.AddRaw, 9, 5, 7, 9, 11, 14));
         definition.PossibleOptions.Add(this.CreateHarmonyOptions(8, ItemOptionDefinitionNumbers.HarmonyWizardry, Stats.ShieldBypassChance, AggregateType.AddRaw, 13, 0.15f));
     }   
 


### PR DESCRIPTION
- Added required item level check for item option upgrade (was only present in option addition)
- Added required item level check for Item option power up activation (the client also grays out the option if this is not met)
- Added ancient item requirement check for JoH application ([reference 1](https://muonline.webzen.com/en/gameinfo/guide/detail/117), §3-1; [reference 2](https://github.com/kyleruss/emu-server/blob/202856a74c905c203b9b2795fd161f564ca8b257/GameServer/Source/JewelOfHarmonySystem.cpp#L495))
- Updated excluded items list for Lower Refining Stone crafting ([reference](https://github.com/kyleruss/emu-server/blob/202856a74c905c203b9b2795fd161f564ca8b257/Template/zGameServer/Data/Item/JewelOfHarmonySmelt.txt))
- Updated requirements for Higher/Lower Refining Stones crafting ([reference](https://github.com/kyleruss/emu-server/blob/202856a74c905c203b9b2795fd161f564ca8b257/GameServer/Source/JewelOfHarmonySystem.cpp#L901))
- Added new plugin _RefineStoneUpgradeConsumeHandlerPlugIn.cs_ to encompass the particular rule of max dmg - min damage >= 1 ([reference](https://github.com/kyleruss/emu-server/blob/202856a74c905c203b9b2795fd161f564ca8b257/GameServer/Source/JewelOfHarmonySystem.cpp#L1101))
- Updated Higher/Lower Refining Stones and JoH success rates ([reference 1](https://muonline.webzen.com/en/gameinfo/guide/detail/117), §3-6; [reference 2](https://github.com/kyleruss/emu-server/blob/202856a74c905c203b9b2795fd161f564ca8b257/Template/zGameServer/Data/CommonServer.cfg#L4))
- Fixed item fail result for Higher/Lower Refining Stones -> reset to base option level (can be 0, 3, 6 or 9)
- Added requirement for Personal Store opening to exclude JoH'ed items, since these can't be traded ([reference](https://github.com/kyleruss/emu-server/blob/202856a74c905c203b9b2795fd161f564ca8b257/GameServer/Source/user.cpp#L13298))
- Fixed some JoH options values ([reference](https://github.com/kyleruss/emu-server/blob/202856a74c905c203b9b2795fd161f564ca8b257/Template/zGameServer/Data/Item/JewelOfHarmonyOption.txt))
- Fixed restore item crafting `ItemCraftingRequiredItem` properties

**P.S**.: JoH options also have weights ([reference](https://github.com/kyleruss/emu-server/blob/202856a74c905c203b9b2795fd161f564ca8b257/Template/zGameServer/Data/Item/JewelOfHarmonyOption.txt)). I think this should be added too, but since it involves a migration and DB data, I wanted to check with you first :)