### PR TITLE
Configure IP-Resolver after startup

### DIFF
--- a/src/Startup/Program.cs
+++ b/src/Startup/Program.cs
@@ -135,6 +135,12 @@ internal sealed class Program : IDisposable
                         || args.Contains("-autostart")
                         || !this.IsAdminPanelEnabled(args);
 
+        if (_systemConfiguration is { }
+            && this._serverHost.Services.GetService<IIpAddressResolver>() is ConfigurableIpResolver resolver)
+        {
+            resolver.Configure(_systemConfiguration.IpResolver, _systemConfiguration.IpResolverParameter);
+        }
+
         if (autoStart)
         {
             foreach (var chatServer in this._servers.OfType<ChatServer>())


### PR DESCRIPTION
The ip resolver didn't get initialized with the configuration. In the moment it gets created, the configuration is not loaded yet.