### PR TITLE
feature: split guaranteed and chance drop groups respecting NumberOfMaximumItemDrops

### DIFF
--- a/src/GameLogic/DefaultDropGenerator.cs
+++ b/src/GameLogic/DefaultDropGenerator.cs
@@ -16,7 +16,7 @@ public class DefaultDropGenerator : IDropGenerator
     /// <summary>
     /// The amount of money which is dropped at least, and added to the gained experience.
     /// </summary>
-    public const int BaseMoneyDrop = 7;
+    public static readonly int BaseMoneyDrop = 7;
 
     private const int DropLevelMaxGap = 12;
     private const int JewelOfChaosMaxMonsterLevel = 66;

--- a/src/GameLogic/DefaultDropGenerator.cs
+++ b/src/GameLogic/DefaultDropGenerator.cs
@@ -85,7 +85,7 @@ public class DefaultDropGenerator : IDropGenerator
             this.PartitionDropGroups(monster.DropItemGroups ?? []);
             this.PartitionDropGroups(character.DropItemGroups ?? [], monster);
             this.PartitionDropGroups(map.DropItemGroups ?? [], monster);
-            this.PartitionDropGroups(await GetQuestItemGroupsAsync(player).ConfigureAwait(false), monster);
+            this.PartitionDropGroups(await GetQuestItemGroupsAsync(player).ConfigureAwait(false) ?? [], monster);
         }
 
         uint money = 0;

--- a/src/GameLogic/DefaultDropGenerator.cs
+++ b/src/GameLogic/DefaultDropGenerator.cs
@@ -16,16 +16,21 @@ public class DefaultDropGenerator : IDropGenerator
     /// <summary>
     /// The amount of money which is dropped at least, and added to the gained experience.
     /// </summary>
-    public static readonly int BaseMoneyDrop = 7;
+    public const int BaseMoneyDrop = 7;
 
-    private static readonly int DropLevelMaxGap = 12;
+    private const int DropLevelMaxGap = 12;
+    private const int JewelOfChaosMaxMonsterLevel = 66;
+    private const int JewelOfChaosGroup = 12;
+    private const int JewelOfChaosNumber = 15;
+    private const int SkillDropChancePercent = 50;
 
     private readonly IRandomizer _randomizer;
 
     /// <summary>
-    /// A re-useable list of drop item groups.
+    /// A re-usable list of drop item groups.
     /// </summary>
-    private readonly List<DropItemGroup> _dropGroups = new(64);
+    private readonly List<DropItemGroup> _chanceDropGroups = new(64);
+    private readonly List<DropItemGroup> _guaranteedDropGroups = new(8);
 
     private readonly AsyncLock _lock = new();
 
@@ -52,7 +57,7 @@ public class DefaultDropGenerator : IDropGenerator
         this._droppableItems = config.Items.Where(i => i.DropsFromMonsters).ToList();
         this._ancientItems = this._droppableItems.Where(
             i => i.PossibleItemSetGroups.Any(
-                o => o.Options?.PossibleOptions.Any(
+                g => g.Options?.PossibleOptions.Any(
                     o => object.Equals(o.OptionType, ItemOptionTypes.AncientOption)) ?? false))
             .ToList();
     }
@@ -68,41 +73,37 @@ public class DefaultDropGenerator : IDropGenerator
         }
 
         using var l = await this._lock.LockAsync();
-        this._dropGroups.Clear();
-        if (monster.DropItemGroups.MaxBy(g => g.Chance) is { Chance: >= 1.0 } alwaysDrops)
+        this._guaranteedDropGroups.Clear();
+        this._chanceDropGroups.Clear();
+
+        if (monster.ObjectKind == NpcObjectKind.Destructible)
         {
-            this._dropGroups.Add(alwaysDrops);
-        }
-        else if (monster.ObjectKind == NpcObjectKind.Destructible)
-        {
-            this._dropGroups.AddRange(monster.DropItemGroups ?? []);
+            this.PartitionDropGroups(monster.DropItemGroups ?? []);
         }
         else
         {
-            this._dropGroups.AddRange(monster.DropItemGroups ?? []);
-            this._dropGroups.AddRange(character.DropItemGroups ?? []);
-            this._dropGroups.AddRange(map.DropItemGroups ?? []);
-            this._dropGroups.AddRange(await GetQuestItemGroupsAsync(player).ConfigureAwait(false) ?? []);
-
-            this._dropGroups.RemoveAll(g => !IsGroupRelevant(monster, g));
-            this._dropGroups.Sort((x, y) => x.Chance.CompareTo(y.Chance));
+            this.PartitionDropGroups(monster.DropItemGroups ?? []);
+            this.PartitionDropGroups(character.DropItemGroups ?? [], monster);
+            this.PartitionDropGroups(map.DropItemGroups ?? [], monster);
+            this.PartitionDropGroups(await GetQuestItemGroupsAsync(player).ConfigureAwait(false), monster);
         }
 
