### PR TITLE
Fix typos on quickstart and exception messages

### DIFF
--- a/QuickStart.md
+++ b/QuickStart.md
@@ -40,7 +40,7 @@ postgres database connection strings.
 |------|---------------------|
 | DB_HOST | The hostname of the database. If the local configuration file is still configured to use 'localhost', the value of this variable replaces it |
 | DB_ADMIN_USER | The user name of the postgres admin account. If the local configuration file is still configured to use 'postgres' for the user name of the admin (first entry in the ConnectionSettings.xml), the value of this variable replaces it. |
-| DB_ADMIN_PW | The user name of the postgres admin account. If the local configuration file is still configured to use 'admin' for the user password of the admin (first entry in the ConnectionSettings.xml), the value of this variable replaces it. |
+| DB_ADMIN_PW | The password of the postgres admin account. If the local configuration file is still configured to use 'admin' for the user password of the admin (first entry in the ConnectionSettings.xml), the value of this variable replaces it. |
 
 ## Manually
 
@@ -58,7 +58,7 @@ Requirements:
   * Visual Studio 2026 installed, with workloads for ASP.NET Web development
     and .NET Desktop development. Please keep it up-to-date to prevent any issues.
   
-  * Visual Stuido Extension "Web Compiler 2022+", if you plan to edit SCSS files
+  * Visual Studio Extension "Web Compiler 2022+", if you plan to edit SCSS files
     for the admin panel.
     * https://marketplace.visualstudio.com/items?itemName=Failwyn.WebCompiler64
 
@@ -77,7 +77,7 @@ If you have that, you'll need to do:
 
 * Right click the solution and 'Restore NuGet Packages'
 
-* Edit OpenMU\Persistence\EntityFramework\ConnectionSettings.xml, so that the
+* Edit src\Persistence\EntityFramework\ConnectionSettings.xml, so that the
   connection strings are correct - however only the user/password of the first
   and second connection string need to be correct. The server will try to create
   the other roles specified by the settings.

--- a/src/Dapr/Common/Extensions.cs
+++ b/src/Dapr/Common/Extensions.cs
@@ -321,7 +321,7 @@ public static class Extensions
             }
             catch (Exception ex)
             {
-                serviceProvider.GetService<ILogger<IIpAddressResolver>>()?.LogError(ex, "Unexpected error when trying to load the system configuration during ip resolver creation: {ex}", ex);
+                serviceProvider.GetService<ILogger<IIpAddressResolver>>()?.LogError(ex, "Unexpected error when trying to load the system configuration during ip resolver creation.");
             }
 
             return IpAddressResolverFactory.CreateIpResolver(args, settings, serviceProvider.GetService<ILoggerFactory>()!);

--- a/src/Dapr/Common/SecretStoreDatabaseConnectionSettingsProvider.cs
+++ b/src/Dapr/Common/SecretStoreDatabaseConnectionSettingsProvider.cs
@@ -68,7 +68,7 @@ public class SecretStoreDatabaseConnectionSettingsProvider : IDatabaseConnection
                             this._connectionSettings.Add(contextTypeName, setting);
                         }
 
-                        Console.WriteLine("secrects retrieved :)");
+                        Console.WriteLine("secrets retrieved :)");
 
                         this._isInitialized = true;
                     }

--- a/src/GameLogic/PlugIns/PeriodicSaveProgressPlugIn.cs
+++ b/src/GameLogic/PlugIns/PeriodicSaveProgressPlugIn.cs
@@ -63,7 +63,7 @@ public class PeriodicSaveProgressPlugIn : IPeriodicTaskPlugIn, ISupportCustomCon
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "Unexpected error when saving player data periodically: {ex}", ex);
+            logger.LogError(ex, "Unexpected error when saving player data periodically.");
         }
     }
 

--- a/src/GameServer/DefaultTcpGameServerListener.cs
+++ b/src/GameServer/DefaultTcpGameServerListener.cs
@@ -140,7 +140,7 @@ public class DefaultTcpGameServerListener : IGameServerListener
         }
         catch (Exception ex)
         {
-            this._logger.LogError(ex, "Failed to re-register at game server state observer after the ip resolver has been changed. Error: {ex}", ex);
+            this._logger.LogError(ex, "Failed to re-register at game server state observer after the ip resolver has been changed.");
         }
     }
 

--- a/src/Web/AdminPanel/Pages/EditBase.cs
+++ b/src/Web/AdminPanel/Pages/EditBase.cs
@@ -400,7 +400,7 @@ public abstract class EditBase : ComponentBase, IAsyncDisposable
         }
         catch (Exception ex)
         {
-            this.Logger?.LogError(ex, "Unexpected error when loading data: {ex}", ex);
+            this.Logger?.LogError(ex, "Unexpected error when loading data.");
         }
     }
 }


### PR DESCRIPTION
My first contribution with something small.
1. Typo: "secrects" → "secrets" in src/Dapr/Common/SecretStoreDatabaseConnectionSettingsProvider.cs:71
2. Redundant exception parameter in logging (4 instances) - The exception was being passed both as the first parameter (which Serilog handles specially) and again as a format argument, causing duplicate output:
   - src/Dapr/Common/Extensions.cs:324
   - src/Web/AdminPanel/Pages/EditBase.cs:403
   - src/GameServer/DefaultTcpGameServerListener.cs:143
   - src/GameLogic/PlugIns/PeriodicSaveProgressPlugIn.cs:66