### PR TITLE
Prevent invalid player walk origin

### DIFF
--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -1230,7 +1230,8 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         var startPoint = steps.Span[0].From;
         var currentPosition = this.Position;
         var startOffset = startPoint.EuclideanDistanceTo(currentPosition);
-        if (startOffset > 3)
+        const int maxAllowedWalkStartOffset = 3;
+        if (startOffset > maxAllowedWalkStartOffset)
         {
             this.Logger.LogWarning("WalkToAsync: Player requested to walk from {0}, but it's currently at {1}", startPoint, currentPosition);
 


### PR DESCRIPTION
Previously, it was possible to trick the server from walking from a coordinate which is too far away from the actual coordinate, like a 'teleport'...