### PR TITLE
Damage calculations refactoring

### DIFF
--- a/src/AttributeSystem/AttributeRelationship.cs
+++ b/src/AttributeSystem/AttributeRelationship.cs
@@ -12,24 +12,29 @@ using System.Globalization;
 public enum InputOperator
 {
     /// <summary>
-    /// The <see cref="AttributeRelationship.InputAttribute"/> is multiplied with the <see cref="AttributeRelationship.InputOperand"/> before adding to the <see cref="AttributeRelationship.TargetAttribute"/>.
+    /// The <see cref="AttributeRelationship.InputAttribute"/> is multiplied with the <see cref="AttributeRelationship.InputOperand"/> before effecting the <see cref="AttributeRelationship.TargetAttribute"/>.
     /// </summary>
     Multiply,
 
     /// <summary>
-    /// The <see cref="AttributeRelationship.InputAttribute"/> is increased by the <see cref="AttributeRelationship.InputOperand"/> before adding to the <see cref="AttributeRelationship.TargetAttribute"/>.
+    /// The <see cref="AttributeRelationship.InputAttribute"/> is increased by the <see cref="AttributeRelationship.InputOperand"/> before effecting the <see cref="AttributeRelationship.TargetAttribute"/>.
     /// </summary>
     Add,
 
     /// <summary>
-    /// The <see cref="AttributeRelationship.InputAttribute"/> is exponentiated by the <see cref="AttributeRelationship.InputOperand"/> before adding to the <see cref="AttributeRelationship.TargetAttribute"/>.
+    /// The <see cref="AttributeRelationship.InputAttribute"/> is exponentiated by the <see cref="AttributeRelationship.InputOperand"/> before effecting the <see cref="AttributeRelationship.TargetAttribute"/>.
     /// </summary>
     Exponentiate,
 
     /// <summary>
-    /// The <see cref="AttributeRelationship.InputOperand"/> is exponentiated by the <see cref="AttributeRelationship.InputAttribute"/> before adding to the <see cref="AttributeRelationship.TargetAttribute"/>.
+    /// The <see cref="AttributeRelationship.InputOperand"/> is exponentiated by the <see cref="AttributeRelationship.InputAttribute"/> before effecting the <see cref="AttributeRelationship.TargetAttribute"/>.
     /// </summary>
     ExponentiateByAttribute,
+
+    /// <summary>
+    /// The maximum between <see cref="AttributeRelationship.InputAttribute"/> and <see cref="AttributeRelationship.InputOperand"/> is taken before effecting the <see cref="AttributeRelationship.TargetAttribute"/>.
+    /// </summary>
+    Maximum,
 }
 
 /// <summary>

--- a/src/AttributeSystem/AttributeRelationshipElement.cs
+++ b/src/AttributeSystem/AttributeRelationshipElement.cs
@@ -76,6 +76,9 @@ public class AttributeRelationshipElement : SimpleElement
             InputOperator.ExponentiateByAttribute => (float)Math.Pow(
                 this.InputOperand.Value,
                 this.InputElements.Sum(a => a.Value)),
+            InputOperator.Maximum => Math.Max(
+                this.InputElements.Sum(a => a.Value),
+                this.InputOperand.Value),
             _ => throw new InvalidOperationException($"Input operator {this.InputOperator} unknown"),
         };
     }

--- a/src/AttributeSystem/Extensions.cs
+++ b/src/AttributeSystem/Extensions.cs
@@ -22,6 +22,7 @@ public static class Extensions
             InputOperator.Multiply => "*",
             InputOperator.Exponentiate => "^",
             InputOperator.ExponentiateByAttribute => "^",
+            InputOperator.Maximum => "<max>",
             _ => string.Empty,
         };
     }

