### PR TITLE
fix for the issue #645 where the player would spawn in an incorrect…

### DIFF
--- a/src/Persistence/Initialization/VersionSeasonSix/Gates.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Gates.cs
@@ -195,7 +195,7 @@ public class Gates : InitializerBase
         targetGates.Add(266, this.CreateExitGate(maps[7], 16, 19, 17, 20, 0));
 
         // Tarkan
-        targetGates.Add(57, this.CreateExitGate(maps[8], 187, 54, 203, 69, 0, true));
+        targetGates.Add(57, this.CreateExitGate(maps[8], 187, 63, 203, 69, 0, true));
         targetGates.Add(77, this.CreateExitGate(maps[8], 91, 160, 93, 161, 0));
         targetGates.Add(54, this.CreateExitGate(maps[8], 248, 40, 251, 44, 7));
         targetGates.Add(128, this.CreateExitGate(maps[8], 7, 199, 7, 201, 0));


### PR DESCRIPTION
…location and be stuck inside the collisions.
The Spawn region's Y needs to be at least 62 to avoid being stuck inside a part of the map, changed to 63.
This alters the default value for this, for anyone who's already running the server, change the Y1 location for Tarkan's spawn from 54 to 63 and save.