### PR TITLE
Refactored stats update

### DIFF
--- a/src/AttributeSystem/AttributeSystem.cs
+++ b/src/AttributeSystem/AttributeSystem.cs
@@ -4,10 +4,12 @@
 
 namespace MUnique.OpenMU.AttributeSystem;
 
+using System.Collections;
+
 /// <summary>
 /// The attribute system which holds all attributes of a character.
 /// </summary>
-public class AttributeSystem : IAttributeSystem
+public class AttributeSystem : IAttributeSystem, IEnumerable<IAttribute>
 {
     private readonly IDictionary<AttributeDefinition, IAttribute> _attributes = new Dictionary<AttributeDefinition, IAttribute>();
 
@@ -16,7 +18,7 @@ public class AttributeSystem : IAttributeSystem
     /// </summary>
     /// <param name="statAttributes">The stat attributes. These attributes are added just as-is and are not wrapped by a <see cref="ComposableAttribute"/>.</param>
     /// <param name="baseAttributes">The initial base attributes. These attributes contain the base values which will be wrapped by a <see cref="ComposableAttribute"/>, so additional elements can contribute to the attributes value. Instead of providing them here, you could also add them to the system by calling <see cref="AddElement"/> later.</param>
-    /// <param name="attributeRelationships">The initial attribute relationships. Instead of providing them here, you could also add them to the system by calling <see cref="AddAttributeRelationship(AttributeRelationship, IAttributeSystem)"/> later.</param>
+    /// <param name="attributeRelationships">The initial attribute relationships. Instead of providing them here, you could also add them to the system by calling <see cref="AddAttributeRelationship(AttributeRelationship, IAttributeSystem, AggregateType)"/> later.</param>
     public AttributeSystem(IEnumerable<IAttribute> statAttributes, IEnumerable<IAttribute> baseAttributes, IEnumerable<AttributeRelationship> attributeRelationships)
     {
         foreach (var statAttribute in statAttributes)
@@ -129,6 +131,7 @@ public class AttributeSystem : IAttributeSystem
         {
             attribute = new ComposableAttribute(targetAttribute);
             this._attributes.Add(targetAttribute, attribute);
+            this.OnAttributeAdded(attribute);
         }
 
         if (attribute is IComposableAttribute composableAttribute)
@@ -180,6 +183,18 @@ public class AttributeSystem : IAttributeSystem
         return stringBuilder.ToString();
     }
 
+    /// <inheritdoc />
+    public IEnumerator<IAttribute> GetEnumerator()
+    {
+        return this._attributes.Values.GetEnumerator();
+    }
+
+    /// <inheritdoc />
+    IEnumerator IEnumerable.GetEnumerator()
+    {
+        return this.GetEnumerator();
+    }
+
     /// <summary>
     /// Gets or creates the element with the specified attribute.
     /// </summary>
@@ -193,9 +208,28 @@ public class AttributeSystem : IAttributeSystem
             var composableAttribute = new ComposableAttribute(attributeDefinition);
             element = composableAttribute;
             this._attributes.Add(attributeDefinition, composableAttribute);
+            this.OnAttributeAdded(composableAttribute);
         }
 
         return element;
+    }
+
+    /// <summary>
+    /// Called when an attribute was added to the system after the initial construction.
+    /// </summary>
+    /// <param name="attribute">The attribute.</param>
+    protected virtual void OnAttributeAdded(IAttribute attribute)
+    {
+        // can be overwritten.
+    }
+
+    /// <summary>
+    /// Called when an attribute was removed from the system.
+    /// </summary>
+    /// <param name="attribute">The attribute.</param>
+    protected virtual void OnAttributeRemoved(IAttribute attribute)
+    {
+        // can be overwritten.
     }
 
     /// <summary>

--- a/src/GameLogic/AttackableExtensions.cs
+++ b/src/GameLogic/AttackableExtensions.cs
@@ -174,8 +174,6 @@ public static class AttackableExtensions
 
         skillEntry.ThrowNotInitializedProperty(skillEntry.Skill is null, nameof(skillEntry.Skill));
 