--- a/src/DataModel/Configuration/Skill.cs
+++ b/src/DataModel/Configuration/Skill.cs
@@ -55,7 +55,7 @@ public enum DamageType
 public enum SkillType
 {
     /// <summary>
-    /// The skill hit its target directly.
+    /// The skill hits its target directly.
     /// </summary>
     DirectHit = 0,
 
@@ -65,7 +65,7 @@ public enum SkillType
     CastleSiegeSpecial = 1,
 
     /// <summary>
-    /// Same as <see cref="DirectHit"/> but only applyable during castle siege event.
+    /// Same as <see cref="DirectHit"/> but only appliable during castle siege event.
     /// </summary>
     CastleSiegeSkill = 2,
 
@@ -90,6 +90,21 @@ public enum SkillType
     Nova = 6,
 
     /// <summary>
+    /// The earthshake skill which hits all targets in range and applies some base bonus damage.
+    /// </summary>
+    Earthshake = 7,
+
+    /// <summary>
+    /// The electric spike skill which hits all targets in range and applies some base bonus damage.
+    /// </summary>
+    ElectricSpike = 8,
+
+    /// <summary>
+    /// The chaotic diseier skill which hits all targets in range and applies some base bonus damage.
+    /// </summary>
+    ChaoticDiseier = 9,
+
+    /// <summary>
     /// The buff skill type. Applies magic effects on players.
     /// </summary>
     Buff = 10,
@@ -98,6 +113,17 @@ public enum SkillType
     /// The regeneration skill type. Regenerates the target attribute of the defined effect.
     /// </summary>
     Regeneration = 11,
+
+    /// <summary>
+    /// A dark lord/lord emperor skill which hits all targets in range and applies some base bonus damage.
+    /// </summary>
+    /// <remarks>Common to any lord skill other than <see cref="ElectricSpike"/>, <see cref="ChaoticDiseier"/>, and <see cref="Earthshake"/>.</remarks>
+    LordGeneric = 12,
+
+    /// <summary>
+    /// The multishot skill which hits all targets in range and has a 0.8 base damage multiplier.
+    /// </summary>
+    MultiShot = 13,
 
     /// <summary>
     /// The passive boost skill type. Applies boosts to the player who has learned this skill, without the need to be casted.

--- a/src/GameLogic/Attributes/Stats.cs
+++ b/src/GameLogic/Attributes/Stats.cs
@@ -87,6 +87,11 @@ public class Stats
     public static AttributeDefinition TotalLeadershipRequirementValue { get; } = new(new Guid("E38A897E-ED6F-4C06-AE11-7CAA7EAEC5A9"), "Total Leadership Requirement Value", "The total leadership requirement value of an item, which is used to calculate the required total leadership of a character to equip an item. The required total leadership depends on the options, drop level and level of the item.");
 
     /// <summary>
+    /// Gets the total strength and agility attribute definition.
+    /// </summary>
+    public static AttributeDefinition TotalStrengthAndAgility { get; } = new(new Guid("4DFA4E4A-D185-4BCE-952C-5E78A92DC4AF"), "Total Strength and Agility", string.Empty);
+
+    /// <summary>
     /// Gets the level attribute definition.
     /// </summary>
     public static AttributeDefinition Level { get; } = new(new Guid("560931AD-0901-4342-B7F4-FD2E2FCC0563"), "Level", "The level of the character.");
@@ -201,13 +206,32 @@ public class Stats
     public static AttributeDefinition MaximumPhysBaseDmgByWeapon { get; } = new(new Guid("EC0D70BE-839C-4BAD-9FC5-1AD7438C75F8"), "Maximum Physical Base Damage By Weapon", string.Empty);
 
     /// <summary>
+    /// Gets the minimum physical base DMG by right hand weapon attribute definition.
+    /// </summary>
+    /// <remarks>Used to isolate RH weapon min damage for double weapon wield logic.
+    /// On a staff-sword (mixed) or double-staff wield (MG), the LH weapon alone dictates the "attack type":
+    ///   LH: staff; RH: sword/staff => LH physical damage and rise (ene-MG).
+    ///   LH: sword; RH: staff => LH physical damage (str-MG).
+    /// Other than these, it's a "true" double wield (two one-handed physical weapons) and both weapons' damage attributes count.
+    /// Summoner can also double weapon wield (stick and book), but books have no damage.</remarks>
+    public static AttributeDefinition MinPhysBaseDmgByRightWeapon { get; } = new(new Guid("99F42E8D-2C03-4D23-94F8-F920DCF032B4"), "Minimum Physical Base Damage By Right Weapon", string.Empty);
+
+    /// <summary>
+    /// Gets the maximum physical base DMG by right hand weapon attribute definition.
+    /// </summary>
+    /// <remarks>Used to isolate RH weapon max damage for double weapon wield logic (refer to <see cref="MinPhysBaseDmgByRightWeapon"/> docs).</remarks>
+    public static AttributeDefinition MaxPhysBaseDmgByRightWeapon { get; } = new(new Guid("84F794AE-D7EB-4AC6-B56B-79D1E9FF3AF4"), "Maximum Physical Base Damage By Right Weapon", string.Empty);
+
+    /// <summary>
     /// Gets the minimum physical base DMG attribute definition.
     /// </summary>
+    /// <remarks>The "resting" physical minimum base damage.</remarks>
     public static AttributeDefinition MinimumPhysBaseDmg { get; } = new(new Guid("3E8D6A02-E973-4AE4-9DF3-CDDC3D3183B3"), "Minimum Physical Base Damage", string.Empty);
 
     /// <summary>
     /// Gets the maximum physical base DMG attribute definition.
     /// </summary>
+    /// <remarks>The "resting" physical maximum base damage.</remarks>
     public static AttributeDefinition MaximumPhysBaseDmg { get; } = new(new Guid("8A918EA2-893A-48B2-A684-3E71526CA71F"), "Maximum Physical Base Damage", string.Empty);
 
     /// <summary>
@@ -218,11 +242,13 @@ public class Stats
     /// <summary>
     /// Gets the minimum wiz base DMG attribute definition.
     /// </summary>
+    /// <remarks>The "resting" wizardry minimum base damage.</remarks>
     public static AttributeDefinition MinimumWizBaseDmg { get; } = new(new Guid("65583A02-AB94-4A17-9B79-86ECC82DC835"), "Minimum Wizardry Base Damage", string.Empty);
 
     /// <summary>
     /// Gets the maximum wiz base DMG attribute definition.
     /// </summary>
+    /// <remarks>The "resting" wizardry maximum base damage.</remarks>
     public static AttributeDefinition MaximumWizBaseDmg { get; } = new(new Guid("44B8236A-BF5B-4082-BA8B-5DEDA1458D33"), "Maximum Wizardry Base Damage", string.Empty);
 
     /// <summary>
@@ -248,17 +274,30 @@ public class Stats
     /// <summary>
     /// Gets the minimum curse base DMG attribute definition.
     /// </summary>
+    /// <remarks>The "resting" curse minimum base damage.</remarks>
     public static AttributeDefinition MinimumCurseBaseDmg { get; } = new(new Guid("B8AE2D6B-05CE-43A9-B2BB-3C32F288A043"), "Minimum Curse Base Damage", string.Empty);
 
     /// <summary>
     /// Gets the maximum curse base DMG attribute definition.
     /// </summary>
+    /// <remarks>The "resting" curse maximum base damage.</remarks>
     public static AttributeDefinition MaximumCurseBaseDmg { get; } = new(new Guid("5E7B5B56-BB4D-4645-9593-836FE86E80EA"), "Maximum Curse Base Damage", string.Empty);
 
     /// <summary>
     /// Gets the the min and max curse base DMG attribute definition.
     /// </summary>
+    /// <remarks>Includes xfm rings curse damage bonus (panda, skeleton, robot knight, mini robot, great heavenly mage).</remarks>
     public static AttributeDefinition CurseBaseDmg { get; } = new(new Guid("60868001-6A67-408C-BFDB-320670A9A682"), "Curse Base Damage (min and max)", string.Empty);
+
+    /// <summary>
+    /// Gets the the min wizardry and curse common MST DMG bonus attribute definition.
+    /// </summary>
+    public static AttributeDefinition MinWizardryAndCurseDmgBonus { get; } = new(new Guid("7E32A2B5-54F2-4D95-9968-9DE53100D3D4"), "Minimum Wizardry And Curse Base Damage Bonus (MST)", string.Empty);
+
+    /// <summary>
+    /// Gets the the min and max wizardry and curse common MST DMG bonus attribute definition.
+    /// </summary>
+    public static AttributeDefinition WizardryAndCurseBaseDmgBonus { get; } = new(new Guid("A4F57534-4185-450D-93B1-0CE4246FE2D3"), "Wizardry And Curse Base Damage Bonus (min and max, MST)", string.Empty);
 
     /// <summary>
     /// Gets the attribute definition for the base damage of the fenrir pet.
@@ -266,19 +305,26 @@ public class Stats
     public static AttributeDefinition FenrirBaseDmg { get; } = new(new Guid("96F47E70-5C85-4A92-B224-944A9359240E"), "Fenrir Base Damage", string.Empty);
 
     /// <summary>
-    /// Gets the base damage bonus attribute definition.
+    /// Gets the min and max (physical and wizardry) base DMG bonus attribute definition.
     /// </summary>
-    public static AttributeDefinition BaseDamageBonus { get; } = new(new Guid("BB6F0151-EAB2-4A9D-BFE3-51E145F36C52"), "Base Damage Bonus", "A bonus value which gets added to all min/max damage values during the damage calculation");
+    /// <remarks>Includes MG swords double option, socket (fire and bonus), xfm rings (christmas, panda, skeleton, robot knight, mini robot, great heavenly mage), Jack O'Lantern Wrath, and Cherry Blossom Flower Petal.</remarks>
+    public static AttributeDefinition BaseDamageBonus { get; } = new(new Guid("BB6F0151-EAB2-4A9D-BFE3-51E145F36C52"), "Base Damage Bonus (physical and wizardry, min and max)", "A bonus value which gets added to physical and wizardry base min and max damage values during the damage calculation.");
 
     /// <summary>
-    /// Gets the base min damage bonus attribute definition.
+    /// Gets the min (physical and wizardry) base DMG bonus attribute definition.
     /// </summary>
-    public static AttributeDefinition BaseMinDamageBonus { get; } = new(new Guid("ACE8CC0A-3288-491C-A49F-4B754A18BA1F"), "Base Min Damage Bonus", "A bonus value which gets added to all min damage values during the damage calculation");
+    public static AttributeDefinition BaseMinDamageBonus { get; } = new(new Guid("8C175E46-D614-495C-9990-EECD98547381"), "Base Min Damage Bonus (physical and wizardry)", "A bonus value which gets added to physical and wizardry base min damage values during the damage calculation.");
 
     /// <summary>
-    /// Gets the base max damage bonus attribute definition.
+    /// Gets the max (physical and wizardry) base DMG bonus attribute definition.
     /// </summary>
-    public static AttributeDefinition BaseMaxDamageBonus { get; } = new(new Guid("7C9E419B-63B0-4237-B799-B80418693A61"), "Base Max Damage Bonus", "A bonus value which gets added to all max damage values during the damage calculation");
+    public static AttributeDefinition BaseMaxDamageBonus { get; } = new(new Guid("7C9E419B-63B0-4237-B799-B80418693A61"), "Base Max Damage Bonus (physical and wizardry)", "A bonus value which gets added to physical and wizardry base max damage values during the damage calculation.");
+
+    /// <summary>
+    /// Gets the final damage (any type) bonus attribute definition.
+    /// </summary>
+    /// <remarks>So far includes the ancient set option.</remarks>
+    public static AttributeDefinition FinalDamageBonus { get; } = new(new Guid("88316AEC-1D82-4103-BF09-CA6A3C0B177A"), "Late Damage Bonus (any type)", "A bonus value which gets added to the final damage value during the damage calculation.");
 
     /// <summary>
     /// Gets the skill multiplier attribute definition.
@@ -288,16 +334,19 @@ public class Stats
     /// <summary>
     /// Gets the skill damage bonus attribute definition.
     /// </summary>
+    /// <remarks>Includes ancient set, harmony, and socket (ice and bonus) options. Does not apply to Fenrir's skill.</remarks>
     public static AttributeDefinition SkillDamageBonus { get; } = new(new Guid("B8B214B1-396B-4CA8-9A77-240AA70A989B"), "Skill Damage Bonus", "A bonus value which gets added to the damage calculation when the damage is calculated with a skill.");
 
     /// <summary>
     /// Gets the critical damage bonus attribute definition.
     /// </summary>
+    /// <remarks>Includes ancient set, harmony, and socket (lightning) options, critical damage increase skill.</remarks>
     public static AttributeDefinition CriticalDamageBonus { get; } = new(new Guid("33F53519-16F3-44C2-9D36-432C36329C78"), "Critical Damage Bonus", "A bonus value which gets added to the damage calculation when the damage is calculated and critical damage applies.");
 
     /// <summary>
     /// Gets the excellent damage bonus attribute definition.
     /// </summary>
+    /// <remarks>Includes ancient set, and socket (lightning) options.</remarks>
     public static AttributeDefinition ExcellentDamageBonus { get; } = new(new Guid("9CB8705A-398D-4158-BC60-D6ADBED36A28"), "Excellent Damage Bonus", "A bonus value which gets added to the damage calculation when the damage is calculated and excellent damage applies.");
 
     /// <summary>
@@ -319,22 +368,47 @@ public class Stats
     public static AttributeDefinition AttackSpeedByWeapon { get; } = new(new Guid("45EEEDEE-C76B-40E6-A0BC-2B493E10B140"), "Attack Speed by Weapons", string.Empty);
 
     /// <summary>
-    /// Gets the attribute which says, if two weapons are equipped.
+    /// Gets the attribute which says, if any two weapons are equipped (DK, MG, Sum, RF).
     /// </summary>
+    /// <remarks>Used to average out the <see cref="AttackSpeedAny"/>.</remarks>
     public static AttributeDefinition AreTwoWeaponsEquipped { get; } = new(new Guid("56DA895D-BAFD-4A5C-9864-B17AB8369998"), "Are two weapons equipped", string.Empty)
     {
         MaximumValue = 1,
     };
 
     /// <summary>
-    /// Gets the attribute which counts the equipped weapons.
+    /// Gets the attribute which counts the equipped weapons. Unlocks <see cref="AreTwoWeaponsEquipped"/>.
     /// </summary>
     public static AttributeDefinition EquippedWeaponCount { get; } = new(new Guid("15D6493F-549D-455F-9FFF-A0D589FD7DA2"), "Equipped Weapon Count", string.Empty);
+
+    /// <summary>
+    /// Gets the attribute which says if the player has a double wield (DK, MG, RF).
+    /// </summary>
+    /// <remarks>This is different from the <see cref="AreTwoWeaponsEquipped"/> attribute, where two staffs can be equipped, for example.
+    /// For a double wield only physical attack type weapons are considered.</remarks>
+    public static AttributeDefinition HasDoubleWield { get; } = new(new Guid("4AD0E3CA-526D-4DBF-AB65-87BEB7A1F080"), "Has Double Wield", "A double weapon wield grants a 10% increase in physical damage. Only DK, MG, and RF can double wield.");
+
+    /// <summary>
+    /// Gets the double wield weapon count attribute. Unlocks <see cref="HasDoubleWield"/>.
+    /// </summary>
+    public static AttributeDefinition DoubleWieldWeaponCount { get; } = new(new Guid("84252905-3DAD-4E38-AE4D-C18FE2A99395"), "Double Wield Weapon Count", string.Empty);
 
     /// <summary>
     /// Gets the magic speed attribute definition which is used for some skills.
     /// </summary>
     public static AttributeDefinition MagicSpeed { get; } = new(new Guid("AE32AA45-9C18-43B3-9F7B-648FD7F4B0AD"), "Magic Speed", string.Empty);
+
+    /// <summary>
+    /// Gets the wizardry base (min and max) damage increase attribute definition>.
+    /// </summary>
+    /// <remarks>Includes ancient set wizardry increase option, and excellent 2% wizardry increase option.</remarks>
+    public static AttributeDefinition WizardryBaseDmgIncrease { get; } = new(new Guid("D9DBAA2C-BA56-4F7F-A516-8DE6354406FE"), "Wizardry Base Damage Increase", string.Empty);
+
+    /// <summary>
+    /// Gets the physical base (min and max) damage increase attribute definition>.
+    /// </summary>
+    /// <remarks>Includes excellent 2% physical increase option, and the double wield multiplier (55%).</remarks>
+    public static AttributeDefinition PhysicalBaseDmgIncrease { get; } = new(new Guid("104B4DAA-C507-4CBB-AF38-D53DDBB4817E"), "Physical Base Damage Increase", string.Empty);
 
     /// <summary>
     /// Gets the walk speed attribute definition.
@@ -344,7 +418,18 @@ public class Stats
     /// <summary>
     /// Gets the attack damage increase attribute definition.
     /// </summary>
+    /// <remarks>Includes wings, imp, and dinorant.</remarks>
     public static AttributeDefinition AttackDamageIncrease { get; } = new(new Guid("0765CCD2-C70A-4338-BF49-0D652364C223"), "Attack Damage Increase Multiplier", string.Empty);
+
+    /// <summary>
+    /// Gets the fenrir pet attack damage increase attribute definition.
+    /// </summary>
+    public static AttributeDefinition FenrirAttackDamageIncrease { get; } = new(new Guid("46437116-2974-4595-A15A-DD9FC6CC673E"), "Fenrir Attack Damage Increase", "The fenrir attack damage multiplier which is multiplied with the final damage and added to it.");
+
+    /// <summary>
+    /// Gets the fenrir pet damage receive decrement attribute definition.
+    /// </summary>
+    public static AttributeDefinition FenrirDamageReceiveDecrement { get; } = new(new Guid("1204AF41-706E-47CE-8D03-71F1F80F0B05"), "Fenrir Damage Receive Decrement", "The fenrir receive damage multiplier which is multiplied with the final damage and subtracted from it.");
 
     /// <summary>
     /// Gets the wizardry attack damage increase attribute definition.
@@ -352,9 +437,9 @@ public class Stats
     public static AttributeDefinition WizardryAttackDamageIncrease { get; } = new(new Guid("8F1CD5A5-3792-42FC-89B8-E6D50F997F4B"), "Wizardry Attack Damage Increase Multiplier", "The wizardry damage increase which is multiplied with the min/max wiz base damage and added to it.");
 
     /// <summary>
-    /// Gets the pet attack damage increase attribute definition.
+    /// Gets the raven attack damage increase attribute definition.
     /// </summary>
-    public static AttributeDefinition PetAttackDamageIncrease { get; } = new(new Guid("662467B2-CBCF-4347-9B39-A2BBEE04E6D7"), "Pet Attack Damage Increase Multiplier", "The pet damage increase which is multiplied with the min/max wiz base damage and added to it.");
+    public static AttributeDefinition RavenAttackDamageIncrease { get; } = new(new Guid("662467B2-CBCF-4347-9B39-A2BBEE04E6D7"), "Raven Attack Damage Increase Multiplier", "The raven damage increase which is multiplied with the min/max raven base damage and added to it.");
 
     /// <summary>
     /// Gets the curse attack damage increase attribute definition.
@@ -362,9 +447,9 @@ public class Stats
     public static AttributeDefinition CurseAttackDamageIncrease { get; } = new(new Guid("2B8904D5-9901-40C0-BFDE-66675672D9DC"), "Curse Attack Damage Increase Multiplier", "The cursed damage increase which is multiplied with the min/max curse base damage and added to it.");
 
     /// <summary>
-    /// Gets the two handed weapon damage increase attribute definition.
+    /// Gets the two handed weapon physical damage increase ancient set option attribute definition.
     /// </summary>
-    public static AttributeDefinition TwoHandedWeaponDamageIncrease { get; } = new(new Guid("BA3D57E9-68A5-47AC-A6E9-43793F4DDE2A"), "Two-Handed Weapon Damage Increase", "The damage increase which is multiplied with the min/max base damage and added to it when using a two-handed weapon.");
+    public static AttributeDefinition TwoHandedWeaponDamageIncrease { get; } = new(new Guid("BA3D57E9-68A5-47AC-A6E9-43793F4DDE2A"), "Two-Handed Weapon Physical Damage Increase (Ancient Option)", "The physical damage increase which is multiplied with the final damage and added to it when using a two-handed weapon.");
 
     /// <summary>
     /// Gets the is two handed weapon equipped.
@@ -377,9 +462,9 @@ public class Stats
     public static AttributeDefinition IsBowEquipped { get; } = new(new Guid("8B1135B7-C323-4822-9B98-1A56C802BB6A"), "Is Bow Equipped", string.Empty);
 
     /// <summary>
-    /// Gets the bow bonus base damage.
+    /// Gets the bow strengthener MST bonus damage.
     /// </summary>
-    public static AttributeDefinition BowBonusBaseDamage { get; } = new(new Guid("AF19A56D-2F31-4A80-8DF7-B99ADF7D275B"), "Bow Bonus Base Damage", string.Empty);
+    public static AttributeDefinition BowStrBonusDamage { get; } = new(new Guid("AF19A56D-2F31-4A80-8DF7-B99ADF7D275B"), "Bow Strengthener Bonus Damage (MST)", string.Empty);
 
     /// <summary>
     /// Gets the is a cross bow equipped.
@@ -387,9 +472,54 @@ public class Stats
     public static AttributeDefinition IsCrossBowEquipped { get; } = new(new Guid("EDB70177-D824-45FC-8B76-7AE26859B7E5"), "Is Cross Bow Equipped", string.Empty);
 
     /// <summary>
-    /// Gets the bow bonus base damage.
+    /// Gets the cross bow strengthener MST bonus damage.
     /// </summary>
-    public static AttributeDefinition CrossBowBonusBaseDamage { get; } = new(new Guid("DBAD454A-EB1C-4FEE-9B40-97EA70278BB5"), "Cross Bow Bonus Base Damage", string.Empty);
+    public static AttributeDefinition CrossBowStrBonusDamage { get; } = new(new Guid("DBAD454A-EB1C-4FEE-9B40-97EA70278BB5"), "Cross Bow Strengthener Bonus Damage (MST)", string.Empty);
+
+    /// <summary>
+    /// Gets the cross bow mastery MST bonus damage.
+    /// </summary>
+    public static AttributeDefinition CrossBowMasteryBonusDamage { get; } = new(new Guid("B3AF7F51-6D6B-42FB-B8FF-689D03890F3E"), "Cross Bow Mastery Bonus Damage (MST)", string.Empty);
+
+    /// <summary>
+    /// Gets elf's melee attack mode attribute definition.
+    /// </summary>
+    public static AttributeDefinition MeleeAttackMode { get; } = new(new Guid("2121E586-B511-4D27-9E1A-67BFCACD7F41"), "Melee Attack Mode", "The elf's melee attack mode switch.");
+
+    /// <summary>
+    /// Gets elf's melee minimum damage attribute definition.
+    /// </summary>
+    public static AttributeDefinition MeleeMinDmg { get; } = new(new Guid("A85BD4A5-9649-49F9-A7E2-B24D9114CC3E"), "Melee Minimum Damage", "The elf's minimum melee damage, which is added to close range attacks.");
+
+    /// <summary>
+    /// Gets elf's melee maximum damage attribute definition.
+    /// </summary>
+    public static AttributeDefinition MeleeMaxDmg { get; } = new(new Guid("35A2224D-FD1C-4D19-B64B-EB7247530DE4"), "Melee Maximum Damage", "The elf's maximum melee damage, which is added to close range attacks.");
+
+    /// <summary>
+    /// Gets elf's archery attack mode attribute definition.
+    /// </summary>
+    public static AttributeDefinition ArcheryAttackMode { get; } = new(new Guid("371E1237-6AE9-4AC1-9A7F-20CBEC897091"), "Archery Attack Mode", "The elf's archery attack mode switch.");
+
+    /// <summary>
+    /// Gets elf's archery minimum damage attribute definition.
+    /// </summary>
+    public static AttributeDefinition ArcheryMinDmg { get; } = new(new Guid("9308EF7C-4DC4-4A0A-8747-02AAB7CC051A"), "Archery Minimum Damage", "The elf's minimum archery damage, which is added to projectile weapon attacks.");
+
+    /// <summary>
+    /// Gets elf's archery maximum damage attribute definition.
+    /// </summary>
+    public static AttributeDefinition ArcheryMaxDmg { get; } = new(new Guid("EC807B7C-4004-4D13-BED2-326E13F8EFEB"), "Archery Maximum Damage", "The elf's maximum archery damage, which is added to projectile weapon attacks.");
+
+    /// <summary>
+    /// Gets the elf's greater damage buff bonus damage attribute definition.
+    /// </summary>
+    public static AttributeDefinition GreaterDamageBonus { get; } = new(new Guid("5CFE3ED7-AF45-4790-BDD9-0DC55B981296"), "Greater Damage Bonus", string.Empty);
+
+    /// <summary>
+    /// Gets the infinity arrow strengthener attack damage multiplier attribute definition.
+    /// </summary>
+    public static AttributeDefinition InfinityArrowStrMultiplier { get; } = new(new Guid("62536721-6C69-46D9-A6C4-1E4F0F7AC5AB"), "Infinity Arrow Strengthener Multiplier", "The infinity arrow strengthener damage multiplier which is multiplied with the final damage and added to it.");
 
     /// <summary>
     /// Gets the is a one handed sword equipped.
@@ -397,9 +527,15 @@ public class Stats
     public static AttributeDefinition IsOneHandedSwordEquipped { get; } = new(new Guid("21B71774-EB4F-41F6-A0AA-0E600F41226C"), "Is One Handed Sword Equipped", string.Empty);
 
     /// <summary>
-    /// Gets the one handed sword bonus base damage.
+    /// Gets the one handed sword MST bonus base damage.
     /// </summary>
-    public static AttributeDefinition OneHandedSwordBonusBaseDamage { get; } = new(new Guid("60FA78A3-4E8C-4304-9077-5D3312EB1BE8"), "One Handed Sword Bonus Base Damage", string.Empty);
+    public static AttributeDefinition OneHandedSwordBonusDamage { get; } = new(new Guid("60FA78A3-4E8C-4304-9077-5D3312EB1BE8"), "One Handed Sword Bonus Damage (MST)", string.Empty);
+
+    /// <summary>
+    /// Gets the weapon mastery MST bonus attack speed.
+    /// </summary>
+    /// <remarks>Bucket attribute for the master skills: one handed sword mastery (DK), bow mastery (Elf), one handed staff mastery (DW), other world tome mastery (Summoner).</remarks>
+    public static AttributeDefinition WeaponMasteryAttackSpeed { get; } = new(new Guid("CD16D6FD-5495-4BD9-A112-DBAF83BB4008"), "Weapon Mastery Bonus Attack Speed (MST)", "A generic master tree attack speed bonus attribute, which serves as a bucket for \"mastery\" skills.");
 
     /// <summary>
     /// Gets the is a two handed sword equipped.
@@ -407,9 +543,14 @@ public class Stats
     public static AttributeDefinition IsTwoHandedSwordEquipped { get; } = new(new Guid("15530767-556E-45F6-8C2D-9AC71FC4070F"), "Is Two Handed Sword Equipped", string.Empty);
 
     /// <summary>
-    /// Gets the two handed sword bonus base damage.
+    /// Gets the two handed sword strengthener MST bonus damage.
     /// </summary>
-    public static AttributeDefinition TwoHandedSwordBonusBaseDamage { get; } = new(new Guid("C77F9C38-336B-43AE-8B82-A8D73612E9D2"), "Two Handed Sword Bonus Base Damage", string.Empty);
+    public static AttributeDefinition TwoHandedSwordStrBonusDamage { get; } = new(new Guid("C77F9C38-336B-43AE-8B82-A8D73612E9D2"), "Two Handed Sword Strengthener Bonus Damage (MST)", string.Empty);
+
+    /// <summary>
+    /// Gets the two handed sword mastery MST bonus damage.
+    /// </summary>
+    public static AttributeDefinition TwoHandedSwordMasteryBonusDamage { get; } = new(new Guid("77B2B093-7418-4A71-AD52-12DB162B4461"), "Two Handed Sword Mastery Bonus Damage (MST)", string.Empty);
 
     /// <summary>
     /// Gets the is a mace equipped.
@@ -417,9 +558,9 @@ public class Stats
     public static AttributeDefinition IsMaceEquipped { get; } = new(new Guid("47BD42D1-2E27-407B-92B5-925F418C30DE"), "Is Mace Equipped", string.Empty);
 
     /// <summary>
-    /// Gets the mace bonus base damage.
+    /// Gets the mace bonus MST damage.
     /// </summary>
-    public static AttributeDefinition MaceBonusBaseDamage { get; } = new(new Guid("E7F2A75F-E8F5-4877-A0D8-59D59041A973"), "Mace Bonus Base Damage", string.Empty);
+    public static AttributeDefinition MaceBonusDamage { get; } = new(new Guid("E7F2A75F-E8F5-4877-A0D8-59D59041A973"), "Mace Bonus Damage (MST)", string.Empty);
 
     /// <summary>
     /// Gets the is a spear equipped.
@@ -427,19 +568,29 @@ public class Stats
     public static AttributeDefinition IsSpearEquipped { get; } = new(new Guid("5CBBD700-B897-4425-AADE-FDE249318505"), "Is Spear Equipped", string.Empty);
 
     /// <summary>
-    /// Gets the spear bonus base damage.
+    /// Gets the spear MST bonus damage.
     /// </summary>
-    public static AttributeDefinition SpearBonusBaseDamage { get; } = new(new Guid("207DA941-CDDC-4231-A82C-B76A2441B77A"), "Spear Bonus Base Damage", string.Empty);
+    public static AttributeDefinition SpearBonusDamage { get; } = new(new Guid("207DA941-CDDC-4231-A82C-B76A2441B77A"), "Spear Bonus Damage (MST)", string.Empty);
+
+    /// <summary>
+    /// Gets the generic physical MST bonus damage attribute, which serves as a bucket for late stage bonus physical damage.
+    /// </summary>
+    /// <remarks>So far includes the Weapon Mastery (DK, Elf, MG, DL, RF) passive skills, and the end product of Command Attack Increase (DL).</remarks>
+    public static AttributeDefinition MasterSkillPhysBonusDmg { get; } = new(new Guid("48BD920B-9C6F-4884-A307-AD3AB58B7927"), "Master Skill Physical Bonus Damage (MST)", "A generic master tree physical damage bonus attribute, which serves as a bucket for late stage bonus physical damage.");
 
     /// <summary>
     /// Gets the is a one handed staff equipped.
     /// </summary>
-    public static AttributeDefinition IsOneHandedStaffEquipped { get; } = new(new Guid("C452EFD8-9FFE-4015-BE93-8BC8D5D81572"), "Is One Handed Staff Equipped", string.Empty);
+    /// <remarks>MG can equip two.</remarks>
+    public static AttributeDefinition IsOneHandedStaffEquipped { get; } = new(new Guid("C452EFD8-9FFE-4015-BE93-8BC8D5D81572"), "Is One Handed Staff Equipped", string.Empty)
+    {
+        MaximumValue = 1,
+    };
 
     /// <summary>
-    /// Gets the one handed staff bonus base damage.
+    /// Gets the one handed staff MST bonus base damage.
     /// </summary>
-    public static AttributeDefinition OneHandedStaffBonusBaseDamage { get; } = new(new Guid("12F2F553-DA04-432F-83E0-28F30C1B93A2"), "One Handed Staff Bonus Base Damage", string.Empty);
+    public static AttributeDefinition OneHandedStaffBonusBaseDamage { get; } = new(new Guid("12F2F553-DA04-432F-83E0-28F30C1B93A2"), "One Handed Staff Bonus Base Damage (MST)", string.Empty);
 
     /// <summary>
     /// Gets the is a two handed staff equipped.
@@ -447,9 +598,14 @@ public class Stats
     public static AttributeDefinition IsTwoHandedStaffEquipped { get; } = new(new Guid("FE669B70-D36D-4F56-A1DA-4A4B98ED503D"), "Is Two Handed Staff Equipped", string.Empty);
 
     /// <summary>
-    /// Gets the two handed staff bonus base damage.
+    /// Gets the two handed staff MST bonus base damage.
     /// </summary>
-    public static AttributeDefinition TwoHandedStaffBonusBaseDamage { get; } = new(new Guid("8A46D105-4B58-4E42-B602-52715F6BEE61"), "Two Handed Staff Bonus Base Damage", string.Empty);
+    public static AttributeDefinition TwoHandedStaffBonusBaseDamage { get; } = new(new Guid("8A46D105-4B58-4E42-B602-52715F6BEE61"), "Two Handed Staff Bonus Base Damage (MST)", string.Empty);
+
+    /// <summary>
+    /// Gets the two handed staff mastery MST bonus damage.
+    /// </summary>
+    public static AttributeDefinition TwoHandedStaffMasteryBonusDamage { get; } = new(new Guid("1E6B1569-A36D-4C41-97B1-DD6E0A9746EE"), "Two Handed Staff Mastery Bonus Damage (MST)", string.Empty);
 
     /// <summary>
     /// Gets the is a stick equipped.
@@ -457,9 +613,24 @@ public class Stats
     public static AttributeDefinition IsStickEquipped { get; } = new(new Guid("85C46193-8EC9-4CCE-B18B-F79E938FE9C3"), "Is Stick Equipped", string.Empty);
 
     /// <summary>
-    /// Gets the stick bonus base damage.
+    /// Gets the is a book equipped.
     /// </summary>
-    public static AttributeDefinition StickBonusBaseDamage { get; } = new(new Guid("0EF0D78B-9518-445B-BE5A-469962AF7C9D"), "Stick Bonus Base Damage", string.Empty);
+    public static AttributeDefinition IsBookEquipped { get; } = new(new Guid("1EE456B6-65EF-46E9-A90D-D3BA7D23CBF5"), "Is Book Equipped", string.Empty);
+
+    /// <summary>
+    /// Gets the book MST (tome strengthener) bonus base damage.
+    /// </summary>
+    public static AttributeDefinition BookBonusBaseDamage { get; } = new(new Guid("6B15592C-70A4-4EE0-A713-DDC4794313DA"), "Book Bonus Base Damage (MST)", string.Empty);
+
+    /// <summary>
+    /// Gets the stick MST bonus base damage.
+    /// </summary>
+    public static AttributeDefinition StickBonusBaseDamage { get; } = new(new Guid("0EF0D78B-9518-445B-BE5A-469962AF7C9D"), "Stick Bonus Base Damage (MST)", string.Empty);
+
+    /// <summary>
+    /// Gets the stick mastery MST bonus damage.
+    /// </summary>
+    public static AttributeDefinition StickMasteryBonusDamage { get; } = new(new Guid("E79B2B06-9A32-451F-9B2D-2B91FD79B614"), "Stick Mastery Bonus Damage (MST)", string.Empty);
 
     /// <summary>
     /// Gets the is a scepter equipped.
@@ -467,19 +638,24 @@ public class Stats
     public static AttributeDefinition IsScepterEquipped { get; } = new(new Guid("8650DE3B-BE11-458E-B352-4046CE264402"), "Is Scepter Equipped", string.Empty);
 
     /// <summary>
-    /// Gets the scepter bonus base damage.
+    /// Gets the scepter strengthener MST bonus damage.
     /// </summary>
-    public static AttributeDefinition ScepterBonusBaseDamage { get; } = new(new Guid("4E4373A5-F5DB-4D06-B5C1-EE798B58017E"), "Scepter Bonus Base Damage", string.Empty);
+    public static AttributeDefinition ScepterStrBonusDamage { get; } = new(new Guid("4E4373A5-F5DB-4D06-B5C1-EE798B58017E"), "Scepter Strengthener Bonus Damage (MST)", string.Empty);
 
     /// <summary>
-    /// Gets the scepter pet bonus base damage.
+    /// Gets the scepter mastery MST bonus damage.
     /// </summary>
-    public static AttributeDefinition ScepterPetBonusBaseDamage { get; } = new(new Guid("5706451D-6A73-4462-B559-31C7F847994E"), "Scepter Pet Bonus Base Damage", string.Empty);
+    public static AttributeDefinition ScepterMasteryBonusDamage { get; } = new(new Guid("39C1837C-B19F-4FA3-B16F-03A0F5AE624A"), "Scepter Mastery Bonus Damage (MST)", string.Empty);
+
+    /// <summary>
+    /// Gets the scepter pet MST bonus damage.
+    /// </summary>
+    public static AttributeDefinition ScepterPetBonusDamage { get; } = new(new Guid("5706451D-6A73-4462-B559-31C7F847994E"), "Scepter Pet Bonus Base Damage (MST)", string.Empty);
 
     /// <summary>
     /// Gets the is a horse equipped.
     /// </summary>
-    public static AttributeDefinition IsHorseEquipped { get; } = new(new Guid("4CDC3CCC-9266-4EEE-9C91-0E6AAFA8B636"), "Is Horse equipped", string.Empty);
+    public static AttributeDefinition IsHorseEquipped { get; } = new(new Guid("4CDC3CCC-9266-4EEE-9C91-0E6AAFA8B636"), "Is Horse Equipped", string.Empty);
 
     /// <summary>
     /// Gets the is a glove weapon equipped.
@@ -487,9 +663,9 @@ public class Stats
     public static AttributeDefinition IsGloveWeaponEquipped { get; } = new(new Guid("BC8FFFCA-A593-4B64-BE37-BF7EDC97CA1E"), "Is Glove Weapon Equipped", string.Empty);
 
     /// <summary>
-    /// Gets the glove weapon bonus base damage.
+    /// Gets the glove weapon MST bonus damage.
     /// </summary>
-    public static AttributeDefinition GloveWeaponBonusBaseDamage { get; } = new(new Guid("F9CB1174-0184-4F21-B71D-AFC7359BC594"), "Glove Weapon Bonus Base Damage", string.Empty);
+    public static AttributeDefinition GloveWeaponBonusDamage { get; } = new(new Guid("F9CB1174-0184-4F21-B71D-AFC7359BC594"), "Glove Weapon Bonus Damage (MST)", string.Empty);
 
     /// <summary>
     /// Gets the summoned monster health increase, percentage.
@@ -517,7 +693,7 @@ public class Stats
     public static AttributeDefinition GainHeroStatusQuestCompleted { get; } = new(new Guid("4A847231-171B-4FE2-A203-009CB4A26227"), "Is 'Gain Hero Status' Quest completed?", string.Empty);
 
     /// <summary>
-    /// Gets the final damage increase PVP attribute definition.
+    /// Gets the final damage (any type) increase PVP attribute definition.
     /// </summary>
     public static AttributeDefinition FinalDamageIncreasePvp { get; } = new(new Guid("20BE9BFA-A2DC-4868-8ABF-B6DE4B51D4D2"), "Final Damage Increase (PvP)", string.Empty);
 
@@ -595,12 +771,19 @@ public class Stats
     /// <summary>
     /// Gets the damage receive decrement attribute definition.
     /// </summary>
+    /// <remarks>Includes wings, angel, spirit of guardian, dinorant, and shield's defense skill.</remarks>
     public static AttributeDefinition DamageReceiveDecrement { get; } = new(new Guid("9D9761EF-EF47-4E5C-8106-EBC555786F20"), "Damage Receive Multiplier", string.Empty);
 
     /// <summary>
     /// Gets the damage receive decrement from dark horse attribute definition.
     /// </summary>
     public static AttributeDefinition DamageReceiveHorseDecrement { get; } = new(new Guid("041B2811-05C0-49DE-B083-4D1FBD7E6286"), "Damage Receive From Dark Horse Multiplier", string.Empty);
+
+    /// <summary>
+    /// Gets the total armor damage decrease (receive) attribute definition.
+    /// <remarks>Includes the sum of excellent, harmony, and socket DD options.</remarks>
+    /// </summary>
+    public static AttributeDefinition ArmorDamageDecrease { get; } = new(new Guid("BFCF7096-44E9-473F-8162-416E9AD61477"), "Armor Damage Decrease", "The total excellent, harmony, and socket options damage decrease multiplier which is multiplied with the final damage and subtracted from it.");
 
     /// <summary>
     /// Gets the defense increase with equipped shield (ancient) attribute definition.
@@ -628,24 +811,112 @@ public class Stats
     public static AttributeDefinition BonusDefenseWithShield { get; } = new(new Guid("05F08D89-9BC6-4164-9B30-26EFAF4C0E0F"), "Defense Increase Bonus (absolute) With equipped Shield (MST)", string.Empty);
 
     /// <summary>
-    /// Gets the bonus defense (absolute) with an equipped scepter attribute definition.
-    /// </summary>
-    public static AttributeDefinition BonusDefenseWithScepter { get; } = new(new Guid("7977FE44-FC22-4A6B-A4E0-BA522FE807DF"), "Defense Increase Bonus (absolute) with equipped Scepter", string.Empty);
-
-    /// <summary>
     /// Gets the bonus PvM defense rate (absolute) with an equipped shield MST attribute definition.
     /// </summary>
     public static AttributeDefinition BonusDefenseRateWithShield { get; } = new(new Guid("C8CF9CE1-F7AC-48DE-BFCC-349ABBFB1FCA"), "Defense Rate (PvM) Increase Bonus (absolute) With equipped Shield (MST)", string.Empty);
 
     /// <summary>
-    /// Gets the bonus defense (absolute) command/leadership divisor with an equipped shield attribute definition.
+    /// Gets the bonus damage (absolute) with an equipped scepter attribute definition.
     /// </summary>
-    public static AttributeDefinition BonusDefenseWithScepterCmdDiv { get; } = new(new Guid("9A3C99C4-4F94-4CD0-8BFC-C8B870CD5FE4"), "Defense Increase Bonus (absolute) with equipped Scepter (command div)", string.Empty);
+    public static AttributeDefinition BonusDamageWithScepter { get; } = new(new Guid("7977FE44-FC22-4A6B-A4E0-BA522FE807DF"), "Damage Increase Bonus (absolute) With equipped Scepter", string.Empty);
+
+    /// <summary>
+    /// Gets the bonus damage (absolute) command/leadership divisor with an equipped scepter MST attribute definition.
+    /// </summary>
+    public static AttributeDefinition BonusDamageWithScepterCmdDiv { get; } = new(new Guid("9A3C99C4-4F94-4CD0-8BFC-C8B870CD5FE4"), "Damage Increase Bonus (absolute) With equipped Scepter command divisor (MST)", string.Empty);
 
     /// <summary>
     /// Gets the bonus defense (absolute) with an equipped dark horse MST attribute definition.
     /// </summary>
     public static AttributeDefinition BonusDefenseWithHorse { get; } = new(new Guid("8D22E36C-EB36-47DB-8CE0-9ABD599C533C"), "Defense Increase Bonus (absolute) With equipped Horse (MST)", string.Empty);
+
+    /// <summary>
+    /// Gets the electric spike skill bonus damage attribute definition.
+    /// </summary>
+    public static AttributeDefinition ElectricSpikeBonusDmg { get; } = new(new Guid("2DDBCE01-88CF-4A01-B691-1772FA836D9B"), "Electric Spike Bonus Damage", "The electric spike skill bonus damage, which depends on other stats.");
+
+    /// <summary>
+    /// Gets the earthshake skill bonus damage attribute definition.
+    /// </summary>
+    public static AttributeDefinition EarthshakeBonusDmg { get; } = new(new Guid("6370BB15-5602-44BC-8FDC-A787A6FAB4F2"), "Earthshake Bonus Damage", "The earthshake skill bonus damage, which depends on other stats.");
+
+    /// <summary>
+    /// Gets the chaotic diseier skill bonus damage attribute definition.
+    /// </summary>
+    public static AttributeDefinition ChaoticDiseierBonusDmg { get; } = new(new Guid("BF691FDC-2791-49DD-8725-602C6762A57D"), "Chaotic Diseier Bonus Damage", "The chaotic diseier skill bonus damage, which depends on other stats.");
+
+    /// <summary>
+    /// Gets the dark lord/lord emperor generic skill bonus damage attribute definition.
+    /// </summary>
+    /// <remarks>Applies to any lord specific skill other than earthshake, electric spike, and chaotic diseier.</remarks>
+    public static AttributeDefinition LordGenericSkillBonusDmg { get; } = new(new Guid("8D6E3761-0C88-48F7-91DC-9D520038F12F"), "Lord Generic Skill Bonus Damage", "The lord generic skill bonus damage, which depends on other stats. Any skill other than Electric Spike, Earthshake, and Chaotic Diseier.");
+
+    /// <summary>
+    /// Gets the berserker buff mana (and damage) multiplier attribute definition.
+    /// </summary>
+    public static AttributeDefinition BerserkerManaMultiplier { get; } = new(new Guid("9B6AA0DA-9ABA-4C14-B094-F1AC70BCB52D"), "Berserker Mana Multiplier", "The berserker mana multiplier which is used to increase both the caster's mana and damage (any type).");
+
+    /// <summary>
+    /// Gets the berserker buff health decrement attribute definition.
+    /// </summary>
+    public static AttributeDefinition BerserkerHealthDecrement { get; } = new(new Guid("D1948382-23F6-43A4-AD84-69227BF2ABA3"), "Berserker Health Decrement", "The berserker health decrement which is compared against a minimum value (-10%) to lower the caster's total health.")
+    {
+        MaximumValue = -0.1f, // At least -10% HP
+    };
+
+    /// <summary>
+    /// Gets the berserker buff curse damage multiplier MST attribute definition.
+    /// </summary>
+    /// <remarks>Increases with MST berserker strengthener. Applies on <see cref="DamageType.Curse"/> skills.</remarks>
+    public static AttributeDefinition BerserkerCurseMultiplier { get; } = new(new Guid("AD1A3A3F-B461-4CAE-B3A3-D03DD0714A96"), "Berserker Curse Multiplier", "The berserker strengthener curse damage multiplier which is multiplied with the base min/max and added to it.");
+
+    /// <summary>
+    /// Gets the berserker buff wizardry damage multiplier attribute definition.
+    /// </summary>
+    /// <remarks>The sum of <see cref="BerserkerManaMultiplier"/> and <see cref="BerserkerProficiencyMultiplier"/>. Applies on <see cref="DamageType.Wizardry"/> skills.</remarks>
+    public static AttributeDefinition BerserkerWizardryMultiplier { get; } = new(new Guid("8DA7B8C2-F28B-4472-AE8F-28F08D4E7E93"), "Berserker Wizardry Multiplier", "The berserker wizardry damage multiplier which is multiplied with the base min/max and added to it.");
+
+    /// <summary>
+    /// Gets the berserker proficiency buff damage multiplier MST attribute definition.
+    /// </summary>
+    /// <remarks>Increases with MST berserker proficiency. Applies on <see cref="DamageType.Curse"/> and <see cref="DamageType.Wizardry"/> skills.</remarks>
+    public static AttributeDefinition BerserkerProficiencyMultiplier { get; } = new(new Guid("55124C97-6EF3-4C46-AEC9-D01C11BE18A4"), "Berserker Proficiency Multiplier (MST)", "The berserker proficiency damage multiplier which is added to the wizardry multiplier but also by itself is multiplied by the wizardry/curse final damage and added to it.");
+
+    /// <summary>
+    /// Gets the berserker buff minimum physical damage bonus attribute definition.
+    /// </summary>
+    public static AttributeDefinition BerserkerMinPhysDmgBonus { get; } = new(new Guid("81B5B942-A6D4-4343-BD4D-106CFFF34F4E"), "Berserker Minimum Physical Damage Bonus", string.Empty);
+
+    /// <summary>
+    /// Gets the berserker buff maximum physical damage bonus attribute definition.
+    /// </summary>
+    public static AttributeDefinition BerserkerMaxPhysDmgBonus { get; } = new(new Guid("602D5FC4-AB85-423A-9C91-D23B0A28996C"), "Berserker Maximum Physical Damage Bonus", string.Empty);
+
+    /// <summary>
+    /// Gets the berserker buff minimum wizardry damage bonus attribute definition.
+    /// </summary>
+    public static AttributeDefinition BerserkerMinWizDmgBonus { get; } = new(new Guid("DFCEC75A-BFB4-4FD4-922D-12EAAB4AEF18"), "Berserker Minimum Wizardry Damage Bonus", string.Empty);
+
+    /// <summary>
+    /// Gets the berserker buff maximum wizardry damage bonus attribute definition.
+    /// </summary>
+    public static AttributeDefinition BerserkerMaxWizDmgBonus { get; } = new(new Guid("B2A85454-B442-44C5-BAD0-4933F0C5E6E0"), "Berserker Maximum Wizardry Damage Bonus", string.Empty);
+
+    /// <summary>
+    /// Gets the berserker buff minimum curse damage bonus attribute definition.
+    /// </summary>
+    public static AttributeDefinition BerserkerMinCurseDmgBonus { get; } = new(new Guid("06BA893F-F9EF-4813-8233-DAB0D83CC4EC"), "Berserker Minimum Curse Damage Bonus", string.Empty);
+
+    /// <summary>
+    /// Gets the berserker buff maximum curse damage bonus attribute definition.
+    /// </summary>
+    public static AttributeDefinition BerserkerMaxCurseDmgBonus { get; } = new(new Guid("B519555A-748D-4462-A8C0-A7E7DA0C3B67"), "Berserker Maximum Curse Damage Bonus", string.Empty);
+
+    /// <summary>
+    /// Gets the weakness physical damage decrement due to magic effects of weakness (Summoner) or killing blow (RF) skills attribute definition.
+    /// </summary>
+    /// <remarks>Only applies to physical damage.</remarks>
+    public static AttributeDefinition WeaknessPhysDmgDecrement { get; } = new(new Guid("37497650-139B-4DA1-9FB6-27AEB8F04CF6"), "Weakness Physical Damage Decrement", "The inflicted physical damage decrement due to the magic effects of weakness or killing blow skills, which is multiplied with the final damage and subtracted from it.");
 
     /// <summary>
     /// Gets the 'is shield equipped' attribute definition.
@@ -706,6 +977,41 @@ public class Stats
     /// Gets the lightning resistance attribute definition. Value range from 0 to 1.
     /// </summary>
     public static AttributeDefinition LightningResistance { get; } = new(new Guid("3E339393-2D17-452E-81D9-3987947A407F"), "Lightning Resistance", string.Empty);
+
+    /// <summary>
+    /// Gets the ancient jewelry ice DMG bonus attribute definition.
+    /// </summary>
+    public static AttributeDefinition IceDamageBonus { get; } = new(new Guid("9D96E235-2615-4DE4-9C1E-56F4A6B8CDC0"), "Ice Damage Bonus", string.Empty);
+
+    /// <summary>
+    /// Gets the ancient jewelry fire DMG bonus attribute definition.
+    /// </summary>
+    public static AttributeDefinition FireDamageBonus { get; } = new(new Guid("04B2BAD0-5993-4BF6-B5BF-390E8B7696C8"), "Fire Damage Bonus", string.Empty);
+
+    /// <summary>
+    /// Gets the ancient jewelry water DMG bonus attribute definition.
+    /// </summary>
+    public static AttributeDefinition WaterDamageBonus { get; } = new(new Guid("404E4BBC-B62B-4330-A383-EF6A732A18D7"), "Water Damage Bonus", string.Empty);
+
+    /// <summary>
+    /// Gets the ancient jewelry earth DMG bonus attribute definition.
+    /// </summary>
+    public static AttributeDefinition EarthDamageBonus { get; } = new(new Guid("8E928D90-CB7B-4CB1-97E8-748BDE2B1704"), "Earth Damage Bonus", string.Empty);
+
+    /// <summary>
+    /// Gets the ancient jewelry wind DMG bonus attribute definition.
+    /// </summary>
+    public static AttributeDefinition WindDamageBonus { get; } = new(new Guid("1EB5FF3A-D964-414E-A917-01BF2705B27D"), "Wind Damage Bonus", string.Empty);
+
+    /// <summary>
+    /// Gets the ancient jewelry poison DMG bonus attribute definition.
+    /// </summary>
+    public static AttributeDefinition PoisonDamageBonus { get; } = new(new Guid("36746FE4-D09A-466D-B45E-0A80CFE3F291"), "Poison Damage Bonus", string.Empty);
+
+    /// <summary>
+    /// Gets the ancient jewelry lightning DMG bonus attribute definition.
+    /// </summary>
+    public static AttributeDefinition LightningDamageBonus { get; } = new(new Guid("C588BAC4-38DA-4377-805B-909B0A6DF8A0"), "Lightning Damage Bonus", string.Empty);
 
     /// <summary>
     /// Gets the damage reflection attribute definition.
@@ -856,7 +1162,7 @@ public class Stats
     /// <summary>
     /// Gets the pet duration increase attribute definition.
     /// </summary>
-    public static AttributeDefinition PetDurationIncrease { get; } = new(new Guid("B4455150-D3A9-4A5F-914B-F41F9387FE9A"), "Pet Duraction Increase", string.Empty);
+    public static AttributeDefinition PetDurationIncrease { get; } = new(new Guid("B4455150-D3A9-4A5F-914B-F41F9387FE9A"), "Pet Duration Increase", string.Empty);
 
     /// <summary>
     /// Gets the horse level attribute definition.
@@ -869,9 +1175,9 @@ public class Stats
     public static AttributeDefinition RavenLevel { get; } = new(new Guid("2C9AA85C-AB8B-4E0F-8F0B-BC6E49EE134E"), "Dark Raven Level", string.Empty);
 
     /// <summary>
-    /// Gets the raven base damage definition.
+    /// Gets the raven bonus damage MST definition.
     /// </summary>
-    public static AttributeDefinition RavenBaseDamage { get; } = new(new Guid("3F77AD23-3833-4F2F-A264-23F7A4688FDA"), "Min and Max damage of the dark raven.", string.Empty);
+    public static AttributeDefinition RavenBonusDamage { get; } = new(new Guid("3F77AD23-3833-4F2F-A264-23F7A4688FDA"), "Dark Raven Bonus Damage (MST)", string.Empty);
 
     /// <summary>
     /// Gets the raven minimum damage definition.
@@ -894,14 +1200,14 @@ public class Stats
     public static AttributeDefinition RavenAttackSpeed { get; } = new(new Guid("3359F7E9-936C-48DD-BB0A-E44E2347D3CA"), "Attack speed of the dark raven.", string.Empty);
 
     /// <summary>
-    /// Gets the raven critical damage chance bonus.
+    /// Gets the raven critical damage chance.
     /// </summary>
-    public static AttributeDefinition RavenCriticalDamageChanceBonus { get; } = new(new Guid("D9C8D708-F94A-430E-B812-99A2F3F0768E"), "Raven critical damage chance bonus", string.Empty);
+    public static AttributeDefinition RavenCriticalDamageChance { get; } = new(new Guid("D9C8D708-F94A-430E-B812-99A2F3F0768E"), "Raven critical damage chance", string.Empty);
 
     /// <summary>
-    /// Gets the raven excellent damage chance bonus.
+    /// Gets the raven excellent damage chance.
     /// </summary>
-    public static AttributeDefinition RavenExcDamageChanceBonus { get; } = new(new Guid("31EF09B0-0F79-439B-900C-C9350BAD99DF"), "Raven exc damage chance bonus", string.Empty);
+    public static AttributeDefinition RavenExcDamageChance { get; } = new(new Guid("31EF09B0-0F79-439B-900C-C9350BAD99DF"), "Raven exc damage chance", string.Empty);
 
     /// <summary>
     /// Gets the maximum guild size attribute definition.
@@ -934,7 +1240,12 @@ public class Stats
     public static AttributeDefinition CanFly { get; } = new(new Guid("EC34C673-84DE-4811-8962-CD2164A2248C"), "Requirement of the Icarus map.", "You can enter Icarus only with wings, dinorant, fenrir.");
 
     /// <summary>
-    /// Gets the MoonstonePendantEquipped attribute for warping to Karutan.
+    /// Gets the is dinorant equipped attribute definition.
+    /// </summary>
+    public static AttributeDefinition IsDinorantEquipped { get; } = new(new Guid("C52B5CA4-34BA-4E31-963B-E37089671C37"), "Is Dinorant Equipped", string.Empty);
+
+    /// <summary>
+    /// Gets the MoonstonePendantEquipped attribute for entering Kanturu event.
     /// </summary>
     public static AttributeDefinition MoonstonePendantEquipped { get; } = new(new Guid("4BC010D0-9E75-4ECB-8963-08A3697278C3"), "Requirement of the Kanturu Event Map during the event.", "You can enter the Kanturu Event only with an equipped Moonstone Pendant.");
 
@@ -947,6 +1258,11 @@ public class Stats
     /// Gets the Ammo attribute which defines how much ammo is available.
     /// </summary>
     public static AttributeDefinition AmmunitionAmount { get; } = new(new Guid("064543E6-2559-4033-B363-AE76214E7DEE"), "The amount of ammo which is equipped.", "You can only execute certain skills if you have enough ammo, or if the ammo consumption rate is 0.");
+
+    /// <summary>
+    /// Gets the Ammo damage bonus (relative) increase attribute.
+    /// </summary>
+    public static AttributeDefinition AmmunitionDamageBonus { get; } = new(new Guid("C715CC22-9D8A-4056-BB5E-AC681CFC9E44"), "Ammunition Damage Bonus", "The ammunition damage bonus (relative) which is multiplied by the min/max base damage.");
 
     /// <summary>
     /// Gets the <see cref="IsInSafezone"/> attribute which defines if the character is located in a safezone of a game map.
@@ -1029,6 +1345,20 @@ public class Stats
     /// Gets the attribute for the number of points this class will receive for reset, overwrites the default <see cref="Resets.ResetConfiguration.PointsPerReset"/> value.
     /// </summary>
     public static AttributeDefinition PointsPerReset { get; } = new(new Guid("a34f4f57-b364-4cdb-9989-64cedd2cd831"), "Points Per Reset", "The number of points the player will receive for reset, overwrites the default 'PointsPerReset' value of the reset configuration.");
+
+    /// <summary>
+    /// Gets the dictionary which relates the jewelry element resistance attribute to the correspondent DMG bonus attribute.
+    /// </summary>
+    public static Dictionary<AttributeDefinition, AttributeDefinition> ElementResistanceToDamageBonus { get; } = new()
+    {
+        { IceResistance, IceDamageBonus },
+        { PoisonResistance, PoisonDamageBonus },
+        { LightningResistance, LightningDamageBonus },
+        { FireResistance, FireDamageBonus },
+        { EarthResistance, EarthDamageBonus },
+        { WindResistance, WindDamageBonus },
+        { WaterResistance, WaterDamageBonus },
+    };
 
     /// <summary>
     /// Gets the attributes which are regenerated in an interval.

--- a/src/GameLogic/ItemPowerUpFactory.cs
+++ b/src/GameLogic/ItemPowerUpFactory.cs
@@ -45,9 +45,33 @@ public class ItemPowerUpFactory : IItemPowerUpFactory
             yield break;
         }
 
