### PR TITLE
Fix weapon skills bug: prevent casting without weapon

### DIFF
--- a/src/GameLogic/PlayerActions/Skills/AreaSkillAttackAction.cs
+++ b/src/GameLogic/PlayerActions/Skills/AreaSkillAttackAction.cs
@@ -168,6 +168,12 @@ public class AreaSkillAttackAction
             return;
         }
 
+        // Skills that move attacker to target (e.g., Twisting Slash, Death Stab) require a weapon
+        if (skill.MovesToTarget && player.Inventory?.GetItem(InventoryConstants.RightHandSlot) is null)
+        {
+            return;
+        }
+
         if (player.Attributes[Stats.AmmunitionConsumptionRate] > player.Attributes[Stats.AmmunitionAmount])
         {
             return;


### PR DESCRIPTION
## Summary
Prevents weapon-based skills from being cast without a weapon equipped.

## Problem
Players could exploit weapon skills (like Twisting Slash) by casting them without a weapon, potentially causing unexpected behavior or exploits.

## Solution
Added a check in `AreaSkillAttackAction.PerformAutomaticHitsAsync()` that validates weapon presence for skills with `MovesToTarget = true`.

## Changes
- Uses `skill.MovesToTarget` property instead of hardcoding skill number 41
- This covers all weapon-based melee skills (Twisting Slash, Death Stab, etc.)
- More maintainable and data-driven approach

## Code Change
```csharp
// Before (hardcoded)
if (skill.Number == 41 && player.Inventory?.GetItem(InventoryConstants.RightHandSlot) is null)

// After (data-driven)
if (skill.MovesToTarget && player.Inventory?.GetItem(InventoryConstants.RightHandSlot) is null)
```