-        var isHealthUpdated = false;
-        var isManaUpdated = false;
         var skill = skillEntry.Skill;
         foreach (var powerUpDefinition in skill.MagicEffectDef?.PowerUpDefinitions ?? Enumerable.Empty<PowerUpDefinition>())
         {
@@ -187,25 +185,11 @@ public static class AttackableExtensions
                 target.Attributes[regeneration.CurrentAttribute] = Math.Min(
                     target.Attributes[regeneration.CurrentAttribute] + value,
                     target.Attributes[regeneration.MaximumAttribute]);
-                isHealthUpdated |= regeneration.CurrentAttribute == Stats.CurrentHealth || regeneration.CurrentAttribute == Stats.CurrentShield;
-                isManaUpdated |= regeneration.CurrentAttribute == Stats.CurrentMana || regeneration.CurrentAttribute == Stats.CurrentAbility;
             }
             else
             {
                 player.Logger.LogWarning(
                     $"Regeneration skill {skill.Name} is configured to regenerate a non-regeneration-able target attribute {powerUpDefinition.TargetAttribute}.");
-            }
-        }
-
-        if (target is IWorldObserver observer)
-        {
-            var updatedStats =
-                (isHealthUpdated ? IUpdateStatsPlugIn.UpdatedStats.Health : IUpdateStatsPlugIn.UpdatedStats.Undefined)
-                | (isManaUpdated ? IUpdateStatsPlugIn.UpdatedStats.Mana : IUpdateStatsPlugIn.UpdatedStats.Undefined);
-
-            if (updatedStats != IUpdateStatsPlugIn.UpdatedStats.Undefined)
-            {
-                await observer.InvokeViewPlugInAsync<IUpdateStatsPlugIn>(p => p.UpdateCurrentStatsAsync(updatedStats)).ConfigureAwait(false);
             }
         }
     }

--- a/src/GameLogic/PlayerActions/ItemConsumeActions/HealthPotionConsumeHandlerPlugIn.cs
+++ b/src/GameLogic/PlayerActions/ItemConsumeActions/HealthPotionConsumeHandlerPlugIn.cs
@@ -8,7 +8,6 @@ namespace MUnique.OpenMU.GameLogic.PlayerActions.ItemConsumeActions;
 
 using MUnique.OpenMU.AttributeSystem;
 using MUnique.OpenMU.GameLogic.Attributes;
-using MUnique.OpenMU.GameLogic.Views.Character;
 
 /// <summary>
 /// The consume handler for a potion that recovers health.
@@ -20,11 +19,4 @@ public abstract class HealthPotionConsumeHandlerPlugIn : RecoverConsumeHandlerPl
 
     /// <inheritdoc/>
     protected override AttributeDefinition CurrentAttribute => Stats.CurrentHealth;
-
-    /// <inheritdoc />
-    protected override async ValueTask OnAfterRecoverAsync(Player player)
-    {
-        // maybe instead of calling UpdateCurrentHealth etc. provide a more general method where we pass this.CurrentAttribute. The view can then decide what to do with it.
-        await player.InvokeViewPlugInAsync<IUpdateStatsPlugIn>(p => p.UpdateCurrentStatsAsync(IUpdateStatsPlugIn.UpdatedStats.Health)).ConfigureAwait(false);
-    }
 }

--- a/src/GameLogic/PlayerActions/ItemConsumeActions/ManaPotionConsumeHandler.cs
+++ b/src/GameLogic/PlayerActions/ItemConsumeActions/ManaPotionConsumeHandler.cs
@@ -20,10 +20,4 @@ public abstract class ManaPotionConsumeHandler : RecoverConsumeHandlerPlugIn.Man
 
     /// <inheritdoc/>
     protected override AttributeDefinition CurrentAttribute => Stats.CurrentMana;
-
-    /// <inheritdoc />
-    protected override async ValueTask OnAfterRecoverAsync(Player player)
-    {
-        await player.InvokeViewPlugInAsync<IUpdateStatsPlugIn>(p => p.UpdateCurrentStatsAsync(IUpdateStatsPlugIn.UpdatedStats.Mana)).ConfigureAwait(false);
-    }
 }