+        var isRightWieldWeapon = item.ItemSlot == InventoryConstants.RightHandSlot
+            && item.Definition!.BasePowerUpAttributes.Any(pu => pu.TargetAttribute == Stats.DoubleWieldWeaponCount || pu.TargetAttribute == Stats.IsOneHandedStaffEquipped);
+
+        AttributeDefinition? targetAttribute = null;
         foreach (var attribute in item.Definition.BasePowerUpAttributes)
         {
-            foreach (var powerUp in this.GetBasePowerUpWrappers(item, attributeHolder, attribute))
+            if (isRightWieldWeapon)
+            {
+                if (attribute.TargetAttribute == Stats.StaffRise)
+                {
+                    continue;
+                }
+                else if (attribute.TargetAttribute == Stats.MinimumPhysBaseDmgByWeapon)
+                {
+                    targetAttribute = Stats.MinPhysBaseDmgByRightWeapon;
+                }
+                else if (attribute.TargetAttribute == Stats.MaximumPhysBaseDmgByWeapon)
+                {
+                    targetAttribute = Stats.MaxPhysBaseDmgByRightWeapon;
+                }
+                else
+                {
+                    targetAttribute = null;
+                }
+            }
+
+            foreach (var powerUp in this.GetBasePowerUpWrappers(item, attributeHolder, attribute, targetAttribute))
             {
                 yield return powerUp;
             }
@@ -179,7 +203,7 @@ public class ItemPowerUpFactory : IItemPowerUpFactory
         return true;
     }
 
-    private IEnumerable<PowerUpWrapper> GetBasePowerUpWrappers(Item item, AttributeSystem attributeHolder, ItemBasePowerUpDefinition attribute)
+    private IEnumerable<PowerUpWrapper> GetBasePowerUpWrappers(Item item, AttributeSystem attributeHolder, ItemBasePowerUpDefinition attribute, AttributeDefinition? targetAttribute = null)
     {
         attribute.ThrowNotInitializedProperty(attribute.BaseValueElement is null, nameof(attribute.BaseValueElement));
         attribute.ThrowNotInitializedProperty(attribute.TargetAttribute is null, nameof(attribute.TargetAttribute));
@@ -190,13 +214,13 @@ public class ItemPowerUpFactory : IItemPowerUpFactory
 
         if (levelBonusElmt is null)
         {
-            yield return new PowerUpWrapper(attribute.BaseValueElement, attribute.TargetAttribute, attributeHolder);
+            yield return new PowerUpWrapper(attribute.BaseValueElement, targetAttribute ?? attribute.TargetAttribute, attributeHolder);
         }
         else
         {
             yield return new PowerUpWrapper(
                 new CombinedElement(attribute.BaseValueElement, levelBonusElmt),
-                attribute.TargetAttribute,
+                targetAttribute ?? attribute.TargetAttribute,
                 attributeHolder);
         }
     }
@@ -215,6 +239,12 @@ public class ItemPowerUpFactory : IItemPowerUpFactory
             if (option is null)
             {
                 this._logger.LogWarning("Item {item} (id {itemId}) has ItemOptionLink ({optionLinkId}) without option.", item, item.GetId(), optionLink.GetId());
+                continue;
+            }
+
+            if (item.ItemSlot == InventoryConstants.RightHandSlot && option.PowerUpDefinition?.TargetAttribute == Stats.WizardryBaseDmg)
+            {
+                // For a RH-wielded staff (MG), its wizardry item option doesn't count (but the others do!)
                 continue;
             }
 
@@ -294,18 +324,30 @@ public class ItemPowerUpFactory : IItemPowerUpFactory
 
         if (item.IsPhysicalWeapon(out var minPhysDmg))
         {
-            var additionalDmg = ((int)minPhysDmg * 25 / baseDropLevel) + 5;
-            yield return new PowerUpWrapper(new SimpleElement(additionalDmg, AggregateType.AddRaw), Stats.MinimumPhysBaseDmgByWeapon, attributeHolder);
-            yield return new PowerUpWrapper(new SimpleElement(additionalDmg, AggregateType.AddRaw), Stats.MaximumPhysBaseDmgByWeapon, attributeHolder);
+            var minDmgAttribute = Stats.MinimumPhysBaseDmgByWeapon;
+            var maxDmgAttribute = Stats.MaximumPhysBaseDmgByWeapon;
+            if (item.ItemSlot == InventoryConstants.RightHandSlot
+                && item.Definition!.BasePowerUpAttributes.Any(pu => pu.TargetAttribute == Stats.DoubleWieldWeaponCount || pu.TargetAttribute == Stats.IsOneHandedStaffEquipped))
+            {
+                minDmgAttribute = Stats.MinPhysBaseDmgByRightWeapon;
+                maxDmgAttribute = Stats.MaxPhysBaseDmgByRightWeapon;
+            }
+
+            var dmgFactor = item.Definition!.Group == 5 ? 2 : 1;
+            minPhysDmg *= dmgFactor; // For staffs/sticks the nominal damage is halved initially, so we have to restore it first
+
+            var additionalDmg = (((int)minPhysDmg * 25 / baseDropLevel) + 5) / dmgFactor;
+            yield return new PowerUpWrapper(new SimpleElement(additionalDmg, AggregateType.AddRaw), minDmgAttribute, attributeHolder);
+            yield return new PowerUpWrapper(new SimpleElement(additionalDmg, AggregateType.AddRaw), maxDmgAttribute, attributeHolder);
             if (itemIsAncient)
             {
-                var ancientBonus = 5 + (ancientDropLevel / 40);
-                yield return new PowerUpWrapper(new SimpleElement(ancientBonus, AggregateType.AddRaw), Stats.MinimumPhysBaseDmgByWeapon, attributeHolder);
-                yield return new PowerUpWrapper(new SimpleElement(ancientBonus, AggregateType.AddRaw), Stats.MaximumPhysBaseDmgByWeapon, attributeHolder);
+                var ancientBonus = (5 + (ancientDropLevel / 40)) / dmgFactor;
+                yield return new PowerUpWrapper(new SimpleElement(ancientBonus, AggregateType.AddRaw), minDmgAttribute, attributeHolder);
+                yield return new PowerUpWrapper(new SimpleElement(ancientBonus, AggregateType.AddRaw), maxDmgAttribute, attributeHolder);
             }
         }
 
-        if (item.IsWizardryWeapon(out var staffRise))
+        if (item.IsWizardryWeapon(out var staffRise) && item.ItemSlot == InventoryConstants.LeftHandSlot)
         {
             var additionalRise = (((int)staffRise * 2 * 25 / baseDropLevel) + 5) / 2;
             yield return new PowerUpWrapper(new SimpleElement(additionalRise, AggregateType.AddRaw), Stats.StaffRise, attributeHolder);
@@ -335,6 +377,17 @@ public class ItemPowerUpFactory : IItemPowerUpFactory
             {
                 var ancientRiseBonus = (2 + (ancientDropLevel / 60)) / 2;
                 yield return new PowerUpWrapper(new SimpleElement(ancientRiseBonus, AggregateType.AddRaw), Stats.BookRise, attributeHolder);
+            }
+        }
+
+        if (itemIsAncient && item.IsJewelry())
+        {
+            foreach (var baseAttribute in item.Definition!.BasePowerUpAttributes)
+            {
+                if (Stats.ElementResistanceToDamageBonus.Keys.FirstOrDefault(resistance => resistance == baseAttribute.TargetAttribute) is { } key)
+                {
+                    yield return new PowerUpWrapper(new SimpleElement(5, AggregateType.AddRaw), Stats.ElementResistanceToDamageBonus[key], attributeHolder);
+                }
             }
         }
     }

--- a/src/GameLogic/NPC/AttackableNpcBase.cs
+++ b/src/GameLogic/NPC/AttackableNpcBase.cs
@@ -112,12 +112,12 @@ public abstract class AttackableNpcBase : NonPlayerCharacter, IAttackable
             attacker.ApplyAmmunitionConsumption(hitInfo);
             if (attacker is Player player)
             {
-                await player.AfterHitTargetAsync().ConfigureAwait(false);
+                await player.AfterHitTargetAsync(skill).ConfigureAwait(false);
             }
 
             if (attacker as IPlayerSurrogate is { } playerSurrogate)
             {
-                await playerSurrogate.Owner.AfterHitTargetAsync().ConfigureAwait(false);
+                await playerSurrogate.Owner.AfterHitTargetAsync(skill).ConfigureAwait(false);
             }
         }
 

--- a/src/GameLogic/Pet/RavenAttributeSystem.cs
+++ b/src/GameLogic/Pet/RavenAttributeSystem.cs
@@ -19,7 +19,7 @@ public class RavenAttributeSystem : IAttributeSystem
                 Stats.MinimumPhysBaseDmg, player =>
                 {
                     var minDamage = player.Attributes?[Stats.RavenMinimumDamage] ?? 0;
-                    minDamage += minDamage * (player.Attributes?[Stats.PetAttackDamageIncrease] ?? 1);
+                    minDamage += minDamage * (player.Attributes?[Stats.RavenAttackDamageIncrease] ?? 1);
                     return minDamage;
                 }
             },
@@ -27,24 +27,20 @@ public class RavenAttributeSystem : IAttributeSystem
                 Stats.MaximumPhysBaseDmg, player =>
                 {
                     var maxDamage = player.Attributes?[Stats.RavenMaximumDamage] ?? 0;
-                    maxDamage += maxDamage * (player.Attributes?[Stats.PetAttackDamageIncrease] ?? 1);
+                    maxDamage += maxDamage * (player.Attributes?[Stats.RavenAttackDamageIncrease] ?? 1);
                     return maxDamage;
                 }
             },
-            { Stats.BaseDamageBonus, player => player.Attributes?[Stats.BaseDamageBonus] ?? 0 },
+            { Stats.RavenBonusDamage, player => player.Attributes?[Stats.RavenBonusDamage] ?? 0 },
             { Stats.AttackSpeed, player => player.Attributes?[Stats.RavenAttackSpeed] ?? 0 },
             { Stats.AttackRatePvm, player => player.Attributes?[Stats.RavenAttackRate] ?? 0 },
-            { Stats.AttackRatePvp, player => player.Attributes?[Stats.RavenAttackRate] ?? 0 },
-            { Stats.CriticalDamageChance, player => player.Attributes?[Stats.CriticalDamageChance] + player.Attributes?[Stats.RavenCriticalDamageChanceBonus] ?? 0 },
-            { Stats.CriticalDamageBonus, player => player.Attributes?[Stats.CriticalDamageBonus] ?? 0 },
-            { Stats.ExcellentDamageChance, player => player.Attributes?[Stats.ExcellentDamageChance] ?? 0 + player.Attributes?[Stats.RavenExcDamageChanceBonus] ?? 0 },
-            { Stats.ExcellentDamageBonus, player => player.Attributes?[Stats.ExcellentDamageBonus] ?? 0 },
+            { Stats.AttackRatePvp, player => player.Attributes?[Stats.AttackRatePvp] ?? 0 },
+            { Stats.CriticalDamageChance, player => player.Attributes?[Stats.RavenCriticalDamageChance] ?? 0 },
+            { Stats.ExcellentDamageChance, player => player.Attributes?[Stats.RavenExcDamageChance] ?? 0 },
             { Stats.DefenseIgnoreChance, player => player.Attributes?[Stats.DefenseIgnoreChance] ?? 0 },
-            { Stats.DoubleDamageChance, player => player.Attributes?[Stats.DoubleDamageChance] ?? 0 },
             { Stats.ShieldBypassChance, player => player.Attributes?[Stats.ShieldBypassChance] ?? 0 },
             { Stats.ShieldDecreaseRateIncrease, player => player.Attributes?[Stats.ShieldDecreaseRateIncrease] ?? 0 },
-            { Stats.AttackDamageIncrease, player => player.Attributes?[Stats.AttackDamageIncrease] ?? 0 },
-            { Stats.FinalDamageIncreasePvp, player => player.Attributes?[Stats.FinalDamageIncreasePvp] ?? 0 },
+            { Stats.AttackDamageIncrease, player => 1.0f },
         };
 
     private readonly Player _owner;

--- a/src/GameLogic/PlayerActions/Quests/ElfSoldierBuffRequestAction.cs
+++ b/src/GameLogic/PlayerActions/Quests/ElfSoldierBuffRequestAction.cs
@@ -51,7 +51,7 @@ public class ElfSoldierBuffRequestAction
             TimeSpan.FromMinutes(60),
             BuffEffect,
             new MagicEffect.ElementWithTarget(new ConstantElement(50 + (player.Level / 5), AggregateType.AddFinal), Stats.DefenseFinal),
-            new MagicEffect.ElementWithTarget(new ConstantElement(45 + (player.Level / 3)), Stats.BaseDamageBonus))).ConfigureAwait(false);
+            new MagicEffect.ElementWithTarget(new ConstantElement(45 + (player.Level / 3)), Stats.GreaterDamageBonus))).ConfigureAwait(false);
     }
 
     private sealed class SoldierBuffMagicEffectDefinition : MagicEffectDefinition

--- a/src/GameLogic/PlayerActions/Skills/AreaSkillAttackAction.cs
+++ b/src/GameLogic/PlayerActions/Skills/AreaSkillAttackAction.cs
@@ -46,7 +46,13 @@ public class AreaSkillAttackAction
             return;
         }
 
-        if (skill.SkillType is SkillType.AreaSkillAutomaticHits or SkillType.AreaSkillExplicitTarget
+        if (skill.SkillType is SkillType.AreaSkillAutomaticHits
+                or SkillType.AreaSkillExplicitTarget
+                or SkillType.Earthshake
+                or SkillType.ElectricSpike
+                or SkillType.ChaoticDiseier
+                or SkillType.LordGeneric // fire scream
+                or SkillType.MultiShot
             || (skill.SkillType is SkillType.AreaSkillExplicitHits && hitImplicitlyForExplicitSkill))
         {
             // todo: delayed automatic hits, like evil spirit, flame, triple shot... when hitImplicitlyForExplicitSkill = true.

--- a/src/GameLogic/PlayerActions/Skills/TargetedSkillDefaultPlugin.cs
+++ b/src/GameLogic/PlayerActions/Skills/TargetedSkillDefaultPlugin.cs
@@ -247,7 +247,7 @@ public class TargetedSkillDefaultPlugin : TargetedSkillPluginBase
 
         foreach (var target in targets)
         {
-            if (skill.SkillType == SkillType.DirectHit || skill.SkillType == SkillType.CastleSiegeSkill)
+            if (skill.SkillType == SkillType.DirectHit || skill.SkillType == SkillType.CastleSiegeSkill || skill.SkillType == SkillType.LordGeneric)
             {
                 if (player.Attributes![Stats.AmmunitionConsumptionRate] > player.Attributes[Stats.AmmunitionAmount])
                 {

--- a/src/GameLogic/PlugIns/ITargetedSkillPlugin.cs
+++ b/src/GameLogic/PlugIns/ITargetedSkillPlugin.cs
@@ -5,7 +5,6 @@
 namespace MUnique.OpenMU.GameLogic.PlugIns;
 
 using System.Runtime.InteropServices;
-using MUnique.OpenMU.Pathfinding;
 using MUnique.OpenMU.PlugIns;
 
 /// <summary>
@@ -18,10 +17,10 @@ public interface ITargetedSkillPlugin : IStrategyPlugIn<short>
 {
     /// <summary>
     /// Callback function to trigger when specific skill is invoked.
+    /// </summary>
     /// <param name="player">The player invoking the skill.</param>
     /// <param name="target">The target of the skill.</param>
     /// <param name="skillId">The skill identifier.</param>
     /// <returns>Returns the coroutine for the skill action.</returns>
-    /// </summary>
     ValueTask PerformSkillAsync(Player player, IAttackable target, ushort skillId);
 }

--- a/src/Persistence/Initialization/CharacterClasses/CharacterClassInitialization.cs
+++ b/src/Persistence/Initialization/CharacterClasses/CharacterClassInitialization.cs
@@ -108,7 +108,17 @@ internal partial class CharacterClassInitialization : InitializerBase
         attributeRelationships.Add(this.CreateAttributeRelationship(Stats.AttackSpeed, 1, Stats.AttackSpeedAny));
         attributeRelationships.Add(this.CreateAttributeRelationship(Stats.MagicSpeed, 1, Stats.AttackSpeedAny));
 
-        // If two weapons are equipped we subtract the half of the sum of the speeds again from the attack speed
+        attributeRelationships.Add(this.CreateAttributeRelationship(Stats.MinimumPhysBaseDmg, 1, Stats.MinimumPhysBaseDmgByWeapon));
+        attributeRelationships.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1, Stats.MaximumPhysBaseDmgByWeapon));
+        attributeRelationships.Add(this.CreateAttributeRelationship(Stats.MinimumPhysBaseDmg, 1, Stats.BaseMinDamageBonus));
+        attributeRelationships.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1, Stats.BaseMaxDamageBonus));
+        attributeRelationships.Add(this.CreateAttributeRelationship(Stats.PhysicalBaseDmg, 1, Stats.BaseDamageBonus));
+        attributeRelationships.Add(this.CreateAttributeRelationship(Stats.MinimumPhysBaseDmg, 1, Stats.PhysicalBaseDmg));
+        attributeRelationships.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1, Stats.PhysicalBaseDmg));
+        attributeRelationships.Add(this.CreateAttributeRelationship(Stats.MinimumPhysBaseDmg, 1, Stats.PhysicalBaseDmgIncrease, aggregateType: AggregateType.Multiplicate));
+        attributeRelationships.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1, Stats.PhysicalBaseDmgIncrease, aggregateType: AggregateType.Multiplicate));
+
+        // If two weapons are equipped (DK, MG, Sum, RF) we subtract the half of the sum of the speeds again from the attack speed
         attributeRelationships.Add(this.CreateAttributeRelationship(Stats.AreTwoWeaponsEquipped, 1, Stats.EquippedWeaponCount));
         var tempSpeed = this.Context.CreateNew<AttributeDefinition>(Guid.NewGuid(), "Temp Half weapon attack speed", string.Empty);
         this.GameConfiguration.Attributes.Add(tempSpeed);
@@ -118,7 +128,7 @@ internal partial class CharacterClassInitialization : InitializerBase
         var tempDefense = this.Context.CreateNew<AttributeDefinition>(Guid.NewGuid(), "Temp Defense Bonus multiplier with Shield", string.Empty);
         this.GameConfiguration.Attributes.Add(tempDefense);
         attributeRelationships.Add(this.CreateConditionalRelationship(tempDefense, Stats.IsShieldEquipped, Stats.DefenseIncreaseWithEquippedShield));
-        attributeRelationships.Add(this.CreateAttributeRelationship(Stats.DefenseFinal, 1, tempDefense, InputOperator.Add, aggregateType: AggregateType.Multiplicate));
+        attributeRelationships.Add(this.CreateAttributeRelationship(Stats.DefenseFinal, 1, tempDefense, InputOperator.Add, AggregateType.Multiplicate));
 
         attributeRelationships.Add(this.CreateConditionalRelationship(Stats.DefenseFinal, Stats.DefenseShield, Stats.ShieldItemDefenseIncrease));
         attributeRelationships.Add(this.CreateConditionalRelationship(Stats.DefenseFinal, Stats.IsShieldEquipped, Stats.BonusDefenseWithShield, AggregateType.AddFinal));
@@ -136,6 +146,7 @@ internal partial class CharacterClassInitialization : InitializerBase
         }
 
         attributeRelationships.Add(this.CreateAttributeRelationship(Stats.MaximumGuildSize, 0.1f, Stats.Level));
+        attributeRelationships.Add(this.CreateAttributeRelationship(Stats.CanFly, 1, Stats.IsDinorantEquipped));
     }
 
     private void AddCommonBaseAttributeValues(ICollection<ConstValueAttribute> baseAttributeValues, bool isMaster)
@@ -143,13 +154,13 @@ internal partial class CharacterClassInitialization : InitializerBase
         baseAttributeValues.Add(this.CreateConstValueAttribute(1.0f / 27.5f, Stats.ManaRecoveryMultiplier));
         baseAttributeValues.Add(this.CreateConstValueAttribute(1, Stats.DamageReceiveDecrement));
         baseAttributeValues.Add(this.CreateConstValueAttribute(1, Stats.AttackDamageIncrease));
-        baseAttributeValues.Add(this.CreateConstValueAttribute(1, Stats.TwoHandedWeaponDamageIncrease));
         baseAttributeValues.Add(this.CreateConstValueAttribute(1, Stats.MoneyAmountRate));
         baseAttributeValues.Add(this.CreateConstValueAttribute(1, Stats.ExperienceRate));
         baseAttributeValues.Add(this.CreateConstValueAttribute(0.03f, Stats.PoisonDamageMultiplier));
         baseAttributeValues.Add(this.CreateConstValueAttribute(1, Stats.ItemDurationIncrease));
         baseAttributeValues.Add(this.CreateConstValueAttribute(2, Stats.AbilityRecoveryAbsolute));
         baseAttributeValues.Add(this.CreateConstValueAttribute(-1, Stats.AreTwoWeaponsEquipped));
+        baseAttributeValues.Add(this.CreateConstValueAttribute(-1, Stats.HasDoubleWield));
 
         if (isMaster)
         {
@@ -161,5 +172,20 @@ internal partial class CharacterClassInitialization : InitializerBase
         {
             baseAttributeValues.Add(this.CreateConstValueAttribute(0.01f, Stats.ShieldRecoveryMultiplier));
         }
+    }
+
+    /// <summary>
+    /// Adds double wield attribute relationships applicable to characters that can double wield (DK, MG, and RF).
+    /// A double wield grants 110% physical attack damage (55% base damage, later doubled on damage calculations).
+    /// </summary>
+    private void AddDoubleWieldAttributeRelationships(ICollection<AttributeRelationship> attributeRelationships)
+    {
+        attributeRelationships.Add(this.CreateAttributeRelationship(Stats.HasDoubleWield, 1, Stats.DoubleWieldWeaponCount, InputOperator.Maximum));
+        var tempDoubleWield = this.Context.CreateNew<AttributeDefinition>(Guid.NewGuid(), "Temp Double Wield multiplier", string.Empty);
+        this.GameConfiguration.Attributes.Add(tempDoubleWield);
+        attributeRelationships.Add(this.CreateAttributeRelationship(tempDoubleWield, -0.45f, Stats.HasDoubleWield));
+        attributeRelationships.Add(this.CreateAttributeRelationship(Stats.PhysicalBaseDmgIncrease, 1, tempDoubleWield, InputOperator.Add, AggregateType.Multiplicate));
+        attributeRelationships.Add(this.CreateConditionalRelationship(Stats.MinimumPhysBaseDmgByWeapon, Stats.HasDoubleWield, Stats.MinPhysBaseDmgByRightWeapon));
+        attributeRelationships.Add(this.CreateConditionalRelationship(Stats.MaximumPhysBaseDmgByWeapon, Stats.HasDoubleWield, Stats.MaxPhysBaseDmgByRightWeapon));
     }
 }

--- a/src/Persistence/Initialization/CharacterClasses/ClassDarkKnight.cs
+++ b/src/Persistence/Initialization/CharacterClasses/ClassDarkKnight.cs
@@ -1,4 +1,4 @@
-// <copyright file="ClassDarkKnight.cs" company="MUnique">
+﻿// <copyright file="ClassDarkKnight.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
@@ -46,6 +46,7 @@ internal partial class CharacterClassInitialization
         result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.Resets, 0, false));
 
         this.AddCommonAttributeRelationships(result.AttributeCombinations);
+        this.AddDoubleWieldAttributeRelationships(result.AttributeCombinations);
 
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.DefenseBase, 1.0f / 3, Stats.TotalAgility));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.DefenseRatePvm, 1.0f / 3, Stats.TotalAgility));
@@ -68,25 +69,18 @@ internal partial class CharacterClassInitialization
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumHealth, 3, Stats.TotalVitality));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumPhysBaseDmg, 1.0f / 6, Stats.TotalStrength));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1.0f / 4, Stats.TotalStrength));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumPhysBaseDmg, 1, Stats.MinimumPhysBaseDmgByWeapon));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1, Stats.MaximumPhysBaseDmgByWeapon));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumPhysBaseDmg, 1, Stats.PhysicalBaseDmg));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1, Stats.PhysicalBaseDmg));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.SkillMultiplier, 0.001f, Stats.TotalEnergy));
 
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.ComboBonus, 0.5f, Stats.TotalStrength));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.ComboBonus, 0.5f, Stats.TotalAgility));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.ComboBonus, 0.5f, Stats.TotalEnergy));
 
