### PR TITLE
Implemented a warning message for double-login

### DIFF
--- a/src/Dapr/GameServer.Host/EventPublisher.cs
+++ b/src/Dapr/GameServer.Host/EventPublisher.cs
@@ -97,4 +97,26 @@ public class EventPublisher : IEventPublisher
             this._logger.LogError(ex, "Unexpected error when publishing an alliance message");
         }
     }
+
+    /// <summary>
+    /// Notifies that a client tried to log into an already logged-in account.
+    /// The connected player can be notified about that.
+    /// </summary>
+    /// <param name="serverId">The identifier of the server on which the client tried to enter.</param>
+    /// <param name="loginName">The login name.</param>
+    public async ValueTask PlayerAlreadyLoggedInAsync(byte serverId, string loginName)
+    {
+        try
+        {
+            await this._daprClient
+                .PublishEventAsync(
+                    PubSubName,
+                    nameof(IGameServer.PlayerAlreadyLoggedInAsync),
+                    new PlayerLoggedInArguments(serverId, loginName)).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            this._logger.LogError(ex, "Unexpected error when publishing an alliance message");
+        }
+    }
 }

--- a/src/Dapr/ServerClients/GameServer.cs
+++ b/src/Dapr/ServerClients/GameServer.cs
@@ -6,8 +6,8 @@ namespace MUnique.OpenMU.ServerClients;
 
 using System.ComponentModel;
 using Dapr.Client;
-using Nito.AsyncEx.Synchronous;
 using MUnique.OpenMU.Interfaces;
+using Nito.AsyncEx.Synchronous;
 
 /// <summary>
 /// Implementation of an <see cref="IGameServer"/> which accesses another game server remotely over Dapr.
@@ -116,6 +116,12 @@ public class GameServer : IGameServer
     public async ValueTask AssignGuildToPlayerAsync(string characterName, GuildMemberStatus guildStatus)
     {
         await this._client.InvokeMethodAsync(this._targetAppId, nameof(this.AssignGuildToPlayerAsync), new GuildMemberAssignArguments(characterName, guildStatus)).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask PlayerAlreadyLoggedInAsync(byte serverId, string loginName)
+    {
+        await this._client.InvokeMethodAsync(this._targetAppId, nameof(this.PlayerAlreadyLoggedInAsync), new PlayerLoggedInArguments(serverId, loginName)).ConfigureAwait(false);
     }
 
     /// <inheritdoc />

--- a/src/Dapr/ServerClients/PlayerLoggedInArguments.cs
+++ b/src/Dapr/ServerClients/PlayerLoggedInArguments.cs
@@ -1,0 +1,12 @@
+﻿// <copyright file="PlayerLoggedInArguments.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.ServerClients;
+
+using MUnique.OpenMU.Interfaces;
+
+/// <summary>
+/// Arguments for <see cref="IGameServer.PlayerAlreadyLoggedInAsync"/>
+/// </summary>
+public record PlayerLoggedInArguments(byte ServerId, string LoginName);

--- a/src/GameLogic/PlayerActions/LoginAction.cs
+++ b/src/GameLogic/PlayerActions/LoginAction.cs
@@ -75,6 +75,11 @@ public class LoginAction
                 {
                     context.Allowed = false;
                     await player.InvokeViewPlugInAsync<IShowLoginResultPlugIn>(p => p.ShowLoginResultAsync(LoginResult.AccountAlreadyConnected)).ConfigureAwait(false);
+
+                    if (player.GameContext is IGameServerContext gameServerContext2)
+                    {
+                        await gameServerContext2.EventPublisher.PlayerAlreadyLoggedInAsync(gameServerContext2.Id, username).ConfigureAwait(false);
+                    }
                 }
             }
             catch (Exception ex)

--- a/src/GameServer/GameServer.cs
+++ b/src/GameServer/GameServer.cs
@@ -12,6 +12,7 @@ using MUnique.OpenMU.DataModel;
 using MUnique.OpenMU.DataModel.Configuration;
 using MUnique.OpenMU.DataModel.Entities;
 using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.PlugIns.ChatCommands;
 using MUnique.OpenMU.GameLogic.Views;
 using MUnique.OpenMU.GameLogic.Views.Guild;
 using MUnique.OpenMU.GameLogic.Views.Login;
@@ -319,6 +320,18 @@ public sealed class GameServer : IGameServer, IDisposable, IGameServerContextPro
         player.GuildStatus = guildStatus;
         await player.ForEachWorldObserverAsync<IAssignPlayersToGuildPlugIn>(p => p.AssignPlayerToGuildAsync(player, true), true).ConfigureAwait(false);
         await this.Context.RegisterGuildMemberAsync(player).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask PlayerAlreadyLoggedInAsync(byte serverId, string loginName)
+    {
+        var players = await this._gameContext.GetPlayersAsync().ConfigureAwait(false);
+        var affectedPlayer = players.FirstOrDefault(p => p.Account?.LoginName == loginName);
+
+        if (affectedPlayer is not null)
+        {
+            await affectedPlayer.ShowMessageAsync("Another user attempted to login this account. If it wasn't you, we suggest you to change your password.").ConfigureAwait(false);
+        }
     }
 
     /// <inheritdoc/>

--- a/src/Interfaces/IEventPublisher.cs
+++ b/src/Interfaces/IEventPublisher.cs
@@ -42,4 +42,12 @@ public interface IEventPublisher
     /// <param name="sender">The sender.</param>
     /// <param name="message">The message.</param>
     ValueTask AllianceMessageAsync(uint guildId, string sender, string message);
+
+    /// <summary>
+    /// Notifies that a client tried to log into an already logged-in account.
+    /// The connected player can be notified about that.
+    /// </summary>
+    /// <param name="serverId">The identifier of the server on which the client tried to enter.</param>
+    /// <param name="loginName">The login name.</param>
+    ValueTask PlayerAlreadyLoggedInAsync(byte serverId, string loginName);
 }

--- a/src/Interfaces/IGameServer.cs
+++ b/src/Interfaces/IGameServer.cs
@@ -123,4 +123,12 @@ public interface IGameServer : IManageableServer, IFriendSystemSubscriber
     /// <param name="characterName">Name of the character.</param>
     /// <param name="guildStatus">The guild status of the character.</param>
     ValueTask AssignGuildToPlayerAsync(string characterName, GuildMemberStatus guildStatus);
+
+    /// <summary>
+    /// Notifies that a client tried to log into an already logged-in account.
+    /// The connected player can be notified about that.
+    /// </summary>
+    /// <param name="serverId">The identifier of the server on which the client tried to enter.</param>
+    /// <param name="loginName">The login name.</param>
+    ValueTask PlayerAlreadyLoggedInAsync(byte serverId, string loginName);
 }

--- a/src/Startup/InMemoryEventPublisher.cs
+++ b/src/Startup/InMemoryEventPublisher.cs
@@ -64,4 +64,13 @@ public class InMemoryEventPublisher : IEventPublisher
             await gameServer.Value.AllianceChatMessageAsync(guildId, sender, message).ConfigureAwait(false);
         }
     }
+
+    /// <inheritdoc />
+    public async ValueTask PlayerAlreadyLoggedInAsync(byte serverId, string loginName)
+    {
+        foreach (var gameServer in this._gameServers)
+        {
+            await gameServer.Value.PlayerAlreadyLoggedInAsync(serverId, loginName).ConfigureAwait(false);
+        }
+    }
 }


### PR DESCRIPTION
The connected player gets a warning when another client is connecting to its account.

Fixes #581 