### PR TITLE
Fixed magic effect updates cause stat value reset

### DIFF
--- a/src/GameLogic/MagicEffectsList.cs
+++ b/src/GameLogic/MagicEffectsList.cs
@@ -166,6 +166,14 @@ public class MagicEffectsList : AsyncDisposable
         //// This doesn't only save traffic, it also looks better in game.
         magicEffect.Duration = effect.Duration;
         magicEffect.ResetTimer();
+
+        if (magicEffect.PowerUpElements.Select(e => e.Element)
+            .SequenceEqual(effect.PowerUpElements.Select(e => e.Element)))
+        {
+            // if the effect power ups are the same, we can leave it like that
+            return;
+        }
+
         foreach (var powerUp in magicEffect.PowerUpElements)
         {
             this._owner.Attributes.RemoveElement(powerUp.Element, powerUp.Target);


### PR DESCRIPTION
Some skills update the max stat, e.g. Swell Life skill. When updating an existing effect, the max stat was reset to the normal value, and directly boosted again. When then the max value is above the current, the current gets capped to the lower max. We prevent that now when the powerups are identical.