+        result.AttributeCombinations.Add(this.CreateConditionalRelationship(Stats.AttackSpeedAny, Stats.IsOneHandedSwordEquipped, Stats.WeaponMasteryAttackSpeed));
+
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.FenrirBaseDmg, 1.0f / 3, Stats.TotalStrength));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.FenrirBaseDmg, 1.0f / 5, Stats.TotalAgility));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.FenrirBaseDmg, 1.0f / 5, Stats.TotalVitality));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.FenrirBaseDmg, 1.0f / 7, Stats.TotalEnergy));
-
-        result.AttributeCombinations.Add(this.CreateConditionalRelationship(Stats.PhysicalBaseDmg, Stats.IsOneHandedSwordEquipped, Stats.OneHandedSwordBonusBaseDamage));
-        result.AttributeCombinations.Add(this.CreateConditionalRelationship(Stats.PhysicalBaseDmg, Stats.IsTwoHandedSwordEquipped, Stats.TwoHandedSwordBonusBaseDamage));
-        result.AttributeCombinations.Add(this.CreateConditionalRelationship(Stats.PhysicalBaseDmg, Stats.IsSpearEquipped, Stats.SpearBonusBaseDamage));
-        result.AttributeCombinations.Add(this.CreateConditionalRelationship(Stats.PhysicalBaseDmg, Stats.IsMaceEquipped, Stats.MaceBonusBaseDamage));
 
         if (!this.UseClassicPvp)
         {

--- a/src/Persistence/Initialization/CharacterClasses/ClassDarkLord.cs
+++ b/src/Persistence/Initialization/CharacterClasses/ClassDarkLord.cs
@@ -80,15 +80,11 @@ internal partial class CharacterClassInitialization
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1.0f / 5, Stats.TotalStrength));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumPhysBaseDmg, 1.0f / 14, Stats.TotalEnergy));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1.0f / 10, Stats.TotalEnergy));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumPhysBaseDmg, 1, Stats.MinimumPhysBaseDmgByWeapon));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1, Stats.MaximumPhysBaseDmgByWeapon));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumPhysBaseDmg, 1, Stats.PhysicalBaseDmg));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1, Stats.PhysicalBaseDmg));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.SkillMultiplier, 0.0005f, Stats.TotalEnergy));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.PetAttackDamageIncrease, 1.0f / 100, Stats.ScepterRise));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.RavenAttackDamageIncrease, 1.0f / 100, Stats.ScepterRise));
 
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumGuildSize, 0.1f, Stats.TotalLeadership));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.DamageReceiveDecrement, 1, Stats.DamageReceiveHorseDecrement, aggregateType: AggregateType.Multiplicate));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.DamageReceiveDecrement, 1, Stats.DamageReceiveHorseDecrement, InputOperator.Add, AggregateType.Multiplicate));
 
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.FenrirBaseDmg, 1.0f / 5, Stats.TotalStrength));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.FenrirBaseDmg, 1.0f / 5, Stats.TotalAgility));
@@ -96,29 +92,28 @@ internal partial class CharacterClassInitialization
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.FenrirBaseDmg, 1.0f / 3, Stats.TotalEnergy));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.FenrirBaseDmg, 1.0f / 3, Stats.TotalLeadership));
 
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.RavenMinimumDamage, 1, Stats.RavenBaseDamage));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.RavenMinimumDamage, 1.0f / 8, Stats.TotalLeadership));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.RavenMinimumDamage, 15, Stats.RavenLevel));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.RavenMaximumDamage, 1.0f / 4, Stats.TotalLeadership));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.RavenMaximumDamage, 15, Stats.RavenLevel));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.RavenMaximumDamage, 1, Stats.RavenBaseDamage));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.RavenAttackSpeed, 1.0f / 50, Stats.TotalLeadership));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.RavenAttackSpeed, 4.0f / 5, Stats.RavenLevel));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.RavenAttackRate, 16, Stats.RavenLevel));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.RavenAttackRate, 16f / 15, Stats.RavenLevel));
 
-        result.AttributeCombinations.Add(this.CreateConditionalRelationship(Stats.PhysicalBaseDmg, Stats.IsScepterEquipped, Stats.ScepterBonusBaseDamage));
-        result.AttributeCombinations.Add(this.CreateConditionalRelationship(Stats.RavenBaseDamage, Stats.IsScepterEquipped, Stats.ScepterPetBonusBaseDamage));
-        result.AttributeCombinations.Add(this.CreateConditionalRelationship(Stats.DefenseBase, Stats.IsScepterEquipped, Stats.BonusDefenseWithScepter));
+        result.AttributeCombinations.Add(this.CreateConditionalRelationship(Stats.RavenBonusDamage, Stats.IsScepterEquipped, Stats.ScepterPetBonusDamage));
+        result.AttributeCombinations.Add(this.CreateConditionalRelationship(Stats.BonusDamageWithScepter, Stats.BonusDamageWithScepterCmdDiv, Stats.TotalLeadership));
+        result.AttributeCombinations.Add(this.CreateConditionalRelationship(Stats.MasterSkillPhysBonusDmg, Stats.IsScepterEquipped, Stats.BonusDamageWithScepter));
         result.AttributeCombinations.Add(this.CreateConditionalRelationship(Stats.DefenseFinal, Stats.IsHorseEquipped, Stats.BonusDefenseWithHorse, aggregateType: AggregateType.AddFinal));
 
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.BonusDefenseWithScepter, Stats.BonusDefenseWithScepterCmdDiv, Stats.TotalLeadership));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.ElectricSpikeBonusDmg, 1.0f / 10, Stats.TotalLeadership));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.EarthshakeBonusDmg, 1.0f / 10, Stats.TotalStrength));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.EarthshakeBonusDmg, 1.0f / 5, Stats.TotalLeadership));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.EarthshakeBonusDmg, 10, Stats.HorseLevel));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.ChaoticDiseierBonusDmg, 1.0f / 30, Stats.TotalStrength));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.ChaoticDiseierBonusDmg, 1.0f / 55, Stats.TotalEnergy));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.LordGenericSkillBonusDmg, 1.0f / 25, Stats.TotalStrength));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.LordGenericSkillBonusDmg, 1.0f / 50, Stats.TotalEnergy));
 
-        /* TODO: Add these stats
-                                    Critical dmg = cmd/25+str/30
-                                    Fireburst bonus min dmg = 100+str/25+ene/50
-                                    Fireburst bonus max dmg = 150+str/25+ene/50
-                                    Horse bonus dmg = 100+horseLvl*10+lvl*2.5+str/10+cmd/5
-                                */
         if (!this.UseClassicPvp)
         {
             result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.CurrentShield, 1, false));
@@ -144,12 +139,12 @@ internal partial class CharacterClassInitialization
         result.BaseAttributeValues.Add(this.CreateConstValueAttribute(2, Stats.SkillMultiplier));
         result.BaseAttributeValues.Add(this.CreateConstValueAttribute(1.0f / 33f, Stats.AbilityRecoveryMultiplier));
         result.BaseAttributeValues.Add(this.CreateConstValueAttribute(1, Stats.PetDurationIncrease));
-        result.BaseAttributeValues.Add(this.CreateConstValueAttribute(1, Stats.DamageReceiveHorseDecrement));
 
         result.BaseAttributeValues.Add(this.CreateConstValueAttribute(180, Stats.RavenMinimumDamage));
         result.BaseAttributeValues.Add(this.CreateConstValueAttribute(200, Stats.RavenMaximumDamage));
         result.BaseAttributeValues.Add(this.CreateConstValueAttribute(20, Stats.RavenAttackSpeed));
         result.BaseAttributeValues.Add(this.CreateConstValueAttribute(1000, Stats.RavenAttackRate));
+        result.BaseAttributeValues.Add(this.CreateConstValueAttribute(0.3f, Stats.RavenCriticalDamageChance));
 
         this.AddCommonBaseAttributeValues(result.BaseAttributeValues, isMaster);
 

--- a/src/Persistence/Initialization/CharacterClasses/ClassDarkWizard.cs
+++ b/src/Persistence/Initialization/CharacterClasses/ClassDarkWizard.cs
@@ -1,4 +1,4 @@
-// <copyright file="ClassDarkWizard.cs" company="MUnique">
+﻿// <copyright file="ClassDarkWizard.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
@@ -69,17 +69,19 @@ internal partial class CharacterClassInitialization
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumHealth, 2, Stats.TotalVitality));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumPhysBaseDmg, 1.0f / 8, Stats.TotalStrength));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1.0f / 4, Stats.TotalStrength));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumPhysBaseDmg, 1, Stats.MinimumPhysBaseDmgByWeapon));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1, Stats.MaximumPhysBaseDmgByWeapon));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumPhysBaseDmg, 1, Stats.PhysicalBaseDmg));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1, Stats.PhysicalBaseDmg));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumWizBaseDmg, 1.0f / 9, Stats.TotalEnergy));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumWizBaseDmg, 1.0f / 4, Stats.TotalEnergy));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumWizBaseDmg, 1, Stats.BaseMinDamageBonus));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumWizBaseDmg, 1, Stats.BaseMaxDamageBonus));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.WizardryBaseDmg, 1, Stats.BaseDamageBonus));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumWizBaseDmg, 1, Stats.WizardryBaseDmg));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumWizBaseDmg, 1, Stats.WizardryBaseDmg));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumWizBaseDmg, 1, Stats.WizardryBaseDmgIncrease, InputOperator.Add, AggregateType.Multiplicate));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumWizBaseDmg, 1, Stats.WizardryBaseDmgIncrease, InputOperator.Add, AggregateType.Multiplicate));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.WizardryAttackDamageIncrease, 1.0f / 100, Stats.StaffRise));
 
         result.AttributeCombinations.Add(this.CreateConditionalRelationship(Stats.WizardryBaseDmg, Stats.IsOneHandedStaffEquipped, Stats.OneHandedStaffBonusBaseDamage));
+        result.AttributeCombinations.Add(this.CreateConditionalRelationship(Stats.AttackSpeedAny, Stats.IsOneHandedStaffEquipped, Stats.WeaponMasteryAttackSpeed));
         result.AttributeCombinations.Add(this.CreateConditionalRelationship(Stats.WizardryBaseDmg, Stats.IsTwoHandedStaffEquipped, Stats.TwoHandedStaffBonusBaseDamage));
 
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.FenrirBaseDmg, 1.0f / 5, Stats.TotalStrength));

--- a/src/Persistence/Initialization/CharacterClasses/ClassFairyElf.cs
+++ b/src/Persistence/Initialization/CharacterClasses/ClassFairyElf.cs
@@ -1,4 +1,4 @@
-// <copyright file="ClassFairyElf.cs" company="MUnique">
+﻿// <copyright file="ClassFairyElf.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
@@ -24,6 +24,9 @@ internal partial class CharacterClassInitialization
     /// <returns>The created character class.</returns>
     protected CharacterClass CreateFairyElf(CharacterClassNumber number, string name, bool isMaster, CharacterClass? nextGenerationClass, bool canGetCreated)
     {
+        var ammunitionDmgIncrease = this.Context.CreateNew<AttributeDefinition>(Guid.NewGuid(), "Ammunition damage increase", string.Empty);
+        this.GameConfiguration.Attributes.Add(ammunitionDmgIncrease);
+
         var result = this.Context.CreateNew<CharacterClass>();
         result.SetGuid((byte)number);
         this.GameConfiguration.CharacterClasses.Add(result);
@@ -48,6 +51,8 @@ internal partial class CharacterClassInitialization
 
         this.AddCommonAttributeRelationships(result.AttributeCombinations);
 
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.TotalStrengthAndAgility, Stats.TotalAgility, Stats.TotalStrength, InputOperator.Add));
+
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.DefenseBase, 1.0f / 10, Stats.TotalAgility));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.DefenseRatePvm, 0.25f, Stats.TotalAgility));
 
@@ -67,23 +72,30 @@ internal partial class CharacterClassInitialization
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumMana, 1.5f, Stats.TotalLevel));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumHealth, 1, Stats.TotalLevel));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumHealth, 2, Stats.TotalVitality));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumPhysBaseDmg, 1.0f / 7, Stats.TotalAgility));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1.0f / 4, Stats.TotalAgility));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumPhysBaseDmg, 1.0f / 14, Stats.TotalStrength));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1.0f / 8, Stats.TotalStrength));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumPhysBaseDmg, 1, Stats.MinimumPhysBaseDmgByWeapon));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1, Stats.MaximumPhysBaseDmgByWeapon));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumPhysBaseDmg, 1, Stats.PhysicalBaseDmg));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1, Stats.PhysicalBaseDmg));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.ArcheryMinDmg, 1.0f / 7, Stats.TotalAgility));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.ArcheryMaxDmg, 1.0f / 4, Stats.TotalAgility));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.ArcheryMinDmg, 1.0f / 14, Stats.TotalStrength));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.ArcheryMaxDmg, 1.0f / 8, Stats.TotalStrength));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MeleeMinDmg, 1.0f / 7, Stats.TotalStrengthAndAgility));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MeleeMaxDmg, 1.0f / 4, Stats.TotalStrengthAndAgility));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumPhysBaseDmg, 1, ammunitionDmgIncrease, InputOperator.Add, AggregateType.Multiplicate));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1, ammunitionDmgIncrease, InputOperator.Add, AggregateType.Multiplicate));
+
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.ArcheryAttackMode, 1, Stats.IsBowEquipped));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.ArcheryAttackMode, 1, Stats.IsCrossBowEquipped));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MeleeAttackMode, -1, Stats.ArcheryAttackMode));
+
+        result.AttributeCombinations.Add(this.CreateConditionalRelationship(Stats.MinimumPhysBaseDmg, Stats.ArcheryAttackMode, Stats.ArcheryMinDmg));
+        result.AttributeCombinations.Add(this.CreateConditionalRelationship(Stats.MaximumPhysBaseDmg, Stats.ArcheryAttackMode, Stats.ArcheryMaxDmg));
+        result.AttributeCombinations.Add(this.CreateConditionalRelationship(ammunitionDmgIncrease, Stats.ArcheryAttackMode, Stats.AmmunitionDamageBonus));
+        result.AttributeCombinations.Add(this.CreateConditionalRelationship(Stats.MinimumPhysBaseDmg, Stats.MeleeAttackMode, Stats.MeleeMinDmg));
+        result.AttributeCombinations.Add(this.CreateConditionalRelationship(Stats.MaximumPhysBaseDmg, Stats.MeleeAttackMode, Stats.MeleeMaxDmg));
+        result.AttributeCombinations.Add(this.CreateConditionalRelationship(Stats.AttackSpeedAny, Stats.IsBowEquipped, Stats.WeaponMasteryAttackSpeed));
 
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.FenrirBaseDmg, 1.0f / 5, Stats.TotalStrength));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.FenrirBaseDmg, 1.0f / 3, Stats.TotalAgility));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.FenrirBaseDmg, 1.0f / 7, Stats.TotalVitality));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.FenrirBaseDmg, 1.0f / 5, Stats.TotalEnergy));
-
-        result.AttributeCombinations.Add(this.CreateConditionalRelationship(Stats.PhysicalBaseDmg, Stats.IsBowEquipped, Stats.BowBonusBaseDamage));
-        result.AttributeCombinations.Add(this.CreateConditionalRelationship(Stats.PhysicalBaseDmg, Stats.IsCrossBowEquipped, Stats.CrossBowBonusBaseDamage));
-
 
         if (!this.UseClassicPvp)
         {
@@ -108,6 +120,7 @@ internal partial class CharacterClassInitialization
         result.BaseAttributeValues.Add(this.CreateConstValueAttribute(6, Stats.MaximumMana));
         result.BaseAttributeValues.Add(this.CreateConstValueAttribute(1, Stats.SkillMultiplier));
         result.BaseAttributeValues.Add(this.CreateConstValueAttribute(1.0f / 33f, Stats.AbilityRecoveryMultiplier));
+        result.BaseAttributeValues.Add(this.CreateConstValueAttribute(1, Stats.MeleeAttackMode));
 
         this.AddCommonBaseAttributeValues(result.BaseAttributeValues, isMaster);
 

--- a/src/Persistence/Initialization/CharacterClasses/ClassMagicGladiator.cs
+++ b/src/Persistence/Initialization/CharacterClasses/ClassMagicGladiator.cs
@@ -1,4 +1,4 @@
-// <copyright file="ClassMagicGladiator.cs" company="MUnique">
+﻿// <copyright file="ClassMagicGladiator.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
@@ -13,13 +13,6 @@ using MUnique.OpenMU.GameLogic.Attributes;
 /// </summary>
 internal partial class CharacterClassInitialization
 {
-    private CharacterClass CreateDuelMaster()
-    {
-        var result = this.CreateMagicGladiator(CharacterClassNumber.DuelMaster, "Duel Master", true, null, false);
-        result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.MasterLevel, 0, false));
-        return result;
-    }
-
     /// <summary>
     /// Creates the magic gladiator.
     /// </summary>
@@ -56,6 +49,7 @@ internal partial class CharacterClassInitialization
         result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.Resets, 0, false));
 
         this.AddCommonAttributeRelationships(result.AttributeCombinations);
+        this.AddDoubleWieldAttributeRelationships(result.AttributeCombinations);
 
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.DefenseBase, 1.0f / 5, Stats.TotalAgility));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.DefenseRatePvm, 1.0f / 3, Stats.TotalAgility));
@@ -80,18 +74,17 @@ internal partial class CharacterClassInitialization
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1.0f / 4, Stats.TotalStrength));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumPhysBaseDmg, 1.0f / 12, Stats.TotalEnergy));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1.0f / 8, Stats.TotalEnergy));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumPhysBaseDmg, 1, Stats.MinimumPhysBaseDmgByWeapon));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1, Stats.MaximumPhysBaseDmgByWeapon));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumPhysBaseDmg, 1, Stats.PhysicalBaseDmg));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1, Stats.PhysicalBaseDmg));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumWizBaseDmg, 1.0f / 9, Stats.TotalEnergy));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumWizBaseDmg, 1.0f / 4, Stats.TotalEnergy));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumWizBaseDmg, 1, Stats.BaseMinDamageBonus));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumWizBaseDmg, 1, Stats.BaseMaxDamageBonus));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.WizardryBaseDmg, 1, Stats.BaseDamageBonus));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumWizBaseDmg, 1, Stats.WizardryBaseDmg));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumWizBaseDmg, 1, Stats.WizardryBaseDmg));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumWizBaseDmg, 1, Stats.WizardryBaseDmgIncrease, InputOperator.Add, AggregateType.Multiplicate));
+        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumWizBaseDmg, 1, Stats.WizardryBaseDmgIncrease, InputOperator.Add, AggregateType.Multiplicate));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.WizardryAttackDamageIncrease, 1.0f / 100, Stats.StaffRise));
 
-        result.AttributeCombinations.Add(this.CreateConditionalRelationship(Stats.PhysicalBaseDmg, Stats.IsOneHandedSwordEquipped, Stats.OneHandedSwordBonusBaseDamage));
-        result.AttributeCombinations.Add(this.CreateConditionalRelationship(Stats.PhysicalBaseDmg, Stats.IsTwoHandedSwordEquipped, Stats.TwoHandedSwordBonusBaseDamage));
         result.AttributeCombinations.Add(this.CreateConditionalRelationship(Stats.WizardryBaseDmg, Stats.IsOneHandedStaffEquipped, Stats.OneHandedStaffBonusBaseDamage));
         result.AttributeCombinations.Add(this.CreateConditionalRelationship(Stats.WizardryBaseDmg, Stats.IsTwoHandedStaffEquipped, Stats.TwoHandedStaffBonusBaseDamage));
 
@@ -127,6 +120,13 @@ internal partial class CharacterClassInitialization
 
         this.AddCommonBaseAttributeValues(result.BaseAttributeValues, isMaster);
 
+        return result;
+    }
+
+    private CharacterClass CreateDuelMaster()
+    {
+        var result = this.CreateMagicGladiator(CharacterClassNumber.DuelMaster, "Duel Master", true, null, false);
+        result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.MasterLevel, 0, false));
         return result;
     }
 }

--- a/src/Persistence/Initialization/CharacterClasses/ClassRageFighter.cs
+++ b/src/Persistence/Initialization/CharacterClasses/ClassRageFighter.cs
@@ -1,4 +1,4 @@
-// <copyright file="ClassRageFighter.cs" company="MUnique">
+﻿// <copyright file="ClassRageFighter.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
@@ -48,6 +48,7 @@ internal partial class CharacterClassInitialization
         result.StatAttributes.Add(this.CreateStatAttributeDefinition(Stats.Resets, 0, false));
 
         this.AddCommonAttributeRelationships(result.AttributeCombinations);
+        this.AddDoubleWieldAttributeRelationships(result.AttributeCombinations);
 
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.DefenseBase, 1.0f / 8, Stats.TotalAgility));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.DefenseRatePvm, 1.0f / 10, Stats.TotalAgility));
@@ -86,21 +87,11 @@ internal partial class CharacterClassInitialization
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1.0f / 5, Stats.TotalStrength));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumPhysBaseDmg, 1.0f / 15, Stats.TotalVitality));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1.0f / 12, Stats.TotalVitality));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumPhysBaseDmg, 1, Stats.MinimumPhysBaseDmgByWeapon));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1, Stats.MaximumPhysBaseDmgByWeapon));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumPhysBaseDmg, 1, Stats.PhysicalBaseDmg));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumPhysBaseDmg, 1, Stats.PhysicalBaseDmg));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumWizBaseDmg, 1.0f / 9, Stats.TotalEnergy));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumWizBaseDmg, 1.0f / 4, Stats.TotalEnergy));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MinimumWizBaseDmg, 1, Stats.WizardryBaseDmg));
-        result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.MaximumWizBaseDmg, 1, Stats.WizardryBaseDmg));
 
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.FenrirBaseDmg, 1.0f / 5, Stats.TotalStrength));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.FenrirBaseDmg, 1.0f / 5, Stats.TotalAgility));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.FenrirBaseDmg, 1.0f / 3, Stats.TotalVitality));
         result.AttributeCombinations.Add(this.CreateAttributeRelationship(Stats.FenrirBaseDmg, 1.0f / 7, Stats.TotalEnergy));
-
-        result.AttributeCombinations.Add(this.CreateConditionalRelationship(Stats.PhysicalBaseDmg, Stats.IsGloveWeaponEquipped, Stats.GloveWeaponBonusBaseDamage));
 
         result.BaseAttributeValues.Add(this.CreateConstValueAttribute(57, Stats.MaximumHealth));
         result.BaseAttributeValues.Add(this.CreateConstValueAttribute(7, Stats.MaximumMana));

--- a/src/Persistence/Initialization/Items/ExcellentOptions.cs
+++ b/src/Persistence/Initialization/Items/ExcellentOptions.cs
@@ -1,4 +1,4 @@
-// <copyright file="ExcellentOptions.cs" company="MUnique">
+﻿// <copyright file="ExcellentOptions.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
@@ -70,8 +70,8 @@ public class ExcellentOptions : InitializerBase
         definition.PossibleOptions.Add(this.CreateExcellentOption(1, Stats.ManaAfterMonsterKillMultiplier, 1f / 8f, AggregateType.AddRaw, ItemOptionDefinitionNumbers.ExcellentCurse));
         definition.PossibleOptions.Add(this.CreateExcellentOption(2, Stats.HealthAfterMonsterKillMultiplier, 1f / 8f, AggregateType.AddRaw, ItemOptionDefinitionNumbers.ExcellentCurse));
         definition.PossibleOptions.Add(this.CreateExcellentOption(3, Stats.AttackSpeedAny, 7, AggregateType.AddRaw, ItemOptionDefinitionNumbers.ExcellentCurse));
-        definition.PossibleOptions.Add(this.CreateExcellentOption(4, Stats.MaximumCurseBaseDmg, 1.02f, AggregateType.Multiplicate, ItemOptionDefinitionNumbers.ExcellentCurse));
-        definition.PossibleOptions.Add(this.CreateRelatedExcellentOption(5, Stats.WizardryBaseDmg, Stats.Level, 1f / 20f, ItemOptionDefinitionNumbers.ExcellentCurse));
+        definition.PossibleOptions.Add(this.CreateExcellentOption(4, Stats.WizardryBaseDmgIncrease, 1.02f, AggregateType.Multiplicate, ItemOptionDefinitionNumbers.ExcellentCurse));
+        definition.PossibleOptions.Add(this.CreateRelatedExcellentOption(5, Stats.WizardryBaseDmg, Stats.TotalLevel, 1f / 20f, ItemOptionDefinitionNumbers.ExcellentCurse));
         definition.PossibleOptions.Add(this.CreateExcellentOption(6, Stats.ExcellentDamageChance, 0.1f, AggregateType.AddRaw, ItemOptionDefinitionNumbers.ExcellentCurse));
     }
 
@@ -88,8 +88,8 @@ public class ExcellentOptions : InitializerBase
         definition.PossibleOptions.Add(this.CreateExcellentOption(1, Stats.ManaAfterMonsterKillMultiplier, 1f / 8f, AggregateType.AddRaw, ItemOptionDefinitionNumbers.ExcellentWizardry));
         definition.PossibleOptions.Add(this.CreateExcellentOption(2, Stats.HealthAfterMonsterKillMultiplier, 1f / 8f, AggregateType.AddRaw, ItemOptionDefinitionNumbers.ExcellentWizardry));
         definition.PossibleOptions.Add(this.CreateExcellentOption(3, Stats.AttackSpeedAny, 7, AggregateType.AddRaw, ItemOptionDefinitionNumbers.ExcellentWizardry));
-        definition.PossibleOptions.Add(this.CreateExcellentOption(4, Stats.MaximumWizBaseDmg, 1.02f, AggregateType.Multiplicate, ItemOptionDefinitionNumbers.ExcellentWizardry));
-        definition.PossibleOptions.Add(this.CreateRelatedExcellentOption(5, Stats.WizardryBaseDmg, Stats.Level, 1f / 20f, ItemOptionDefinitionNumbers.ExcellentWizardry));
+        definition.PossibleOptions.Add(this.CreateExcellentOption(4, Stats.WizardryBaseDmgIncrease, 1.02f, AggregateType.Multiplicate, ItemOptionDefinitionNumbers.ExcellentWizardry));
+        definition.PossibleOptions.Add(this.CreateRelatedExcellentOption(5, Stats.WizardryBaseDmg, Stats.TotalLevel, 1f / 20f, ItemOptionDefinitionNumbers.ExcellentWizardry));
         definition.PossibleOptions.Add(this.CreateExcellentOption(6, Stats.ExcellentDamageChance, 0.1f, AggregateType.AddRaw, ItemOptionDefinitionNumbers.ExcellentWizardry));
     }
 
@@ -106,8 +106,8 @@ public class ExcellentOptions : InitializerBase
         definition.PossibleOptions.Add(this.CreateExcellentOption(1, Stats.ManaAfterMonsterKillMultiplier, 1f / 8f, AggregateType.AddRaw, ItemOptionDefinitionNumbers.ExcellentPhysical));
         definition.PossibleOptions.Add(this.CreateExcellentOption(2, Stats.HealthAfterMonsterKillMultiplier, 1f / 8f, AggregateType.AddRaw, ItemOptionDefinitionNumbers.ExcellentPhysical));
         definition.PossibleOptions.Add(this.CreateExcellentOption(3, Stats.AttackSpeedAny, 7, AggregateType.AddRaw, ItemOptionDefinitionNumbers.ExcellentPhysical));
-        definition.PossibleOptions.Add(this.CreateExcellentOption(4, Stats.MaximumPhysBaseDmg, 1.02f, AggregateType.Multiplicate, ItemOptionDefinitionNumbers.ExcellentPhysical));
-        definition.PossibleOptions.Add(this.CreateRelatedExcellentOption(5, Stats.PhysicalBaseDmg, Stats.Level, 1f / 20f, ItemOptionDefinitionNumbers.ExcellentPhysical));
+        definition.PossibleOptions.Add(this.CreateExcellentOption(4, Stats.PhysicalBaseDmgIncrease, 1.02f, AggregateType.Multiplicate, ItemOptionDefinitionNumbers.ExcellentPhysical));
+        definition.PossibleOptions.Add(this.CreateRelatedExcellentOption(5, Stats.PhysicalBaseDmg, Stats.TotalLevel, 1f / 20f, ItemOptionDefinitionNumbers.ExcellentPhysical));
         definition.PossibleOptions.Add(this.CreateExcellentOption(6, Stats.ExcellentDamageChance, 0.1f, AggregateType.AddRaw, ItemOptionDefinitionNumbers.ExcellentPhysical));
     }
 
@@ -124,7 +124,7 @@ public class ExcellentOptions : InitializerBase
         definition.PossibleOptions.Add(this.CreateExcellentOption(1, Stats.MoneyAmountRate, 1.4f, AggregateType.Multiplicate, ItemOptionDefinitionNumbers.ExcellentDefense));
         definition.PossibleOptions.Add(this.CreateExcellentOption(2, Stats.DefenseRatePvm, 1.1f, AggregateType.Multiplicate, ItemOptionDefinitionNumbers.ExcellentDefense));
         definition.PossibleOptions.Add(this.CreateExcellentOption(3, Stats.DamageReflection, 0.04f, AggregateType.AddRaw, ItemOptionDefinitionNumbers.ExcellentDefense));
-        definition.PossibleOptions.Add(this.CreateExcellentOption(4, Stats.DamageReceiveDecrement, 0.96f, AggregateType.Multiplicate, ItemOptionDefinitionNumbers.ExcellentDefense));
+        definition.PossibleOptions.Add(this.CreateExcellentOption(4, Stats.ArmorDamageDecrease, 0.04f, AggregateType.AddRaw, ItemOptionDefinitionNumbers.ExcellentDefense));
         definition.PossibleOptions.Add(this.CreateExcellentOption(5, Stats.MaximumMana, 1.04f, AggregateType.Multiplicate, ItemOptionDefinitionNumbers.ExcellentDefense));
         definition.PossibleOptions.Add(this.CreateExcellentOption(6, Stats.MaximumHealth, 1.04f, AggregateType.Multiplicate, ItemOptionDefinitionNumbers.ExcellentDefense));
     }

