### PR TITLE
Fix player position desync during movement

### DIFF
--- a/src/GameLogic/LocateableExtensions.cs
+++ b/src/GameLogic/LocateableExtensions.cs
@@ -163,6 +163,7 @@ public static class LocateableExtensions
             return true;
         }
 
-        return map.Terrain.SafezoneMap[obj.Position.X, obj.Position.Y];
+        var position = obj.Position;
+        return map.Terrain.SafezoneMap[position.X, position.Y];
     }
 }

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.Threading;
 using MUnique.OpenMU.AttributeSystem;
 using MUnique.OpenMU.DataModel.Attributes;
+using MUnique.OpenMU.DataModel.Configuration.Items;
 using MUnique.OpenMU.GameLogic.Attributes;
 using MUnique.OpenMU.GameLogic.GuildWar;
 using MUnique.OpenMU.GameLogic.MiniGames;
@@ -41,6 +42,8 @@ using Nito.AsyncEx;
 /// </summary>
 public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacker, ITrader, IPartyMember, IRotatable, IHasBucketInformation, ISupportWalk, IMovable, ILoggerOwner<Player>
 {
+    private const short BlowOfDestructionEffectNumber = 0x56;
+
     private static readonly MagicEffectDefinition GMEffect = new GMMagicEffectDefinition
     {
         InformObservers = true,
@@ -52,7 +55,7 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
     private readonly AsyncLock _moveLock = new();
     private readonly AsyncLock _experienceLock = new();
 
-    private readonly Walker _walker;
+    private readonly ProjectedWalker _projectedWalker;
 
     private readonly AppearanceDataAdapter _appearanceData;
 
@@ -89,7 +92,10 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         this.GameContext = gameContext;
         this.Logger = gameContext.LoggerFactory.CreateLogger<Player>();
         this.PersistenceContext = this.GameContext.PersistenceContextProvider.CreateNewPlayerContext(gameContext.Configuration);
-        this._walker = new Walker(this, this.GetStepDelay);
+        this._projectedWalker = new ProjectedWalker(
+            this.GetStoredPosition,
+            this.SetStoredPosition,
+            this.GetStepDuration);
 
         this.MagicEffectList = new MagicEffectsList(this);
         this._appearanceData = new AppearanceDataAdapter(this);
@@ -145,13 +151,13 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
     public bool CanWalkOnSafezone => true;
 
     /// <inheritdoc />
-    public bool IsWalking => this._walker.CurrentTarget != default;
+    public bool IsWalking => this._projectedWalker.IsWalking;
 
     /// <inheritdoc />
-    public TimeSpan StepDelay => this.GetStepDelay();
+    public TimeSpan StepDelay => this.GetStepDuration(null);
 
     /// <inheritdoc />
-    public Point WalkTarget => this._walker.CurrentTarget;
+    public Point WalkTarget => this._projectedWalker.CurrentTarget;
 
     /// <summary>
     /// Gets a value indicating whether this instance is invisible to other players.
@@ -380,17 +386,9 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
     /// <inheritdoc/>
     public Point Position
     {
-        get => new(this.SelectedCharacter?.PositionX ?? 0, this.SelectedCharacter?.PositionY ?? 0);
+        get => this._projectedWalker.Position;
 
-        set
-        {
-            if (this.Position != value && this.SelectedCharacter is { } character)
-            {
-                character.PositionX = value.X;
-                character.PositionY = value.Y;
-                this.GameContext.PlugInManager?.GetPlugInPoint<IAttackableMovedPlugIn>()?.AttackableMoved(this);
-            }
-        }
+        set => this._projectedWalker.Position = value;
     }
 
     /// <summary>
@@ -816,7 +814,7 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         {
             await (this.SkillCancelTokenSource?.CancelAsync() ?? Task.CompletedTask).ConfigureAwait(false);
 
-            await this._walker.StopAsync().ConfigureAwait(false);
+            this.StopProjectedWalk();
 
             var previous = this.Position;
             this.Position = target;
@@ -866,7 +864,7 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         {
             await (this.SkillCancelTokenSource?.CancelAsync() ?? Task.CompletedTask).ConfigureAwait(false);
 
-            await this._walker.StopAsync().ConfigureAwait(false);
+            this.StopProjectedWalk();
 
             await this.ForEachWorldObserverAsync<IObjectsOutOfScopePlugIn>(p => p.ObjectsOutOfScopeAsync(this.GetAsEnumerable()), false).ConfigureAwait(false);
 
@@ -1331,7 +1329,7 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
     public async ValueTask MoveAsync(Point target)
     {
         this.Logger.LogDebug("MoveAsync: Player is moving to {0}", target);
-        await this._walker.StopAsync().ConfigureAwait(false);
+        this.StopProjectedWalk();
         await this.CurrentMap!.MoveAsync(this, target, this._moveLock, MoveType.Instant).ConfigureAwait(false);
         this.Logger.LogDebug("MoveAsync: Observer Count: {0}", this.Observers.Count);
     }
@@ -1364,7 +1362,7 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
             return;
         }
 
-        await this._walker.StopAsync().ConfigureAwait(false);
+        this.StopProjectedWalk();
 
         var startPoint = steps.Span[0].From;
         var currentPosition = this.Position;
@@ -1379,20 +1377,19 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
             return;
         }
 
-        var canWalkToTarget = currentMap.Terrain.WalkMap[target.X, target.Y];
-        if (canWalkToTarget)
+        if (ProjectedWalker.TryValidateWalkSteps(currentMap.Terrain, steps, target, out var invalidPoint))
         {
             this.Logger.LogDebug("WalkToAsync: Player is walking to {0}", target);
 
-            var token = await this._walker.InitializeWalkToAsync(target, steps).ConfigureAwait(false);
+            this.Position = startPoint;
+            this.InitializeProjectedWalk(target, steps);
             await currentMap.MoveAsync(this, target, this._moveLock, MoveType.Walk).ConfigureAwait(false);
-            await this._walker.StartWalkAsync(token).ConfigureAwait(false);
 
             this.Logger.LogDebug("WalkToAsync: Observer Count: {0}", this.Observers.Count);
         }
         else
         {
-            this.Logger.LogWarning("WalkToAsync: Player requested to walk to {0}, but it's not an allowed target", target);
+            this.Logger.LogWarning("WalkToAsync: Player requested an invalid walk to {0}. Invalid point: {1}", target, invalidPoint);
 
             // We'll send the current coordinates back to the client, so it doesn't appear in the invalid coordinates.
             await this.InvokeViewPlugInAsync<IObjectMovedPlugIn>(p => p.ObjectMovedAsync(this, MoveType.Instant)).ConfigureAwait(false);
@@ -1400,13 +1397,49 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
     }
 
     /// <inheritdoc />
-    public ValueTask<int> GetDirectionsAsync(Memory<Direction> directions) => this._walker.GetDirectionsAsync(directions);
+    public ValueTask<int> GetDirectionsAsync(Memory<Direction> directions) => this._projectedWalker.GetDirectionsAsync(directions);
 
     /// <inheritdoc />
-    public ValueTask<int> GetStepsAsync(Memory<WalkingStep> steps) => this._walker.GetStepsAsync(steps);
+    public ValueTask<int> GetStepsAsync(Memory<WalkingStep> steps) => this._projectedWalker.GetStepsAsync(steps);
 
     /// <inheritdoc />
-    public ValueTask StopWalkingAsync() => this._walker.StopAsync();
+    public ValueTask StopWalkingAsync()
+    {
+        this.StopProjectedWalk();
+        return ValueTask.CompletedTask;
+    }
+
+    private void InitializeProjectedWalk(Point target, Memory<WalkingStep> steps)
+    {
+        this._projectedWalker.Initialize(target, steps);
+    }
+
+    private void StopProjectedWalk()
+    {
+        this._projectedWalker.Stop();
+    }
+
+    private Point GetStoredPosition()
+    {
+        return new(this.SelectedCharacter?.PositionX ?? 0, this.SelectedCharacter?.PositionY ?? 0);
+    }
+
+    private bool SetStoredPosition(Point position)
+    {
+        if (this.SelectedCharacter is not { } character)
+        {
+            return false;
+        }
+
+        if (character.PositionX == position.X && character.PositionY == position.Y)
+        {
+            return false;
+        }
+
+        character.PositionX = position.X;
+        character.PositionY = position.Y;
+        return true;
+    }
 
     /// <summary>
     /// Regenerates the attributes specified in <see cref="Stats.IntervalRegenerationAttributes"/>.
@@ -1420,6 +1453,8 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
             {
                 return;
             }
+
+            attributes.SetStatAttribute(Stats.IsInSafezone, this.IsAtSafezone() ? 1.0f : 0.0f);
 
             foreach (var r in Stats.IntervalRegenerationAttributes.Where(r =>
                          attributes[r.RegenerationMultiplier] > 0 || attributes[r.AbsoluteAttribute] > 0))
@@ -1884,7 +1919,7 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         await this.RemoveFromCurrentMapAsync().ConfigureAwait(false);
         await this._observerToWorldViewAdapter.ClearObservingObjectsListAsync().ConfigureAwait(false);
         this._observerToWorldViewAdapter.Dispose();
-        this._walker.Dispose();
+        this.StopProjectedWalk();
         await this.MagicEffectList.DisposeAsync().ConfigureAwait(false);
         this._respawnAfterDeathCts?.Dispose();
         (this._viewPlugIns as IDisposable)?.Dispose();
@@ -1962,7 +1997,7 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
 
         this.IsAlive = false;
         this.IsTeleporting = false;
-        await this._walker.StopAsync().ConfigureAwait(false);
+        this.StopProjectedWalk();
         await this._observerToWorldViewAdapter.ClearObservingObjectsListAsync().ConfigureAwait(false);
         if (this.Summon?.Item1 is { IsAlive: true } summon)
         {
@@ -2110,16 +2145,95 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
     /// Gets the step delay depending on the equipped items.
     /// </summary>
     /// <returns>The current step delay, depending on equipped items.</returns>
-    private TimeSpan GetStepDelay()
+    private TimeSpan GetStepDuration(WalkingStep? step)
     {
-        if (this.Inventory?.EquippedItems.Any(item => item.Definition?.ItemSlot?.ItemSlots.Contains(7) ?? false) ?? false)
+        const double referenceFrameTimeMilliseconds = 40.0;
+        const double terrainScale = 100.0;
+
+        var speed = this.GetClientMovementSpeed(step?.From);
+        var tileDistance = step is { } walkingStep ? walkingStep.From.EuclideanDistanceTo(walkingStep.To) : 1.0;
+        var movementMilliseconds = terrainScale * Math.Max(1.0, tileDistance) / speed * referenceFrameTimeMilliseconds;
+
+        return TimeSpan.FromMilliseconds(movementMilliseconds);
+    }
+
+    private double GetClientMovementSpeed(Point? position = null)
+    {
+        const double walkSpeed = 12.0;
+        const double runSpeed = 15.0;
+        const double fastWingSpeed = 16.0;
+        const double horseOrFenrirRunSpeed = 17.0;
+        const double excellentFenrirRunSpeed = 19.0;
+
+        double speed;
+        if (this.IsInClientSafezone(position))
         {
-            // Wings
-            return TimeSpan.FromMilliseconds(300);
+            speed = walkSpeed;
+        }
+        else
+        {
+            var pet = this.Inventory?.GetItem(InventoryConstants.PetSlot);
+            if (IsItem(pet, 13, 37))
+            {
+                speed = HasFenrirMovementOption(pet) ? excellentFenrirRunSpeed : horseOrFenrirRunSpeed;
+            }
+            else if (IsItem(pet, 13, 4))
+            {
+                speed = horseOrFenrirRunSpeed;
+            }
+            else
+            {
+                var wings = this.Inventory?.GetItem(InventoryConstants.WingsSlot);
+                speed = HasEquippedWings(wings) || IsItem(pet, 13, 2) || IsItem(pet, 13, 3)
+                    ? IsFastWing(wings) ? fastWingSpeed : runSpeed
+                    : runSpeed;
+            }
         }
 
-        // TODO: Consider pets etc.
-        return TimeSpan.FromMilliseconds(500);
+        if (this.Attributes?[Stats.IsIced] > 0)
+        {
+            speed *= 0.5;
+        }
+        else if (this.MagicEffectList.ActiveEffects.ContainsKey(BlowOfDestructionEffectNumber))
+        {
+            speed *= 0.33;
+        }
+
+        return speed;
+    }
+
+    private bool IsInClientSafezone(Point? position = null)
+    {
+        var checkedPosition = position ?? this.Position;
+        return this.CurrentMap?.Terrain.SafezoneMap[checkedPosition.X, checkedPosition.Y] ?? false;
+    }
+
+    private static bool HasEquippedWings(Item? item)
+    {
+        return item is { Durability: > 0.0 }
+               && item.ItemSlot == InventoryConstants.WingsSlot;
+    }
+
+    private static bool IsFastWing(Item? item)
+    {
+        return IsItem(item, 12, 5)  // Wings of Dragon
+               || IsItem(item, 12, 36); // Wing of Storm
+    }
+
+    private static bool IsItem(Item? item, short group, short number)
+    {
+        return item is { Durability: > 0.0 }
+               && item.Definition is { } definition
+               && definition.Group == group
+               && definition.Number == number;
+    }
+
+    private static bool HasFenrirMovementOption(Item? item)
+    {
+        return item?.ItemOptions.Any(option =>
+            option.ItemOption?.OptionType == ItemOptionTypes.BlueFenrir
+            || option.ItemOption?.OptionType == ItemOptionTypes.BlackFenrir
+            || option.ItemOption?.OptionType == ItemOptionTypes.GoldFenrir) ?? false;
     }
 
     private async ValueTask<ExitGate> GetSpawnGateOfCurrentMapAsync()
@@ -2254,7 +2368,7 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
             return;
         }
 
-        await this._walker.StopAsync().ConfigureAwait(false);
+        this.StopProjectedWalk();
         this.IsAlive = false;
         this._respawnAfterDeathCts = new CancellationTokenSource();
         await this.ForEachWorldObserverAsync<IObjectGotKilledPlugIn>(p => p.ObjectGotKilledAsync(this, killer), true).ConfigureAwait(false);

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -713,6 +713,11 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
             throw new InvalidOperationException("AttributeSystem not set.");
         }
 
+        if (this.IsAttackBlockedBySafezone(attacker))
+        {
+            return null;
+        }
+
         if (!this.GameContext.PvpEnabled && this.CurrentMap?.Definition.BattleZone == null &&
             this.CurrentMiniGame?.AllowPlayerKilling is false)
         {
@@ -1439,6 +1444,17 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         character.PositionX = position.X;
         character.PositionY = position.Y;
         return true;
+    }
+
+    private bool IsAttackBlockedBySafezone(IAttacker attacker)
+    {
+        if (this.IsAtSafezone())
+        {
+            return true;
+        }
+
+        var attackerPlayer = attacker as Player ?? (attacker as IPlayerSurrogate)?.Owner;
+        return attackerPlayer?.IsAtSafezone() is true;
     }
 
     /// <summary>

--- a/src/GameLogic/ProjectedWalker.cs
+++ b/src/GameLogic/ProjectedWalker.cs
@@ -148,9 +148,8 @@ internal sealed class ProjectedWalker
         var count = 0;
         lock (this._walkStateLock)
         {
-            for (var index = this._currentWalkStepCount - 1; index >= 0; index--)
+            foreach (var step in this._currentWalkSteps[..this._currentWalkStepCount])
             {
-                var step = this._currentWalkSteps[index];
                 directions.Span[count] = step.Direction;
                 count++;
             }
@@ -170,9 +169,8 @@ internal sealed class ProjectedWalker
         var count = 0;
         lock (this._walkStateLock)
         {
-            for (var index = this._currentWalkStepCount - 1; index >= 0; index--)
+            foreach (var step in this._currentWalkSteps[..this._currentWalkStepCount])
             {
-                var step = this._currentWalkSteps[index];
                 steps.Span[count] = step;
                 count++;
             }

--- a/src/GameLogic/ProjectedWalker.cs
+++ b/src/GameLogic/ProjectedWalker.cs
@@ -1,0 +1,270 @@
+// <copyright file="ProjectedWalker.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic;
+
+using System;
+using System.Diagnostics;
+using MUnique.OpenMU.Pathfinding;
+
+/// <summary>
+/// Projects walking state based on the elapsed time since a walk started.
+/// </summary>
+internal sealed class ProjectedWalker
+{
+    private readonly object _walkStateLock = new();
+    private readonly WalkingStep[] _currentWalkSteps = new WalkingStep[16];
+    private readonly TimeSpan[] _currentWalkStepEndTimes = new TimeSpan[16];
+    private readonly Func<Point> _getStoredPosition;
+    private readonly Func<Point, bool> _setStoredPosition;
+    private readonly Func<WalkingStep?, TimeSpan> _getStepDuration;
+    private int _currentWalkStepCount;
+    private long _walkStartedTimestamp;
+    private Point _walkTarget;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ProjectedWalker"/> class.
+    /// </summary>
+    /// <param name="getStoredPosition">Gets the persisted position of the walk supporter.</param>
+    /// <param name="setStoredPosition">Sets the persisted position of the walk supporter and returns if it changed.</param>
+    /// <param name="getStepDuration">Gets the duration of the specified walking step.</param>
+    public ProjectedWalker(
+        Func<Point> getStoredPosition,
+        Func<Point, bool> setStoredPosition,
+        Func<WalkingStep?, TimeSpan> getStepDuration)
+    {
+        this._getStoredPosition = getStoredPosition;
+        this._setStoredPosition = setStoredPosition;
+        this._getStepDuration = getStepDuration;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether a walk is currently projected.
+    /// </summary>
+    public bool IsWalking
+    {
+        get
+        {
+            this.RefreshStoredPosition();
+            lock (this._walkStateLock)
+            {
+                return this._currentWalkStepCount > 0;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets the current walk target coordinate.
+    /// </summary>
+    public Point CurrentTarget
+    {
+        get
+        {
+            this.RefreshStoredPosition();
+            lock (this._walkStateLock)
+            {
+                return this._walkTarget;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the projected position.
+    /// </summary>
+    public Point Position
+    {
+        get
+        {
+            this.RefreshStoredPosition();
+            lock (this._walkStateLock)
+            {
+                return this.GetProjectedPositionNoLock(out _);
+            }
+        }
+
+        set
+        {
+            lock (this._walkStateLock)
+            {
+                this.ClearNoLock();
+                this._setStoredPosition(value);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Initializes a projected walk to the specified target.
+    /// </summary>
+    /// <param name="target">The target coordinate.</param>
+    /// <param name="steps">The walk steps.</param>
+    public void Initialize(Point target, Memory<WalkingStep> steps)
+    {
+        if (steps.Length > this._currentWalkSteps.Length)
+        {
+            throw new ArgumentException("Maximum number of steps (16) exceeded.", nameof(steps));
+        }
+
+        lock (this._walkStateLock)
+        {
+            var elapsed = TimeSpan.Zero;
+            this.ClearNoLock();
+
+            for (var i = 0; i < steps.Length; i++)
+            {
+                var step = steps.Span[i];
+                this._currentWalkSteps[i] = step;
+                elapsed += this._getStepDuration(step);
+                this._currentWalkStepEndTimes[i] = elapsed;
+            }
+
+            this._walkTarget = target;
+            this._walkStartedTimestamp = Stopwatch.GetTimestamp();
+            this._currentWalkStepCount = steps.Length;
+        }
+    }
+
+    /// <summary>
+    /// Stops the projected walk and persists the current projected position.
+    /// </summary>
+    public void Stop()
+    {
+        lock (this._walkStateLock)
+        {
+            var currentPosition = this.GetProjectedPositionNoLock(out _);
+            this.ClearNoLock();
+            this._setStoredPosition(currentPosition);
+        }
+    }
+
+    /// <summary>
+    /// Gets the directions of the steps which are about to happen next by writing them into the given span.
+    /// </summary>
+    /// <param name="directions">The directions.</param>
+    /// <returns>The number of written directions.</returns>
+    public ValueTask<int> GetDirectionsAsync(Memory<Direction> directions)
+    {
+        this.RefreshStoredPosition();
+        var count = 0;
+        lock (this._walkStateLock)
+        {
+            for (var index = this._currentWalkStepCount - 1; index >= 0; index--)
+            {
+                var step = this._currentWalkSteps[index];
+                directions.Span[count] = step.Direction;
+                count++;
+            }
+        }
+
+        return ValueTask.FromResult(count);
+    }
+
+    /// <summary>
+    /// Gets the steps which are about to happen next by writing them into the given span.
+    /// </summary>
+    /// <param name="steps">The steps.</param>
+    /// <returns>The number of written steps.</returns>
+    public ValueTask<int> GetStepsAsync(Memory<WalkingStep> steps)
+    {
+        this.RefreshStoredPosition();
+        var count = 0;
+        lock (this._walkStateLock)
+        {
+            for (var index = this._currentWalkStepCount - 1; index >= 0; index--)
+            {
+                var step = this._currentWalkSteps[index];
+                steps.Span[count] = step;
+                count++;
+            }
+        }
+
+        return ValueTask.FromResult(count);
+    }
+
+    /// <summary>
+    /// Validates that the specified steps represent a coherent walk over walkable terrain.
+    /// </summary>
+    /// <param name="terrain">The terrain.</param>
+    /// <param name="steps">The steps.</param>
+    /// <param name="target">The expected target.</param>
+    /// <param name="invalidPoint">The invalid point.</param>
+    /// <returns><c>true</c>, if the steps are valid; otherwise, <c>false</c>.</returns>
+    public static bool TryValidateWalkSteps(GameMapTerrain terrain, Memory<WalkingStep> steps, Point target, out Point invalidPoint)
+    {
+        var span = steps.Span;
+        var expectedFrom = span[0].From;
+        invalidPoint = expectedFrom;
+
+        if (!terrain.WalkMap[expectedFrom.X, expectedFrom.Y])
+        {
+            return false;
+        }
+
+        foreach (var step in span)
+        {
+            if (step.From != expectedFrom || step.Direction == Direction.Undefined)
+            {
+                invalidPoint = step.From;
+                return false;
+            }
+
+            var calculatedTarget = step.From.CalculateTargetPoint(step.Direction);
+            if (step.To != calculatedTarget || !terrain.WalkMap[step.To.X, step.To.Y])
+            {
+                invalidPoint = step.To;
+                return false;
+            }
+
+            expectedFrom = step.To;
+        }
+
+        invalidPoint = expectedFrom;
+        return expectedFrom == target;
+    }
+
+    private void RefreshStoredPosition()
+    {
+        lock (this._walkStateLock)
+        {
+            if (this._currentWalkStepCount == 0)
+            {
+                return;
+            }
+
+            var currentPosition = this.GetProjectedPositionNoLock(out var completed);
+            if (completed)
+            {
+                this.ClearNoLock();
+                this._setStoredPosition(currentPosition);
+            }
+        }
+    }
+
+    private Point GetProjectedPositionNoLock(out bool completed)
+    {
+        completed = false;
+        if (this._currentWalkStepCount == 0)
+        {
+            return this._getStoredPosition();
+        }
+
+        var elapsed = Stopwatch.GetElapsedTime(this._walkStartedTimestamp);
+        for (var i = 0; i < this._currentWalkStepCount; i++)
+        {
+            if (elapsed < this._currentWalkStepEndTimes[i])
+            {
+                return this._currentWalkSteps[i].From;
+            }
+        }
+
+        completed = true;
+        return this._walkTarget;
+    }
+
+    private void ClearNoLock()
+    {
+        this._currentWalkStepCount = 0;
+        this._walkStartedTimestamp = 0;
+        this._walkTarget = default;
+    }
+}

--- a/src/GameServer/RemoteView/World/ObjectMovedPlugIn.cs
+++ b/src/GameServer/RemoteView/World/ObjectMovedPlugIn.cs
@@ -40,7 +40,7 @@ public class ObjectMovedPlugIn : IObjectMovedPlugIn
     /// Gets or sets a value indicating whether the directions provided by <see cref="ISupportWalk.GetDirectionsAsync"/> should be send when an object moved.
     /// This is usually not required, because the game client calculates a proper path anyway and doesn't use the suggested path.
     /// </summary>
-    public bool SendWalkDirections { get; set; } = true;
+    public bool SendWalkDirections { get; set; }
 
     /// <inheritdoc/>
     public async ValueTask ObjectMovedAsync(ILocateable obj, MoveType type)
@@ -95,7 +95,7 @@ public class ObjectMovedPlugIn : IObjectMovedPlugIn
     {
         int Write()
         {
-            var stepsSize = steps.Length == 0 ? 1 : (steps.Length / 2) + 2;
+            var stepsSize = stepsLength == 0 ? 0 : (steps.Length / 2) + 2;
             var size = ObjectWalkedRef.GetRequiredSize(stepsSize);
             var span = connection.Output.GetSpan(size)[..size];
 

--- a/src/GameServer/RemoteView/World/ObjectMovedPlugInExtended.cs
+++ b/src/GameServer/RemoteView/World/ObjectMovedPlugInExtended.cs
@@ -40,7 +40,7 @@ public class ObjectMovedPlugInExtended : ObjectMovedPlugIn
     {
         int Write()
         {
-            var stepsSize = steps.Length == 0 ? 1 : (steps.Length / 2) + 2;
+            var stepsSize = stepsLength == 0 ? 0 : (steps.Length / 2) + 2;
             var size = ObjectWalkedExtended.GetRequiredSize(stepsSize);
             var span = connection.Output.GetSpan(size)[..size];
 

--- a/src/Persistence/Initialization/Skills/BlowOfDestructionEffectInitializer.cs
+++ b/src/Persistence/Initialization/Skills/BlowOfDestructionEffectInitializer.cs
@@ -1,0 +1,38 @@
+// <copyright file="BlowOfDestructionEffectInitializer.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Persistence.Initialization.Skills;
+
+using MUnique.OpenMU.DataModel.Attributes;
+using MUnique.OpenMU.DataModel.Configuration;
+
+/// <summary>
+/// Initializer for the blow of destruction effect which results from the strike of destruction skill.
+/// </summary>
+public class BlowOfDestructionEffectInitializer : InitializerBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BlowOfDestructionEffectInitializer"/> class.
+    /// </summary>
+    /// <param name="context">The context.</param>
+    /// <param name="gameConfiguration">The game configuration.</param>
+    public BlowOfDestructionEffectInitializer(IContext context, GameConfiguration gameConfiguration)
+        : base(context, gameConfiguration)
+    {
+    }
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        var magicEffect = this.Context.CreateNew<MagicEffectDefinition>();
+        this.GameConfiguration.MagicEffects.Add(magicEffect);
+        magicEffect.Number = (byte)MagicEffectNumber.BlowOfDestruction;
+        magicEffect.Name = "Blow of Destruction Effect (Strike of Destruction)";
+        magicEffect.InformObservers = true;
+        magicEffect.SendDuration = true;
+        magicEffect.StopByDeath = true;
+        magicEffect.Duration = this.Context.CreateNew<PowerUpDefinitionValue>();
+        magicEffect.Duration.ConstantValue.Value = (float)TimeSpan.FromSeconds(10).TotalSeconds;
+    }
+}

--- a/src/Persistence/Initialization/Skills/MagicEffectNumber.cs
+++ b/src/Persistence/Initialization/Skills/MagicEffectNumber.cs
@@ -297,6 +297,11 @@ internal enum MagicEffectNumber : short
     WizEnhance = 0x52,
 
     /// <summary>
+    /// The blow of destruction effect.
+    /// </summary>
+    BlowOfDestruction = 0x56,
+
+    /// <summary>
     /// The ignore defense effect of the rage fighter.
     /// </summary>
     IgnoreDefense = 129,

--- a/src/Persistence/Initialization/VersionSeasonSix/SkillsInitializer.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/SkillsInitializer.cs
@@ -71,6 +71,7 @@ internal class SkillsInitializer : SkillsInitializerBase
         { SkillNumber.Weakness, MagicEffectNumber.WeaknessSummoner },
         { SkillNumber.Innovation, MagicEffectNumber.Innovation },
         { SkillNumber.DamageReflection, MagicEffectNumber.Reflection },
+        { SkillNumber.StrikeofDestruction, MagicEffectNumber.BlowOfDestruction },
         { SkillNumber.BeastUppercut, MagicEffectNumber.DefenseReductionBeastUppercut },
         { SkillNumber.PhoenixShot, MagicEffectNumber.DecreaseBlock },
         { SkillNumber.Explosion223, MagicEffectNumber.Explosion },
@@ -688,6 +689,7 @@ internal class SkillsInitializer : SkillsInitializerBase
         new WeaknessSummonerEffectInitializer(this.Context, this.GameConfiguration).Initialize();
         new InnovationEffectInitializer(this.Context, this.GameConfiguration).Initialize();
         new ReflectionEffectInitializer(this.Context, this.GameConfiguration).Initialize();
+        new BlowOfDestructionEffectInitializer(this.Context, this.GameConfiguration).Initialize();
         new DefenseReductionBeastUppercutEffectInitializer(this.Context, this.GameConfiguration).Initialize();
         new DecreaseBlockEffectInitializer(this.Context, this.GameConfiguration).Initialize();
         new ExplosionEffectInitializer(this.Context, this.GameConfiguration).Initialize();

--- a/tests/MUnique.OpenMU.Tests/CharacterMoveTest.cs
+++ b/tests/MUnique.OpenMU.Tests/CharacterMoveTest.cs
@@ -42,7 +42,6 @@ public class CharacterMoveTest
         Assert.That(count, Is.EqualTo(4));
 
         steps = steps.Slice(0, count);
-        steps.Span.Reverse();
         Assert.That(steps.Span[0].From, Is.EqualTo(StartPoint));
         Assert.That(steps.Span[steps.Length - 1].To, Is.EqualTo(EndPoint));
         for (var index = 0; index < steps.Span.Length; index++)


### PR DESCRIPTION
The current Walker implementation is not aligned to client-side player movement. It is based on flaky task delays, uses wrong speeds, and does not account for many parameters that client takes into account when calculating movement speed (safezones, boots, different wings, pets, mounts, diagonal tiles, skill effects such as ice that slows movement, etc). As a result, the server frequently thinks a player was at an older or newer position than the client, rejects valid walk requests, and sends forced move corrections back, causing a flaky movement experience overall. 

Instead of updating player position from a background task with a fixed 300ms/500ms step delay, this PR calculates the player's current position on demand from the active walk path and elapsed movement time. Step duration is calculated per step using client-like movement speed rules, including safezone walking, wings, pets, Fenrir, and diagonal tile distance. When a walk completes or is interrupted, the projected position is persisted back to the stored character position.

Additionally, this PR fixes some issues with attacks involving safe zones, and stops sending movement paths to observers by default (as MuMain does not use them anymore).