### PR TITLE
feat: add max magic speed

### DIFF
--- a/src/GameLogic/Attributes/Stats.cs
+++ b/src/GameLogic/Attributes/Stats.cs
@@ -365,7 +365,7 @@ public class Stats
     /// </summary>
     public static AttributeDefinition AttackSpeed { get; } = new(new Guid("BACC1115-1E8B-4E62-B952-8F8DDB58A949"), "Attack Speed", string.Empty)
     {
-        MaximumValue = 1500,
+        MaximumValue = 200,
     };
 
     /// <summary>
@@ -404,7 +404,7 @@ public class Stats
     /// </summary>
     public static AttributeDefinition MagicSpeed { get; } = new(new Guid("AE32AA45-9C18-43B3-9F7B-648FD7F4B0AD"), "Magic Speed", string.Empty)
     {
-        MaximumValue = 1500,
+        MaximumValue = 200,
     };
 
     /// <summary>

--- a/src/GameServer/RemoteView/Character/UpdateCharacterStatsExtendedPlugIn.cs
+++ b/src/GameServer/RemoteView/Character/UpdateCharacterStatsExtendedPlugIn.cs
@@ -37,7 +37,7 @@ public class UpdateCharacterStatsExtendedPlugIn : IUpdateCharacterStatsPlugIn
             return;
         }
 
-        var maxAttackSpeed = this._player.GameContext.Configuration.Attributes.FirstOrDefault(a => a == Stats.AttackSpeed)?.MaximumValue ?? 1500;
+        var maxAttackSpeed = this._player.GameContext.Configuration.Attributes.FirstOrDefault(a => a == Stats.AttackSpeed)?.MaximumValue ?? 200;
         await connection.SendCharacterInformationExtendedAsync(
                 this._player.Position.X,
                 this._player.Position.Y,


### PR DESCRIPTION
Previously, AttackSpeed was capped at 200 while MagicSpeed had no cap,
causing an imbalance where physical skills (like Twisting Slash, Power Slash)
stopped scaling at high agility levels while magic spells (like Evil Spirit)
continued to scale indefinitely.

Changes:
- Added MagicSpeed MaximumValue of 200 in Stats.cs (previously uncapped)
- Added MagicSpeed MaximumValue initialization in FixAttackSpeedCalculationUpdate

This ensures both physical skills and magic spells scale consistently, balancing gameplay at high agility levels. Both values remain editablein the admin panel through the AttributeDefinition MaximumValue property.