--- a/src/Persistence/Initialization/Skills/BerserkerEffectInitializer.cs
+++ b/src/Persistence/Initialization/Skills/BerserkerEffectInitializer.cs
@@ -1,0 +1,103 @@
+﻿// <copyright file="BerserkerEffectInitializer.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Persistence.Initialization.Skills;
+
+using MUnique.OpenMU.AttributeSystem;
+using MUnique.OpenMU.DataModel.Attributes;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.GameLogic.Attributes;
+
+/// <summary>
+/// Initializer for the berserker buff effect.
+/// </summary>
+public class BerserkerEffectInitializer : InitializerBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BerserkerEffectInitializer"/> class.
+    /// </summary>
+    /// <param name="context">The context.</param>
+    /// <param name="gameConfiguration">The game configuration.</param>
+    public BerserkerEffectInitializer(IContext context, GameConfiguration gameConfiguration)
+        : base(context, gameConfiguration)
+    {
+    }
+
+    /// <inheritdoc />
+    public override void Initialize()
+    {
+        var magicEffect = this.Context.CreateNew<MagicEffectDefinition>();
+        this.GameConfiguration.MagicEffects.Add(magicEffect);
+        magicEffect.Number = (short)MagicEffectNumber.Berserker;
+        magicEffect.Name = "Berserker Buff Skill Effect";
+        magicEffect.InformObservers = true;
+        magicEffect.SendDuration = false;
+        magicEffect.StopByDeath = true;
+        magicEffect.Duration = this.Context.CreateNew<PowerUpDefinitionValue>();
+        magicEffect.Duration.ConstantValue.Value = 30; // 30 Seconds
+
+        var durationPerEnergy = this.Context.CreateNew<AttributeRelationship>();
+        durationPerEnergy.InputAttribute = Stats.TotalEnergy.GetPersistent(this.GameConfiguration);
+        durationPerEnergy.InputOperator = InputOperator.Multiply;
+        durationPerEnergy.InputOperand = 1f / 20f; // 20 energy adds 1 second duration
+        magicEffect.Duration.RelatedValues.Add(durationPerEnergy);
+
+        // Mana (and damage) multiplier (buff)
+        var manaPowerUpDefinition = this.Context.CreateNew<PowerUpDefinition>();
+        magicEffect.PowerUpDefinitions.Add(manaPowerUpDefinition);
+        manaPowerUpDefinition.TargetAttribute = Stats.BerserkerManaMultiplier.GetPersistent(this.GameConfiguration);
+        manaPowerUpDefinition.Boost = this.Context.CreateNew<PowerUpDefinitionValue>();
+
+        var manaMultiplier = this.Context.CreateNew<AttributeRelationship>();
+        manaMultiplier.InputAttribute = Stats.TotalEnergy.GetPersistent(this.GameConfiguration);
+        manaMultiplier.InputOperator = InputOperator.Multiply;
+        manaMultiplier.InputOperand = 1f / 3000f;
+        manaPowerUpDefinition.Boost.RelatedValues.Add(manaMultiplier);
+
+        // Health multiplier factor (debuff)
+        var healthPowerUpDefinition = this.Context.CreateNew<PowerUpDefinition>();
+        magicEffect.PowerUpDefinitions.Add(healthPowerUpDefinition);
+        healthPowerUpDefinition.TargetAttribute = Stats.BerserkerHealthDecrement.GetPersistent(this.GameConfiguration);
+        healthPowerUpDefinition.Boost = this.Context.CreateNew<PowerUpDefinitionValue>();
+        healthPowerUpDefinition.Boost.ConstantValue.Value = -0.4f;
+
+        var healthMultiplier = this.Context.CreateNew<AttributeRelationship>();
+        healthMultiplier.InputAttribute = Stats.TotalEnergy.GetPersistent(this.GameConfiguration);
+        healthMultiplier.InputOperator = InputOperator.Multiply;
+        healthMultiplier.InputOperand = 1f / 6000f;
+        healthPowerUpDefinition.Boost.RelatedValues.Add(healthMultiplier);
+
+        // Min physical damage bonus (later gets multiplied by the mana multiplier)
+        var minPhysPowerUpDefinition = this.Context.CreateNew<PowerUpDefinition>();
+        magicEffect.PowerUpDefinitions.Add(minPhysPowerUpDefinition);
+        minPhysPowerUpDefinition.TargetAttribute = Stats.BerserkerMinPhysDmgBonus.GetPersistent(this.GameConfiguration);
+        minPhysPowerUpDefinition.Boost = this.Context.CreateNew<PowerUpDefinitionValue>();
+        minPhysPowerUpDefinition.Boost.ConstantValue.Value = 140f;
+
+        var minDmgPerStrengthAndAgility = this.Context.CreateNew<AttributeRelationship>();
+        minDmgPerStrengthAndAgility.InputAttribute = Stats.TotalStrengthAndAgility.GetPersistent(this.GameConfiguration);
+        minDmgPerStrengthAndAgility.InputOperator = InputOperator.Multiply;
+        minDmgPerStrengthAndAgility.InputOperand = 1.0f / 50;
+        minPhysPowerUpDefinition.Boost.RelatedValues.Add(minDmgPerStrengthAndAgility);
+
+        // Max physical damage bonus (later gets multiplied by the mana multiplier)
+        var maxPhysPowerUpDefinition = this.Context.CreateNew<PowerUpDefinition>();
+        magicEffect.PowerUpDefinitions.Add(maxPhysPowerUpDefinition);
+        maxPhysPowerUpDefinition.TargetAttribute = Stats.BerserkerMaxPhysDmgBonus.GetPersistent(this.GameConfiguration);
+        maxPhysPowerUpDefinition.Boost = this.Context.CreateNew<PowerUpDefinitionValue>();
+        maxPhysPowerUpDefinition.Boost.ConstantValue.Value = 160f;
+
+        var maxDmgPerStrengthAndAgility = this.Context.CreateNew<AttributeRelationship>();
+        maxDmgPerStrengthAndAgility.InputAttribute = Stats.TotalStrengthAndAgility.GetPersistent(this.GameConfiguration);
+        maxDmgPerStrengthAndAgility.InputOperator = InputOperator.Multiply;
+        maxDmgPerStrengthAndAgility.InputOperand = 1.0f / 30;
+        maxPhysPowerUpDefinition.Boost.RelatedValues.Add(maxDmgPerStrengthAndAgility);
+
+        // Berserker Proficiency master level multiplier placeholder
+        var masterLevelDmgMultiplier = this.Context.CreateNew<PowerUpDefinition>();
+        magicEffect.PowerUpDefinitions.Add(masterLevelDmgMultiplier);
+        masterLevelDmgMultiplier.TargetAttribute = Stats.BerserkerProficiencyMultiplier.GetPersistent(this.GameConfiguration);
+        masterLevelDmgMultiplier.Boost = this.Context.CreateNew<PowerUpDefinitionValue>();
+    }
+}

--- a/src/Persistence/Initialization/Skills/GreaterDamageEffectInitializer.cs
+++ b/src/Persistence/Initialization/Skills/GreaterDamageEffectInitializer.cs
@@ -38,7 +38,7 @@ public class GreaterDamageEffectInitializer : InitializerBase
         magicEffect.Duration.ConstantValue.Value = 60; // 60 Seconds
         var powerUpDefinition = this.Context.CreateNew<PowerUpDefinition>();
         magicEffect.PowerUpDefinitions.Add(powerUpDefinition);
-        powerUpDefinition.TargetAttribute = Stats.BaseDamageBonus.GetPersistent(this.GameConfiguration);
+        powerUpDefinition.TargetAttribute = Stats.GreaterDamageBonus.GetPersistent(this.GameConfiguration);
 
         // The buff gives 3 + (energy / 7) damage
         powerUpDefinition.Boost = this.Context.CreateNew<PowerUpDefinitionValue>();

--- a/src/Persistence/Initialization/Skills/InfiniteArrowEffectInitializer.cs
+++ b/src/Persistence/Initialization/Skills/InfiniteArrowEffectInitializer.cs
@@ -35,7 +35,7 @@ public class InfiniteArrowEffectInitializer : InitializerBase
         magicEffect.SendDuration = true;
         magicEffect.StopByDeath = true;
         magicEffect.Duration = this.Context.CreateNew<PowerUpDefinitionValue>();
-        magicEffect.Duration.ConstantValue.Value = (float)TimeSpan.FromHours(8).TotalSeconds;
+        magicEffect.Duration.ConstantValue.Value = 600;
 
         // Multiply usage rate with 0, so no arrows are consumed anymore.
         var reduceAmmonitionUsage = this.Context.CreateNew<PowerUpDefinition>();
@@ -45,27 +45,18 @@ public class InfiniteArrowEffectInitializer : InitializerBase
         reduceAmmonitionUsage.Boost.ConstantValue.Value = 0f;
         reduceAmmonitionUsage.Boost.ConstantValue.AggregateType = AggregateType.Multiplicate;
 
+        // Mana loss is 5 plus: 0 (arrows/bolts + 0); 2 (arrows/bolts +1); 5 (arrows/bolts +2 or higher).
+        // Because the ammo item can be changed during the magic effect duration, the extra loss is added after each hit.
         var manaLossAfterHit = this.Context.CreateNew<PowerUpDefinition>();
         magicEffect.PowerUpDefinitions.Add(manaLossAfterHit);
         manaLossAfterHit.TargetAttribute = Stats.ManaLossAfterHit.GetPersistent(this.GameConfiguration);
         manaLossAfterHit.Boost = this.Context.CreateNew<PowerUpDefinitionValue>();
-        manaLossAfterHit.Boost.ConstantValue.Value = 3f;
+        manaLossAfterHit.Boost.ConstantValue.Value = 5f;
 
-        var damageBonusPerEnergy = this.Context.CreateNew<PowerUpDefinition>();
-        magicEffect.PowerUpDefinitions.Add(damageBonusPerEnergy);
-        damageBonusPerEnergy.TargetAttribute = Stats.BaseDamageBonus.GetPersistent(this.GameConfiguration);
-        damageBonusPerEnergy.Boost = this.Context.CreateNew<PowerUpDefinitionValue>();
-        var oneDamagePer7Energy = this.Context.CreateNew<AttributeRelationship>();
-        damageBonusPerEnergy.Boost.RelatedValues.Add(oneDamagePer7Energy);
-        oneDamagePer7Energy.InputAttribute = Stats.TotalEnergy.GetPersistent(this.GameConfiguration);
-        oneDamagePer7Energy.InputOperand = 1f / 7f;
-        oneDamagePer7Energy.InputOperator = InputOperator.Add;
-        oneDamagePer7Energy.TargetAttribute = Stats.BaseDamageBonus.GetPersistent(this.GameConfiguration);
-
-        // The next is more like a placeholder in case it's used by the master skill which adds a percentage bonus.
+        // Placeholder for the Infinity Arrow Strengthener master skill
         var damageIncreaseByMasterLevel = this.Context.CreateNew<PowerUpDefinition>();
         magicEffect.PowerUpDefinitions.Add(damageIncreaseByMasterLevel);
-        damageIncreaseByMasterLevel.TargetAttribute = Stats.AttackDamageIncrease.GetPersistent(this.GameConfiguration);
+        damageIncreaseByMasterLevel.TargetAttribute = Stats.InfinityArrowStrMultiplier.GetPersistent(this.GameConfiguration);
         damageIncreaseByMasterLevel.Boost = this.Context.CreateNew<PowerUpDefinitionValue>();
     }
 }

--- a/src/Persistence/Initialization/Skills/MagicEffectNumber.cs
+++ b/src/Persistence/Initialization/Skills/MagicEffectNumber.cs
@@ -236,6 +236,11 @@ internal enum MagicEffectNumber : short
     Blind = 0x49,
 
     /// <summary>
+    /// The weakness effect, which decreases the attacker's physical damage.
+    /// </summary>
+    Weakness = 0x4C,
+
+    /// <summary>
     /// The cherry blossom wine effect (+ 700 Mana).
     /// </summary>
     CherryBlossomWine = 0x4E,
@@ -249,6 +254,11 @@ internal enum MagicEffectNumber : short
     /// The cherry blossom flower petal effect (+ 40 dmg).
     /// </summary>
     CherryBlossomFlowerPetal = 0x50,
+
+    /// <summary>
+    /// The berserker buff effect.
+    /// </summary>
+    Berserker = 0x51,
 
     /// <summary>
     /// The wiz enhance effect.

--- a/src/Persistence/Initialization/Version095d/Items/Pets.cs
+++ b/src/Persistence/Initialization/Version095d/Items/Pets.cs
@@ -1,4 +1,4 @@
-// <copyright file="Pets.cs" company="MUnique">
+﻿// <copyright file="Pets.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
@@ -34,7 +34,7 @@ public class Pets : InitializerBase
         this.CreatePet(1, 0, "Imp", 28, true, (Stats.AttackDamageIncrease, 1.3f, AggregateType.Multiplicate));
         this.CreatePet(2, 0, "Horn of Uniria", 25, true);
 
-        var dinorant = this.CreatePet(3, SkillNumber.FireBreath, "Horn of Dinorant", 110, false, (Stats.DamageReceiveDecrement, 0.9f, AggregateType.Multiplicate), (Stats.AttackDamageIncrease, 1.15f, AggregateType.Multiplicate), (Stats.CanFly, 1.0f, AggregateType.AddRaw));
+        var dinorant = this.CreatePet(3, SkillNumber.FireBreath, "Horn of Dinorant", 110, false, (Stats.IsDinorantEquipped, 1, AggregateType.AddRaw), (Stats.DamageReceiveDecrement, 0.9f, AggregateType.Multiplicate), (Stats.AttackDamageIncrease, 1.15f, AggregateType.Multiplicate));
         this.AddDinorantOptions(dinorant);
     }
 

--- a/src/Persistence/Initialization/Version095d/Items/Weapons.cs
+++ b/src/Persistence/Initialization/Version095d/Items/Weapons.cs
@@ -1,4 +1,4 @@
-// <copyright file="Weapons.cs" company="MUnique">
+﻿// <copyright file="Weapons.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
@@ -29,10 +29,15 @@ internal class Weapons : InitializerBase
     private static readonly float[] StaffRiseIncreaseByLevelEven = { 0, 3, 7, 10, 14, 17, 21, 24, 28, 31, 35, 40, 45, 50, 56, 63 }; // Staff with even magic power
     private static readonly float[] StaffRiseIncreaseByLevelOdd = { 0, 4, 7, 11, 14, 18, 21, 25, 28, 32, 36, 40, 45, 51, 57, 63 }; // Staff with odd magic power
 
+    private static readonly float[] AmmunitionDamageIncreaseByLevel = { 0, 0.03f, 0.05f }; // Bolts/Arrows
+
     private ItemLevelBonusTable? _weaponDamageIncreaseTable;
+    private ItemLevelBonusTable? _staffDamageIncreaseTable;
 
     private ItemLevelBonusTable? _staffRiseTableEven;
     private ItemLevelBonusTable? _staffRiseTableOdd;
+
+    private ItemLevelBonusTable? _ammunitionDamageIncreaseTable;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="Weapons" /> class.
@@ -83,8 +88,10 @@ internal class Weapons : InitializerBase
     public override void Initialize()
     {
         this._weaponDamageIncreaseTable = this.CreateItemBonusTable(DamageIncreaseByLevel, "Damage Increase (Weapons)", "The damage increase by weapon level. It increases by 3 per level, and 1 more after level 10.");
+        this._staffDamageIncreaseTable = this.CreateItemBonusTable([.. DamageIncreaseByLevel.Select(dmg => dmg /= 2.0f)], "Damage Increase (Staffs)", "The damage increase by staff level. It's half of the physical weapons.");
         this._staffRiseTableEven = this.CreateItemBonusTable(StaffRiseIncreaseByLevelEven, "Staff Rise (even)", "The staff rise bonus per item level for even magic power staves.");
         this._staffRiseTableOdd = this.CreateItemBonusTable(StaffRiseIncreaseByLevelOdd, "Staff Rise (odd)", "The staff rise bonus per item level for odd magic power staves.");
+        this._ammunitionDamageIncreaseTable = this.CreateItemBonusTable(AmmunitionDamageIncreaseByLevel, "Damage Increase % (Bolts/Arrows)", "The damage increase % by ammunition item level.");
 
         this.CreateWeapon(0, 0, 0, 0, 1, 2, true, "Kris", 6, 6, 11, 50, 20, 0, 0, 40, 40, 0, 0, 1, 1, 1);
         this.CreateWeapon(0, 1, 0, 0, 1, 3, true, "Short Sword", 3, 3, 7, 20, 22, 0, 0, 60, 0, 0, 0, 1, 1, 1);
@@ -205,6 +212,10 @@ internal class Weapons : InitializerBase
         var qualifiedCharacterClasses = this.GameConfiguration.DetermineCharacterClasses(wizardClass == 1, knightClass == 1, elfClass == 1);
         qualifiedCharacterClasses.ToList().ForEach(item.QualifiedCharacters.Add);
 
+        var damagePowerUp = this.CreateItemBasePowerUpDefinition(Stats.AmmunitionDamageBonus, 0f, AggregateType.AddRaw);
+        damagePowerUp.BonusPerLevelTable = this._ammunitionDamageIncreaseTable;
+        item.BasePowerUpAttributes.Add(damagePowerUp);
+
         item.IsAmmunition = true;
     }
 
@@ -253,7 +264,7 @@ internal class Weapons : InitializerBase
         item.MaximumItemLevel = isAmmunition ? (byte)0 : Constants.MaximumItemLevel;
         item.DropsFromMonsters = dropsFromMonsters;
         item.SetGuid(item.Group, item.Number);
-        if (slot == 0 && knightClass > 0 && width == 1)
+        if (slot == 0 && (knightClass > 0 || magicGladiatorClass > 0) && width == 1)
         {
             item.ItemSlot = this.GameConfiguration.ItemSlotTypes.First(t => t.ItemSlots.Contains(0) && t.ItemSlots.Contains(1));
         }
@@ -276,12 +287,15 @@ internal class Weapons : InitializerBase
         var qualifiedCharacterClasses = this.GameConfiguration.DetermineCharacterClasses(classes);
         qualifiedCharacterClasses.ToList().ForEach(item.QualifiedCharacters.Add);
 
-        var minDamagePowerUp = this.CreateItemBasePowerUpDefinition(Stats.MinimumPhysBaseDmgByWeapon, minimumDamage, AggregateType.AddRaw);
-        minDamagePowerUp.BonusPerLevelTable = this._weaponDamageIncreaseTable;
+        var dmgDivisor = group == (int)ItemGroups.Staff ? 2.0f : 1.0f;
+        var bonusPerLevelTable = group == (int)ItemGroups.Staff ? this._staffDamageIncreaseTable : this._weaponDamageIncreaseTable;
+
+        var minDamagePowerUp = this.CreateItemBasePowerUpDefinition(Stats.MinimumPhysBaseDmgByWeapon, minimumDamage / dmgDivisor, AggregateType.AddRaw);
+        minDamagePowerUp.BonusPerLevelTable = bonusPerLevelTable;
         item.BasePowerUpAttributes.Add(minDamagePowerUp);
 
-        var maxDamagePowerUp = this.CreateItemBasePowerUpDefinition(Stats.MaximumPhysBaseDmgByWeapon, maximumDamage, AggregateType.AddRaw);
-        maxDamagePowerUp.BonusPerLevelTable = this._weaponDamageIncreaseTable;
+        var maxDamagePowerUp = this.CreateItemBasePowerUpDefinition(Stats.MaximumPhysBaseDmgByWeapon, maximumDamage / dmgDivisor, AggregateType.AddRaw);
+        maxDamagePowerUp.BonusPerLevelTable = bonusPerLevelTable;
         item.BasePowerUpAttributes.Add(maxDamagePowerUp);
 
         var speedPowerUp = this.CreateItemBasePowerUpDefinition(Stats.AttackSpeedByWeapon, attackSpeed, AggregateType.AddRaw);
@@ -310,21 +324,21 @@ internal class Weapons : InitializerBase
             item.BasePowerUpAttributes.Add(staffRisePowerUp);
         }
 
-        item.IsAmmunition = isAmmunition;
-        if (!item.IsAmmunition)
+        item.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.EquippedWeaponCount, 1, AggregateType.AddRaw));
+
+        if (group < (int)ItemGroups.Spears && width == 1)
         {
-            var ammunitionConsumption = this.Context.CreateNew<ItemBasePowerUpDefinition>();
-            ammunitionConsumption.TargetAttribute = Stats.AmmunitionConsumptionRate.GetPersistent(this.GameConfiguration);
-            ammunitionConsumption.BaseValue = 1.0f;
-            item.BasePowerUpAttributes.Add(ammunitionConsumption);
+            item.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.DoubleWieldWeaponCount, 1, AggregateType.AddRaw));
         }
 
-        if (group != (int)ItemGroups.Bows && width == 2)
+        if (group == (int)ItemGroups.Bows)
         {
-            var isTwoHandedWeapon = this.Context.CreateNew<ItemBasePowerUpDefinition>();
-            isTwoHandedWeapon.TargetAttribute = Stats.IsTwoHandedWeaponEquipped.GetPersistent(this.GameConfiguration);
-            isTwoHandedWeapon.BaseValue = 1.0f;
-            item.BasePowerUpAttributes.Add(isTwoHandedWeapon);
+            item.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.AmmunitionConsumptionRate, 1, AggregateType.AddRaw));
+        }
+
+        if (group != (int)ItemGroups.Bows && group != (int)ItemGroups.Staff && width == 2)
+        {
+            item.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.IsTwoHandedWeaponEquipped, 1, AggregateType.AddRaw));
         }
     }
 }

--- a/src/Persistence/Initialization/VersionSeasonSix/Items/AncientSets.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Items/AncientSets.cs
@@ -66,7 +66,7 @@ public class AncientSets : InitializerBase
             (Stats.MaximumHealth, 50.0f),
             (Stats.TotalAgility, 50.0f),
             (Stats.DefenseIncreaseWithEquippedShield, 0.25f),
-            (Stats.BaseDamageBonus, 30.0f));
+            (Stats.FinalDamageBonus, 30.0f));
         anonymous.SetGuid(5, 2);
         this.AddItems(
             anonymous,
@@ -106,13 +106,13 @@ public class AncientSets : InitializerBase
         var eplete = this.AddAncientSet(
             "Eplete", // Scale
             5,
-            (Stats.SkillDamageBonus, 15.0f),
-            (Stats.AttackRatePvm, 50.0f),
-            (Stats.WizardryAttackDamageIncrease, 0.05f),
-            (Stats.MaximumHealth, 50.0f),
-            (Stats.MaximumAbility, 30.0f),
-            (Stats.CriticalDamageChance, 0.10f),
-            (Stats.ExcellentDamageChance, 0.10f));
+            (Stats.SkillDamageBonus, 15.0f, AggregateType.AddRaw),
+            (Stats.AttackRatePvm, 50.0f, AggregateType.AddRaw),
+            (Stats.WizardryBaseDmgIncrease, 1.05f, AggregateType.Multiplicate),
+            (Stats.MaximumHealth, 50.0f, AggregateType.AddRaw),
+            (Stats.MaximumAbility, 30.0f, AggregateType.AddRaw),
+            (Stats.CriticalDamageChance, 0.10f, AggregateType.AddRaw),
+            (Stats.ExcellentDamageChance, 0.10f, AggregateType.AddRaw));
         eplete.SetGuid(6, 1);
         this.AddItems(
             eplete,
@@ -143,12 +143,12 @@ public class AncientSets : InitializerBase
         var garuda = this.AddAncientSet(
             "Garuda", // Brass
             7,
-            (Stats.MaximumAbility, 30.0f),
-            (Stats.DoubleDamageChance, 0.05f),
-            (Stats.TotalEnergy, 15.0f),
-            (Stats.MaximumHealth, 50.0f),
-            (Stats.SkillDamageBonus, 25.0f),
-            (Stats.WizardryAttackDamageIncrease, 0.15f));
+            (Stats.MaximumAbility, 30.0f, AggregateType.AddRaw),
+            (Stats.DoubleDamageChance, 0.05f, AggregateType.AddRaw),
+            (Stats.TotalEnergy, 15.0f, AggregateType.AddRaw),
+            (Stats.MaximumHealth, 50.0f, AggregateType.AddRaw),
+            (Stats.SkillDamageBonus, 25.0f, AggregateType.AddRaw),
+            (Stats.WizardryBaseDmgIncrease, 1.15f, AggregateType.Multiplicate));
         garuda.SetGuid(8, 1);
         this.AddItems(
             garuda,
@@ -172,13 +172,13 @@ public class AncientSets : InitializerBase
         var kantata = this.AddAncientSet(
             "Kantata", // Plate
             9,
-            (Stats.TotalEnergy, 15.0f),
-            (Stats.TotalVitality, 30.0f),
-            (Stats.WizardryAttackDamageIncrease, 0.10f),
-            (Stats.TotalStrength, 15.0f),
-            (Stats.SkillDamageBonus, 25.0f),
-            (Stats.ExcellentDamageChance, 10.0f),
-            (Stats.ExcellentDamageBonus, 20.0f));
+            (Stats.TotalEnergy, 15.0f, AggregateType.AddRaw),
+            (Stats.TotalVitality, 30.0f, AggregateType.AddRaw),
+            (Stats.WizardryBaseDmgIncrease, 1.10f, AggregateType.Multiplicate),
+            (Stats.TotalStrength, 15.0f, AggregateType.AddRaw),
+            (Stats.SkillDamageBonus, 25.0f, AggregateType.AddRaw),
+            (Stats.ExcellentDamageChance, 10.0f, AggregateType.AddRaw),
+            (Stats.ExcellentDamageBonus, 20.0f, AggregateType.AddRaw));
         kantata.SetGuid(9, 1);
         this.AddItems(
             kantata,
@@ -224,7 +224,7 @@ public class AncientSets : InitializerBase
             "Vicious", // Dragon
             12,
             (Stats.SkillDamageBonus, 15.0f),
-            (Stats.BaseDamageBonus, 15.0f),
+            (Stats.FinalDamageBonus, 15.0f),
             (Stats.DoubleDamageChance, 0.10f),
             (Stats.MinimumPhysBaseDmg, 20f),
             (Stats.MaximumPhysBaseDmg, 30f),
@@ -240,15 +240,15 @@ public class AncientSets : InitializerBase
         var apollo = this.AddAncientSet(
             "Apollo", // Pad
             13,
-            (Stats.TotalEnergy, 10.0f),
-            (Stats.WizardryAttackDamageIncrease, 0.05f),
-            (Stats.SkillDamageBonus, 10.0f),
-            (Stats.MaximumMana, 30.0f),
-            (Stats.MaximumHealth, 30.0f),
-            (Stats.MaximumAbility, 20.0f),
-            (Stats.CriticalDamageChance, 0.10f),
-            (Stats.ExcellentDamageChance, 0.10f),
-            (Stats.TotalEnergy, 30.0f));
+            (Stats.TotalEnergy, 10.0f, AggregateType.AddRaw),
+            (Stats.WizardryBaseDmgIncrease, 1.05f, AggregateType.Multiplicate),
+            (Stats.SkillDamageBonus, 10.0f, AggregateType.AddRaw),
+            (Stats.MaximumMana, 30.0f, AggregateType.AddRaw),
+            (Stats.MaximumHealth, 30.0f, AggregateType.AddRaw),
+            (Stats.MaximumAbility, 20.0f, AggregateType.AddRaw),
+            (Stats.CriticalDamageChance, 0.10f, AggregateType.AddRaw),
+            (Stats.ExcellentDamageChance, 0.10f, AggregateType.AddRaw),
+            (Stats.TotalEnergy, 30.0f, AggregateType.AddRaw));
         apollo.SetGuid(2, 1);
         this.AddItems(
             apollo,
@@ -263,10 +263,10 @@ public class AncientSets : InitializerBase
         var barnake = this.AddAncientSet(
             "Barnake", // Pad
             14,
-            (Stats.WizardryAttackDamageIncrease, 0.10f),
-            (Stats.TotalEnergy, 20.0f),
-            (Stats.SkillDamageBonus, 30.0f),
-            (Stats.MaximumMana, 100.0f));
+            (Stats.WizardryBaseDmgIncrease, 1.10f, AggregateType.Multiplicate),
+            (Stats.TotalEnergy, 20.0f, AggregateType.AddRaw),
+            (Stats.SkillDamageBonus, 30.0f, AggregateType.AddRaw),
+            (Stats.MaximumMana, 100.0f, AggregateType.AddRaw));
         barnake.SetGuid(2, 2);
         this.AddItems(
             barnake,
@@ -277,12 +277,12 @@ public class AncientSets : InitializerBase
         var evis = this.AddAncientSet(
             "Evis", // Bone
             15,
-            (Stats.SkillDamageBonus, 15.0f),
-            (Stats.TotalVitality, 20.0f),
-            (Stats.WizardryAttackDamageIncrease, 0.10f),
-            (Stats.DoubleDamageChance, 0.05f),
-            (Stats.AttackRatePvm, 50.0f),
-            (Stats.AbilityRecoveryAbsolute, 5.0f));
+            (Stats.SkillDamageBonus, 15.0f, AggregateType.AddRaw),
+            (Stats.TotalVitality, 20.0f, AggregateType.AddRaw),
+            (Stats.WizardryBaseDmgIncrease, 1.10f, AggregateType.Multiplicate),
+            (Stats.DoubleDamageChance, 0.05f, AggregateType.AddRaw),
+            (Stats.AttackRatePvm, 50.0f, AggregateType.AddRaw),
+            (Stats.AbilityRecoveryAbsolute, 5.0f, AggregateType.AddRaw));
         evis.SetGuid(4, 1);
         this.AddItems(
             evis,
@@ -312,15 +312,15 @@ public class AncientSets : InitializerBase
         var heras = this.AddAncientSet(
             "Heras", // Sphinx
             17,
-            (Stats.TotalStrength, 15.0f),
-            (Stats.WizardryAttackDamageIncrease, 0.10f),
-            (Stats.DefenseIncreaseWithEquippedShield, 0.05f),
-            (Stats.TotalEnergy, 15.0f),
-            (Stats.AttackRatePvm, 50.0f),
-            (Stats.CriticalDamageChance, 0.10f),
-            (Stats.ExcellentDamageChance, 0.10f),
-            (Stats.MaximumHealth, 50.0f),
-            (Stats.MaximumMana, 50.0f));
+            (Stats.TotalStrength, 15.0f, AggregateType.AddRaw),
+            (Stats.WizardryBaseDmgIncrease, 1.10f, AggregateType.Multiplicate),
+            (Stats.DefenseIncreaseWithEquippedShield, 0.05f, AggregateType.AddRaw),
+            (Stats.TotalEnergy, 15.0f, AggregateType.AddRaw),
+            (Stats.AttackRatePvm, 50.0f, AggregateType.AddRaw),
+            (Stats.CriticalDamageChance, 0.10f, AggregateType.AddRaw),
+            (Stats.ExcellentDamageChance, 0.10f, AggregateType.AddRaw),
+            (Stats.MaximumHealth, 50.0f, AggregateType.AddRaw),
+            (Stats.MaximumMana, 50.0f, AggregateType.AddRaw));
         heras.SetGuid(7, 1);
         this.AddItems(
             heras,
@@ -348,13 +348,13 @@ public class AncientSets : InitializerBase
         var anubis = this.AddAncientSet(
             "Anubis", // Legendary
             19,
-            (Stats.DoubleDamageChance, 0.10f),
-            (Stats.MaximumMana, 50.0f),
-            (Stats.WizardryAttackDamageIncrease, 0.10f),
-            (Stats.CriticalDamageChance, 0.15f),
-            (Stats.ExcellentDamageChance, 0.15f),
-            (Stats.CriticalDamageBonus, 20.0f),
-            (Stats.ExcellentDamageBonus, 20.0f));
+            (Stats.DoubleDamageChance, 0.10f, AggregateType.AddRaw),
+            (Stats.MaximumMana, 50.0f, AggregateType.AddRaw),
+            (Stats.WizardryBaseDmgIncrease, 1.10f, AggregateType.Multiplicate),
+            (Stats.CriticalDamageChance, 0.15f, AggregateType.AddRaw),
+            (Stats.ExcellentDamageChance, 0.15f, AggregateType.AddRaw),
+            (Stats.CriticalDamageBonus, 20.0f, AggregateType.AddRaw),
+            (Stats.ExcellentDamageBonus, 20.0f, AggregateType.AddRaw));
         anubis.SetGuid(3, 1);
         this.AddItems(
             anubis,
@@ -366,11 +366,11 @@ public class AncientSets : InitializerBase
         var enis = this.AddAncientSet(
             "Enis", // Legendary
             20,
-            (Stats.SkillDamageBonus, 10.0f),
-            (Stats.DoubleDamageChance, 0.10f),
-            (Stats.TotalEnergy, 30.0f),
-            (Stats.WizardryAttackDamageIncrease, 0.10f),
-            (Stats.DefenseIgnoreChance, 0.05f));
+            (Stats.SkillDamageBonus, 10.0f, AggregateType.AddRaw),
+            (Stats.DoubleDamageChance, 0.10f, AggregateType.AddRaw),
+            (Stats.TotalEnergy, 30.0f, AggregateType.AddRaw),
+            (Stats.WizardryBaseDmgIncrease, 1.10f, AggregateType.Multiplicate),
+            (Stats.DefenseIgnoreChance, 0.05f, AggregateType.AddRaw));
         enis.SetGuid(3, 2);
         this.AddItems(
             enis,
@@ -403,7 +403,7 @@ public class AncientSets : InitializerBase
             "Drake", // Vine
             22,
             (Stats.TotalAgility, 20.0f, AggregateType.AddRaw),
-            (Stats.BaseDamageBonus, 25.0f, AggregateType.AddRaw),
+            (Stats.FinalDamageBonus, 25.0f, AggregateType.AddRaw),
             (Stats.DoubleDamageChance, 0.20f, AggregateType.AddRaw),
             (Stats.DefenseBase, 40.0f, AggregateType.AddFinal),
             (Stats.CriticalDamageChance, 0.10f, AggregateType.AddRaw));
