### PR TITLE
Fix IP resolver priority for startup args and env vars

### DIFF
--- a/src/Network/ConfigurableIpResolver.cs
+++ b/src/Network/ConfigurableIpResolver.cs
@@ -13,6 +13,7 @@ using Microsoft.Extensions.Logging;
 public class ConfigurableIpResolver : IIpAddressResolver
 {
     private readonly ILoggerFactory _loggerFactory;
+    private readonly bool _allowRuntimeReconfiguration;
 
     private IpResolverType _resolverType;
     private string? _parameter;
@@ -24,11 +25,15 @@ public class ConfigurableIpResolver : IIpAddressResolver
     /// <param name="resolverType">Type of the resolver.</param>
     /// <param name="parameter">The parameter.</param>
     /// <param name="loggerFactory">The logger factory.</param>
+    /// <param name="allowRuntimeReconfiguration">
+    /// If set to <c>false</c>, calls to <see cref="Configure"/> are ignored after construction.
+    /// </param>
     /// <exception cref="System.ArgumentException">When using a custom resolver type, a parameter with an IP or host name is required. - parameter</exception>
-    public ConfigurableIpResolver(IpResolverType resolverType, string? parameter, ILoggerFactory loggerFactory)
+    public ConfigurableIpResolver(IpResolverType resolverType, string? parameter, ILoggerFactory loggerFactory, bool allowRuntimeReconfiguration = true)
     {
-        this.Configure(resolverType, parameter);
         this._loggerFactory = loggerFactory;
+        this._allowRuntimeReconfiguration = allowRuntimeReconfiguration;
+        this.ApplyConfiguration(resolverType, parameter, raiseEvent: false);
     }
 
     /// <summary>
@@ -50,6 +55,16 @@ public class ConfigurableIpResolver : IIpAddressResolver
     /// <param name="parameter">The parameter.</param>
     public void Configure(IpResolverType resolverType, string? parameter)
     {
+        if (!this._allowRuntimeReconfiguration)
+        {
+            return;
+        }
+
+        this.ApplyConfiguration(resolverType, parameter, raiseEvent: true);
+    }
+
+    private void ApplyConfiguration(IpResolverType resolverType, string? parameter, bool raiseEvent)
+    {
         if (resolverType == IpResolverType.Custom && string.IsNullOrWhiteSpace(parameter))
         {
             throw new ArgumentException("When using a custom resolver type, a parameter with an IP or host name is required.", nameof(parameter));
@@ -59,7 +74,10 @@ public class ConfigurableIpResolver : IIpAddressResolver
         this._resolverType = resolverType;
         this._parameter = parameter;
 
-        this.ConfigurationChanged?.Invoke(this, EventArgs.Empty);
+        if (raiseEvent)
+        {
+            this.ConfigurationChanged?.Invoke(this, EventArgs.Empty);
+        }
     }
 
     private IIpAddressResolver CreateResolver()

--- a/src/Network/IpAddressResolverFactory.cs
+++ b/src/Network/IpAddressResolverFactory.cs
@@ -25,9 +25,10 @@ public static class IpAddressResolverFactory
     /// <returns>The determined resolver.</returns>
     public static IIpAddressResolver CreateIpResolver(string[] args, (IpResolverType, string?)? configuration, ILoggerFactory loggerFactory)
     {
-        var (resolverType, resolverParameter) = DetermineBestFittingResolver(args, configuration);
+        var (resolver, source) = DetermineBestFittingResolverWithSource(args, configuration);
+        var allowRuntimeReconfiguration = source is not ResolverSource.StartParameter and not ResolverSource.EnvironmentVariable;
 
-        return new ConfigurableIpResolver(resolverType, resolverParameter, loggerFactory);
+        return new ConfigurableIpResolver(resolver.Type, resolver.Parameter, loggerFactory, allowRuntimeReconfiguration);
     }
 
     /// <summary>
@@ -38,10 +39,8 @@ public static class IpAddressResolverFactory
     /// <returns>The resolver type with its parameter.</returns>
     public static (IpResolverType Type, string? Parameter) DetermineBestFittingResolver(string[] args, (IpResolverType Type, string? Parameter)? configuration = default)
     {
-        return DetermineIpResolverByParameters(args)
-            ?? DetermineResolverByEnvironmentVariable()
-            ?? configuration
-            ?? DetermineResolverByEnvironment();
+        var (resolver, _) = DetermineBestFittingResolverWithSource(args, configuration);
+        return resolver;
     }
 
     private static (IpResolverType Type, string? Parameter)? DetermineIpResolverByParameters(string[] args)
@@ -94,4 +93,32 @@ public static class IpAddressResolverFactory
     private static string ExtractIpFromParameter(string parameter) => parameter.Substring(parameter.IndexOf(':') + 1);
 
     private static string? GetParameter(string[] args) => args.FirstOrDefault(a => a.StartsWith(ResolveParameterPrefix, StringComparison.InvariantCultureIgnoreCase));
+
+    private static ((IpResolverType Type, string? Parameter) Resolver, ResolverSource Source) DetermineBestFittingResolverWithSource(string[] args, (IpResolverType Type, string? Parameter)? configuration = default)
+    {
+        if (DetermineIpResolverByParameters(args) is { } byParameters)
+        {
+            return (byParameters, ResolverSource.StartParameter);
+        }
+
+        if (DetermineResolverByEnvironmentVariable() is { } byEnvironmentVariable)
+        {
+            return (byEnvironmentVariable, ResolverSource.EnvironmentVariable);
+        }
+
+        if (configuration is { } byConfiguration)
+        {
+            return (byConfiguration, ResolverSource.Configuration);
+        }
+
+        return (DetermineResolverByEnvironment(), ResolverSource.Environment);
+    }
+
+    private enum ResolverSource
+    {
+        StartParameter,
+        EnvironmentVariable,
+        Configuration,
+        Environment,
+    }
 }

--- a/tests/MUnique.OpenMU.Network.Tests/IpAddressResolverFactoryTests.cs
+++ b/tests/MUnique.OpenMU.Network.Tests/IpAddressResolverFactoryTests.cs
@@ -1,0 +1,89 @@
+﻿// <copyright file="IpAddressResolverFactoryTests.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Network.Tests;
+
+using System.Net;
+using Microsoft.Extensions.Logging.Abstractions;
+
+/// <summary>
+/// Tests for <see cref="IpAddressResolverFactory"/>.
+/// </summary>
+[TestFixture]
+[NonParallelizable]
+public class IpAddressResolverFactoryTests
+{
+    private readonly IPAddress _expectedLoopbackAddress = IPAddress.Parse("127.127.127.127");
+
+    private string? _originalResolveIpEnvironmentVariable;
+    private string? _originalAspNetCoreEnvironmentVariable;
+
+    /// <summary>
+    /// Captures and clears the environment variables which influence resolver determination.
+    /// </summary>
+    [SetUp]
+    public void SetUp()
+    {
+        this._originalResolveIpEnvironmentVariable = Environment.GetEnvironmentVariable("RESOLVE_IP");
+        this._originalAspNetCoreEnvironmentVariable = Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT");
+        Environment.SetEnvironmentVariable("RESOLVE_IP", null);
+        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", null);
+    }
+
+    /// <summary>
+    /// Restores the environment variables which were changed during a test.
+    /// </summary>
+    [TearDown]
+    public void TearDown()
+    {
+        Environment.SetEnvironmentVariable("RESOLVE_IP", this._originalResolveIpEnvironmentVariable);
+        Environment.SetEnvironmentVariable("ASPNETCORE_ENVIRONMENT", this._originalAspNetCoreEnvironmentVariable);
+    }
+
+    /// <summary>
+    /// Tests if runtime reconfiguration is ignored when the resolver was configured by startup parameters.
+    /// </summary>
+    /// <returns>The asynchronous operation.</returns>
+    [Test]
+    public async Task ResolverConfiguredByStartupParameterCannotBeOverriddenAsync()
+    {
+        var resolver = (ConfigurableIpResolver)IpAddressResolverFactory.CreateIpResolver(new[] { "-resolveIP:loopback" }, (IpResolverType.Public, null), new NullLoggerFactory());
+
+        resolver.Configure(IpResolverType.Custom, "1.2.3.4");
+        var resolvedAddress = await resolver.ResolveIPv4Async().ConfigureAwait(false);
+
+        Assert.That(resolvedAddress, Is.EqualTo(this._expectedLoopbackAddress));
+    }
+
+    /// <summary>
+    /// Tests if runtime reconfiguration is ignored when the resolver was configured by environment variable.
+    /// </summary>
+    /// <returns>The asynchronous operation.</returns>
+    [Test]
+    public async Task ResolverConfiguredByEnvironmentVariableCannotBeOverriddenAsync()
+    {
+        Environment.SetEnvironmentVariable("RESOLVE_IP", "loopback");
+        var resolver = (ConfigurableIpResolver)IpAddressResolverFactory.CreateIpResolver(Array.Empty<string>(), (IpResolverType.Public, null), new NullLoggerFactory());
+
+        resolver.Configure(IpResolverType.Custom, "1.2.3.4");
+        var resolvedAddress = await resolver.ResolveIPv4Async().ConfigureAwait(false);
+
+        Assert.That(resolvedAddress, Is.EqualTo(this._expectedLoopbackAddress));
+    }
+
+    /// <summary>
+    /// Tests if runtime reconfiguration still works when the resolver was configured by persisted settings.
+    /// </summary>
+    /// <returns>The asynchronous operation.</returns>
+    [Test]
+    public async Task ResolverConfiguredByPersistedSettingsCanBeOverriddenAsync()
+    {
+        var resolver = (ConfigurableIpResolver)IpAddressResolverFactory.CreateIpResolver(Array.Empty<string>(), (IpResolverType.Loopback, null), new NullLoggerFactory());
+
+        resolver.Configure(IpResolverType.Custom, "1.2.3.4");
+        var resolvedAddress = await resolver.ResolveIPv4Async().ConfigureAwait(false);
+
+        Assert.That(resolvedAddress, Is.EqualTo(IPAddress.Parse("1.2.3.4")));
+    }
+}


### PR DESCRIPTION
## Summary
- preserve documented resolver priority by preventing runtime overrides when `-resolveIP` or `RESOLVE_IP` determined the resolver
- keep admin-panel/system configuration reconfiguration enabled when no higher-priority source is set
- add regression tests for startup parameter, environment variable, and persisted configuration behavior

Fixes #696.

## Testing
- `dotnet test tests/MUnique.OpenMU.Network.Tests/MUnique.OpenMU.Network.Tests.csproj --configuration Release` (Passed: 31, Failed: 0, Skipped: 4)