-        var totalChance = this._dropGroups.Sum(g => g.Chance);
         uint money = 0;
         IList<Item>? droppedItems = null;
-        for (int i = 0; i < monster.NumberOfMaximumItemDrops; i++)
+        var remainingDrops = monster.NumberOfMaximumItemDrops;
+
+        // Guaranteed groups, no random selection needed.
+        foreach (var group in this._guaranteedDropGroups)
         {
-            var group = this.SelectRandomGroup(this._dropGroups, totalChance);
-            if (group is null)
+            if (remainingDrops <= 0)
             {
-                continue;
+                break;
             }
 
             var item = this.GenerateItemDropOrMoney(monster, group, gainedExperience, out var droppedMoney);
             if (item is not null)
             {
-                droppedItems ??= new List<Item>(1);
+                droppedItems ??= new List<Item>(monster.NumberOfMaximumItemDrops);
                 droppedItems.Add(item);
             }
 
@@ -110,9 +111,43 @@ public class DefaultDropGenerator : IDropGenerator
             {
                 money += droppedMoney.Value;
             }
+
+            remainingDrops--;
         }
 
-        this._dropGroups.Clear();
+        // Chance based groups with random selection
+        if (remainingDrops > 0 && this._chanceDropGroups.Count > 0)
+        {
+            double totalChance = 0;
+            foreach (var group in this._chanceDropGroups)
+            {
+                totalChance += group.Chance;
+            }
+
+            for (int i = 0; i < remainingDrops; i++)
+            {
+                var group = this.SelectRandomGroup(this._chanceDropGroups, totalChance);
+                if (group is null)
+                {
+                    continue;
+                }
+
+                var item = this.GenerateItemDropOrMoney(monster, group, gainedExperience, out var droppedMoney);
+                if (item is not null)
+                {
+                    droppedItems ??= new List<Item>(monster.NumberOfMaximumItemDrops);
+                    droppedItems.Add(item);
+                }
+
+                if (droppedMoney is not null)
+                {
+                    money += droppedMoney.Value;
+                }
+            }
+        }
+
+        this._guaranteedDropGroups.Clear();
+        this._chanceDropGroups.Clear();
         return (droppedItems ?? Enumerable.Empty<Item>(), money > 0 ? money : null);
     }
 
@@ -185,7 +220,7 @@ public class DefaultDropGenerator : IDropGenerator
 
         if (item.CanHaveSkill())
         {
-            item.HasSkill = this._randomizer.NextRandomBool(50);
+            item.HasSkill = this._randomizer.NextRandomBool(SkillDropChancePercent);
         }
     }
 
@@ -280,6 +315,26 @@ public class DefaultDropGenerator : IDropGenerator
         return true;
     }
 
+    private void PartitionDropGroups(IEnumerable<DropItemGroup> groups, MonsterDefinition? monster = null)
+    {
+        foreach (var group in groups)
+        {
+            if (monster is not null && !IsGroupRelevant(monster, group))
+            {
+                continue;
+            }
+
+            if (group.Chance >= 1.0)
+            {
+                this._guaranteedDropGroups.Add(group);
+            }
+            else
+            {
+                this._chanceDropGroups.Add(group);
+            }
+        }
+    }
+
     private Item? GenerateItemDrop(DropItemGroup selectedGroup, ICollection<ItemDefinition> possibleItems)
     {
         var item = selectedGroup.ItemType switch
@@ -333,9 +388,13 @@ public class DefaultDropGenerator : IDropGenerator
                 var itemOptionLink = new ItemOptionLink
                 {
                     ItemOption = newOption,
-                    Level = newOption?.LevelDependentOptions.Select(ldo => ldo.Level)
+                    Level = newOption.LevelDependentOptions
+                        .Select(ldo => ldo.Level)
                         .Concat(newOption.LevelDependentOptions.Count > 0 ? [1] : []) // For base def/dmg opts level 1 is not an ItemOptionOfLevel entry
-                        .Distinct().Where(l => l <= this._maxItemOptionLevelDrop).SelectRandom() ?? 0,
+                        .Distinct()
+                        .Where(l => l <= this._maxItemOptionLevelDrop)
+                        .DefaultIfEmpty(0)
+                        .SelectRandom(),
                 };
                 item.ItemOptions.Add(itemOptionLink);
             }