@@ -528,7 +528,7 @@ public class AncientSets : InitializerBase
         var aruan = this.AddAncientSet(
             "Aruan", // Guardian
             30,
-            (Stats.BaseDamageBonus, 10.0f),
+            (Stats.FinalDamageBonus, 10.0f),
             (Stats.DoubleDamageChance, 0.10f),
             (Stats.SkillDamageBonus, 20.0f),
             (Stats.CriticalDamageChance, 0.15f),
@@ -545,13 +545,13 @@ public class AncientSets : InitializerBase
         var gaion = this.AddAncientSet(
             "Gaion", // Storm Crow
             31,
-            (Stats.DefenseIgnoreChance, 0.05f),
-            (Stats.DoubleDamageChance, 0.15f),
-            (Stats.SkillDamageBonus, 15.0f),
-            (Stats.ExcellentDamageChance, 0.15f),
-            (Stats.ExcellentDamageBonus, 30.0f),
-            (Stats.WizardryAttackDamageIncrease, 0.10f),
-            (Stats.TotalStrength, 30.0f));
+            (Stats.DefenseIgnoreChance, 0.05f, AggregateType.AddRaw),
+            (Stats.DoubleDamageChance, 0.15f, AggregateType.AddRaw),
+            (Stats.SkillDamageBonus, 15.0f, AggregateType.AddRaw),
+            (Stats.ExcellentDamageChance, 0.15f, AggregateType.AddRaw),
+            (Stats.ExcellentDamageBonus, 30.0f, AggregateType.AddRaw),
+            (Stats.WizardryBaseDmgIncrease, 1.10f, AggregateType.Multiplicate),
+            (Stats.TotalStrength, 30.0f, AggregateType.AddRaw));
         gaion.SetGuid(15, 1);
         this.AddItems(
             gaion,
@@ -564,7 +564,7 @@ public class AncientSets : InitializerBase
             "Muren", // Storm Crow
             32,
             (Stats.SkillDamageBonus, 10.0f, AggregateType.AddRaw),
-            (Stats.WizardryAttackDamageIncrease, 0.10f, AggregateType.AddRaw),
+            (Stats.WizardryBaseDmgIncrease, 1.10f, AggregateType.Multiplicate),
             (Stats.DoubleDamageChance, 0.10f, AggregateType.AddRaw),
             (Stats.CriticalDamageChance, 0.15f, AggregateType.AddRaw),
             (Stats.ExcellentDamageChance, 0.15f, AggregateType.AddRaw),
@@ -599,7 +599,7 @@ public class AncientSets : InitializerBase
         var broy = this.AddAncientSet(
             "Broy", // Adamantine
             34,
-            (Stats.BaseDamageBonus, 20.0f),
+            (Stats.FinalDamageBonus, 20.0f),
             (Stats.SkillDamageBonus, 20.0f),
             (Stats.TotalEnergy, 30.0f),
             (Stats.CriticalDamageChance, 0.15f),
@@ -635,12 +635,12 @@ public class AncientSets : InitializerBase
         var semeden = this.AddAncientSet(
             "Semeden", // Red Wing
             36,
-            (Stats.WizardryAttackDamageIncrease, 0.15f),
-            (Stats.SkillDamageBonus, 25.0f),
-            (Stats.TotalEnergy, 30.0f),
-            (Stats.CriticalDamageChance, 0.15f),
-            (Stats.ExcellentDamageChance, 0.15f),
-            (Stats.DefenseIgnoreChance, 0.05f));
+            (Stats.WizardryBaseDmgIncrease, 1.15f, AggregateType.Multiplicate),
+            (Stats.SkillDamageBonus, 25.0f, AggregateType.AddRaw),
+            (Stats.TotalEnergy, 30.0f, AggregateType.AddRaw),
+            (Stats.CriticalDamageChance, 0.15f, AggregateType.AddRaw),
+            (Stats.ExcellentDamageChance, 0.15f, AggregateType.AddRaw),
+            (Stats.DefenseIgnoreChance, 0.05f, AggregateType.AddRaw));
         semeden.SetGuid(40, 2);
         this.AddItems(
             semeden,

--- a/src/Persistence/Initialization/VersionSeasonSix/Items/HarmonyOptions.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Items/HarmonyOptions.cs
@@ -123,7 +123,7 @@ public class HarmonyOptions : InitializerBase
         definition.PossibleOptions.Add(this.CreateHarmonyOptions(4, ItemOptionDefinitionNumbers.HarmonyDefense, 30, Stats.HealthRecoveryAbsolute, AggregateType.AddRaw, 6, 1, 2, 3, 4, 5, 6, 7, 8));
         definition.PossibleOptions.Add(this.CreateHarmonyOptions(5, ItemOptionDefinitionNumbers.HarmonyDefense, 20, Stats.ManaRecoveryAbsolute, AggregateType.AddRaw, 9, 1, 2, 3, 4, 5));
         definition.PossibleOptions.Add(this.CreateHarmonyOptions(6, ItemOptionDefinitionNumbers.HarmonyDefense, 20, Stats.DefenseRatePvp, AggregateType.AddRaw, 9, 3, 4, 5, 6, 8));
-        definition.PossibleOptions.Add(this.CreateHarmonyOptions(7, ItemOptionDefinitionNumbers.HarmonyDefense, 20, Stats.DamageReceiveDecrement, AggregateType.Multiplicate, 9, 0.97f, 0.96f, 0.95f, 0.94f, 0.93f));
+        definition.PossibleOptions.Add(this.CreateHarmonyOptions(7, ItemOptionDefinitionNumbers.HarmonyDefense, 20, Stats.ArmorDamageDecrease, AggregateType.AddRaw, 9, 0.03f, 0.04f, 0.05f, 0.06f, 0.07f));
         definition.PossibleOptions.Add(this.CreateHarmonyOptions(8, ItemOptionDefinitionNumbers.HarmonyDefense, 10, Stats.ShieldRateIncrease, AggregateType.AddRaw, 13, 0.05f));
     }
 

--- a/src/Persistence/Initialization/VersionSeasonSix/Items/Pets.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Items/Pets.cs
@@ -39,7 +39,7 @@ public class Pets : InitializerBase
         this.CreatePet(0, 0, 1, 1, "Guardian Angel", 23, true, true, (Stats.DamageReceiveDecrement, 0.8f, AggregateType.Multiplicate), (Stats.MaximumHealth, 50f, AggregateType.AddRaw));
         this.CreatePet(1, 0, 1, 1, "Imp", 28, true, true, (Stats.AttackDamageIncrease, 1.3f, AggregateType.Multiplicate));
         this.CreatePet(2, 0, 1, 1, "Horn of Uniria", 25, true, true);
-        var dinorant = this.CreatePet(3, SkillNumber.FireBreath, 1, 1, "Horn of Dinorant", 110, false, true, (Stats.DamageReceiveDecrement, 0.9f, AggregateType.Multiplicate), (Stats.AttackDamageIncrease, 1.15f, AggregateType.Multiplicate), (Stats.CanFly, 1.0f, AggregateType.AddRaw));
+        var dinorant = this.CreatePet(3, SkillNumber.FireBreath, 1, 1, "Horn of Dinorant", 110, false, true, (Stats.IsDinorantEquipped, 1, AggregateType.AddRaw), (Stats.DamageReceiveDecrement, 0.9f, AggregateType.Multiplicate), (Stats.AttackDamageIncrease, 1.15f, AggregateType.Multiplicate));
         this.AddDinorantOptions(dinorant);
 
         var darkHorse = this.CreatePet(4, SkillNumber.Earthshake, 1, 1, "Dark Horse", 218, false, false, (Stats.IsHorseEquipped, 1, AggregateType.AddRaw));
@@ -262,8 +262,8 @@ public class Pets : InitializerBase
 
         fenrirOptionDefinition.Name = "Fenrir Options";
 
-        fenrirOptionDefinition.PossibleOptions.Add(this.CreateOption(ItemOptionTypes.BlackFenrir, 1, Stats.AttackDamageIncrease, 1.1f, AggregateType.Multiplicate, ItemOptionDefinitionNumbers.Fenrir));
-        fenrirOptionDefinition.PossibleOptions.Add(this.CreateOption(ItemOptionTypes.BlueFenrir, 2, Stats.DamageReceiveDecrement, 0.90f, AggregateType.Multiplicate, ItemOptionDefinitionNumbers.Fenrir));
+        fenrirOptionDefinition.PossibleOptions.Add(this.CreateOption(ItemOptionTypes.BlackFenrir, 1, Stats.FenrirAttackDamageIncrease, 0.1f, AggregateType.AddRaw, ItemOptionDefinitionNumbers.Fenrir));
+        fenrirOptionDefinition.PossibleOptions.Add(this.CreateOption(ItemOptionTypes.BlueFenrir, 2, Stats.FenrirDamageReceiveDecrement, 0.1f, AggregateType.AddRaw, ItemOptionDefinitionNumbers.Fenrir));
 
         fenrirOptionDefinition.PossibleOptions.Add(this.CreateRelatedPetOption(ItemOptionTypes.GoldFenrir, 4, Stats.MaximumHealth, AggregateType.AddFinal, ItemOptionDefinitionNumbers.Fenrir, 0, (Stats.TotalLevel, 0.5f)));
         fenrirOptionDefinition.PossibleOptions.Add(this.CreateRelatedPetOption(ItemOptionTypes.GoldFenrir, 4, Stats.MaximumMana, AggregateType.AddFinal, ItemOptionDefinitionNumbers.Fenrir, 0, (Stats.TotalLevel, 0.5f)));

--- a/src/Persistence/Initialization/VersionSeasonSix/Items/SocketSystem.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Items/SocketSystem.cs
@@ -278,7 +278,7 @@ public class SocketSystem : InitializerBase
         definition.Name = "Socket Options (Fire)";
         definition.MaximumOptionsPerItem = 1;
 
-        definition.PossibleOptions.Add(this.CreateRelatedSocketOption(0, SocketSubOptionType.Fire, Stats.MaximumPhysBaseDmg, Stats.Level, 1f / 20f, 1f / 19f, 1f / 18f, 1f / 17f, 1f / 14f));
+        definition.PossibleOptions.Add(this.CreateRelatedSocketOption(0, SocketSubOptionType.Fire, Stats.BaseDamageBonus, Stats.TotalLevel, 1f / 20f, 1f / 19f, 1f / 18f, 1f / 17f, 1f / 14f));
         definition.PossibleOptions.Add(this.CreateSocketOption(1, SocketSubOptionType.Fire, Stats.AttackSpeedAny, AggregateType.AddRaw, 7, 8, 9, 10, 11));
         definition.PossibleOptions.Add(this.CreateSocketOption(2, SocketSubOptionType.Fire, Stats.BaseMaxDamageBonus, AggregateType.AddRaw, 30, 32, 35, 40, 50));
         definition.PossibleOptions.Add(this.CreateSocketOption(3, SocketSubOptionType.Fire, Stats.BaseMinDamageBonus, AggregateType.AddRaw, 20, 22, 25, 30, 35));
@@ -346,7 +346,7 @@ public class SocketSystem : InitializerBase
         definition.PossibleOptions.Add(this.CreateSocketOption(0, SocketSubOptionType.Water, Stats.DefenseRatePvm, AggregateType.Multiplicate, 1.10f, 1.11f, 1.12f, 1.13f, 1.14f));
         definition.PossibleOptions.Add(this.CreateSocketOption(1, SocketSubOptionType.Water, Stats.DefenseFinal, AggregateType.AddRaw, 30, 33, 36, 39, 42));
         definition.PossibleOptions.Add(this.CreateSocketOption(2, SocketSubOptionType.Water, Stats.ShieldItemDefenseIncrease, AggregateType.AddRaw, 0.07f, 0.10f, 0.15f, 0.20f, 0.30f));
-        definition.PossibleOptions.Add(this.CreateSocketOption(3, SocketSubOptionType.Water, Stats.DamageReceiveDecrement, AggregateType.Multiplicate, 0.96f, 0.95f, 0.94f, 0.93f, 0.92f));
+        definition.PossibleOptions.Add(this.CreateSocketOption(3, SocketSubOptionType.Water, Stats.ArmorDamageDecrease, AggregateType.AddRaw, 0.04f, 0.05f, 0.06f, 0.07f, 0.08f));
         definition.PossibleOptions.Add(this.CreateSocketOption(4, SocketSubOptionType.Water, Stats.DamageReflection, AggregateType.AddRaw, 0.05f, 0.06f, 0.07f, 0.08f, 0.09f));
         return definition;
     }

--- a/src/Persistence/Initialization/VersionSeasonSix/SkillsInitializer.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/SkillsInitializer.cs
@@ -1,4 +1,4 @@
-// <copyright file="SkillsInitializer.cs" company="MUnique">
+﻿// <copyright file="SkillsInitializer.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
@@ -60,12 +60,12 @@ internal class SkillsInitializer : SkillsInitializerBase
         { SkillNumber.Heal, MagicEffectNumber.Heal },
         { SkillNumber.Recovery, MagicEffectNumber.ShieldRecover },
         { SkillNumber.InfinityArrow, MagicEffectNumber.InfiniteArrow },
-        { SkillNumber.InfinityArrowStr, MagicEffectNumber.InfiniteArrow },
         { SkillNumber.FireSlash, MagicEffectNumber.DefenseReduction },
         { SkillNumber.IgnoreDefense, MagicEffectNumber.IgnoreDefense },
         { SkillNumber.IncreaseHealth, MagicEffectNumber.IncreaseHealth },
         { SkillNumber.IncreaseBlock, MagicEffectNumber.IncreaseBlock },
         { SkillNumber.ExpansionofWizardry, MagicEffectNumber.WizEnhance },
+        { SkillNumber.Berserker, MagicEffectNumber.Berserker },
     };
 
     private readonly IDictionary<byte, MasterSkillRoot> _masterSkillRoots;
@@ -139,7 +139,7 @@ internal class SkillsInitializer : SkillsInitializerBase
         this.CreateSkill(SkillNumber.RagefulBlow, "Rageful Blow", CharacterClasses.BladeKnightAndBladeMaster, DamageType.Physical, 60, 3, 20, 25, 170, elementalModifier: ElementalType.Earth, skillType: SkillType.AreaSkillAutomaticHits);
         this.CreateSkill(SkillNumber.DeathStab, "Death Stab", CharacterClasses.BladeKnightAndBladeMaster, DamageType.Physical, 70, 2, 12, 15, 160, elementalModifier: ElementalType.Wind, skillType: SkillType.DirectHit, skillTarget: SkillTarget.ExplicitWithImplicitInRange, implicitTargetRange: 1);
         this.CreateSkill(SkillNumber.CrescentMoonSlash, "Crescent Moon Slash", CharacterClasses.AllKnights, DamageType.Physical, 90, 4, 15, 22, movesToTarget: true, movesTarget: true);
-        this.CreateSkill(SkillNumber.Lance, "Lance", CharacterClasses.SoulMasterAndGrandMaster | CharacterClasses.AllSummoners, DamageType.All, 90, 6, 10, 150);
+        this.CreateSkill(SkillNumber.Lance, "Lance", CharacterClasses.SoulMasterAndGrandMaster | CharacterClasses.AllSummoners, DamageType.Wizardry, 90, 6, 10, 150);
         this.CreateSkill(SkillNumber.Starfall, "Starfall", CharacterClasses.AllElfs, DamageType.Physical, 120, 8, 15, 20);
         this.CreateSkill(SkillNumber.Impale, "Impale", CharacterClasses.AllKnights | CharacterClasses.AllMGs, DamageType.Physical, 15, 3, manaConsumption: 8, levelRequirement: 28);
         this.CreateSkill(SkillNumber.SwellLife, "Swell Life", CharacterClasses.AllKnights, abilityConsumption: 24, manaConsumption: 22, levelRequirement: 120, skillType: SkillType.Buff, skillTarget: SkillTarget.ImplicitParty);
@@ -150,17 +150,17 @@ internal class SkillsInitializer : SkillsInitializerBase
         this.AddAreaSkillSettings(SkillNumber.Penetration, true, 1.1f, 1.2f, 8f, useDeferredHits: true, delayPerOneDistance: TimeSpan.FromMilliseconds(50));
         this.CreateSkill(SkillNumber.FireSlash, "Fire Slash", CharacterClasses.AllMGs, DamageType.Physical, 80, 2, 20, 15, elementalModifier: ElementalType.Fire, skillType: SkillType.AreaSkillAutomaticHits);
         this.AddAreaSkillSettings(SkillNumber.FireSlash, true, 1.5f, 2, 2);
-        this.CreateSkill(SkillNumber.PowerSlash, "Power Slash", CharacterClasses.AllMGs, DamageType.Physical, distance: 5, manaConsumption: 15, energyRequirement: 100, skillType: SkillType.AreaSkillAutomaticHits);
+        this.CreateSkill(SkillNumber.PowerSlash, "Power Slash", CharacterClasses.AllMGs, DamageType.Physical, distance: 5, manaConsumption: 15, skillType: SkillType.AreaSkillAutomaticHits);
         this.AddAreaSkillSettings(SkillNumber.PowerSlash, true, 1.0f, 6.0f, 6.0f);
         this.CreateSkill(SkillNumber.SpiralSlash, "Spiral Slash", CharacterClasses.AllMGs, DamageType.Physical, 75, 5, 15, 20);
-        this.CreateSkill(SkillNumber.Force, "Force", CharacterClasses.AllLords, DamageType.Physical, 10, 4, manaConsumption: 10);
-        this.CreateSkill(SkillNumber.FireBurst, "Fire Burst", CharacterClasses.AllLords, DamageType.Physical, 100, 6, manaConsumption: 25, energyRequirement: 79, skillType: SkillType.DirectHit, skillTarget: SkillTarget.ExplicitWithImplicitInRange, implicitTargetRange: 1);
-        this.CreateSkill(SkillNumber.Earthshake, "Earthshake", CharacterClasses.AllLords, DamageType.Physical, 150, 10, 50, elementalModifier: ElementalType.Lightning, skillType: SkillType.AreaSkillAutomaticHits);
+        this.CreateSkill(SkillNumber.Force, "Force", CharacterClasses.AllLords, DamageType.Physical, 10, 4, manaConsumption: 10, skillType: SkillType.LordGeneric);
+        this.CreateSkill(SkillNumber.FireBurst, "Fire Burst", CharacterClasses.AllLords, DamageType.Physical, 100, 6, manaConsumption: 25, energyRequirement: 79, skillType: SkillType.LordGeneric, skillTarget: SkillTarget.ExplicitWithImplicitInRange, implicitTargetRange: 1);
+        this.CreateSkill(SkillNumber.Earthshake, "Earthshake", CharacterClasses.AllLords, DamageType.Physical, 150, 10, 50, elementalModifier: ElementalType.Lightning, skillType: SkillType.Earthshake);
         this.CreateSkill(SkillNumber.Summon, "Summon", CharacterClasses.AllLords, abilityConsumption: 30, manaConsumption: 70, energyRequirement: 153, leadershipRequirement: 400, skillType: SkillType.Other);
         this.CreateSkill(SkillNumber.IncreaseCriticalDamage, "Increase Critical Damage", CharacterClasses.AllLords, abilityConsumption: 50, manaConsumption: 50, energyRequirement: 102, leadershipRequirement: 300, skillType: SkillType.Buff, skillTarget: SkillTarget.ImplicitParty);
-        this.CreateSkill(SkillNumber.ElectricSpike, "Electric Spike", CharacterClasses.AllLords, DamageType.Physical, 250, 10, 100, energyRequirement: 126, leadershipRequirement: 340, skillType: SkillType.AreaSkillAutomaticHits);
+        this.CreateSkill(SkillNumber.ElectricSpike, "Electric Spike", CharacterClasses.AllLords, DamageType.Physical, 250, 10, 100, energyRequirement: 126, leadershipRequirement: 340, skillType: SkillType.ElectricSpike);
         this.AddAreaSkillSettings(SkillNumber.ElectricSpike, true, 1.5f, 1.5f, 12f, useDeferredHits: true, delayPerOneDistance: TimeSpan.FromMilliseconds(10));
-        this.CreateSkill(SkillNumber.ForceWave, "Force Wave", CharacterClasses.AllLords, DamageType.Physical, 50, 4, manaConsumption: 10, skillType: SkillType.DirectHit, skillTarget: SkillTarget.ExplicitWithImplicitInRange);
+        this.CreateSkill(SkillNumber.ForceWave, "Force Wave", CharacterClasses.AllLords, DamageType.Physical, 50, 4, manaConsumption: 10, skillType: SkillType.LordGeneric, skillTarget: SkillTarget.ExplicitWithImplicitInRange);
         this.AddAreaSkillSettings(SkillNumber.ForceWave, true, 1f, 1f, 4f);
         this.CreateSkill(SkillNumber.Stun, "Stun", CharacterClasses.All, distance: 2, abilityConsumption: 50, manaConsumption: 70, skillType: SkillType.AreaSkillAutomaticHits, cooldownMinutes: 4);
         this.AddAreaSkillSettings(SkillNumber.Stun, true, 1.5f, 1.5f, 3f);
@@ -170,10 +170,10 @@ internal class SkillsInitializer : SkillsInitializerBase
         this.CreateSkill(SkillNumber.CancelInvisibility, "Cancel Invisibility", CharacterClasses.All, abilityConsumption: 30, manaConsumption: 40, cooldownMinutes: 2);
         this.CreateSkill(SkillNumber.AbolishMagic, "Abolish Magic", CharacterClasses.AllLords, abilityConsumption: 70, manaConsumption: 90, cooldownMinutes: 8);
         this.CreateSkill(SkillNumber.ManaRays, "Mana Rays", CharacterClasses.AllMGs, DamageType.Wizardry, 85, 6, 7, 130);
-        this.CreateSkill(SkillNumber.FireBlast, "Fire Blast", CharacterClasses.AllLords, DamageType.Physical, 150, 6, 10, 30);
+        this.CreateSkill(SkillNumber.FireBlast, "Fire Blast", CharacterClasses.AllLords, DamageType.Physical, 150, 6, 10, 30, skillType: SkillType.LordGeneric);
         this.CreateSkill(SkillNumber.PlasmaStorm, "Plasma Storm", CharacterClasses.AllMastersAndSecondClass, DamageType.Fenrir, damage: 60, distance: 6, abilityConsumption: 20, manaConsumption: 50, levelRequirement: 110, skillType: SkillType.AreaSkillAutomaticHits);
         this.CreateSkill(SkillNumber.InfinityArrow, "Infinity Arrow", CharacterClasses.MuseElfAndHighElf, distance: 6, abilityConsumption: 10, manaConsumption: 50, levelRequirement: 220, skillType: SkillType.Buff, targetRestriction: SkillTargetRestriction.Self);
-        this.CreateSkill(SkillNumber.FireScream, "Fire Scream", CharacterClasses.AllLords, DamageType.Physical, 130, 6, 10, 45, energyRequirement: 70, leadershipRequirement: 150, skillType: SkillType.AreaSkillAutomaticHits);
+        this.CreateSkill(SkillNumber.FireScream, "Fire Scream", CharacterClasses.AllLords, DamageType.Physical, 130, 6, 10, 45, energyRequirement: 70, leadershipRequirement: 150, skillType: SkillType.LordGeneric);
         this.AddAreaSkillSettings(SkillNumber.FireScream, true, 2f, 3f, 6f); // TODO: Add fireScream's explosion (Explosion79) damage effect
         this.CreateSkill(SkillNumber.Explosion79, "Explosion", CharacterClasses.AllLords, DamageType.Physical, distance: 2);
         this.CreateSkill(SkillNumber.SummonMonster, "Summon Monster", manaConsumption: 40, energyRequirement: 90);
@@ -185,26 +185,26 @@ internal class SkillsInitializer : SkillsInitializerBase
         this.CreateSkill(SkillNumber.SpellofRestriction, "Spell of Restriction", CharacterClasses.All, distance: 3, manaConsumption: 30, elementalModifier: ElementalType.Ice, cooldownMinutes: 5);
         this.CreateSkill(SkillNumber.SpellofPursuit, "Spell of Pursuit", CharacterClasses.All, manaConsumption: 30, elementalModifier: ElementalType.Ice, cooldownMinutes: 10);
         this.CreateSkill(SkillNumber.ShieldBurn, "Shield-Burn", CharacterClasses.All, distance: 3, manaConsumption: 30, elementalModifier: ElementalType.Ice, cooldownMinutes: 5);
