### PR TITLE
fix: InvalidOperationException when creating entity. And result list not updating on create and on delete

### DIFF
--- a/src/Persistence/DataSourceBase.cs
+++ b/src/Persistence/DataSourceBase.cs
@@ -119,6 +119,13 @@ public abstract class DataSourceBase<TOwner> : IDataSource<TOwner>
     }
 
     /// <inheritdoc />
+    public async ValueTask ForceDiscardChangesAsync()
+    {
+        using var l = await _loadLock.LockAsync().ConfigureAwait(false);
+        this.Reset();
+    }
+
+    /// <inheritdoc />
     public IEnumerable<T> GetAll<T>()
     {
         return this.GetAll(typeof(T)).OfType<T>();

--- a/src/Persistence/EntityFramework/TypedContext.cs
+++ b/src/Persistence/EntityFramework/TypedContext.cs
@@ -82,12 +82,13 @@ internal class TypedContext : EntityDataContext, ITypedContext
         var gameConfigType = modelTypes.FirstOrDefault(mt => mt.ClrType == typeof(EntityFramework.Model.GameConfiguration));
         var gameConfigNav = gameConfigType?.GetNavigations().FirstOrDefault(nav => nav.IsCollection && nav.TargetEntityType.ClrType == mainType);
 
-        var additionalTypes = (from et in editTypes
-                               let entityType = modelTypes.FirstOrDefault(mt => mt.ClrType == et.EntityType)
-                               where entityType is not null
-                               from additional in DetermineAdditionalTypes(modelTypes.Select(t => t.ClrType), entityType!)
-                               select additional).ToList();
+        var additionalTypes = editTypes
+            .Select(et => (et, entityType: modelTypes.FirstOrDefault(mt => mt.ClrType == et.EntityType)))
+            .Where(t => t.entityType is not null)
+            .SelectMany(t => DetermineAdditionalTypes(modelTypes.Select(m => m.ClrType), t.entityType!))
+            .ToList();
         editTypes.AddRange(additionalTypes);
+
         var finalEditTypes = new HashSet<Type>();
         foreach (var type in editTypes)
         {
@@ -215,10 +216,13 @@ internal class TypedContext : EntityDataContext, ITypedContext
     private void OnSavingChanges(object? sender, SavingChangesEventArgs e)
     {
         var readOnlyTypes = this.ReadOnlyTypes;
-        var gameConfigNavigation = this.Model.FindEntityType(typeof(EntityFramework.Model.GameConfiguration))?.GetNavigations().FirstOrDefault(nav => nav.Name == this.GameConfigNavigationName);
-        this.ChangeTracker.DetectChanges();
+        var gameConfigNavigation = this.Model.FindEntityType(typeof(EntityFramework.Model.GameConfiguration))
+            ?.GetNavigations()
+            .FirstOrDefault(nav => nav.Name == this.GameConfigNavigationName);
+
         foreach (var entry in this.ChangeTracker.Entries().ToList())
         {
+            // Prevent accidental saves of read-only reference types.
             if ((entry.State == EntityState.Added || entry.State == EntityState.Modified)
                 && readOnlyTypes.Contains(entry.Entity.GetType()))
             {
@@ -226,12 +230,19 @@ internal class TypedContext : EntityDataContext, ITypedContext
             }
 
             if (entry.State == EntityState.Added
-                && this.CurrentGameConfiguration is { } currentGameConfiguration
                 && gameConfigNavigation is { }
+                && this.CurrentGameConfiguration is { } currentGameConfiguration
                 && entry.Entity.GetType().IsAssignableTo(this.EditType))
             {
-                this.Attach(currentGameConfiguration);
-                gameConfigNavigation.GetCollectionAccessor()?.Add(currentGameConfiguration, entry.Entity, false);
+                // Set the FK value directly so EF writes the correct GameConfigurationId
+                // without needing to Attach currentGameConfiguration (which would traverse
+                // its entire graph and conflict with already-tracked read-only instances).
+                var fkProperty = gameConfigNavigation.ForeignKey?.Properties.FirstOrDefault();
+                var fkPropertyEntry = entry.Properties.FirstOrDefault(p => p.Metadata == fkProperty);
+                if (fkPropertyEntry is not null)
+                {
+                    fkPropertyEntry.CurrentValue = currentGameConfiguration.GetId();
+                }
             }
         }
     }

--- a/src/Persistence/IDataSource.cs
+++ b/src/Persistence/IDataSource.cs
@@ -50,6 +50,13 @@ public interface IDataSource : IDisposable
     ValueTask DiscardChangesAsync();
 
     /// <summary>
+    /// Discards the changes and resets the cache unconditionally, regardless of whether
+    /// the context has tracked changes. Use this after an external context (e.g. a typed
+    /// context) has persisted structural changes such as creating or deleting objects.
+    /// </summary>
+    ValueTask ForceDiscardChangesAsync();
+
+    /// <summary>
     /// Gets all objects of the given type.
     /// </summary>
     /// <typeparam name="T">The type of the requested objects.</typeparam>

--- a/src/Web/AdminPanel/Pages/EditConfigGrid.razor.cs
+++ b/src/Web/AdminPanel/Pages/EditConfigGrid.razor.cs
@@ -177,10 +177,17 @@ public partial class EditConfigGrid : ComponentBase, IAsyncDisposable
 
             var cancellationToken = this._disposeCts?.Token ?? default;
             var gameConfiguration = await this.DataSource.GetOwnerAsync(cancellationToken: cancellationToken).ConfigureAwait(false);
-            using var deleteContext = this.PersistenceContextProvider.CreateNewContext(gameConfiguration);
-            deleteContext.Attach(viewModel.Parent);
-            await deleteContext.DeleteAsync(viewModel.Parent).ConfigureAwait(false);
+            using var deleteContext = this.PersistenceContextProvider.CreateNewTypedContext(this.Type!, false, gameConfiguration);
+            var toDelete = await deleteContext.GetByIdAsync(viewModel.Id, this.Type!, cancellationToken).ConfigureAwait(false);
+            if (toDelete is null)
+            {
+                this.ToastService.ShowError($"Couldn't find '{viewModel.Name}' to delete.");
+                return;
+            }
+
+            await deleteContext.DeleteAsync(toDelete).ConfigureAwait(false);
             await deleteContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await this.DataSource.ForceDiscardChangesAsync().ConfigureAwait(false);
             this.ToastService.ShowSuccess($"Deleted '{viewModel.Name}' successfully.");
             this._viewModels = null;
             this._loadTask = Task.Run(() => this.LoadDataAsync(cancellationToken), cancellationToken);
@@ -213,7 +220,7 @@ public partial class EditConfigGrid : ComponentBase, IAsyncDisposable
         if (!result.Cancelled)
         {
             await creationContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-            await this.DataSource.DiscardChangesAsync().ConfigureAwait(false);
+            await this.DataSource.ForceDiscardChangesAsync().ConfigureAwait(false);
 
             this.ToastService.ShowSuccess("New object successfully created.");
             this._viewModels = null;

--- a/src/Web/Shared/Components/Form/AutoForm.razor
+++ b/src/Web/Shared/Components/Form/AutoForm.razor
@@ -1,11 +1,11 @@
 ﻿@typeparam T
 
-<EditForm Model="@Model" OnValidSubmit="OnValidSubmit">
+<EditForm Model="@Model" OnValidSubmit="OnValidSubmit" class="auto-form">
     <DataAnnotationsValidator />
     <AutoFields HideCollections="@this.HideCollections"/>
 
     <ValidationSummary />
-    <div>
+    <div class="form-actions">
         <button type="submit" class="primary-button">Save</button>
         @if (this.OnCancel != null)
         {

--- a/src/Web/Shared/Components/Form/AutoForm.razor.css
+++ b/src/Web/Shared/Components/Form/AutoForm.razor.css
@@ -1,0 +1,21 @@
+.auto-form {
+    background: #fff;
+    border: 1px solid #dee2e6;
+    border-radius: 0.375rem;
+    padding: 1.5rem;
+    margin-bottom: 1rem;
+}
+
+.form-actions {
+    position: sticky;
+    bottom: 0;
+    background-color: #fff;
+    padding: 1rem 0 0 0;
+    margin: 1rem -1.5rem -1.5rem -1.5rem;
+    border-top: 1px solid #dee2e6;
+    display: flex;
+    gap: 0.5rem;
+    justify-content: flex-start;
+    padding: 1rem 1.5rem;
+    border-radius: 0 0 0.375rem 0.375rem;
+}

--- a/src/Web/Shared/Components/Form/LocalizedStringField.razor
+++ b/src/Web/Shared/Components/Form/LocalizedStringField.razor
@@ -13,18 +13,29 @@
     <FieldLabel Text="@Label" ValueExpression="@this.ValueExpression" />
   </div>
 
-  @foreach (var culture in this.LocalizationOptions.Value.SupportedUICultures)
+  @if (this.LocalizationOptions.Value.SupportedUICultures is { Count: > 0 } cultures)
   {
-    <div class="mb-1">
-      <input id="@(MUnique.OpenMU.Interfaces.LocalizedString.NeutralLanguageCode == culture.TwoLetterISOLanguageName ? this.FieldIdentifier.FieldName : this.FieldIdentifier.FieldName + "_" + culture.TwoLetterISOLanguageName)"
-             class="@(this.GetInputClass(culture))"
-             value="@GetValueForCulture(culture)"
-             @onchange="(e => SetValueForCulture(culture, e.Value?.ToString()))"
-      />
-      <span class="badge @(this.GetBadge(culture))">@culture.TwoLetterISOLanguageName</span>
-    </div>
+    @foreach (var culture in cultures)
+    {
+      <div class="mb-1">
+        <input id="@(MUnique.OpenMU.Interfaces.LocalizedString.NeutralLanguageCode == culture.TwoLetterISOLanguageName ? this.FieldIdentifier.FieldName : this.FieldIdentifier.FieldName + "_" + culture.TwoLetterISOLanguageName)"
+               class="@(this.GetInputClass(culture))"
+               value="@GetValueForCulture(culture)"
+               @onchange="(e => SetValueForCulture(culture, e.Value?.ToString()))"
+        />
+        <span class="badge @(this.GetBadge(culture))">@culture.TwoLetterISOLanguageName</span>
+      </div>
+    }
   }
-    
+  else
+  {
+    @* No cultures configured - render a plain input bound to the neutral/default value *@
+    <input id="@this.FieldIdentifier.FieldName"
+           value="@(this.Value.Value ?? string.Empty)"
+           @onchange="(e => this.CurrentValue = new MUnique.OpenMU.Interfaces.LocalizedString(e.Value?.ToString() ?? string.Empty))"
+    />
+  }
+
 </div>
 <ValidationMessage For="@this.ValueExpression" />
 


### PR DESCRIPTION
1. Persistence: ForceDiscardChangesAsync
  Added a new ForceDiscardChangesAsync() method to IDataSource and
  DataSourceBase. Unlike DiscardChangesAsync(), this unconditionally resets
  the cache without checking for tracked changes. Needed after an external
  typed context has persisted structural changes (create/delete) so the main
  data source reflects the new state.

2. Persistence: TypedContext save fix
  Fixed a bug where saving a new object via TypedContext would call
  Attach(currentGameConfiguration), which traversed the entire game config
  graph and conflicted with already-tracked read-only instances. Now sets the
  FK (GameConfigurationId) directly on the entry instead, avoiding the graph
  traversal. Also minor LINQ refactor in the additional-types resolution query.

3. Admin Panel: Delete flow rewrite
  The delete action in EditConfigGrid now uses a typed context
  (CreateNewTypedContext) instead of a generic context, fetches the object by
  ID before deleting it, shows a proper error if the object is not found, and
  calls ForceDiscardChangesAsync() after deletion so the list reloads cleanly.

4. Admin Panel: Create flow cache fix
  After creating a new object, the panel now calls ForceDiscardChangesAsync()
  instead of DiscardChangesAsync() to ensure the cache is fully reset and the
  new object appears in the list immediately.

5. UI: AutoForm sticky save button
The save/cancel button bar in AutoForm is now sticky to the bottom of the
  viewport so it remains visible while scrolling through long forms. Added a
  scoped CSS file (AutoForm.razor.css) with styling for the form container and
  the actions bar.

6. Add ICU globalization support to Alpine image
Installs icu-libs and sets DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false so that .NET culture APIs (CultureInfo.GetCultures) work correctly on Alpine, enabling the admin panel to detect and register supported UI cultures at startup.