### PR TITLE
Better navigation on "Edit"

### DIFF
--- a/src/Web/AdminPanel/Components/Form/ItemTable.razor
+++ b/src/Web/AdminPanel/Components/Form/ItemTable.razor
@@ -56,7 +56,7 @@
                                         urlPrefix = "edit-account";                                        
                                     }
 
-                                    <button type="button" class="btn-info" @onclick="@(() => this._navigationManager.NavigateTo($"{urlPrefix}/{typeof(TItem).FullName}/{item.Id}"))">Edit</button>
+                                    <a href="@($"{urlPrefix}/{typeof(TItem).FullName}/{item.Id}")" class="btn btn-info">Edit</a>
                                 }
                             </td>
                             <td>

--- a/src/Web/AdminPanel/Pages/EditConfigGrid.razor
+++ b/src/Web/AdminPanel/Pages/EditConfigGrid.razor
@@ -32,7 +32,7 @@
             @{
                 var targetUrl = $"edit-config/{this.TypeString}/" + context.Id;
             }
-            <button type="button" class="btn-info" @onclick="@(() => this.NavigationManager.NavigateTo(targetUrl))">Edit</button>
+            <a href="@(targetUrl)" class="btn btn-info">Edit</a>
         </TemplateColumn>
     </QuickGrid>
 </div>

--- a/src/Web/AdminPanel/Shared/ConfigNavMenu.razor
+++ b/src/Web/AdminPanel/Shared/ConfigNavMenu.razor
@@ -19,6 +19,7 @@
             <NavLink href="@($"edit-config-grid/{typeof(CharacterClass).FullName}/")">Character Classes</NavLink>
             <NavLink href="@($"edit-config-grid/{typeof(Skill).FullName}/")">Skills</NavLink>
             <NavLink href="@($"edit-config-grid/{typeof(ItemDefinition).FullName}/")">Items</NavLink>
+            <NavLink href="@($"edit-config-grid/{typeof(DropItemGroup).FullName}/")">Drop Item Groups</NavLink>
             <NavLink href="@($"edit-config-grid/{typeof(GameMapDefinition).FullName}/")">Maps</NavLink>
             <NavLink href="@($"edit-config-grid/{typeof(MiniGameDefinition).FullName}/")">Mini Games</NavLink>
             <NavLink href="@($"edit-config-grid/{typeof(WarpInfo).FullName}/")">Warp List</NavLink>


### PR DESCRIPTION
it was made for issue #518 

The "Edit" are now links, they can be opened in the current tab or in a new tab.
PS. I didn't alter the Merchants "Edit" button since it was not simply an URL, I'll have to look further into it.

I also added a "Drop Item Groups" in the navbar. It'll be easier to use it this way.