-        this.CreateSkill(SkillNumber.DrainLife, "Drain Life", CharacterClasses.AllSummoners, DamageType.Curse, 35, 6, manaConsumption: 50, energyRequirement: 150, skillType: SkillType.AreaSkillExplicitTarget);
-        this.CreateSkill(SkillNumber.ChainLightning, "Chain Lightning", CharacterClasses.AllSummoners, DamageType.Curse, 70, 6, manaConsumption: 85, energyRequirement: 245, skillType: SkillType.AreaSkillExplicitTarget, skillTarget: SkillTarget.Explicit);
+        this.CreateSkill(SkillNumber.DrainLife, "Drain Life", CharacterClasses.AllSummoners, DamageType.Wizardry, 35, 6, manaConsumption: 50, energyRequirement: 150, skillType: SkillType.AreaSkillExplicitTarget);
+        this.CreateSkill(SkillNumber.ChainLightning, "Chain Lightning", CharacterClasses.AllSummoners, DamageType.Wizardry, 70, 6, manaConsumption: 85, energyRequirement: 245, skillType: SkillType.AreaSkillExplicitTarget, skillTarget: SkillTarget.Explicit);
         this.CreateSkill(SkillNumber.DamageReflection, "Damage Reflection", CharacterClasses.AllSummoners, distance: 5, abilityConsumption: 10, manaConsumption: 40, energyRequirement: 375);
-        this.CreateSkill(SkillNumber.Berserker, "Berserker", CharacterClasses.AllSummoners, DamageType.Curse, distance: 5, abilityConsumption: 50, manaConsumption: 100, energyRequirement: 620);
+        this.CreateSkill(SkillNumber.Berserker, "Berserker", CharacterClasses.AllSummoners, distance: 5, abilityConsumption: 50, manaConsumption: 100, energyRequirement: 620, skillType: SkillType.Buff, targetRestriction: SkillTargetRestriction.Self);
         this.CreateSkill(SkillNumber.Sleep, "Sleep", CharacterClasses.AllSummoners, distance: 6, abilityConsumption: 3, manaConsumption: 20, energyRequirement: 180);
         this.CreateSkill(SkillNumber.Weakness, "Weakness", CharacterClasses.AllSummoners, distance: 6, abilityConsumption: 15, manaConsumption: 50, energyRequirement: 663);
         this.CreateSkill(SkillNumber.Innovation, "Innovation", CharacterClasses.AllSummoners, distance: 6, abilityConsumption: 15, manaConsumption: 70, energyRequirement: 912);
-        this.CreateSkill(SkillNumber.Explosion223, "Explosion", CharacterClasses.AllSummoners, DamageType.Curse, 40, 6, 5, 90, energyRequirement: 100, elementalModifier: ElementalType.Fire);
-        this.CreateSkill(SkillNumber.Requiem, "Requiem", CharacterClasses.AllSummoners, DamageType.Curse, 65, 6, 10, 110, energyRequirement: 99, elementalModifier: ElementalType.Wind);
-        this.CreateSkill(SkillNumber.Pollution, "Pollution", CharacterClasses.AllSummoners, DamageType.Curse, 80, 6, 15, 120, energyRequirement: 115, elementalModifier: ElementalType.Lightning);
-        this.CreateSkill(SkillNumber.LightningShock, "Lightning Shock", CharacterClasses.AllSummoners, DamageType.Curse, 95, 6, 7, 115, energyRequirement: 823, elementalModifier: ElementalType.Lightning);
+        this.CreateSkill(SkillNumber.Explosion223, "Explosion", CharacterClasses.AllSummoners, DamageType.Curse, 40, 6, 5, 90, energyRequirement: 100, elementalModifier: ElementalType.Fire); // Book of Samut's skill
+        this.CreateSkill(SkillNumber.Requiem, "Requiem", CharacterClasses.AllSummoners, DamageType.Curse, 65, 6, 10, 110, energyRequirement: 99, elementalModifier: ElementalType.Wind); // Book of Neil's skill
+        this.CreateSkill(SkillNumber.Pollution, "Pollution", CharacterClasses.AllSummoners, DamageType.Curse, 80, 6, 15, 120, energyRequirement: 115, elementalModifier: ElementalType.Lightning); // Book of Lagle's skill
+        this.CreateSkill(SkillNumber.LightningShock, "Lightning Shock", CharacterClasses.AllSummoners, DamageType.Wizardry, 95, 6, 7, 115, energyRequirement: 823, elementalModifier: ElementalType.Lightning);
         this.CreateSkill(SkillNumber.StrikeofDestruction, "Strike of Destruction", CharacterClasses.BladeKnightAndBladeMaster, DamageType.Physical, 110, 5, 24, 30, 100, elementalModifier: ElementalType.Ice, skillType: SkillType.AreaSkillAutomaticHits);
         this.CreateSkill(SkillNumber.ExpansionofWizardry, "Expansion of Wizardry", CharacterClasses.SoulMasterAndGrandMaster, distance: 6, abilityConsumption: 50, manaConsumption: 200, levelRequirement: 220, energyRequirement: 118, skillType: SkillType.Buff, targetRestriction: SkillTargetRestriction.Player, skillTarget: SkillTarget.ImplicitPlayer);
         this.CreateSkill(SkillNumber.Recovery, "Recovery", CharacterClasses.MuseElfAndHighElf, distance: 6, abilityConsumption: 10, manaConsumption: 40, levelRequirement: 100, energyRequirement: 37, skillType: SkillType.Regeneration, targetRestriction: SkillTargetRestriction.Player);
-        this.CreateSkill(SkillNumber.MultiShot, "Multi-Shot", CharacterClasses.MuseElfAndHighElf, DamageType.Physical, 40, 6, 7, 10, 100, skillType: SkillType.AreaSkillAutomaticHits);
+        this.CreateSkill(SkillNumber.MultiShot, "Multi-Shot", CharacterClasses.MuseElfAndHighElf, DamageType.Physical, 40, 6, 7, 10, 100, skillType: SkillType.MultiShot);
         this.AddAreaSkillSettings(SkillNumber.MultiShot, true, 1f, 6f, 7f);
         this.CreateSkill(SkillNumber.FlameStrike, "Flame Strike", CharacterClasses.AllMGs, DamageType.Physical, 140, 3, 25, 20, 100, elementalModifier: ElementalType.Fire, skillType: SkillType.AreaSkillAutomaticHits);
         this.AddAreaSkillSettings(SkillNumber.FlameStrike, true, 5f, 2f, 4f);
         this.CreateSkill(SkillNumber.GiganticStorm, "Gigantic Storm", CharacterClasses.AllMGs, DamageType.Wizardry, 110, 6, 10, 120, 220, 118, elementalModifier: ElementalType.Wind, skillType: SkillType.AreaSkillAutomaticHits);
-        this.CreateSkill(SkillNumber.ChaoticDiseier, "Chaotic Diseier", CharacterClasses.AllLords, DamageType.Physical, 190, 6, 15, 50, 100, 16, skillType: SkillType.AreaSkillAutomaticHits);
+        this.CreateSkill(SkillNumber.ChaoticDiseier, "Chaotic Diseier", CharacterClasses.AllLords, DamageType.Physical, 190, 6, 15, 50, 100, 16, skillType: SkillType.ChaoticDiseier);
         this.AddAreaSkillSettings(SkillNumber.ChaoticDiseier, true, 1.5f, 1.5f, 6f);
         this.CreateSkill(SkillNumber.DoppelgangerSelfExplosion, "Doppelganger Self Explosion", CharacterClasses.AllMGs, DamageType.Wizardry, 140, 3, 25, 20, 100, elementalModifier: ElementalType.Fire);
         this.CreateSkill(SkillNumber.KillingBlow, "Killing Blow", CharacterClasses.AllFighters, DamageType.Physical, distance: 2, manaConsumption: 9, elementalModifier: ElementalType.Earth);
@@ -324,10 +324,10 @@ internal class SkillsInitializer : SkillsInitializerBase
         this.CreateSkill(SkillNumber.WindTomeMastery, "Wind Tome Mastery", CharacterClasses.DimensionMaster, damage: 1, skillType: SkillType.PassiveBoost);
         this.CreateSkill(SkillNumber.LightningTomeMastery, "Lightning Tome Mastery", CharacterClasses.DimensionMaster, DamageType.Curse, 7, elementalModifier: ElementalType.Lightning, skillType: SkillType.PassiveBoost);
         this.CreateSkill(SkillNumber.SleepStrengthener, "Sleep Strengthener", CharacterClasses.DimensionMaster, damage: 1, distance: 6, abilityConsumption: 7, manaConsumption: 30, levelRequirement: 40, energyRequirement: 100);
-        this.CreateSkill(SkillNumber.ChainLightningStr, "Chain Lightning Str", CharacterClasses.DimensionMaster, DamageType.Curse, 22, 6, manaConsumption: 103, levelRequirement: 75, energyRequirement: 75, skillTarget: SkillTarget.Explicit, skillType: SkillType.AreaSkillExplicitTarget);
-        this.CreateSkill(SkillNumber.LightningShockStr, "Lightning Shock Str", CharacterClasses.DimensionMaster, DamageType.Curse, 22, 6, 10, 125, 93, 216, elementalModifier: ElementalType.Lightning);
+        this.CreateSkill(SkillNumber.ChainLightningStr, "Chain Lightning Str", CharacterClasses.DimensionMaster, DamageType.Wizardry, 22, 6, manaConsumption: 103, levelRequirement: 75, energyRequirement: 75, skillTarget: SkillTarget.Explicit, skillType: SkillType.AreaSkillExplicitTarget);
+        this.CreateSkill(SkillNumber.LightningShockStr, "Lightning Shock Str", CharacterClasses.DimensionMaster, DamageType.Wizardry, 22, 6, 10, 125, 93, 216, elementalModifier: ElementalType.Lightning);
         this.CreateSkill(SkillNumber.MagicMasterySummoner, "Magic Mastery", CharacterClasses.DimensionMaster, DamageType.Curse, 22, skillType: SkillType.PassiveBoost);
-        this.CreateSkill(SkillNumber.DrainLifeStrengthener, "Drain Life Strengthener", CharacterClasses.DimensionMaster, DamageType.Curse, 22, 6, manaConsumption: 57, levelRequirement: 35, energyRequirement: 93);
+        this.CreateSkill(SkillNumber.DrainLifeStrengthener, "Drain Life Strengthener", CharacterClasses.DimensionMaster, DamageType.Wizardry, 22, 6, manaConsumption: 57, levelRequirement: 35, energyRequirement: 93);
         this.CreateSkill(SkillNumber.StickStrengthener, "Stick Strengthener", CharacterClasses.DimensionMaster, DamageType.Curse, 22, skillType: SkillType.PassiveBoost);
         this.CreateSkill(SkillNumber.OtherWorldTomeStreng, "Other World Tome Streng", CharacterClasses.DimensionMaster, DamageType.Curse, 3, skillType: SkillType.PassiveBoost);
         this.CreateSkill(SkillNumber.StickMastery, "Stick Mastery", CharacterClasses.DimensionMaster, DamageType.Curse, 5, skillType: SkillType.PassiveBoost);
@@ -351,17 +351,17 @@ internal class SkillsInitializer : SkillsInitializerBase
         this.CreateSkill(SkillNumber.BloodAttackStrengthen, "Blood Attack Strengthen", CharacterClasses.DuelMaster, damage: 22, distance: 3, abilityConsumption: 22, manaConsumption: 15, elementalModifier: ElementalType.Poison);
 
         // Lord Emperor (DL):
-        this.CreateSkill(SkillNumber.FireBurstStreng, "Fire Burst Streng", CharacterClasses.LordEmperor, DamageType.Physical, 22, 6, manaConsumption: 25, levelRequirement: 74, energyRequirement: 20);
-        this.CreateSkill(SkillNumber.ForceWaveStreng, "Force Wave Streng", CharacterClasses.LordEmperor, DamageType.Physical, 3, 4, manaConsumption: 15);
+        this.CreateSkill(SkillNumber.FireBurstStreng, "Fire Burst Streng", CharacterClasses.LordEmperor, DamageType.Physical, 22, 6, manaConsumption: 25, levelRequirement: 74, energyRequirement: 20, skillType: SkillType.LordGeneric);
+        this.CreateSkill(SkillNumber.ForceWaveStreng, "Force Wave Streng", CharacterClasses.LordEmperor, DamageType.Physical, 3, 4, manaConsumption: 15, skillType: SkillType.LordGeneric);
         this.CreateSkill(SkillNumber.DarkHorseStreng1, "Dark Horse Streng (1)", CharacterClasses.LordEmperor, damage: 17, skillType: SkillType.PassiveBoost);
         this.CreateSkill(SkillNumber.CriticalDmgIncPowUp, "Critical DMG Inc PowUp", CharacterClasses.LordEmperor, damage: 3, abilityConsumption: 75, manaConsumption: 75, levelRequirement: 82, energyRequirement: 25, leadershipRequirement: 300);
-        this.CreateSkill(SkillNumber.EarthshakeStreng, "Earthshake Streng", CharacterClasses.LordEmperor, DamageType.Physical, 22, 10, 75, elementalModifier: ElementalType.Lightning);
+        this.CreateSkill(SkillNumber.EarthshakeStreng, "Earthshake Streng", CharacterClasses.LordEmperor, DamageType.Physical, 22, 10, 75, elementalModifier: ElementalType.Lightning, skillType: SkillType.Earthshake);
         this.CreateSkill(SkillNumber.WeaponMasteryLordEmperor, "Weapon Mastery", CharacterClasses.LordEmperor, damage: 22, skillType: SkillType.PassiveBoost);
-        this.CreateSkill(SkillNumber.FireBurstMastery, "Fire Burst Mastery", CharacterClasses.LordEmperor, DamageType.Physical, 1, 6, manaConsumption: 27, levelRequirement: 74, energyRequirement: 20);
+        this.CreateSkill(SkillNumber.FireBurstMastery, "Fire Burst Mastery", CharacterClasses.LordEmperor, DamageType.Physical, 1, 6, manaConsumption: 27, levelRequirement: 74, energyRequirement: 20, skillType: SkillType.LordGeneric);
         this.CreateSkill(SkillNumber.CritDmgIncPowUp2, "Crit DMG Inc PowUp (2)", CharacterClasses.LordEmperor, damage: 10, abilityConsumption: 82, manaConsumption: 82, levelRequirement: 82, energyRequirement: 25, leadershipRequirement: 300);
-        this.CreateSkill(SkillNumber.EarthshakeMastery, "Earthshake Mastery", CharacterClasses.LordEmperor, DamageType.Physical, 1, 10, 75, elementalModifier: ElementalType.Lightning);
+        this.CreateSkill(SkillNumber.EarthshakeMastery, "Earthshake Mastery", CharacterClasses.LordEmperor, DamageType.Physical, 1, 10, 75, elementalModifier: ElementalType.Lightning, skillType: SkillType.Earthshake);
         this.CreateSkill(SkillNumber.CritDmgIncPowUp3, "Crit DMG Inc PowUp (3)", CharacterClasses.LordEmperor, damage: 7, abilityConsumption: 100, manaConsumption: 100, levelRequirement: 82, energyRequirement: 25, leadershipRequirement: 300);
-        this.CreateSkill(SkillNumber.FireScreamStren, "Fire Scream Stren", CharacterClasses.LordEmperor, DamageType.Physical, 22, 6, 11, 45, 102, 32, 70);
+        this.CreateSkill(SkillNumber.FireScreamStren, "Fire Scream Stren", CharacterClasses.LordEmperor, DamageType.Physical, 22, 6, 11, 45, 102, 32, 70, skillType: SkillType.LordGeneric);
         this.CreateSkill(SkillNumber.DarkSpiritStr, "Dark Spirit Str", CharacterClasses.LordEmperor, damage: 3, skillType: SkillType.PassiveBoost);
         this.CreateSkill(SkillNumber.ScepterStrengthener, "Scepter Strengthener", CharacterClasses.LordEmperor, DamageType.Physical, 22, skillType: SkillType.PassiveBoost);
         this.CreateSkill(SkillNumber.ShieldStrengthenerLordEmperor, "Shield Strengthener", CharacterClasses.LordEmperor, damage: 10, skillType: SkillType.PassiveBoost);
@@ -470,7 +470,7 @@ internal class SkillsInitializer : SkillsInitializerBase
         // High Elf:
         this.CreateSkill(SkillNumber.IllusionWingsAbsPowUp, "Illusion Wings Abs PowUp", CharacterClasses.HighElf, damage: 1, skillType: SkillType.PassiveBoost);
         this.CreateSkill(SkillNumber.IllusionWingsDefPowUp, "Illusion Wings Def PowUp", CharacterClasses.HighElf, damage: 17, skillType: SkillType.PassiveBoost);
-        this.CreateSkill(SkillNumber.MultiShotStreng, "Multi-Shot Streng", CharacterClasses.HighElf, DamageType.Physical, 22, 6, 7, 11, 100, skillType: SkillType.AreaSkillAutomaticHits);
+        this.CreateSkill(SkillNumber.MultiShotStreng, "Multi-Shot Streng", CharacterClasses.HighElf, DamageType.Physical, 22, 6, 7, 11, 100, skillType: SkillType.MultiShot);
         this.CreateSkill(SkillNumber.IllusionWingsAttPowUp, "Illusion Wings Att PowUp", CharacterClasses.HighElf, damage: 17, skillType: SkillType.PassiveBoost);
         this.CreateSkill(SkillNumber.Cure, "Cure", CharacterClasses.HighElf, distance: 6, abilityConsumption: 10, manaConsumption: 72);
         this.CreateSkill(SkillNumber.PartyHealing, "Party Healing", CharacterClasses.HighElf, distance: 6, abilityConsumption: 12, manaConsumption: 66, energyRequirement: 100);
@@ -478,7 +478,7 @@ internal class SkillsInitializer : SkillsInitializerBase
         this.CreateSkill(SkillNumber.SummonedMonsterStr3, "Summoned Monster Str (3)", CharacterClasses.HighElf, damage: 16, skillType: SkillType.PassiveBoost);
         this.CreateSkill(SkillNumber.PartyHealingStr, "Party Healing Str", CharacterClasses.HighElf, damage: 22, distance: 6, abilityConsumption: 13, manaConsumption: 72, energyRequirement: 100);
         this.CreateSkill(SkillNumber.Bless, "Bless", CharacterClasses.HighElf, distance: 6, abilityConsumption: 18, manaConsumption: 108, energyRequirement: 100);
-        this.CreateSkill(SkillNumber.MultiShotMastery, "Multi-Shot Mastery", CharacterClasses.HighElf, DamageType.Physical, 1, 6, 8, 12, 100, skillType: SkillType.AreaSkillAutomaticHits);
+        this.CreateSkill(SkillNumber.MultiShotMastery, "Multi-Shot Mastery", CharacterClasses.HighElf, DamageType.Physical, 1, 6, 8, 12, 100, skillType: SkillType.MultiShot);
         this.CreateSkill(SkillNumber.SummonSatyros, "Summon Satyros", CharacterClasses.HighElf, abilityConsumption: 52, manaConsumption: 525, energyRequirement: 280);
         this.CreateSkill(SkillNumber.BlessStrengthener, "Bless Strengthener", CharacterClasses.HighElf, damage: 10, distance: 6, abilityConsumption: 20, manaConsumption: 118, energyRequirement: 100);
         this.CreateSkill(SkillNumber.PoisonArrowStr, "Poison Arrow Str", CharacterClasses.HighElf, DamageType.Physical, 22, 6, 29, 24, elementalModifier: ElementalType.Poison);
@@ -513,11 +513,11 @@ internal class SkillsInitializer : SkillsInitializerBase
         this.CreateSkill(SkillNumber.EmperorCapeDefPowUp, "Emperor Cape Def PowUp", CharacterClasses.LordEmperor, damage: 17, skillType: SkillType.PassiveBoost);
         this.CreateSkill(SkillNumber.AddsCommandStat, "Adds Command Stat", CharacterClasses.LordEmperor, damage: 17, skillType: SkillType.PassiveBoost);
         this.CreateSkill(SkillNumber.EmperorCapeAttPowUp, "Emperor Cape Att PowUp", CharacterClasses.LordEmperor, damage: 17, skillType: SkillType.PassiveBoost);
-        this.CreateSkill(SkillNumber.ElectricSparkStreng, "Electric Spark Streng", CharacterClasses.LordEmperor, DamageType.Physical, 3, 10, 150, levelRequirement: 92, energyRequirement: 29, leadershipRequirement: 340);
-        this.CreateSkill(SkillNumber.FireScreamMastery, "Fire Scream Mastery", CharacterClasses.LordEmperor, DamageType.Physical, 5, 6, 12, 49, 102, 32, 70);
+        this.CreateSkill(SkillNumber.ElectricSparkStreng, "Electric Spark Streng", CharacterClasses.LordEmperor, DamageType.Physical, 3, 10, 150, levelRequirement: 92, energyRequirement: 29, leadershipRequirement: 340, skillType: SkillType.ElectricSpike);
+        this.CreateSkill(SkillNumber.FireScreamMastery, "Fire Scream Mastery", CharacterClasses.LordEmperor, DamageType.Physical, 5, 6, 12, 49, 102, 32, 70, skillType: SkillType.LordGeneric);
         this.CreateSkill(SkillNumber.IronDefenseLordEmperor, "Iron Defense", CharacterClasses.LordEmperor, damage: 28, abilityConsumption: 29, manaConsumption: 64);
         this.CreateSkill(SkillNumber.CriticalDamageIncM, "Critical Damage Inc M", CharacterClasses.LordEmperor, damage: 1, abilityConsumption: 110, manaConsumption: 110, levelRequirement: 82, energyRequirement: 25, leadershipRequirement: 300);
-        this.CreateSkill(SkillNumber.ChaoticDiseierStr, "Chaotic Diseier Str", CharacterClasses.LordEmperor, DamageType.Physical, 22, 6, 22, 75, 100, 16);
+        this.CreateSkill(SkillNumber.ChaoticDiseierStr, "Chaotic Diseier Str", CharacterClasses.LordEmperor, DamageType.Physical, 22, 6, 22, 75, 100, 16, skillType: SkillType.ChaoticDiseier);
         this.CreateSkill(SkillNumber.IronDefenseStr, "Iron Defense Str", CharacterClasses.LordEmperor, damage: 3, abilityConsumption: 31, manaConsumption: 70);
         this.CreateSkill(SkillNumber.DarkSpiritStr4, "Dark Spirit Str (4)", CharacterClasses.LordEmperor, damage: 23, skillType: SkillType.PassiveBoost);
         this.CreateSkill(SkillNumber.DarkSpiritStr5, "Dark Spirit Str (5)", CharacterClasses.LordEmperor, damage: 1, skillType: SkillType.PassiveBoost);
@@ -592,6 +592,7 @@ internal class SkillsInitializer : SkillsInitializerBase
         new AlcoholEffectInitializer(this.Context, this.GameConfiguration).Initialize();
         new SoulPotionEffectInitializer(this.Context, this.GameConfiguration).Initialize();
         new BlessPotionEffectInitializer(this.Context, this.GameConfiguration).Initialize();
+        new BerserkerEffectInitializer(this.Context, this.GameConfiguration).Initialize();
     }
 
     private void MapSkillsToEffects()
@@ -650,17 +651,17 @@ internal class SkillsInitializer : SkillsInitializerBase
         this.AddMasterSkillDefinition(SkillNumber.TwistingSlashMastery, SkillNumber.TwistingSlashStreng, SkillNumber.Undefined, 2, 4, SkillNumber.TwistingSlash, 20, Formula120);
         this.AddMasterSkillDefinition(SkillNumber.RagefulBlowMastery, SkillNumber.RagefulBlowStreng, SkillNumber.Undefined, 2, 4, SkillNumber.RagefulBlow, 20, Formula120);
         this.AddPassiveMasterSkillDefinition(SkillNumber.MaximumLifeIncrease, Stats.MaximumHealth, AggregateType.AddRaw, Formula10235, 4, 2);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.WeaponMasteryBladeMaster, Stats.PhysicalBaseDmg, AggregateType.AddRaw, Formula502, 4, 2);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.WeaponMasteryBladeMaster, Stats.MasterSkillPhysBonusDmg, AggregateType.AddRaw, Formula502, 4, 2);
         this.AddMasterSkillDefinition(SkillNumber.DeathStabStrengthener, SkillNumber.DeathStab, SkillNumber.Undefined, 2, 5, SkillNumber.DeathStab, 20, Formula502);
         this.AddMasterSkillDefinition(SkillNumber.StrikeofDestrStr, SkillNumber.StrikeofDestruction, SkillNumber.Undefined, 2, 5, SkillNumber.StrikeofDestruction, 20, Formula502);
         this.AddPassiveMasterSkillDefinition(SkillNumber.MaximumManaIncrease, Stats.MaximumMana, AggregateType.AddRaw, Formula10235, 5, 2, SkillNumber.MaximumLifeIncrease);
         this.AddPassiveMasterSkillDefinition(SkillNumber.PvPAttackRate, Stats.AttackRatePvp, AggregateType.AddRaw, Formula81877, 1, 3);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.TwoHandedSwordStrengthener, Stats.TwoHandedSwordBonusBaseDamage, AggregateType.AddRaw, Formula883, 2, 3);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.OneHandedSwordStrengthener, Stats.OneHandedSwordBonusBaseDamage, AggregateType.AddRaw, Formula502, 2, 3);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.MaceStrengthener, Stats.MaceBonusBaseDamage, AggregateType.AddRaw, Formula632, 2, 3);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.SpearStrengthener, Stats.SpearBonusBaseDamage, AggregateType.AddRaw, Formula632, 2, 3);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.TwoHandedSwordMaster, Stats.TwoHandedSwordBonusBaseDamage, AggregateType.AddRaw, Formula1154, 3, 3, SkillNumber.TwoHandedSwordStrengthener); // todo: this is only pvp damage
-        this.AddPassiveMasterSkillDefinition(SkillNumber.OneHandedSwordMaster, Stats.AttackSpeed, AggregateType.AddRaw, Formula1, 3, 3, SkillNumber.OneHandedSwordStrengthener, SkillNumber.Undefined, 10);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.TwoHandedSwordStrengthener, Stats.TwoHandedSwordStrBonusDamage, AggregateType.AddRaw, Formula883, 2, 3);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.OneHandedSwordStrengthener, Stats.OneHandedSwordBonusDamage, AggregateType.AddRaw, Formula502, 2, 3);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.MaceStrengthener, Stats.MaceBonusDamage, AggregateType.AddRaw, Formula632, 2, 3);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.SpearStrengthener, Stats.SpearBonusDamage, AggregateType.AddRaw, Formula632, 2, 3);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.TwoHandedSwordMaster, Stats.TwoHandedSwordMasteryBonusDamage, AggregateType.AddRaw, Formula1154, 3, 3, SkillNumber.TwoHandedSwordStrengthener);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.OneHandedSwordMaster, Stats.WeaponMasteryAttackSpeed, AggregateType.AddRaw, Formula1, 3, 3, SkillNumber.OneHandedSwordStrengthener, SkillNumber.Undefined, 10);
 
         // todo: Probability of stunning the target for 2 seconds according to the assigned Skill Level while using a Mace.
         this.AddMasterSkillDefinition(SkillNumber.MaceMastery, SkillNumber.MaceStrengthener, SkillNumber.Undefined, 3, 3, SkillNumber.Undefined, 20, Formula120);
@@ -689,11 +690,11 @@ internal class SkillsInitializer : SkillsInitializerBase
         this.AddMasterSkillDefinition(SkillNumber.DecayStrengthener, SkillNumber.Decay, SkillNumber.PoisonStrengthener, 2, 4, SkillNumber.Decay, 20, Formula502);
         this.AddMasterSkillDefinition(SkillNumber.HellfireStrengthener, SkillNumber.Hellfire, SkillNumber.Undefined, 2, 5, SkillNumber.Hellfire, 20, Formula632);
         this.AddMasterSkillDefinition(SkillNumber.IceStrengthener, SkillNumber.Ice, SkillNumber.Undefined, 2, 5, SkillNumber.Ice, 20, Formula632);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.OneHandedStaffStrengthener, Stats.WizardryBaseDmg, AggregateType.AddRaw, Formula502, 2, 3);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.TwoHandedStaffStrengthener, Stats.WizardryBaseDmg, AggregateType.AddRaw, Formula883, 2, 3);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.ShieldStrengthenerGrandMaster, Stats.BonusDefenseWithShield, AggregateType.AddRaw, Formula803, 2, 3); // todo: check if this is correct