--- a/src/GameLogic/PlayerActions/Skills/DrainLifeSkillPlugIn.cs
+++ b/src/GameLogic/PlayerActions/Skills/DrainLifeSkillPlugIn.cs
@@ -24,15 +24,13 @@ public class DrainLifeSkillPlugIn : IAreaSkillPlugIn
     /// <inheritdoc/>
     public async ValueTask AfterTargetGotAttackedAsync(IAttacker attacker, IAttackable target, SkillEntry skillEntry, Point targetAreaCenter, HitInfo? hitInfo)
     {
-        if (attacker is Player attackerPlayer && hitInfo != null && hitInfo.Value.HealthDamage > 0)
+        if (attacker is not Player attackerPlayer
+            || hitInfo is not { HealthDamage: > 0 }
+            || attackerPlayer.Attributes is not { } playerAttributes)
         {
-            var playerAttributes = attackerPlayer.Attributes;
-
-            if (playerAttributes != null)
-            {
-                playerAttributes[Stats.CurrentHealth] = (uint)Math.Min(playerAttributes[Stats.MaximumHealth], playerAttributes[Stats.CurrentHealth] + hitInfo.Value.HealthDamage);
-                await attackerPlayer.InvokeViewPlugInAsync<IUpdateStatsPlugIn>(p => p.UpdateCurrentStatsAsync(IUpdateStatsPlugIn.UpdatedStats.Health)).ConfigureAwait(false);
-            }
+            return;
         }
+
+        playerAttributes[Stats.CurrentHealth] = (uint)Math.Min(playerAttributes[Stats.MaximumHealth], playerAttributes[Stats.CurrentHealth] + hitInfo.Value.HealthDamage);
     }
 }

--- a/src/GameLogic/Views/Character/IUpdateStatsPlugIn.cs
+++ b/src/GameLogic/Views/Character/IUpdateStatsPlugIn.cs
@@ -12,42 +12,9 @@ using MUnique.OpenMU.AttributeSystem;
 public interface IUpdateStatsPlugIn : IViewPlugIn
 {
     /// <summary>
-    /// Updates the maximum stats.
+    /// Updates the attribute value.
     /// </summary>
-    /// <param name="updatedStats">The updated stats.</param>
-    ValueTask UpdateMaximumStatsAsync(UpdatedStats updatedStats = UpdatedStats.Health | UpdatedStats.Mana | UpdatedStats.Speed);
-
-    /// <summary>
-    /// Updates the current stats.
-    /// </summary>
-    /// <param name="updatedStats">The updated stats.</param>
-    ValueTask UpdateCurrentStatsAsync(UpdatedStats updatedStats = UpdatedStats.Health | UpdatedStats.Mana | UpdatedStats.Speed);
-
-    /// <summary>
-    /// The updated stat.
-    /// This might be replaced by the actual <see cref="AttributeDefinition"/> in the future.
-    /// </summary>
-    [Flags]
-    public enum UpdatedStats
-    {
-        /// <summary>
-        /// Undefined.
-        /// </summary>
-        Undefined,
-
-        /// <summary>
-        /// The health or shield changed.
-        /// </summary>
-        Health = 0x01,
-
-        /// <summary>
-        /// The mana or ability changed.
-        /// </summary>
-        Mana = 0x02,
-
-        /// <summary>
-        /// The attack speed changed.
-        /// </summary>
-        Speed = 0x04,
-    }
+    /// <param name="attribute">The attribute.</param>
+    /// <param name="value">The value.</param>
+    ValueTask UpdateStatsAsync(AttributeDefinition attribute, float value);
 }

--- a/src/GameServer/GameServer.cs
+++ b/src/GameServer/GameServer.cs
@@ -431,7 +431,7 @@ public sealed class GameServer : IGameServer, IDisposable, IGameServerContextPro
     {
         await this.SaveSessionOfPlayerAsync(remotePlayer).ConfigureAwait(false);
         await this.SetOfflineAtLoginServerAsync(remotePlayer).ConfigureAwait(false);
-        remotePlayer.Dispose();
+        await remotePlayer.DisposeAsync().ConfigureAwait(false);
         this.OnPropertyChanged(nameof(this.CurrentConnections));
     }
 

