### PR TITLE
Recover items placed in NPC when player is disconnected

### DIFF
--- a/src/GameLogic/PlayerActions/Items/BaseItemCraftingHandler.cs
+++ b/src/GameLogic/PlayerActions/Items/BaseItemCraftingHandler.cs
@@ -45,6 +45,8 @@ public abstract class BaseItemCraftingHandler : IItemCraftingHandler
             if (await this.DoTheMixAsync(items, player, socketSlot).ConfigureAwait(false) is { } item)
             {
                 player.Logger.LogInformation("Crafted item: {item}", item);
+                player.BackupInventory = null;
+
                 return (CraftingResult.Success, item);
             }
 

--- a/src/GameLogic/PlayerActions/TalkNpcAction.cs
+++ b/src/GameLogic/PlayerActions/TalkNpcAction.cs
@@ -129,6 +129,11 @@ public class TalkNpcAction
                 });
 
                 break;
+            case NpcWindow.ChaosMachine:
+            case NpcWindow.RemoveJohOption:
+                player.BackupInventory = new BackupItemStorage(player.Inventory!.ItemStorage);
+                await player.InvokeViewPlugInAsync<IOpenNpcWindowPlugIn>(p => p.OpenNpcWindowAsync(npcStats.NpcWindow)).ConfigureAwait(false);
+                break;
             default:
                 await player.InvokeViewPlugInAsync<IOpenNpcWindowPlugIn>(p => p.OpenNpcWindowAsync(npcStats.NpcWindow)).ConfigureAwait(false);
                 break;

--- a/src/GameLogic/PlayerActions/Trade/BaseTradeAction.cs
+++ b/src/GameLogic/PlayerActions/Trade/BaseTradeAction.cs
@@ -56,6 +56,7 @@ public class BaseTradeAction
                 }
 
                 trader.Inventory.ItemStorage.Money = trader.BackupInventory.Money;
+                trader.BackupInventory = null;
             }
         }
 

--- a/src/GameServer/GameServer.cs
+++ b/src/GameServer/GameServer.cs
@@ -454,8 +454,8 @@ public sealed class GameServer : IGameServer, IDisposable, IGameServerContextPro
     {
         try
         {
-            // Recover items placed in the NPC when player is diconnected
-            if (player.OpenedNpc is not null && player.BackupInventory is not null)
+            // Recover items placed in an NPC or trade dialog when player is diconnected
+            if (player.BackupInventory is not null)
             {
                 player.Inventory!.Clear();
                 player.BackupInventory.RestoreItemStates();

--- a/src/GameServer/GameServer.cs
+++ b/src/GameServer/GameServer.cs
@@ -466,6 +466,14 @@ public sealed class GameServer : IGameServer, IDisposable, IGameServerContextPro
 
                 player.Inventory.ItemStorage.Money = player.BackupInventory.Money;
             }
+            else if (player is { TemporaryStorage: { } storage, Inventory: { } inventory })
+            {
+                if (!await inventory.TryTakeAllAsync(storage).ConfigureAwait(false))
+                {
+                    // This should never happen since the space is checked before mixing
+                    this._logger.LogWarning($"Could not take fit items of player {player}");
+                }
+            }
 
             if (!await player.PersistenceContext.SaveChangesAsync().ConfigureAwait(false))
             {

--- a/src/GameServer/GameServer.cs
+++ b/src/GameServer/GameServer.cs
@@ -454,6 +454,19 @@ public sealed class GameServer : IGameServer, IDisposable, IGameServerContextPro
     {
         try
         {
+            // Recover items placed in the NPC when player is diconnected
+            if (player.OpenedNpc is not null && player.BackupInventory is not null)
+            {
+                player.Inventory!.Clear();
+                player.BackupInventory.RestoreItemStates();
+                foreach (var item in player.BackupInventory.Items)
+                {
+                    await player.Inventory.AddItemAsync(item.ItemSlot, item).ConfigureAwait(false);
+                }
+
+                player.Inventory.ItemStorage.Money = player.BackupInventory.Money;
+            }
+
             if (!await player.PersistenceContext.SaveChangesAsync().ConfigureAwait(false))
             {
                 this._logger.LogWarning($"Could not save session of player {player}");


### PR DESCRIPTION
Resolves: https://github.com/MUnique/OpenMU/issues/534

Notes:
- [x] Chaos Goblin Failed mix - can not be recovered
- [x] Chaos Goblin Successful mix - new/upgraded item can be recovered
- [x] Jerridon (JOH restore)