-        this.AddPassiveMasterSkillDefinition(SkillNumber.OneHandedStaffMaster, Stats.AttackSpeed, AggregateType.AddRaw, Formula1, 3, 3, SkillNumber.OneHandedStaffStrengthener, SkillNumber.Undefined, 10);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.TwoHandedStaffMaster, Stats.TwoHandedStaffBonusBaseDamage, AggregateType.AddRaw, Formula1154, 3, 3, SkillNumber.TwoHandedStaffStrengthener); // todo: only pvp
+        this.AddPassiveMasterSkillDefinition(SkillNumber.OneHandedStaffStrengthener, Stats.OneHandedStaffBonusBaseDamage, AggregateType.AddRaw, Formula502, 2, 3);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.TwoHandedStaffStrengthener, Stats.TwoHandedStaffBonusBaseDamage, AggregateType.AddRaw, Formula883, 2, 3);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.ShieldStrengthenerGrandMaster, Stats.BonusDefenseWithShield, AggregateType.AddRaw, Formula803, 2, 3);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.OneHandedStaffMaster, Stats.WeaponMasteryAttackSpeed, AggregateType.AddRaw, Formula1, 3, 3, SkillNumber.OneHandedStaffStrengthener, SkillNumber.Undefined, 10);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.TwoHandedStaffMaster, Stats.TwoHandedStaffMasteryBonusDamage, AggregateType.AddRaw, Formula1154, 3, 3, SkillNumber.TwoHandedStaffStrengthener);
         this.AddPassiveMasterSkillDefinition(SkillNumber.ShieldMasteryGrandMaster, Stats.BonusDefenseRateWithShield, AggregateType.AddRaw, Formula1204, 3, 3, SkillNumber.ShieldStrengthenerGrandMaster);
         this.AddMasterSkillDefinition(SkillNumber.SoulBarrierStrength, SkillNumber.SoulBarrier, SkillNumber.Undefined, 3, 4, SkillNumber.SoulBarrier, 20, $"{Formula181} / 100", Formula181, Stats.SoulBarrierReceiveDecrement, AggregateType.AddRaw);
         this.AddMasterSkillDefinition(SkillNumber.SoulBarrierProficie, SkillNumber.SoulBarrierStrength, SkillNumber.Undefined, 3, 5, SkillNumber.SoulBarrierStrength, 20, Formula803, extendsDuration: true);
@@ -708,17 +709,17 @@ internal class SkillsInitializer : SkillsInitializerBase
         this.AddMasterSkillDefinition(SkillNumber.TripleShotMastery, SkillNumber.TripleShotStrengthener, SkillNumber.Undefined, 2, 3, SkillNumber.TripleShot, 10, Formula1WhenComplete);
         this.AddPassiveMasterSkillDefinition(SkillNumber.SummonedMonsterStr2, Stats.SummonedMonsterDefenseIncrease, AggregateType.AddRaw, Formula6020, 2, 3, SkillNumber.SummonGoblin);
         this.AddMasterSkillDefinition(SkillNumber.AttackIncreaseStr, SkillNumber.GreaterDamage, SkillNumber.Undefined, 2, 4, SkillNumber.GreaterDamage, 20, Formula502);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.WeaponMasteryHighElf, Stats.PhysicalBaseDmg, AggregateType.AddRaw, Formula502, 4, 2);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.WeaponMasteryHighElf, Stats.MasterSkillPhysBonusDmg, AggregateType.AddRaw, Formula502, 4, 2);
         this.AddMasterSkillDefinition(SkillNumber.AttackIncreaseMastery, SkillNumber.AttackIncreaseStr, SkillNumber.Undefined, 2, 5, SkillNumber.GreaterDamage, 20, Formula502);
         this.AddMasterSkillDefinition(SkillNumber.DefenseIncreaseMastery, SkillNumber.DefenseIncreaseStr, SkillNumber.Undefined, 2, 5, SkillNumber.GreaterDefense, 20, Formula502);
         this.AddMasterSkillDefinition(SkillNumber.IceArrowStrengthener, SkillNumber.IceArrow, SkillNumber.Undefined, 2, 5, SkillNumber.IceArrow, 20, Formula502);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.BowStrengthener, Stats.BowBonusBaseDamage, AggregateType.AddRaw, Formula502, 2, 3);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.CrossbowStrengthener, Stats.CrossBowBonusBaseDamage, AggregateType.AddRaw, Formula632, 2, 3);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.BowStrengthener, Stats.BowStrBonusDamage, AggregateType.AddRaw, Formula502, 2, 3);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.CrossbowStrengthener, Stats.CrossBowStrBonusDamage, AggregateType.AddRaw, Formula632, 2, 3);
         this.AddPassiveMasterSkillDefinition(SkillNumber.ShieldStrengthenerHighElf, Stats.BonusDefenseWithShield, AggregateType.AddRaw, Formula803, 2, 3);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.BowMastery, Stats.AttackSpeed, AggregateType.AddRaw, Formula1, 3, 3, SkillNumber.BowStrengthener, SkillNumber.Undefined, 10);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.CrossbowMastery, Stats.CrossBowBonusBaseDamage, AggregateType.AddRaw, Formula1154, 3, 3, SkillNumber.CrossbowStrengthener); // todo only pvp
+        this.AddPassiveMasterSkillDefinition(SkillNumber.BowMastery, Stats.WeaponMasteryAttackSpeed, AggregateType.AddRaw, Formula1, 3, 3, SkillNumber.BowStrengthener, SkillNumber.Undefined, 10);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.CrossbowMastery, Stats.CrossBowMasteryBonusDamage, AggregateType.AddRaw, Formula1154, 3, 3, SkillNumber.CrossbowStrengthener);
         this.AddPassiveMasterSkillDefinition(SkillNumber.ShieldMasteryHighElf, Stats.BonusDefenseRateWithShield, AggregateType.AddRaw, Formula1806, 3, 3, SkillNumber.ShieldStrengthenerHighElf);
-        this.AddMasterSkillDefinition(SkillNumber.InfinityArrowStr, SkillNumber.InfinityArrow, SkillNumber.Undefined, 3, 5, SkillNumber.InfinityArrow, 20, $"{Formula120} / 100", Formula120, Stats.AttackDamageIncrease, AggregateType.AddRaw);
+        this.AddMasterSkillDefinition(SkillNumber.InfinityArrowStr, SkillNumber.InfinityArrow, SkillNumber.Undefined, 3, 5, SkillNumber.InfinityArrow, 20, $"{Formula120} / 100", Formula120, Stats.InfinityArrowStrMultiplier, AggregateType.AddRaw);
         this.AddPassiveMasterSkillDefinition(SkillNumber.MinimumAttPowerInc, Stats.MinimumPhysBaseDmg, AggregateType.AddRaw, Formula502, 5, 3);
 
         // SUM
@@ -731,15 +732,15 @@ internal class SkillsInitializer : SkillsInitializerBase
         this.AddMasterSkillDefinition(SkillNumber.SleepStrengthener, SkillNumber.Sleep, SkillNumber.Undefined, 2, 3, SkillNumber.Sleep, 20, Formula120);
         this.AddMasterSkillDefinition(SkillNumber.ChainLightningStr, SkillNumber.ChainLightning, SkillNumber.Undefined, 2, 4, SkillNumber.ChainLightning, 20, Formula502);
         this.AddMasterSkillDefinition(SkillNumber.LightningShockStr, SkillNumber.LightningShock, SkillNumber.Undefined, 2, 4, SkillNumber.LightningShock, 20, Formula502);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.MagicMasterySummoner, Stats.WizardryBaseDmg, AggregateType.AddRaw, Formula502, 5, 2); // todo? curse AND wiz bonus,
+        this.AddPassiveMasterSkillDefinition(SkillNumber.MagicMasterySummoner, Stats.WizardryAndCurseBaseDmgBonus, AggregateType.AddRaw, Formula502, 5, 2);
         this.AddMasterSkillDefinition(SkillNumber.DrainLifeStrengthener, SkillNumber.DrainLife, SkillNumber.Undefined, 2, 5, SkillNumber.DrainLife, 20, Formula502);
         this.AddPassiveMasterSkillDefinition(SkillNumber.StickStrengthener, Stats.StickBonusBaseDamage, AggregateType.AddRaw, Formula502, 2, 3);
-        this.AddMasterSkillDefinition(SkillNumber.OtherWorldTomeStreng, SkillNumber.Undefined, SkillNumber.Undefined, 3, 2, SkillNumber.Undefined, 20, Formula632);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.StickMastery, Stats.StickBonusBaseDamage, AggregateType.AddRaw, Formula1154, 3, 3, SkillNumber.StickStrengthener); // todo: only PVP
-        this.AddPassiveMasterSkillDefinition(SkillNumber.OtherWorldTomeMastery, Stats.AttackSpeed, AggregateType.AddRaw, Formula1, 3, 3, SkillNumber.OtherWorldTomeStreng, SkillNumber.Undefined, 10);
-        this.AddMasterSkillDefinition(SkillNumber.BerserkerStrengthener, SkillNumber.Berserker, SkillNumber.Undefined, 3, 4, SkillNumber.Berserker, 20, Formula181);
-        this.AddMasterSkillDefinition(SkillNumber.BerserkerProficiency, SkillNumber.BerserkerStrengthener, SkillNumber.Undefined, 3, 5, SkillNumber.Undefined, 20, Formula181);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.MinimumWizCurseInc, Stats.MinimumCurseBaseDmg, AggregateType.AddRaw, Formula502, 5, 3);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.OtherWorldTomeStreng, Stats.BookBonusBaseDamage, AggregateType.AddRaw, Formula632, 2, 3);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.StickMastery, Stats.StickMasteryBonusDamage, AggregateType.AddRaw, Formula1154, 3, 3, SkillNumber.StickStrengthener);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.OtherWorldTomeMastery, Stats.WeaponMasteryAttackSpeed, AggregateType.AddRaw, Formula1, 3, 3, SkillNumber.OtherWorldTomeStreng, SkillNumber.Undefined, 10);
+        this.AddMasterSkillDefinition(SkillNumber.BerserkerStrengthener, SkillNumber.Berserker, SkillNumber.Undefined, 3, 4, SkillNumber.Berserker, 20, Formula181, Formula181, Stats.BerserkerCurseMultiplier, AggregateType.AddRaw);
+        this.AddMasterSkillDefinition(SkillNumber.BerserkerProficiency, SkillNumber.BerserkerStrengthener, SkillNumber.Undefined, 3, 5, SkillNumber.Berserker, 20, $"{Formula181} / 100", Formula181, Stats.BerserkerProficiencyMultiplier, AggregateType.AddRaw);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.MinimumWizCurseInc, Stats.MinWizardryAndCurseDmgBonus, AggregateType.AddRaw, Formula502, 5, 3);
 
         // MG
         this.AddMasterSkillDefinition(SkillNumber.CycloneStrengthenerDuelMaster, SkillNumber.Cyclone, SkillNumber.Undefined, 2, 2, SkillNumber.Cyclone, 20, Formula502);
@@ -748,7 +749,7 @@ internal class SkillsInitializer : SkillsInitializerBase
         this.AddMasterSkillDefinition(SkillNumber.PowerSlashStreng, SkillNumber.PowerSlash, SkillNumber.Undefined, 2, 2, SkillNumber.PowerSlash, 20, Formula632);
         this.AddMasterSkillDefinition(SkillNumber.FlameStrengthenerDuelMaster, SkillNumber.Flame, SkillNumber.Undefined, 2, 3, SkillNumber.Flame, 20, Formula632);
         this.AddMasterSkillDefinition(SkillNumber.BlastStrengthenerDuelMaster, SkillNumber.Cometfall, SkillNumber.LightningStrengthenerDuelMaster, 2, 3, SkillNumber.Cometfall, 20, Formula502);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.WeaponMasteryDuelMaster, Stats.PhysicalBaseDmg, AggregateType.AddRaw, Formula502, 3, 2, SkillNumber.TwistingSlashStrengthenerDuelMaster, SkillNumber.PowerSlashStreng);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.WeaponMasteryDuelMaster, Stats.MasterSkillPhysBonusDmg, AggregateType.AddRaw, Formula502, 3, 2, SkillNumber.TwistingSlashStrengthenerDuelMaster, SkillNumber.PowerSlashStreng);
         this.AddMasterSkillDefinition(SkillNumber.InfernoStrengthenerDuelMaster, SkillNumber.Inferno, SkillNumber.FlameStrengthenerDuelMaster, 2, 4, SkillNumber.Inferno, 20, Formula502);
         this.AddMasterSkillDefinition(SkillNumber.EvilSpiritStrengthenerDuelMaster, SkillNumber.EvilSpirit, SkillNumber.Undefined, 2, 4, SkillNumber.EvilSpirit, 20, Formula502);
         this.AddPassiveMasterSkillDefinition(SkillNumber.MagicMasteryDuelMaster, Stats.WizardryBaseDmg, AggregateType.AddRaw, Formula502, 4, 2, SkillNumber.EvilSpiritStrengthenerDuelMaster);
@@ -761,21 +762,21 @@ internal class SkillsInitializer : SkillsInitializerBase
         this.AddPassiveMasterSkillDefinition(SkillNumber.DarkHorseStreng1, Stats.BonusDefenseWithHorse, AggregateType.AddRaw, Formula1204, 2, 2);
         this.AddMasterSkillDefinition(SkillNumber.CriticalDmgIncPowUp, SkillNumber.IncreaseCriticalDamage, SkillNumber.Undefined, 2, 3, SkillNumber.IncreaseCriticalDamage, 20, Formula632);
         this.AddMasterSkillDefinition(SkillNumber.EarthshakeStreng, SkillNumber.Earthshake, SkillNumber.DarkHorseStreng1, 2, 3, SkillNumber.Earthshake, 20, Formula502);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.WeaponMasteryLordEmperor, Stats.PhysicalBaseDmg, AggregateType.AddRaw, Formula502, 3, 2);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.WeaponMasteryLordEmperor, Stats.MasterSkillPhysBonusDmg, AggregateType.AddRaw, Formula502, 3, 2);
         this.AddMasterSkillDefinition(SkillNumber.FireBurstMastery, SkillNumber.FireBurstStreng, SkillNumber.Undefined, 2, 4, SkillNumber.FireBurst, 20, Formula120);
         this.AddMasterSkillDefinition(SkillNumber.CritDmgIncPowUp2, SkillNumber.CriticalDmgIncPowUp, SkillNumber.Undefined, 2, 4, SkillNumber.IncreaseCriticalDamage, 20, Formula803);
         this.AddMasterSkillDefinition(SkillNumber.EarthshakeMastery, SkillNumber.EarthshakeStreng, SkillNumber.Undefined, 2, 4, SkillNumber.Earthshake, 20, Formula120);
         this.AddMasterSkillDefinition(SkillNumber.CritDmgIncPowUp3, SkillNumber.CritDmgIncPowUp2, SkillNumber.Undefined, 2, 5, SkillNumber.IncreaseCriticalDamage, 20, Formula181);
         this.AddMasterSkillDefinition(SkillNumber.FireScreamStren, SkillNumber.FireScream, SkillNumber.Undefined, 2, 5, SkillNumber.FireScream, 20, Formula502);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.DarkSpiritStr, Stats.RavenBaseDamage, AggregateType.AddRaw, Formula632, 2, 3);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.ScepterStrengthener, Stats.ScepterBonusBaseDamage, AggregateType.AddRaw, Formula502, 2, 3);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.DarkSpiritStr, Stats.RavenBonusDamage, AggregateType.AddRaw, Formula632, 2, 3);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.ScepterStrengthener, Stats.ScepterStrBonusDamage, AggregateType.AddRaw, Formula502, 2, 3);
         this.AddPassiveMasterSkillDefinition(SkillNumber.ShieldStrengthenerLordEmperor, Stats.BonusDefenseWithShield, AggregateType.AddRaw, Formula803, 2, 3);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.UseScepterPetStr, Stats.ScepterPetBonusBaseDamage, AggregateType.AddRaw, Formula632, 2, 3);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.DarkSpiritStr2, Stats.RavenCriticalDamageChanceBonus, AggregateType.AddRaw, $"{Formula181} / 100", Formula181, 3, 3, SkillNumber.DarkSpiritStr);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.ScepterMastery, Stats.ScepterBonusBaseDamage, AggregateType.AddRaw, Formula1154, 3, 3, SkillNumber.ScepterStrengthener); // todo pvp
+        this.AddPassiveMasterSkillDefinition(SkillNumber.UseScepterPetStr, Stats.ScepterPetBonusDamage, AggregateType.AddRaw, Formula632, 2, 3);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.DarkSpiritStr2, Stats.RavenCriticalDamageChance, AggregateType.AddRaw, $"{Formula181} / 100", Formula181, 3, 3, SkillNumber.DarkSpiritStr);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.ScepterMastery, Stats.ScepterMasteryBonusDamage, AggregateType.AddRaw, Formula1154, 3, 3, SkillNumber.ScepterStrengthener);
         this.AddPassiveMasterSkillDefinition(SkillNumber.ShieldMastery, Stats.BonusDefenseRateWithShield, AggregateType.AddRaw, Formula1204, 3, 3, SkillNumber.ShieldStrengthenerLordEmperor);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.CommandAttackInc, Stats.BonusDefenseWithScepterCmdDiv, AggregateType.AddRaw, $"1 / ({Formula3822})", Formula3822, 3, 3);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.DarkSpiritStr3, Stats.RavenExcDamageChanceBonus, AggregateType.AddRaw, $"{Formula120} / 100", Formula120, 5, 3, SkillNumber.DarkSpiritStr2);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.CommandAttackInc, Stats.BonusDamageWithScepterCmdDiv, AggregateType.AddRaw, $"1 / ({Formula3822})", Formula3822, 3, 3);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.DarkSpiritStr3, Stats.RavenExcDamageChance, AggregateType.AddRaw, $"{Formula120} / 100", Formula120, 5, 3, SkillNumber.DarkSpiritStr2);
         this.AddPassiveMasterSkillDefinition(SkillNumber.PetDurabilityStr, Stats.PetDurationIncrease, AggregateType.Multiplicate, Formula1204, 5, 3);
 
         // RF
@@ -799,14 +800,16 @@ internal class SkillsInitializer : SkillsInitializerBase
         this.AddMasterSkillDefinition(SkillNumber.KillingBlowMastery, SkillNumber.KillingBlowStrengthener, SkillNumber.Undefined, 2, 3, SkillNumber.KillingBlow, 20, Formula120);
         this.AddMasterSkillDefinition(SkillNumber.BeastUppercutMastery, SkillNumber.BeastUppercutStrengthener, SkillNumber.Undefined, 2, 3, SkillNumber.BeastUppercut, 20, Formula120);
         this.AddPassiveMasterSkillDefinition(SkillNumber.IncreaseMaximumHp, Stats.MaximumHealth, AggregateType.AddRaw, Formula5418, 4, 2);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.WeaponMasteryFistMaster, Stats.PhysicalBaseDmg, AggregateType.AddRaw, Formula502, 4, 2);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.WeaponMasteryFistMaster, Stats.MasterSkillPhysBonusDmg, AggregateType.AddRaw, Formula502, 4, 2);
         this.AddMasterSkillDefinition(SkillNumber.ChainDriveStrengthener, SkillNumber.ChainDrive, SkillNumber.Undefined, 2, 5, SkillNumber.ChainDrive, 20, Formula502);
         this.AddMasterSkillDefinition(SkillNumber.DarkSideStrengthener, SkillNumber.DarkSide, SkillNumber.Undefined, 2, 5, SkillNumber.DarkSide, 20, Formula502);
         this.AddPassiveMasterSkillDefinition(SkillNumber.IncreaseMaximumMana, Stats.MaximumMana, AggregateType.AddRaw, Formula5418, 5, 2, SkillNumber.IncreaseMaximumHp);
         this.AddMasterSkillDefinition(SkillNumber.DragonRoarStrengthener, SkillNumber.DragonRoar, SkillNumber.Undefined, 2, 5, SkillNumber.DragonRoar, 20, Formula502);
         this.AddPassiveMasterSkillDefinition(SkillNumber.IncreasePvPAttackRate, Stats.AttackRatePvp, AggregateType.AddRaw, Formula32751, 1, 3);
-        this.AddPassiveMasterSkillDefinition(SkillNumber.EquippedWeaponStrengthener, Stats.GloveWeaponBonusBaseDamage, AggregateType.AddRaw, Formula502, 2, 3);
+        this.AddPassiveMasterSkillDefinition(SkillNumber.EquippedWeaponStrengthener, Stats.GloveWeaponBonusDamage, AggregateType.AddRaw, Formula502, 2, 3);
         this.AddMasterSkillDefinition(SkillNumber.DefSuccessRateIncPowUp, SkillNumber.IncreaseBlock, SkillNumber.Undefined, 3, 2, SkillNumber.IncreaseBlock, 20, Formula502);
+
+        // todo: Increases the probability of Double Damage while using gloves according to the assigned Skill Level.
         this.AddMasterSkillDefinition(SkillNumber.EquippedWeaponMastery, SkillNumber.EquippedWeaponStrengthener, SkillNumber.Undefined, 3, 3, SkillNumber.Undefined, 20, Formula120);
         this.AddMasterSkillDefinition(SkillNumber.DefSuccessRateIncMastery, SkillNumber.DefSuccessRateIncPowUp, SkillNumber.Undefined, 3, 3, SkillNumber.IncreaseBlock, 20, Formula502);
         this.AddMasterSkillDefinition(SkillNumber.StaminaIncreaseStrengthener, SkillNumber.IncreaseHealth, SkillNumber.Undefined, 3, 4, SkillNumber.IncreaseHealth, 20, Formula1154);

--- a/src/Persistence/Initialization/VersionSeasonSix/TestAccounts/Level300.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/TestAccounts/Level300.cs
@@ -38,7 +38,7 @@ internal class Level300 : AccountInitializerBase
 
         character.Inventory!.Items.Add(this.CreateWeapon(InventoryConstants.LeftHandSlot, 2, 12, 13, 4, true, true, Stats.ExcellentDamageChance)); // Exc Great Lord Scepter+13+16+L+ExcDmg
         character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.HelmSlot, 26, 7, Stats.MaximumHealth, 13, 4, true)); // Exc Ada Helm+13+16+L
-        character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.ArmorSlot, 26, 8, Stats.DamageReceiveDecrement, 13, 4, true)); // Exc Ada Armor+13+16+L
+        character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.ArmorSlot, 26, 8, Stats.ArmorDamageDecrease, 13, 4, true)); // Exc Ada Armor+13+16+L
         character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.PantsSlot, 26, 9, Stats.MoneyAmountRate, 13, 4, true)); // Exc Ada Pants+13+16+L
         character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.GlovesSlot, 26, 10, Stats.MaximumMana, 13, 4, true)); // Exc Ada Gloves+13+16+L
         character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.BootsSlot, 26, 11, Stats.DamageReflection, 13, 4, true)); // Exc Ada Boots+13+16+L
@@ -63,7 +63,7 @@ internal class Level300 : AccountInitializerBase
 
         character.Inventory!.Items.Add(this.CreateWeapon(InventoryConstants.LeftHandSlot, 0, 0, 13, 4, true, false, Stats.ExcellentDamageChance)); // Exc Kris+13+16+L+ExcDmg
         character.Inventory.Items.Add(this.CreateWeapon(InventoryConstants.RightHandSlot, 0, 5, 13, 4, true, true, Stats.ExcellentDamageChance)); // Exc Blade+13+16+L+ExcDmg
-        character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.ArmorSlot, 6, 8, Stats.DamageReceiveDecrement, 13, 4, true)); // Exc Scale Armor+13+16+L
+        character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.ArmorSlot, 6, 8, Stats.ArmorDamageDecrease, 13, 4, true)); // Exc Scale Armor+13+16+L
         character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.HelmSlot, 6, 7, Stats.MaximumHealth, 13, 4, true)); // Exc Scale Helm+13+16+L
         character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.PantsSlot, 6, 9, Stats.MoneyAmountRate, 13, 4, true)); // Exc Scale Pants+13+16+L
         character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.GlovesSlot, 6, 10, Stats.MaximumMana, 13, 4, true)); // Exc Scale Gloves+13+16+L

--- a/src/Persistence/Initialization/VersionSeasonSix/TestAccounts/QuestBase.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/TestAccounts/QuestBase.cs
@@ -50,11 +50,11 @@ internal class QuestBase : AccountInitializerBase
         character.Attributes.First(a => a.Definition == Stats.BaseEnergy).Value += 100;
         character.LevelUpPoints -= 700;
         character.Inventory!.Items.Add(this.CreateWeapon(InventoryConstants.LeftHandSlot, 0, 0, 13, 4, true, false, Stats.ExcellentDamageChance)); // Exc Kris+13+16+L+ExcDmg
-        character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.ArmorSlot, 5, 8, Stats.DamageReceiveDecrement, 13, 4, true)); // Leather Armor
-        character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.HelmSlot, 5, 7, Stats.DamageReceiveDecrement, 13, 4, true)); // Leather Helm
-        character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.PantsSlot, 5, 9, Stats.DamageReceiveDecrement, 13, 4, true)); // Leather Pants
-        character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.GlovesSlot, 5, 10, Stats.DamageReceiveDecrement, 13, 4, true)); // Leather Gloves
-        character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.BootsSlot, 5, 11, Stats.DamageReceiveDecrement, 13, 4, true)); // Leather Boots
+        character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.ArmorSlot, 5, 8, Stats.ArmorDamageDecrease, 13, 4, true)); // Leather Armor
+        character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.HelmSlot, 5, 7, Stats.ArmorDamageDecrease, 13, 4, true)); // Leather Helm
+        character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.PantsSlot, 5, 9, Stats.ArmorDamageDecrease, 13, 4, true)); // Leather Pants
+        character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.GlovesSlot, 5, 10, Stats.ArmorDamageDecrease, 13, 4, true)); // Leather Gloves
+        character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.BootsSlot, 5, 11, Stats.ArmorDamageDecrease, 13, 4, true)); // Leather Boots
 
         this.AddDarkLordItems(character.Inventory);
         this.AddTestJewelsAndPotions(character.Inventory);
@@ -73,11 +73,11 @@ internal class QuestBase : AccountInitializerBase
         character.LevelUpPoints -= 700;
         character.Inventory!.Items.Add(this.CreateWeapon(InventoryConstants.LeftHandSlot, 0, 0, 13, 4, true, false, Stats.ExcellentDamageChance)); // Exc Kris+13+16+L+ExcDmg
         character.Inventory.Items.Add(this.CreateWeapon(InventoryConstants.RightHandSlot, 1, 3, 13, 4, true, true, Stats.ExcellentDamageChance)); // Exc Tomahawk+13+16+L+ExcDmg
-        character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.ArmorSlot, 5, 8, Stats.DamageReceiveDecrement, 13, 4, true)); // Leather Armor
-        character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.HelmSlot, 5, 7, Stats.DamageReceiveDecrement, 13, 4, true)); // Leather Helm
-        character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.PantsSlot, 5, 9, Stats.DamageReceiveDecrement, 13, 4, true)); // Leather Pants
-        character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.GlovesSlot, 5, 10, Stats.DamageReceiveDecrement, 13, 4, true)); // Leather Gloves
-        character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.BootsSlot, 5, 11, Stats.DamageReceiveDecrement, 13, 4, true)); // Leather Boots
+        character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.ArmorSlot, 5, 8, Stats.ArmorDamageDecrease, 13, 4, true)); // Leather Armor
+        character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.HelmSlot, 5, 7, Stats.ArmorDamageDecrease, 13, 4, true)); // Leather Helm
+        character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.PantsSlot, 5, 9, Stats.ArmorDamageDecrease, 13, 4, true)); // Leather Pants
+        character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.GlovesSlot, 5, 10, Stats.ArmorDamageDecrease, 13, 4, true)); // Leather Gloves
+        character.Inventory.Items.Add(this.CreateArmorItem(InventoryConstants.BootsSlot, 5, 11, Stats.ArmorDamageDecrease, 13, 4, true)); // Leather Boots
         character.Inventory.Items.Add(this.CreateJewel(47, Items.Quest.ScrollOfEmperorNumber));
         character.Inventory.Items.Add(this.CreateJewel(48, Items.Quest.BrokenSwordNumber));
         this.AddTestJewelsAndPotions(character.Inventory);


### PR DESCRIPTION
Still to do:
- [ ] Comment changed files with rationale & source references
- [ ] Update plugins (after discussion)

**Changes**

- Damage calculations reviewed end to end
- Added Elf's melee dmg logic
- Added Elf's bolts/arrows dmg increase
- Added "double wield" logic
- Added DL skills dmg attribute relationships
- Added Sum's _Berserker_ magic effect
- Added Sum's curse/wizardry dmg calcs/attribute relationships

**Bugfixes**
- Fire socket option
- MG can now equip a staff on RH
- Removed _Powerslash_ skill energy requirement 
- Halved staffs weapon group physical dmg

**Notes**

I followed the damage calculation sequence in [zTeamS6.3](https://github.com/MuSeason6FixTeam/zTeamS6.3/blob/565c579e61f150f6019dee60d22443d30ddfaf42/zGameServer/GameServer/ObjCalCharacter.cpp#L255) and [emu](https://github.com/kyleruss/emu-server/blob/202856a74c905c203b9b2795fd161f564ca8b257/GameServer/Source/ObjCalCharacter.cpp#L185) sources and tried to keep things relatively close whenever possible (as usual, with some compromises here and there).

The original Summoner damage calculations seem to diverge a bit from the more "classical" ones (with its own specific [method](https://github.com/MuSeason6FixTeam/zTeamS6.3/blob/565c579e61f150f6019dee60d22443d30ddfaf42/zGameServer/GameServer/ObjAttack.cpp#L3615)), which gave rise to a few more `if`'s here and there :smile:. Anyway, let's discuss and seek out the possible better final product!