--- a/src/GameServer/RemoteView/Character/UpdateStatsBasePlugIn.cs
+++ b/src/GameServer/RemoteView/Character/UpdateStatsBasePlugIn.cs
@@ -74,7 +74,7 @@ public abstract class UpdateStatsBasePlugIn : Disposable, IUpdateStatsPlugIn
         base.Dispose(disposing);
     }
 
-    private async ValueTask SendDelayedUpdateAsync(UpdateAction action, AttributeDefinition attribute)
+    private async ValueTask SendDelayedUpdateAsync(UpdateAction action)
     {
         var autoResetEvent = this._resetEvents[this._actionIndexMapping[action]];
         if (!autoResetEvent.WaitOne(0))

--- a/src/GameServer/RemoteView/Character/UpdateStatsBasePlugIn.cs
+++ b/src/GameServer/RemoteView/Character/UpdateStatsBasePlugIn.cs
@@ -1,0 +1,106 @@
+﻿// <copyright file="UpdateStatsBasePlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.RemoteView.Character;
+
+using System.Collections.Concurrent;
+using System.Collections.Frozen;
+using System.Threading;
+using MUnique.OpenMU.AttributeSystem;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.Views.Character;
+using UpdateAction = Func<RemotePlayer, ValueTask>;
+
+/// <summary>
+/// The default implementation of the <see cref="IUpdateStatsPlugIn"/> which is forwarding everything to the game client with specific data packets.
+/// </summary>
+public abstract class UpdateStatsBasePlugIn : Disposable, IUpdateStatsPlugIn
+{
+    private static readonly int SendDelayMs = 16;
+
+    private static readonly ConcurrentDictionary<
+        FrozenDictionary<AttributeDefinition, UpdateAction>,
+        FrozenDictionary<UpdateAction, int>> ActionIndexMappings = new();
+
+    private readonly RemotePlayer _player;
+
+    private readonly FrozenDictionary<UpdateAction, int> _actionIndexMapping;
+
+    private readonly FrozenDictionary<AttributeDefinition, UpdateAction> _changeActions;
+
+    private readonly AutoResetEvent[] _resetEvents;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UpdateStatsBasePlugIn" /> class.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="changeActions">The change actions.</param>
+    protected UpdateStatsBasePlugIn(RemotePlayer player, FrozenDictionary<AttributeDefinition, UpdateAction> changeActions)
+    {
+        this._player = player;
+        this._changeActions = changeActions;
+        this._actionIndexMapping = GetActionIndexMapping(changeActions);
+        this._resetEvents = new AutoResetEvent[changeActions.Count];
+        for (int i = 0; i < this._resetEvents.Length; i++)
+        {
+            this._resetEvents[i] = new AutoResetEvent(true);
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask UpdateStatsAsync(AttributeDefinition attribute, float value)
+    {
+        if (this._player.Attributes is null
+            || !(this._player.Connection?.Connected ?? false))
+        {
+            return;
+        }
+
+        if (this._changeActions.TryGetValue(attribute, out var action))
+        {
+            _ = this.SendDelayedUpdateAsync(action, attribute);
+        }
+    }
+
+    /// <inheritdoc />
+    protected override void Dispose(bool disposing)
+    {
+        foreach (var are in this._resetEvents)
+        {
+            are.Dispose();
+        }
+
+        base.Dispose(disposing);
+    }
+
+    private async ValueTask SendDelayedUpdateAsync(UpdateAction action, AttributeDefinition attribute)
+    {
+        var autoResetEvent = this._resetEvents[this._actionIndexMapping[action]];
+        if (!autoResetEvent.WaitOne(0))
+        {
+            // we're sending an update already.
+            return;
+        }
+
+        try
+        {
+            await Task.Delay(SendDelayMs).ConfigureAwait(false);
+            await action(this._player).ConfigureAwait(false);
+        }
+        finally
+        {
+            autoResetEvent.Set();
+        }
+    }
+
+    private static FrozenDictionary<UpdateAction, int> GetActionIndexMapping(FrozenDictionary<AttributeDefinition, UpdateAction> changeActions)
+    {
+        return ActionIndexMappings.GetOrAdd(changeActions, CreateNewIndexDictionary);
+
+        FrozenDictionary<UpdateAction, int> CreateNewIndexDictionary(FrozenDictionary<AttributeDefinition, UpdateAction> dict)
+        {
+            return dict.Values.Distinct().Index().ToFrozenDictionary(tuple => tuple.Item, tuple => tuple.Index);
+        }
+    }
+}

--- a/src/GameServer/RemoteView/Character/UpdateStatsBasePlugIn.cs
+++ b/src/GameServer/RemoteView/Character/UpdateStatsBasePlugIn.cs
@@ -59,7 +59,7 @@ public abstract class UpdateStatsBasePlugIn : Disposable, IUpdateStatsPlugIn
 
         if (this._changeActions.TryGetValue(attribute, out var action))
         {
-            _ = this.SendDelayedUpdateAsync(action, attribute);
+            _ = this.SendDelayedUpdateAsync(action);
         }
     }
 

--- a/src/GameServer/RemoteView/Character/UpdateStatsExtendedPlugIn.cs
+++ b/src/GameServer/RemoteView/Character/UpdateStatsExtendedPlugIn.cs
@@ -1,10 +1,12 @@
-﻿// <copyright file="UpdateMaximumManaExtendedPlugIn.cs" company="MUnique">
+﻿// <copyright file="UpdateStatsExtendedPlugIn.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
 namespace MUnique.OpenMU.GameServer.RemoteView.Character;
 
+using System.Collections.Frozen;
 using System.Runtime.InteropServices;
+using MUnique.OpenMU.AttributeSystem;
 using MUnique.OpenMU.GameLogic.Attributes;
 using MUnique.OpenMU.GameLogic.Views.Character;
 using MUnique.OpenMU.Network.Packets.ServerToClient;
@@ -17,47 +19,49 @@ using MUnique.OpenMU.PlugIns;
 [PlugIn(nameof(UpdateStatsExtendedPlugIn), "The extended implementation of the IUpdateStatsPlugIn which is forwarding everything to the game client with specific data packets.")]
 [Guid("E9A1CCBE-416F-41BA-8E74-74CBEB7042DD")]
 [MinimumClient(106, 3, ClientLanguage.Invariant)]
-public class UpdateStatsExtendedPlugIn : IUpdateStatsPlugIn
+public class UpdateStatsExtendedPlugIn : UpdateStatsBasePlugIn
 {
-    private readonly RemotePlayer _player;
+    private static readonly FrozenDictionary<AttributeDefinition, Func<RemotePlayer, ValueTask>> AttributeChangeActions = new Dictionary<AttributeDefinition, Func<RemotePlayer, ValueTask>>
+    {
+        { Stats.MaximumHealth, OnMaximumStatsChangedAsync },
+        { Stats.MaximumShield, OnMaximumStatsChangedAsync },
+        { Stats.MaximumMana, OnMaximumStatsChangedAsync },
+        { Stats.MaximumAbility, OnMaximumStatsChangedAsync },
+
+        { Stats.CurrentHealth, OnCurrentStatsChangedAsync },
+        { Stats.CurrentShield, OnCurrentStatsChangedAsync },
+        { Stats.CurrentMana, OnCurrentStatsChangedAsync },
+        { Stats.CurrentAbility, OnCurrentStatsChangedAsync },
+        { Stats.AttackSpeed, OnCurrentStatsChangedAsync },
+        { Stats.MagicSpeed, OnCurrentStatsChangedAsync },
+    }.ToFrozenDictionary();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="UpdateStatsExtendedPlugIn"/> class.
     /// </summary>
     /// <param name="player">The player.</param>
-    public UpdateStatsExtendedPlugIn(RemotePlayer player) => this._player = player;
-
-    /// <inheritdoc />
-    public async ValueTask UpdateMaximumStatsAsync(IUpdateStatsPlugIn.UpdatedStats updatedStats = IUpdateStatsPlugIn.UpdatedStats.Undefined)
+    public UpdateStatsExtendedPlugIn(RemotePlayer player)
+        : base(player, AttributeChangeActions)
     {
-        if (this._player.Attributes is null
-            || !(this._player.Connection?.Connected ?? false))
-        {
-            return;
-        }
-
-        await this._player.Connection.SendMaximumStatsExtendedAsync(
-            (uint)this._player.Attributes[Stats.MaximumHealth],
-            (uint)this._player.Attributes[Stats.MaximumShield],
-            (uint)this._player.Attributes[Stats.MaximumMana],
-            (uint)this._player.Attributes[Stats.MaximumAbility]).ConfigureAwait(false);
     }
 
-    /// <inheritdoc />
-    public async ValueTask UpdateCurrentStatsAsync(IUpdateStatsPlugIn.UpdatedStats updatedStats = IUpdateStatsPlugIn.UpdatedStats.Undefined)
+    private static async ValueTask OnMaximumStatsChangedAsync(RemotePlayer player)
     {
-        if (this._player.Attributes is null
-            || !(this._player.Connection?.Connected ?? false))
-        {
-            return;
-        }
+        await player.Connection.SendMaximumStatsExtendedAsync(
+            (uint)player.Attributes![Stats.MaximumHealth],
+            (uint)player.Attributes[Stats.MaximumShield],
+            (uint)player.Attributes[Stats.MaximumMana],
+            (uint)player.Attributes[Stats.MaximumAbility]).ConfigureAwait(false);
+    }
 
-        await this._player.Connection.SendCurrentStatsExtendedAsync(
-            (uint)this._player.Attributes[Stats.CurrentHealth],
-            (uint)this._player.Attributes[Stats.CurrentShield],
-            (uint)this._player.Attributes[Stats.CurrentMana],
-            (uint)this._player.Attributes[Stats.CurrentAbility],
-            (ushort)this._player.Attributes[Stats.AttackSpeed],
-            (ushort)this._player.Attributes[Stats.MagicSpeed]).ConfigureAwait(false);
+    private static async ValueTask OnCurrentStatsChangedAsync(RemotePlayer player)
+    {
+        await player.Connection.SendCurrentStatsExtendedAsync(
+            (uint)player.Attributes![Stats.CurrentHealth],
+            (uint)player.Attributes[Stats.CurrentShield],
+            (uint)player.Attributes[Stats.CurrentMana],
+            (uint)player.Attributes[Stats.CurrentAbility],
+            (ushort)player.Attributes[Stats.AttackSpeed],
+            (ushort)player.Attributes[Stats.MagicSpeed]).ConfigureAwait(false);
     }
 }

--- a/src/GameServer/RemoteView/ViewPlugInContainer.cs
+++ b/src/GameServer/RemoteView/ViewPlugInContainer.cs
@@ -7,6 +7,7 @@ namespace MUnique.OpenMU.GameServer.RemoteView;
 using System.ComponentModel.Design;
 using System.Reflection;
 using Microsoft.Extensions.DependencyInjection;
+using MUnique.OpenMU.GameLogic;
 using MUnique.OpenMU.GameLogic.Views;
 using MUnique.OpenMU.Network.PlugIns;
 using MUnique.OpenMU.PlugIns;
@@ -58,6 +59,7 @@ internal sealed class ViewPlugInContainer : CustomPlugInContainerBase<IViewPlugI
     public void Dispose()
     {
         this._serviceContainer.Dispose();
+        this.KnownPlugIns.OfType<IDisposable>().ForEach(d => d.Dispose());
     }
 
     /// <inheritdoc/>


### PR DESCRIPTION
The IUpdateStatsPlugIn (view-plugin) implementations are responsible to inform the client about changes in certain stats like Health, Mana etc.
Previously, only a fixed subset of the available stats were available for updates. Now we support to update all stats - the implementation can decide which stat it wants to send to the client.
Because some messages include more than one stat, and they can change in short amount of time, I implemented a mechanism which sends the update after a short delay of 16 ms. This results in less network messages. Additionally, I removed the periodically sending of the messages, when nothing changed.