### PR TITLE
Fixed server info handler when running inside docker

### DIFF
--- a/src/ConnectServer/PacketHandler/ServerInfoRequestHandler.cs
+++ b/src/ConnectServer/PacketHandler/ServerInfoRequestHandler.cs
@@ -46,8 +46,7 @@ internal class ServerInfoRequestHandler : IPacketHandler<Client>
         var serverItem = this._connectServer.ServerList.GetItem(serverId);
         var isGameServerOnSameMachineAsConnectServer = (serverItem?.EndPoint.Address).IsOnSameHost();
         var isClientConnectedOnNonRegisteredAddress = !object.Equals(serverItem?.EndPoint.Address, localIpEndPoint?.Address);
-        var isRunningOnDocker = Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER") == "true";
-
+        bool.TryParse(Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER"), out var isRunningOnDocker);
         if (isGameServerOnSameMachineAsConnectServer
             && !isRunningOnDocker
             && isClientConnectedOnNonRegisteredAddress) // only if we can't use the cached data


### PR DESCRIPTION
The connect server has a mechanism to improve connectability when a client connects through an address which was not registered before. When connecting to a all-in-one server which is running inside docker on windows, the local endpoint ip is set to the container ip within the docker network. This IP is not available from outside. So in this case, we cannot return that back to the caller, because it will not be able to connect. So to be sure, we don't use this "smart" logic when the server is running in docker anymore.

This should fix #624 