@@ -361,7 +420,9 @@ public class DefaultDropGenerator : IDropGenerator
 
     private void ApplyRandomAncientOption(Item item)
     {
-        var ancientSet = item.Definition?.PossibleItemSetGroups.Where(g => g!.Options?.PossibleOptions.Any(o => object.Equals(o.OptionType, ItemOptionTypes.AncientOption)) ?? false).SelectRandom(this._randomizer);
+        var ancientSet = item.Definition?.PossibleItemSetGroups
+            .Where(g => g!.Options?.PossibleOptions.Any(o => object.Equals(o.OptionType, ItemOptionTypes.AncientOption)) ?? false)
+            .SelectRandom(this._randomizer);
         if (ancientSet is null)
         {
             return;
@@ -383,12 +444,14 @@ public class DefaultDropGenerator : IDropGenerator
         var possibleItemOptions = item.Definition!.PossibleItemOptions;
         var excellentOptions = possibleItemOptions.FirstOrDefault(
             o => o.PossibleOptions.Any(p => object.Equals(p.OptionType, ItemOptionTypes.Excellent)));
+
         if (excellentOptions is null)
         {
             return;
         }
 
         var existingOptionCount = item.ItemOptions.Count(o => object.Equals(o.ItemOption?.OptionType, ItemOptionTypes.Excellent));
+
         for (int i = existingOptionCount; i < excellentOptions.MaximumOptionsPerItem; i++)
         {
             if (i == 0)
@@ -444,10 +507,10 @@ public class DefaultDropGenerator : IDropGenerator
                 {
                     filteredPossibleItems = [.. selectedGroup.PossibleItems.Where(it => it.DropLevel <= monsterLevel)];
 
-                    if (monsterLevel > 66)
+                    if (monsterLevel > JewelOfChaosMaxMonsterLevel)
                     {
                         // Jewel of Chaos doesn't drop after a certain monster level
-                        filteredPossibleItems.RemoveAll(it => it.Group == 12 && it.Number == 15);
+                        filteredPossibleItems.RemoveAll(it => it.Group == JewelOfChaosGroup && it.Number == JewelOfChaosNumber);
                     }
                 }
                 else

--- a/src/GameLogic/DefaultDropGenerator.cs
+++ b/src/GameLogic/DefaultDropGenerator.cs
@@ -30,7 +30,7 @@ public class DefaultDropGenerator : IDropGenerator
     /// A re-usable list of drop item groups.
     /// </summary>
     private readonly List<DropItemGroup> _chanceDropGroups = new(64);
-    private readonly List<DropItemGroup> _guaranteedDropGroups = new(8);
+    private readonly List<DropItemGroup> _guaranteedDropGroups = new(16);
 
     private readonly AsyncLock _lock = new();
 


### PR DESCRIPTION
Updated guaranteed drop groups not being processed. Groups with Chance >= 1.0 are now always dropped without going through random selection. Previously only the single highest chance group was considered via MaxBy.

Split _dropGroups into _guaranteedDropGroups and _chanceDropGroups. Removes the need for runtime partitioning, filtering and sorting on every drop call. Guaranteed and chance-based groups are separated at collection time via PartitionDropGroups, which also inlines the relevance check eliminating the RemoveAll pass.

Replace magic numbers with named constants.

Fix droppedItems initial capacity, changed from new List<Item>(1) to new List<Item>(monster.NumberOfMaximumItemDrops) to avoid unnecessary list resizing.