### PR TITLE
Fix player position desync during movement

### DIFF
--- a/src/GameLogic/AttackableExtensions.cs
+++ b/src/GameLogic/AttackableExtensions.cs
@@ -37,6 +37,23 @@ public static class AttackableExtensions
     }
 
     /// <summary>
+    /// Determines whether an attack is blocked because the target or the player attacker is in a safezone.
+    /// </summary>
+    /// <param name="target">The attack target.</param>
+    /// <param name="attacker">The attacker.</param>
+    /// <returns><c>true</c>, if the attack is blocked; otherwise, <c>false</c>.</returns>
+    public static bool IsAttackBlockedBySafezone(this IAttackable target, IAttacker attacker)
+    {
+        if (target.IsAtSafezone())
+        {
+            return true;
+        }
+
+        var attackerPlayer = attacker as Player ?? (attacker as IPlayerSurrogate)?.Owner;
+        return attackerPlayer?.IsAtSafezone() is true;
+    }
+
+    /// <summary>
     /// Calculates the damage using a skill.
     /// </summary>
     /// <param name="attacker">The object that is attacking.</param>

--- a/src/GameLogic/AttackableExtensions.cs
+++ b/src/GameLogic/AttackableExtensions.cs
@@ -425,12 +425,11 @@ public static class AttackableExtensions
     /// <param name="target">The target.</param>
     /// <param name="attacker">The attacker.</param>
     /// <param name="skill">The skill.</param>
-    /// <param name="powerUp">The power up.</param>
+    /// <param name="powerUps">The power ups.</param>
     /// <param name="duration">The duration.</param>
-    /// <param name="targetAttribute">The target attribute.</param>
     /// <param name="hitInfo">The hit information.</param>
     /// <returns>The success of the appliance.</returns>
-    public static async ValueTask<bool> TryApplyElementalEffectsAsync(this IAttackable target, IAttacker attacker, Skill skill, IElement? powerUp, IElement? duration, AttributeDefinition? targetAttribute, HitInfo? hitInfo)
+    public static async ValueTask<bool> TryApplyElementalEffectsAsync(this IAttackable target, IAttacker attacker, Skill skill, IReadOnlyCollection<(AttributeDefinition Target, IElement Boost)> powerUps, IElement? duration, HitInfo? hitInfo)
     {
         if (!target.IsAlive)
         {
@@ -453,12 +452,11 @@ public static class AttackableExtensions
 
         if (skill.MagicEffectDef is { } effectDefinition
             && !target.MagicEffectList.ActiveEffects.ContainsKey(effectDefinition.Number)
-            && powerUp is not null
             && duration is not null
-            && targetAttribute is not null)
+            && powerUps.Count > 0)
         {
             // power-up is the wrong term here... it's more like a power-down ;-)
-            await target.ApplyMagicEffectAsync(attacker, effectDefinition, duration, hitInfo, (targetAttribute, powerUp)).ConfigureAwait(false);
+            await target.ApplyMagicEffectAsync(attacker, effectDefinition, duration, hitInfo, [.. powerUps]).ConfigureAwait(false);
             applied = true;
         }
 

--- a/src/GameLogic/Attributes/MonsterAttributeHolder.cs
+++ b/src/GameLogic/Attributes/MonsterAttributeHolder.cs
@@ -21,6 +21,7 @@ public class MonsterAttributeHolder : IAttributeSystem
             { Stats.DefensePvp, m => m.Attributes.GetValueOfAttribute(Stats.DefenseBase) + ((m as Monster)?.SummonedBy?.Attributes?[Stats.SummonedMonsterDefenseIncrease] ?? 0) },
             { Stats.DamageReceiveDecrement, m => 1.0f },
             { Stats.AttackDamageIncrease, m => 1.0f },
+            { Stats.MovementSpeedFactor, m => 1.0f },
             { Stats.ShieldBypassChance, m => 1.0f },
             { Stats.DefenseDecrement, m => 1.0f - m.Attributes.GetValueOfAttribute(Stats.InnovationDefDecrement) },
         };
@@ -131,7 +132,7 @@ public class MonsterAttributeHolder : IAttributeSystem
         if (attributes.TryGetValue(targetAttribute, out var attribute))
         {
             attribute.RemoveElement(element);
-            if (attribute.Elements.Skip(1).Take(1).Any())
+            if (!attribute.Elements.Skip(1).Any())
             {
                 attributes.Remove(targetAttribute);
             }

--- a/src/GameLogic/Attributes/Stats.cs
+++ b/src/GameLogic/Attributes/Stats.cs
@@ -440,6 +440,21 @@ public class Stats
     public static AttributeDefinition WalkSpeed { get; } = new(new Guid("9CDDC598-E5F3-4372-9294-505455E4A40B"), "Walk Speed", string.Empty);
 
     /// <summary>
+    /// Gets the maximum movement speed attribute definition.
+    /// </summary>
+    public static AttributeDefinition MaxMovementSpeed { get; } = new(new Guid("E29301BE-626B-4B42-9F68-0DFAC18B3856"), "Maximum Movement Speed", "The maximum movement speed of a character on regular terrain.");
+
+    /// <summary>
+    /// Gets the maximum underwater movement speed attribute definition.
+    /// </summary>
+    public static AttributeDefinition MaxMovementSpeedUnderwater { get; } = new(new Guid("12128DC7-0740-48A5-A653-E546191CD7E0"), "Maximum Underwater Movement Speed", "The maximum movement speed of a character on underwater terrain.");
+
+    /// <summary>
+    /// Gets the movement speed factor attribute definition.
+    /// </summary>
+    public static AttributeDefinition MovementSpeedFactor { get; } = new(new Guid("003E1F2E-661D-4258-BEF0-33111D5F4AD2"), "Movement Speed Factor", "The factor which is applied to the final movement speed of a character.");
+
+    /// <summary>
     /// Gets the attack damage increase attribute definition.
     /// </summary>
     /// <remarks>Includes wings, imp, dinorant, black fenrir, and infinite arrow strengthener.</remarks>
@@ -1330,6 +1345,11 @@ public class Stats
     /// Gets the <see cref="IsInSafezone"/> attribute which defines if the character is located in a safezone of a game map.
     /// </summary>
     public static AttributeDefinition IsInSafezone { get; } = new(new Guid("82044DF9-F528-4AD6-9AAA-6FEAA4C786E7"), "Flag, if the character is located in a safezone of a game map", "Characters at the safezone recover additional health and shield.");
+
+    /// <summary>
+    /// Gets the <see cref="IsUnderwater"/> attribute which defines if the character is located on an underwater game map.
+    /// </summary>
+    public static AttributeDefinition IsUnderwater { get; } = new(new Guid("72A684C1-102B-4FDE-B637-2665ADD5F4AE"), "Flag, if the character is located on an underwater game map", "Characters on underwater maps use underwater movement speed attributes.");
 
     /// <summary>
     /// Gets the attribute definition, which defines if a player has MU Helper activated.

--- a/src/GameLogic/Attributes/Stats.cs
+++ b/src/GameLogic/Attributes/Stats.cs
@@ -440,14 +440,14 @@ public class Stats
     public static AttributeDefinition WalkSpeed { get; } = new(new Guid("9CDDC598-E5F3-4372-9294-505455E4A40B"), "Walk Speed", string.Empty);
 
     /// <summary>
-    /// Gets the maximum movement speed attribute definition.
+    /// Gets the movement speed attribute definition.
     /// </summary>
-    public static AttributeDefinition MaxMovementSpeed { get; } = new(new Guid("E29301BE-626B-4B42-9F68-0DFAC18B3856"), "Maximum Movement Speed", "The maximum movement speed of a character on regular terrain.");
+    public static AttributeDefinition MovementSpeed { get; } = new(new Guid("E29301BE-626B-4B42-9F68-0DFAC18B3856"), "Movement Speed", "The movement speed of a character on regular terrain.");
 
     /// <summary>
-    /// Gets the maximum underwater movement speed attribute definition.
+    /// Gets the underwater movement speed attribute definition.
     /// </summary>
-    public static AttributeDefinition MaxMovementSpeedUnderwater { get; } = new(new Guid("12128DC7-0740-48A5-A653-E546191CD7E0"), "Maximum Underwater Movement Speed", "The maximum movement speed of a character on underwater terrain.");
+    public static AttributeDefinition MovementSpeedUnderwater { get; } = new(new Guid("12128DC7-0740-48A5-A653-E546191CD7E0"), "Underwater Movement Speed", "The movement speed of a character on underwater terrain.");
 
     /// <summary>
     /// Gets the movement speed factor attribute definition.

--- a/src/GameLogic/InventoryStorage.cs
+++ b/src/GameLogic/InventoryStorage.cs
@@ -155,10 +155,7 @@ public class InventoryStorage : Storage, IInventoryStorage
             }
         }
 
-        if (item.Definition!.PossibleItemSetGroups.Count > 0)
-        {
-            this.UpdateSetPowerUps();
-        }
+        this.UpdateSetPowerUps();
 
         var itemAdded = this.EquippedItems.Contains(item);
         if (itemAdded)

--- a/src/GameLogic/NPC/AttackableNpcBase.cs
+++ b/src/GameLogic/NPC/AttackableNpcBase.cs
@@ -104,7 +104,7 @@ public abstract class AttackableNpcBase : NonPlayerCharacter, IAttackable
     /// <inheritdoc />
     public async ValueTask<HitInfo?> AttackByAsync(IAttacker attacker, SkillEntry? skill, bool isCombo, double damageFactor = 1.0, bool? isFinalStreakHit = null)
     {
-        if (this.Definition.ObjectKind == NpcObjectKind.Guard)
+        if (this.Definition.ObjectKind == NpcObjectKind.Guard || this.IsAttackBlockedBySafezone(attacker))
         {
             return null;
         }

--- a/src/GameLogic/NPC/Monster.cs
+++ b/src/GameLogic/NPC/Monster.cs
@@ -18,6 +18,11 @@ using Nito.AsyncEx;
 /// </summary>
 public sealed class Monster : AttackableNpcBase, IAttackable, IAttacker, ISupportWalk, IMovable, ISummonable
 {
+    private const short IcedEffectNumber = 0x38;
+    private const short BlowOfDestructionEffectNumber = 0x56;
+    private const double IcedMovementSpeedFactor = 0.5;
+    private const double BlowOfDestructionMovementSpeedFactor = 0.33;
+
     private readonly AsyncLock _moveLock = new();
     private readonly INpcIntelligence _intelligence;
     private readonly Walker _walker;
@@ -59,7 +64,7 @@ public sealed class Monster : AttackableNpcBase, IAttackable, IAttacker, ISuppor
         : base(spawnInfo, stats, map, eventStateProvider, dropGenerator, plugInManager)
     {
         this._pathFinderPool = pathFinderPool;
-        this._walker = new Walker(this, () => this.StepDelay);
+        this._walker = new Walker(this, this.GetStepDelay);
         this._intelligence = npcIntelligence;
 
         (this._skillPowerUp, this._skillPowerUpDuration, this._skillPowerUpTarget) = this.CreateMagicEffectPowerUp();
@@ -87,7 +92,7 @@ public sealed class Monster : AttackableNpcBase, IAttackable, IAttacker, ISuppor
     public Point WalkTarget => this._walker.CurrentTarget;
 
     /// <inheritdoc/>
-    public TimeSpan StepDelay => this.Definition.MoveDelay;
+    public TimeSpan StepDelay => this.GetStepDelay(null);
 
     /// <inheritdoc/>
     /// <remarks>Monsters don't do combos.</remarks>
@@ -354,6 +359,30 @@ public sealed class Monster : AttackableNpcBase, IAttackable, IAttacker, ISuppor
             From = node.PreviousPoint,
             To = new Point(node.X, node.Y),
         };
+    }
+
+    private TimeSpan GetStepDelay(WalkingStep? step)
+    {
+        var tileDistance = step is { } walkingStep ? walkingStep.From.EuclideanDistanceTo(walkingStep.To) : 1.0;
+        var delayMilliseconds = this.Definition.MoveDelay.TotalMilliseconds * Math.Max(1.0, tileDistance);
+        delayMilliseconds /= this.GetMovementSpeedFactor();
+
+        return TimeSpan.FromMilliseconds(delayMilliseconds);
+    }
+
+    private double GetMovementSpeedFactor()
+    {
+        if (this.MagicEffectList.ActiveEffects.ContainsKey(IcedEffectNumber))
+        {
+            return IcedMovementSpeedFactor;
+        }
+
+        if (this.MagicEffectList.ActiveEffects.ContainsKey(BlowOfDestructionEffectNumber))
+        {
+            return BlowOfDestructionMovementSpeedFactor;
+        }
+
+        return 1.0;
     }
 
     /// <summary>

--- a/src/GameLogic/NPC/Monster.cs
+++ b/src/GameLogic/NPC/Monster.cs
@@ -18,30 +18,20 @@ using Nito.AsyncEx;
 /// </summary>
 public sealed class Monster : AttackableNpcBase, IAttackable, IAttacker, ISupportWalk, IMovable, ISummonable
 {
-    private const short IcedEffectNumber = 0x38;
-    private const short BlowOfDestructionEffectNumber = 0x56;
-    private const double IcedMovementSpeedFactor = 0.5;
-    private const double BlowOfDestructionMovementSpeedFactor = 0.33;
-
     private readonly AsyncLock _moveLock = new();
     private readonly INpcIntelligence _intelligence;
     private readonly Walker _walker;
 
     /// <summary>
-    /// The power up element of the monster skill.
-    /// It is a "cached" element which will be created on demand and can be applied multiple times.
+    /// The power up elements of the monster skill.
+    /// These are "cached" elements which will be created on demand and can be applied multiple times.
     /// </summary>
-    private readonly IElement? _skillPowerUp;
+    private readonly (AttributeDefinition Target, IElement Boost)[] _skillPowerUps;
 
     /// <summary>
-    /// The duration of the <see cref="_skillPowerUp"/>.
+    /// The duration of the <see cref="_skillPowerUps"/>.
     /// </summary>
     private readonly IElement? _skillPowerUpDuration;
-
-    /// <summary>
-    /// The target attribute of the <see cref="_skillPowerUp"/>.
-    /// </summary>
-    private readonly AttributeDefinition? _skillPowerUpTarget;
 
     private readonly IObjectPool<PathFinder> _pathFinderPool;
 
@@ -67,7 +57,7 @@ public sealed class Monster : AttackableNpcBase, IAttackable, IAttacker, ISuppor
         this._walker = new Walker(this, this.GetStepDelay);
         this._intelligence = npcIntelligence;
 
-        (this._skillPowerUp, this._skillPowerUpDuration, this._skillPowerUpTarget) = this.CreateMagicEffectPowerUp();
+        (this._skillPowerUps, this._skillPowerUpDuration) = this.CreateMagicEffectPowerUps();
 
         this._intelligence.Npc = this;
     }
@@ -127,7 +117,7 @@ public sealed class Monster : AttackableNpcBase, IAttackable, IAttacker, ISuppor
         await this.ForEachWorldObserverAsync<IShowAnimationPlugIn>(p => p.ShowMonsterAttackAnimationAsync(this, target, this.GetDirectionTo(target)), true).ConfigureAwait(false);
         if (this.Definition.AttackSkill is { } attackSkill)
         {
-            await target.TryApplyElementalEffectsAsync(this, attackSkill, this._skillPowerUp, this._skillPowerUpDuration, this._skillPowerUpTarget, hitInfo).ConfigureAwait(false);
+            await target.TryApplyElementalEffectsAsync(this, attackSkill, this._skillPowerUps, this._skillPowerUpDuration, hitInfo).ConfigureAwait(false);
 
             await this.ForEachWorldObserverAsync<IShowSkillAnimationPlugIn>(p => p.ShowSkillAnimationAsync(this, target, attackSkill, true), true).ConfigureAwait(false);
         }
@@ -372,40 +362,31 @@ public sealed class Monster : AttackableNpcBase, IAttackable, IAttacker, ISuppor
 
     private double GetMovementSpeedFactor()
     {
-        if (this.MagicEffectList.ActiveEffects.ContainsKey(IcedEffectNumber))
-        {
-            return IcedMovementSpeedFactor;
-        }
+        var movementSpeedFactor = this.Attributes[Stats.MovementSpeedFactor];
 
-        if (this.MagicEffectList.ActiveEffects.ContainsKey(BlowOfDestructionEffectNumber))
-        {
-            return BlowOfDestructionMovementSpeedFactor;
-        }
-
-        return 1.0;
+        return movementSpeedFactor > 0 ? movementSpeedFactor : 1.0;
     }
 
     /// <summary>
-    /// Creates the magic effect power up for the given skill of a monster.
+    /// Creates the magic effect power ups for the given skill of a monster.
     /// </summary>
-    /// <remarks>
-    /// Currently, we just support one effect for monsters.
-    /// </remarks>
-    private (IElement? PowerUp, IElement? Duration, AttributeDefinition? Target) CreateMagicEffectPowerUp()
+    private ((AttributeDefinition Target, IElement Boost)[] PowerUps, IElement? Duration) CreateMagicEffectPowerUps()
     {
         var skill = this.Definition.AttackSkill;
-        if (skill?.MagicEffectDef?.PowerUpDefinitions.FirstOrDefault() is not { } powerUpDefinition
-            || skill.MagicEffectDef.Duration is not { } duration)
+        if (skill?.MagicEffectDef is not { } magicEffectDefinition
+            || magicEffectDefinition.Duration is not { } duration)
         {
-            return (null, null, null);
+            return ([], null);
         }
 
-        if (powerUpDefinition.Boost is null)
+        if (magicEffectDefinition.PowerUpDefinitions.Any(p => p.Boost is null || p.TargetAttribute is null))
         {
             throw new InvalidOperationException($"Skill {skill.Name} ({skill.Number}) has no magic effect definition or is without a PowerUpDefinition.");
         }
 
-        return (this.Attributes.CreateElement(powerUpDefinition), this.Attributes.CreateDurationElement(duration), powerUpDefinition.TargetAttribute);
+        return (
+            [.. magicEffectDefinition.PowerUpDefinitions.Select(p => (p.TargetAttribute!, this.Attributes.CreateElement(p)))],
+            this.Attributes.CreateDurationElement(duration));
     }
 
     private void ValidatePath(Memory<WalkingStep> steps)

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -42,16 +42,7 @@ using Nito.AsyncEx;
 /// </summary>
 public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacker, ITrader, IPartyMember, IRotatable, IHasBucketInformation, ISupportWalk, IMovable, ILoggerOwner<Player>
 {
-    private const short IcedEffectNumber = 0x38;
-    private const short BlowOfDestructionEffectNumber = 0x56;
-    private const double IcedMovementSpeedFactor = 0.5;
-    private const double BlowOfDestructionMovementSpeedFactor = 0.33;
-    private const byte RunningGearMinimumLevel = 5;
-    private const ushort AtlansMapNumber = 7;
-    private const ushort Kalima1MapNumber = 24;
-    private const ushort Kalima6MapNumber = 29;
-    private const ushort Kalima7MapNumber = 36;
-    private const ushort Doppelgaenger3MapNumber = 67;
+    private const double WalkMovementSpeed = 12.0;
 
     private static readonly MagicEffectDefinition GMEffect = new GMMagicEffectDefinition
     {
@@ -2195,117 +2186,30 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
 
     private double GetClientMovementSpeed(Point? position = null)
     {
-        const double walkSpeed = 12.0;
         if (this.IsInClientSafezone(position))
         {
-            return this.ApplyMovementEffects(walkSpeed);
+            return this.ApplyMovementSpeedFactor(WalkMovementSpeed);
         }
 
-        return this.ApplyMovementEffects(this.GetMountedOrRunningSpeed(walkSpeed));
+        var speedAttribute = this.Attributes?[Stats.IsUnderwater] > 0
+            ? Stats.MaxMovementSpeedUnderwater
+            : Stats.MaxMovementSpeed;
+        var speed = this.Attributes?[speedAttribute] ?? 0;
+
+        return this.ApplyMovementSpeedFactor(Math.Max(WalkMovementSpeed, speed));
     }
 
-    private double ApplyMovementEffects(double speed)
+    private double ApplyMovementSpeedFactor(double speed)
     {
-        if (this.MagicEffectList.ActiveEffects.ContainsKey(IcedEffectNumber))
-        {
-            return speed * IcedMovementSpeedFactor;
-        }
+        var movementSpeedFactor = this.Attributes?[Stats.MovementSpeedFactor] ?? 1.0;
 
-        if (this.MagicEffectList.ActiveEffects.ContainsKey(BlowOfDestructionEffectNumber))
-        {
-            return speed * BlowOfDestructionMovementSpeedFactor;
-        }
-
-        return speed;
-    }
-
-    private double GetMountedOrRunningSpeed(double walkSpeed)
-    {
-        const double runSpeed = 15.0;
-        const double fastWingSpeed = 16.0;
-        const double horseOrFenrirRunSpeed = 17.0;
-        const double excellentFenrirRunSpeed = 19.0;
-
-        var pet = this.Inventory?.GetItem(InventoryConstants.PetSlot);
-        if (this.IsItem(pet, 13, 37))
-        {
-            if (this.HasFenrirMovementOption(pet))
-            {
-                return excellentFenrirRunSpeed;
-            }
-
-            return horseOrFenrirRunSpeed;
-        }
-
-        if (this.IsItem(pet, 13, 4))
-        {
-            return horseOrFenrirRunSpeed;
-        }
-
-        var wings = this.Inventory?.GetItem(InventoryConstants.WingsSlot);
-        if (this.HasEquippedWings(wings)
-            || this.IsItem(pet, 13, 2)
-            || this.IsItem(pet, 13, 3))
-        {
-            return this.GetWingMovementSpeed(wings, runSpeed, fastWingSpeed);
-        }
-
-        return this.HasRunningGear() ? runSpeed : walkSpeed;
-    }
-
-    private double GetWingMovementSpeed(Item? wings, double runSpeed, double fastWingSpeed)
-    {
-        return this.IsFastWing(wings) ? fastWingSpeed : runSpeed;
+        return speed * (movementSpeedFactor > 0 ? movementSpeedFactor : 1.0);
     }
 
     private bool IsInClientSafezone(Point? position = null)
     {
         var checkedPosition = position ?? this.Position;
         return this.CurrentMap?.Terrain.SafezoneMap[checkedPosition.X, checkedPosition.Y] ?? false;
-    }
-
-    private bool HasEquippedWings(Item? item)
-    {
-        return item is { Durability: > 0.0 }
-               && item.ItemSlot == InventoryConstants.WingsSlot;
-    }
-
-    private bool IsFastWing(Item? item)
-    {
-        return this.IsItem(item, 12, 5)
-               || this.IsItem(item, 12, 36);
-    }
-
-    private bool HasRunningGear()
-    {
-        var slot = this.IsSwimmingMovementMap()
-            ? InventoryConstants.GlovesSlot
-            : InventoryConstants.BootsSlot;
-        return this.Inventory?.GetItem(slot) is { Durability: > 0.0, Level: >= RunningGearMinimumLevel };
-    }
-
-    private bool IsSwimmingMovementMap()
-    {
-        return this.CurrentMap?.MapId is AtlansMapNumber
-            or >= Kalima1MapNumber and <= Kalima6MapNumber
-            or Kalima7MapNumber
-            or Doppelgaenger3MapNumber;
-    }
-
-    private bool IsItem(Item? item, short group, short number)
-    {
-        return item is { Durability: > 0.0 }
-               && item.Definition is { } definition
-               && definition.Group == group
-               && definition.Number == number;
-    }
-
-    private bool HasFenrirMovementOption(Item? item)
-    {
-        return item?.ItemOptions.Any(option =>
-            option.ItemOption?.OptionType == ItemOptionTypes.BlueFenrir
-            || option.ItemOption?.OptionType == ItemOptionTypes.BlackFenrir
-            || option.ItemOption?.OptionType == ItemOptionTypes.GoldFenrir) ?? false;
     }
 
     private async ValueTask<ExitGate> GetSpawnGateOfCurrentMapAsync()
@@ -2599,7 +2503,7 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         {
             foreach (var powerUpDefinition in powerUpDefinitions)
             {
-                if (powerUpDefinition.TargetAttribute is not { } targetAttribute)
+                if (powerUpDefinition.TargetAttribute is null)
                 {
                     continue;
                 }
@@ -2607,13 +2511,12 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
                 var powerUps = PowerUpWrapper.CreateByPowerUpDefinition(powerUpDefinition, attributes);
                 powerUps.ForEach(p =>
                 {
-                    this.Attributes?.AddElement(p, targetAttribute);
                     this.PlayerLeftMap += OnPlayerLeftMap;
 
                     void OnPlayerLeftMap(object? o, (Player, GameMap) args)
                     {
                         this.PlayerLeftMap -= OnPlayerLeftMap;
-                        attributes.RemoveElement(p, targetAttribute);
+                        p.Dispose();
                     }
                 });
             }

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -727,6 +727,11 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
             throw new InvalidOperationException("AttributeSystem not set.");
         }
 
+        if (this.IsAttackBlockedBySafezone(attacker))
+        {
+            return null;
+        }
+
         if (!this.GameContext.PvpEnabled && this.CurrentMap?.Definition.BattleZone == null &&
             this.CurrentMiniGame?.AllowPlayerKilling is false)
         {
@@ -1461,6 +1466,17 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
 
     /// <inheritdoc />
     public ValueTask StopWalkingAsync() => this._walker.StopAsync();
+
+    private bool IsAttackBlockedBySafezone(IAttacker attacker)
+    {
+        if (this.IsAtSafezone())
+        {
+            return true;
+        }
+
+        var attackerPlayer = attacker as Player ?? (attacker as IPlayerSurrogate)?.Owner;
+        return attackerPlayer?.IsAtSafezone() is true;
+    }
 
     /// <summary>
     /// Regenerates the attributes specified in <see cref="Stats.IntervalRegenerationAttributes"/>.

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -1458,17 +1458,6 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
     /// <inheritdoc />
     public ValueTask StopWalkingAsync() => this._walker.StopAsync();
 
-    private bool IsAttackBlockedBySafezone(IAttacker attacker)
-    {
-        if (this.IsAtSafezone())
-        {
-            return true;
-        }
-
-        var attackerPlayer = attacker as Player ?? (attacker as IPlayerSurrogate)?.Owner;
-        return attackerPlayer?.IsAtSafezone() is true;
-    }
-
     /// <summary>
     /// Regenerates the attributes specified in <see cref="Stats.IntervalRegenerationAttributes"/>.
     /// </summary>

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -9,6 +9,7 @@ using System.Globalization;
 using System.Threading;
 using MUnique.OpenMU.AttributeSystem;
 using MUnique.OpenMU.DataModel.Attributes;
+using MUnique.OpenMU.DataModel.Configuration.Items;
 using MUnique.OpenMU.GameLogic.Attributes;
 using MUnique.OpenMU.GameLogic.GuildWar;
 using MUnique.OpenMU.GameLogic.MiniGames;
@@ -41,6 +42,17 @@ using Nito.AsyncEx;
 /// </summary>
 public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacker, ITrader, IPartyMember, IRotatable, IHasBucketInformation, ISupportWalk, IMovable, ILoggerOwner<Player>
 {
+    private const short IcedEffectNumber = 0x38;
+    private const short BlowOfDestructionEffectNumber = 0x56;
+    private const double IcedMovementSpeedFactor = 0.5;
+    private const double BlowOfDestructionMovementSpeedFactor = 0.33;
+    private const byte RunningGearMinimumLevel = 5;
+    private const ushort AtlansMapNumber = 7;
+    private const ushort Kalima1MapNumber = 24;
+    private const ushort Kalima6MapNumber = 29;
+    private const ushort Kalima7MapNumber = 36;
+    private const ushort Doppelgaenger3MapNumber = 67;
+
     private static readonly MagicEffectDefinition GMEffect = new GMMagicEffectDefinition
     {
         InformObservers = true,
@@ -148,7 +160,7 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
     public bool IsWalking => this._walker.CurrentTarget != default;
 
     /// <inheritdoc />
-    public TimeSpan StepDelay => this.GetStepDelay();
+    public TimeSpan StepDelay => this.GetStepDelay(null);
 
     /// <inheritdoc />
     public Point WalkTarget => this._walker.CurrentTarget;
@@ -2149,19 +2161,135 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
     }
 
     /// <summary>
-    /// Gets the step delay depending on the equipped items.
+    /// Gets the step delay depending on the equipped items and current movement effects.
     /// </summary>
+    /// <param name="step">The walking step for which the delay is calculated.</param>
     /// <returns>The current step delay, depending on equipped items.</returns>
-    private TimeSpan GetStepDelay()
+    private TimeSpan GetStepDelay(WalkingStep? step)
     {
-        if (this.Inventory?.EquippedItems.Any(item => item.Definition?.ItemSlot?.ItemSlots.Contains(7) ?? false) ?? false)
+        const double referenceFrameTimeMilliseconds = 40.0;
+        const double terrainScale = 100.0;
+
+        var speed = this.GetClientMovementSpeed(step?.From);
+        var tileDistance = step is { } walkingStep ? walkingStep.From.EuclideanDistanceTo(walkingStep.To) : 1.0;
+        var movementMilliseconds = terrainScale * Math.Max(1.0, tileDistance) / speed * referenceFrameTimeMilliseconds;
+
+        return TimeSpan.FromMilliseconds(movementMilliseconds);
+    }
+
+    private double GetClientMovementSpeed(Point? position = null)
+    {
+        const double walkSpeed = 12.0;
+        if (this.IsInClientSafezone(position))
         {
-            // Wings
-            return TimeSpan.FromMilliseconds(300);
+            return this.ApplyMovementEffects(walkSpeed);
         }
 
-        // TODO: Consider pets etc.
-        return TimeSpan.FromMilliseconds(500);
+        return this.ApplyMovementEffects(this.GetMountedOrRunningSpeed(walkSpeed));
+    }
+
+    private double ApplyMovementEffects(double speed)
+    {
+        if (this.MagicEffectList.ActiveEffects.ContainsKey(IcedEffectNumber))
+        {
+            return speed * IcedMovementSpeedFactor;
+        }
+
+        if (this.MagicEffectList.ActiveEffects.ContainsKey(BlowOfDestructionEffectNumber))
+        {
+            return speed * BlowOfDestructionMovementSpeedFactor;
+        }
+
+        return speed;
+    }
+
+    private double GetMountedOrRunningSpeed(double walkSpeed)
+    {
+        const double runSpeed = 15.0;
+        const double fastWingSpeed = 16.0;
+        const double horseOrFenrirRunSpeed = 17.0;
+        const double excellentFenrirRunSpeed = 19.0;
+
+        var pet = this.Inventory?.GetItem(InventoryConstants.PetSlot);
+        if (this.IsItem(pet, 13, 37))
+        {
+            if (this.HasFenrirMovementOption(pet))
+            {
+                return excellentFenrirRunSpeed;
+            }
+
+            return horseOrFenrirRunSpeed;
+        }
+
+        if (this.IsItem(pet, 13, 4))
+        {
+            return horseOrFenrirRunSpeed;
+        }
+
+        var wings = this.Inventory?.GetItem(InventoryConstants.WingsSlot);
+        if (this.HasEquippedWings(wings)
+            || this.IsItem(pet, 13, 2)
+            || this.IsItem(pet, 13, 3))
+        {
+            return this.GetWingMovementSpeed(wings, runSpeed, fastWingSpeed);
+        }
+
+        return this.HasRunningGear() ? runSpeed : walkSpeed;
+    }
+
+    private double GetWingMovementSpeed(Item? wings, double runSpeed, double fastWingSpeed)
+    {
+        return this.IsFastWing(wings) ? fastWingSpeed : runSpeed;
+    }
+
+    private bool IsInClientSafezone(Point? position = null)
+    {
+        var checkedPosition = position ?? this.Position;
+        return this.CurrentMap?.Terrain.SafezoneMap[checkedPosition.X, checkedPosition.Y] ?? false;
+    }
+
+    private bool HasEquippedWings(Item? item)
+    {
+        return item is { Durability: > 0.0 }
+               && item.ItemSlot == InventoryConstants.WingsSlot;
+    }
+
+    private bool IsFastWing(Item? item)
+    {
+        return this.IsItem(item, 12, 5)
+               || this.IsItem(item, 12, 36);
+    }
+
+    private bool HasRunningGear()
+    {
+        var slot = this.IsSwimmingMovementMap()
+            ? InventoryConstants.GlovesSlot
+            : InventoryConstants.BootsSlot;
+        return this.Inventory?.GetItem(slot) is { Durability: > 0.0, Level: >= RunningGearMinimumLevel };
+    }
+
+    private bool IsSwimmingMovementMap()
+    {
+        return this.CurrentMap?.MapId is AtlansMapNumber
+            or >= Kalima1MapNumber and <= Kalima6MapNumber
+            or Kalima7MapNumber
+            or Doppelgaenger3MapNumber;
+    }
+
+    private bool IsItem(Item? item, short group, short number)
+    {
+        return item is { Durability: > 0.0 }
+               && item.Definition is { } definition
+               && definition.Group == group
+               && definition.Number == number;
+    }
+
+    private bool HasFenrirMovementOption(Item? item)
+    {
+        return item?.ItemOptions.Any(option =>
+            option.ItemOption?.OptionType == ItemOptionTypes.BlueFenrir
+            || option.ItemOption?.OptionType == ItemOptionTypes.BlackFenrir
+            || option.ItemOption?.OptionType == ItemOptionTypes.GoldFenrir) ?? false;
     }
 
     private async ValueTask<ExitGate> GetSpawnGateOfCurrentMapAsync()

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -2181,8 +2181,8 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         }
 
         var speedAttribute = this.Attributes?[Stats.IsUnderwater] > 0
-            ? Stats.MaxMovementSpeedUnderwater
-            : Stats.MaxMovementSpeed;
+            ? Stats.MovementSpeedUnderwater
+            : Stats.MovementSpeed;
         var speed = this.Attributes?[speedAttribute] ?? 0;
 
         return this.ApplyMovementSpeedFactor(Math.Max(WalkMovementSpeed, speed));

--- a/src/GameLogic/Walker.cs
+++ b/src/GameLogic/Walker.cs
@@ -16,7 +16,6 @@ using Nito.AsyncEx.Synchronous;
 public sealed class Walker : IDisposable
 {
     private readonly ISupportWalk _walkSupporter;
-    private readonly Func<TimeSpan> _stepDelay;
     private readonly Queue<WalkingStep> _nextSteps = new(5);
 
     /// <summary>
@@ -39,10 +38,10 @@ public sealed class Walker : IDisposable
     /// </summary>
     /// <param name="walkSupporter">The walk supporter.</param>
     /// <param name="stepDelay">The delay between performing a step.</param>
-    public Walker(ISupportWalk walkSupporter, Func<TimeSpan> stepDelay)
+    public Walker(ISupportWalk walkSupporter, Func<WalkingStep?, TimeSpan> stepDelay)
     {
         this._walkSupporter = walkSupporter;
-        this._stepDelay = stepDelay;
+        this.StepDelay = stepDelay;
         this._walkLock = new AsyncReaderWriterLock();
     }
 
@@ -50,6 +49,8 @@ public sealed class Walker : IDisposable
     /// Gets the current walk target.
     /// </summary>
     public Point CurrentTarget { get; private set; }
+
+    private Func<WalkingStep?, TimeSpan> StepDelay { get; }
 
     /// <summary>
     /// Initializes a new walk to the specified target with the specified steps.
@@ -180,15 +181,18 @@ public sealed class Walker : IDisposable
 
     private async Task WalkLoopAsync(CancellationToken cancellationToken)
     {
-        var delay = this._stepDelay().Subtract(TimeSpan.FromMilliseconds(50));
-
         // Task.Delay might take longer than we specify. We need to compensate that.
         var lastOffset = TimeSpan.Zero;
         while (!cancellationToken.IsCancellationRequested)
         {
             var sw = Stopwatch.StartNew();
-            await this.WalkStepAsync(cancellationToken).ConfigureAwait(false);
+            var step = await this.WalkStepAsync(cancellationToken).ConfigureAwait(false);
+            if (step is null)
+            {
+                continue;
+            }
 
+            var delay = this.StepDelay(step);
             var nextDelay = delay - lastOffset;
             if (nextDelay > TimeSpan.Zero)
             {
@@ -207,14 +211,14 @@ public sealed class Walker : IDisposable
     /// <summary>
     /// Performs the next step of a walk.
     /// </summary>
-    private async ValueTask WalkStepAsync(CancellationToken cancellationToken)
+    private async ValueTask<WalkingStep?> WalkStepAsync(CancellationToken cancellationToken)
     {
         try
         {
             if (this._isDisposed)
             {
                 Debug.WriteLine("walker already disposed");
-                return;
+                return null;
             }
 
             bool stop;
@@ -226,13 +230,13 @@ public sealed class Walker : IDisposable
             if (stop)
             {
                 await this.StopAsync().ConfigureAwait(false);
-                return;
+                return null;
             }
 
             // Update new coords
             using (await this._walkLock.WriterLockAsync(cancellationToken))
             {
-                this.WalkNextStepIfStepAvailable();
+                return this.WalkNextStepIfStepAvailable();
             }
         }
         catch (OperationCanceledException)
@@ -243,13 +247,15 @@ public sealed class Walker : IDisposable
         {
             Debug.Fail(ex.Message, ex.StackTrace);
         }
+
+        return null;
     }
 
-    private void WalkNextStepIfStepAvailable()
+    private WalkingStep? WalkNextStepIfStepAvailable()
     {
         if (this.ShouldWalkerStop())
         {
-            return;
+            return null;
         }
 
         var nextStep = this._nextSteps.Dequeue();
@@ -259,6 +265,8 @@ public sealed class Walker : IDisposable
         {
             rotatable.Rotation = nextStep.Direction;
         }
+
+        return nextStep;
     }
 
     private bool ShouldWalkerStop() => !((this._walkSupporter as IAttackable)?.IsActive() ?? false) || this._nextSteps.Count <= 0;

--- a/src/GameLogic/Walker.cs
+++ b/src/GameLogic/Walker.cs
@@ -189,6 +189,11 @@ public sealed class Walker : IDisposable
             var step = await this.WalkStepAsync(cancellationToken).ConfigureAwait(false);
             if (step is null)
             {
+                if (!cancellationToken.IsCancellationRequested)
+                {
+                    await this.StopAsync().ConfigureAwait(false);
+                }
+
                 continue;
             }
 

--- a/src/GameServer/RemoteView/World/ObjectMovedPlugIn.cs
+++ b/src/GameServer/RemoteView/World/ObjectMovedPlugIn.cs
@@ -40,7 +40,7 @@ public class ObjectMovedPlugIn : IObjectMovedPlugIn
     /// Gets or sets a value indicating whether the directions provided by <see cref="ISupportWalk.GetDirectionsAsync"/> should be send when an object moved.
     /// This is usually not required, because the game client calculates a proper path anyway and doesn't use the suggested path.
     /// </summary>
-    public bool SendWalkDirections { get; set; } = true;
+    public bool SendWalkDirections { get; set; }
 
     /// <inheritdoc/>
     public async ValueTask ObjectMovedAsync(ILocateable obj, MoveType type)
@@ -95,7 +95,7 @@ public class ObjectMovedPlugIn : IObjectMovedPlugIn
     {
         int Write()
         {
-            var stepsSize = steps.Length == 0 ? 1 : (steps.Length / 2) + 2;
+            var stepsSize = stepsLength == 0 ? 0 : (stepsLength / 2) + 2;
             var size = ObjectWalkedRef.GetRequiredSize(stepsSize);
             var span = connection.Output.GetSpan(size)[..size];
 
@@ -109,7 +109,7 @@ public class ObjectMovedPlugIn : IObjectMovedPlugIn
                 StepCount = (byte)stepsLength,
             };
 
-            this.SetStepData(walkPacket, steps.Span, stepsSize);
+            this.SetStepData(walkPacket, steps.Span[..stepsLength], stepsSize);
             return size;
         }
 

--- a/src/GameServer/RemoteView/World/ObjectMovedPlugInExtended.cs
+++ b/src/GameServer/RemoteView/World/ObjectMovedPlugInExtended.cs
@@ -40,7 +40,7 @@ public class ObjectMovedPlugInExtended : ObjectMovedPlugIn
     {
         int Write()
         {
-            var stepsSize = steps.Length == 0 ? 1 : (steps.Length / 2) + 2;
+            var stepsSize = stepsLength == 0 ? 0 : (stepsLength / 2) + 2;
             var size = ObjectWalkedExtended.GetRequiredSize(stepsSize);
             var span = connection.Output.GetSpan(size)[..size];
 
@@ -56,7 +56,7 @@ public class ObjectMovedPlugInExtended : ObjectMovedPlugIn
                 StepCount = (byte)stepsLength,
             };
 
-            this.SetStepData(walkPacket, steps.Span, stepsSize);
+            this.SetStepData(walkPacket, steps.Span[..stepsLength], stepsSize);
             return size;
         }
 

--- a/src/Persistence/Initialization/BaseMapInitializer.cs
+++ b/src/Persistence/Initialization/BaseMapInitializer.cs
@@ -8,9 +8,11 @@ using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 using MUnique.OpenMU.AttributeSystem;
+using MUnique.OpenMU.DataModel.Attributes;
 using MUnique.OpenMU.DataModel.Configuration;
 using MUnique.OpenMU.DataModel.Configuration.Items;
 using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.Attributes;
 using MUnique.OpenMU.Network;
 using MUnique.OpenMU.Persistence.Initialization.Updates;
 
@@ -292,6 +294,35 @@ internal abstract class BaseMapInitializer : IMapInitializer
         requirement.Attribute = attribute.GetPersistent(this.GameConfiguration);
         requirement.MinimumValue = minimumValue;
         this._mapDefinition.MapRequirements.Add(requirement);
+    }
+
+    /// <summary>
+    /// Adds a character power up to the current map.
+    /// </summary>
+    /// <param name="attribute">The target attribute.</param>
+    /// <param name="value">The power up value.</param>
+    /// <param name="aggregateType">The aggregate type.</param>
+    protected void AddCharacterPowerUp(AttributeDefinition attribute, float value, AggregateType aggregateType = AggregateType.AddRaw)
+    {
+        if (this._mapDefinition is null)
+        {
+            throw new InvalidOperationException("MapDefinition not set yet.");
+        }
+
+        var powerUp = this.Context.CreateNew<PowerUpDefinition>();
+        powerUp.TargetAttribute = attribute.GetPersistent(this.GameConfiguration);
+        powerUp.Boost = this.Context.CreateNew<PowerUpDefinitionValue>();
+        powerUp.Boost.ConstantValue.Value = value;
+        powerUp.Boost.ConstantValue.AggregateType = aggregateType;
+        this._mapDefinition.CharacterPowerUpDefinitions.Add(powerUp);
+    }
+
+    /// <summary>
+    /// Marks the current map as underwater for character movement.
+    /// </summary>
+    protected void AddUnderwaterMovementPowerUp()
+    {
+        this.AddCharacterPowerUp(Stats.IsUnderwater, 1);
     }
 
     private string? GetTerrainFileName()

--- a/src/Persistence/Initialization/GameConfigurationInitializerBase.cs
+++ b/src/Persistence/Initialization/GameConfigurationInitializerBase.cs
@@ -244,6 +244,8 @@ public abstract class GameConfigurationInitializerBase : InitializerBase
 
         var randomExperienceMaxMultiplier = this.Context.CreateNew<ConstValueAttribute>(1.2f, Stats.RandomExperienceMaxMultiplier.GetPersistent(this.GameConfiguration));
         this.GameConfiguration.GlobalBaseAttributeValues.Add(randomExperienceMaxMultiplier);
+
+        this.GameConfiguration.GlobalBaseAttributeValues.Add(this.Context.CreateNew<ConstValueAttribute>(1f, Stats.MovementSpeedFactor.GetPersistent(this.GameConfiguration)));
     }
 
     private long CalcNeededMasterExp(long lvl)

--- a/src/Persistence/Initialization/Items/ArmorInitializerBase.cs
+++ b/src/Persistence/Initialization/Items/ArmorInitializerBase.cs
@@ -22,6 +22,7 @@ public abstract class ArmorInitializerBase : InitializerBase
     private ItemLevelBonusTable? _defenseIncreaseTable;
     private ItemLevelBonusTable? _shieldDefenseIncreaseTable;
     private ItemLevelBonusTable? _shieldDefenseRateIncreaseTable;
+    private ItemLevelBonusTable? _runningMovementSpeedTable;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="ArmorInitializerBase"/> class.
@@ -44,6 +45,7 @@ public abstract class ArmorInitializerBase : InitializerBase
         this._defenseIncreaseTable = this.CreateItemBonusTable(DefenseIncreaseByLevel, "Defense Increase (Armors)", "Defines the defense increase per item level for armors. It's 3 per item level until level 9, then it's always 1 more for each level.");
         this._shieldDefenseIncreaseTable = this.CreateItemBonusTable(ShieldDefenseIncreaseByLevel, "Defense Increase (Shields)", "Defines the defense increase per item level for shields. It's always 1 per item level.");
         this._shieldDefenseRateIncreaseTable = this.CreateItemBonusTable(DefenseIncreaseByLevel, "Defense Rate Increase (Shields)", "Defines the defense rate increase per item level for shields. It's 3 per item level until level 9, then it's always 1 more for each level.");
+        this._runningMovementSpeedTable = this.CreateRunningMovementSpeedTable();
     }
 
     /// <summary>
@@ -147,6 +149,7 @@ public abstract class ArmorInitializerBase : InitializerBase
             gloves.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.AttackSpeedAny, attackSpeed, AggregateType.AddRaw));
         }
 
+        this.AddRunningMovementSpeed(gloves, Stats.MaxMovementSpeedUnderwater);
         return gloves;
     }
 
@@ -158,6 +161,7 @@ public abstract class ArmorInitializerBase : InitializerBase
             gloves.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.AttackSpeedAny, attackSpeed, AggregateType.AddRaw));
         }
 
+        this.AddRunningMovementSpeed(gloves, Stats.MaxMovementSpeedUnderwater);
         return gloves;
     }
 
@@ -169,6 +173,7 @@ public abstract class ArmorInitializerBase : InitializerBase
             boots.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.WalkSpeed, walkSpeed, AggregateType.AddRaw));
         }
 
+        this.AddRunningMovementSpeed(boots, Stats.MaxMovementSpeed);
         return boots;
     }
 
@@ -180,7 +185,33 @@ public abstract class ArmorInitializerBase : InitializerBase
             boots.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.WalkSpeed, walkSpeed, AggregateType.AddRaw));
         }
 
+        this.AddRunningMovementSpeed(boots, Stats.MaxMovementSpeed);
         return boots;
+    }
+
+    private void AddRunningMovementSpeed(ItemDefinition item, AttributeDefinition targetAttribute)
+    {
+        var powerUp = this.CreateItemBasePowerUpDefinition(targetAttribute, 0, AggregateType.Maximum);
+        powerUp.BonusPerLevelTable = this._runningMovementSpeedTable;
+        item.BasePowerUpAttributes.Add(powerUp);
+    }
+
+    private ItemLevelBonusTable CreateRunningMovementSpeedTable()
+    {
+        var table = this.Context.CreateNew<ItemLevelBonusTable>();
+        this.GameConfiguration.ItemLevelBonusTables.Add(table);
+        table.Name = "Running Movement Speed";
+        table.Description = "Defines the running movement speed for boots and underwater gloves from item level 5.";
+
+        for (int level = MovementSpeedConstants.RunningGearMinimumLevel; level <= this.MaximumArmorLevel; level++)
+        {
+            var levelBonus = this.Context.CreateNew<LevelBonus>();
+            levelBonus.Level = level;
+            levelBonus.AdditionalValue = MovementSpeedConstants.RunningGearMovementSpeed;
+            table.BonusPerLevel.Add(levelBonus);
+        }
+
+        return table;
     }
 
     protected ItemDefinition CreateArmor(byte number, byte slot, byte width, byte height, string name, byte dropLevel, int defense, byte durability, int strengthRequirement, int agilityRequirement, int darkWizardClassLevel, int darkKnightClassLevel, int elfClassLevel)

--- a/src/Persistence/Initialization/Items/ArmorInitializerBase.cs
+++ b/src/Persistence/Initialization/Items/ArmorInitializerBase.cs
@@ -149,7 +149,7 @@ public abstract class ArmorInitializerBase : InitializerBase
             gloves.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.AttackSpeedAny, attackSpeed, AggregateType.AddRaw));
         }
 
-        this.AddRunningMovementSpeed(gloves, Stats.MaxMovementSpeedUnderwater);
+        this.AddRunningMovementSpeed(gloves, Stats.MovementSpeedUnderwater);
         return gloves;
     }
 
@@ -161,7 +161,7 @@ public abstract class ArmorInitializerBase : InitializerBase
             gloves.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.AttackSpeedAny, attackSpeed, AggregateType.AddRaw));
         }
 
-        this.AddRunningMovementSpeed(gloves, Stats.MaxMovementSpeedUnderwater);
+        this.AddRunningMovementSpeed(gloves, Stats.MovementSpeedUnderwater);
         return gloves;
     }
 
@@ -173,7 +173,7 @@ public abstract class ArmorInitializerBase : InitializerBase
             boots.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.WalkSpeed, walkSpeed, AggregateType.AddRaw));
         }
 
-        this.AddRunningMovementSpeed(boots, Stats.MaxMovementSpeed);
+        this.AddRunningMovementSpeed(boots, Stats.MovementSpeed);
         return boots;
     }
 
@@ -185,7 +185,7 @@ public abstract class ArmorInitializerBase : InitializerBase
             boots.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.WalkSpeed, walkSpeed, AggregateType.AddRaw));
         }
 
-        this.AddRunningMovementSpeed(boots, Stats.MaxMovementSpeed);
+        this.AddRunningMovementSpeed(boots, Stats.MovementSpeed);
         return boots;
     }
 

--- a/src/Persistence/Initialization/MovementSpeedConstants.cs
+++ b/src/Persistence/Initialization/MovementSpeedConstants.cs
@@ -17,5 +17,5 @@ internal static class MovementSpeedConstants
     internal const float HorseOrFenrirMovementSpeed = 17f;
     internal const float UpgradedFenrirMovementSpeed = 19f;
     internal const float IcedMovementSpeedFactor = 0.5f;
-    internal const float BlowOfDestructionMovementSpeedFactor = 0.33f;
+    internal const float ColdMovementSpeedFactor = 0.33f;
 }

--- a/src/Persistence/Initialization/MovementSpeedConstants.cs
+++ b/src/Persistence/Initialization/MovementSpeedConstants.cs
@@ -1,0 +1,21 @@
+// <copyright file="MovementSpeedConstants.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Persistence.Initialization;
+
+/// <summary>
+/// Movement speed constants used by configuration initializers and update plugins.
+/// </summary>
+internal static class MovementSpeedConstants
+{
+    internal const int RunningGearMinimumLevel = 5;
+    internal const float RunningGearMovementSpeed = 15f;
+    internal const float DefaultWingMovementSpeed = 15f;
+    internal const float FastWingMovementSpeed = 16f;
+    internal const float BasicMountMovementSpeed = 15f;
+    internal const float HorseOrFenrirMovementSpeed = 17f;
+    internal const float UpgradedFenrirMovementSpeed = 19f;
+    internal const float IcedMovementSpeedFactor = 0.5f;
+    internal const float BlowOfDestructionMovementSpeedFactor = 0.33f;
+}

--- a/src/Persistence/Initialization/Skills/BlowOfDestructionEffectInitializer.cs
+++ b/src/Persistence/Initialization/Skills/BlowOfDestructionEffectInitializer.cs
@@ -1,0 +1,38 @@
+// <copyright file="BlowOfDestructionEffectInitializer.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Persistence.Initialization.Skills;
+
+using MUnique.OpenMU.DataModel.Attributes;
+using MUnique.OpenMU.DataModel.Configuration;
+
+/// <summary>
+/// Initializer for the blow of destruction effect which results from the strike of destruction skill.
+/// </summary>
+public class BlowOfDestructionEffectInitializer : InitializerBase
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="BlowOfDestructionEffectInitializer"/> class.
+    /// </summary>
+    /// <param name="context">The context.</param>
+    /// <param name="gameConfiguration">The game configuration.</param>
+    public BlowOfDestructionEffectInitializer(IContext context, GameConfiguration gameConfiguration)
+        : base(context, gameConfiguration)
+    {
+    }
+
+    /// <inheritdoc/>
+    public override void Initialize()
+    {
+        var magicEffect = this.Context.CreateNew<MagicEffectDefinition>();
+        this.GameConfiguration.MagicEffects.Add(magicEffect);
+        magicEffect.Number = (short)MagicEffectNumber.BlowOfDestruction;
+        magicEffect.Name = "Blow of Destruction Effect (Strike of Destruction)";
+        magicEffect.InformObservers = true;
+        magicEffect.SendDuration = true;
+        magicEffect.StopByDeath = true;
+        magicEffect.Duration = this.Context.CreateNew<PowerUpDefinitionValue>();
+        magicEffect.Duration.ConstantValue.Value = (float)TimeSpan.FromSeconds(10).TotalSeconds;
+    }
+}

--- a/src/Persistence/Initialization/Skills/BlowOfDestructionEffectInitializer.cs
+++ b/src/Persistence/Initialization/Skills/BlowOfDestructionEffectInitializer.cs
@@ -4,8 +4,10 @@
 
 namespace MUnique.OpenMU.Persistence.Initialization.Skills;
 
+using MUnique.OpenMU.AttributeSystem;
 using MUnique.OpenMU.DataModel.Attributes;
 using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.GameLogic.Attributes;
 
 /// <summary>
 /// Initializer for the blow of destruction effect which results from the strike of destruction skill.
@@ -34,5 +36,12 @@ public class BlowOfDestructionEffectInitializer : InitializerBase
         magicEffect.StopByDeath = true;
         magicEffect.Duration = this.Context.CreateNew<PowerUpDefinitionValue>();
         magicEffect.Duration.ConstantValue.Value = (float)TimeSpan.FromSeconds(10).TotalSeconds;
+
+        var movementSpeedFactorPowerUp = this.Context.CreateNew<PowerUpDefinition>();
+        magicEffect.PowerUpDefinitions.Add(movementSpeedFactorPowerUp);
+        movementSpeedFactorPowerUp.TargetAttribute = Stats.MovementSpeedFactor.GetPersistent(this.GameConfiguration);
+        movementSpeedFactorPowerUp.Boost = this.Context.CreateNew<PowerUpDefinitionValue>();
+        movementSpeedFactorPowerUp.Boost.ConstantValue.Value = MovementSpeedConstants.BlowOfDestructionMovementSpeedFactor;
+        movementSpeedFactorPowerUp.Boost.ConstantValue.AggregateType = AggregateType.Multiplicate;
     }
 }

--- a/src/Persistence/Initialization/Skills/ColdEffectInitializer.cs
+++ b/src/Persistence/Initialization/Skills/ColdEffectInitializer.cs
@@ -1,4 +1,4 @@
-// <copyright file="BlowOfDestructionEffectInitializer.cs" company="MUnique">
+// <copyright file="ColdEffectInitializer.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
@@ -10,16 +10,16 @@ using MUnique.OpenMU.DataModel.Configuration;
 using MUnique.OpenMU.GameLogic.Attributes;
 
 /// <summary>
-/// Initializer for the blow of destruction effect which results from the strike of destruction skill.
+/// Initializer for the cold effect which slows movement speed.
 /// </summary>
-public class BlowOfDestructionEffectInitializer : InitializerBase
+public class ColdEffectInitializer : InitializerBase
 {
     /// <summary>
-    /// Initializes a new instance of the <see cref="BlowOfDestructionEffectInitializer"/> class.
+    /// Initializes a new instance of the <see cref="ColdEffectInitializer"/> class.
     /// </summary>
     /// <param name="context">The context.</param>
     /// <param name="gameConfiguration">The game configuration.</param>
-    public BlowOfDestructionEffectInitializer(IContext context, GameConfiguration gameConfiguration)
+    public ColdEffectInitializer(IContext context, GameConfiguration gameConfiguration)
         : base(context, gameConfiguration)
     {
     }
@@ -29,8 +29,8 @@ public class BlowOfDestructionEffectInitializer : InitializerBase
     {
         var magicEffect = this.Context.CreateNew<MagicEffectDefinition>();
         this.GameConfiguration.MagicEffects.Add(magicEffect);
-        magicEffect.Number = (short)MagicEffectNumber.BlowOfDestruction;
-        magicEffect.Name = "Blow of Destruction Effect (Strike of Destruction)";
+        magicEffect.Number = (short)MagicEffectNumber.Cold;
+        magicEffect.Name = "Cold";
         magicEffect.InformObservers = true;
         magicEffect.SendDuration = true;
         magicEffect.StopByDeath = true;
@@ -41,7 +41,7 @@ public class BlowOfDestructionEffectInitializer : InitializerBase
         magicEffect.PowerUpDefinitions.Add(movementSpeedFactorPowerUp);
         movementSpeedFactorPowerUp.TargetAttribute = Stats.MovementSpeedFactor.GetPersistent(this.GameConfiguration);
         movementSpeedFactorPowerUp.Boost = this.Context.CreateNew<PowerUpDefinitionValue>();
-        movementSpeedFactorPowerUp.Boost.ConstantValue.Value = MovementSpeedConstants.BlowOfDestructionMovementSpeedFactor;
+        movementSpeedFactorPowerUp.Boost.ConstantValue.Value = MovementSpeedConstants.ColdMovementSpeedFactor;
         movementSpeedFactorPowerUp.Boost.ConstantValue.AggregateType = AggregateType.Multiplicate;
     }
 }

--- a/src/Persistence/Initialization/Skills/MagicEffectNumber.cs
+++ b/src/Persistence/Initialization/Skills/MagicEffectNumber.cs
@@ -297,9 +297,9 @@ internal enum MagicEffectNumber : short
     WizEnhance = 0x52,
 
     /// <summary>
-    /// The blow of destruction effect.
+    /// The cold effect caused by skills such as Chain Drive and Strike of Destruction.
     /// </summary>
-    BlowOfDestruction = 0x56,
+    Cold = 0x56,
 
     /// <summary>
     /// The ignore defense effect of the rage fighter.

--- a/src/Persistence/Initialization/Skills/MagicEffectNumber.cs
+++ b/src/Persistence/Initialization/Skills/MagicEffectNumber.cs
@@ -297,6 +297,11 @@ internal enum MagicEffectNumber : short
     WizEnhance = 0x52,
 
     /// <summary>
+    /// The blow of destruction effect.
+    /// </summary>
+    BlowOfDestruction = 0x56,
+
+    /// <summary>
     /// The ignore defense effect of the rage fighter.
     /// </summary>
     IgnoreDefense = 129,

--- a/src/Persistence/Initialization/Skills/SkillsInitializerBase.cs
+++ b/src/Persistence/Initialization/Skills/SkillsInitializerBase.cs
@@ -267,6 +267,16 @@ internal abstract class SkillsInitializerBase : InitializerBase
         powerUpDefinition.Boost = this.Context.CreateNew<PowerUpDefinitionValue>();
         powerUpDefinition.Boost.ConstantValue.Value = 1;
         powerUpDefinition.TargetAttribute = targetAttribute.GetPersistent(this.GameConfiguration);
+        if (targetAttribute == Stats.IsIced)
+        {
+            var movementSpeedFactorPowerUp = this.Context.CreateNew<PowerUpDefinition>();
+            effect.PowerUpDefinitions.Add(movementSpeedFactorPowerUp);
+            movementSpeedFactorPowerUp.Boost = this.Context.CreateNew<PowerUpDefinitionValue>();
+            movementSpeedFactorPowerUp.Boost.ConstantValue.Value = MovementSpeedConstants.IcedMovementSpeedFactor;
+            movementSpeedFactorPowerUp.Boost.ConstantValue.AggregateType = AggregateType.Multiplicate;
+            movementSpeedFactorPowerUp.TargetAttribute = Stats.MovementSpeedFactor.GetPersistent(this.GameConfiguration);
+        }
+
         return effect;
     }
 

--- a/src/Persistence/Initialization/Updates/AddMovementSpeedAttributesPlugIn075.cs
+++ b/src/Persistence/Initialization/Updates/AddMovementSpeedAttributesPlugIn075.cs
@@ -1,0 +1,26 @@
+// <copyright file="AddMovementSpeedAttributesPlugIn075.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Persistence.Initialization.Updates;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Adds movement speed attributes to 0.75 game configurations.
+/// </summary>
+[PlugIn]
+[Display(Name = PlugInName, Description = PlugInDescription)]
+[Guid("890E2FCB-EC93-4CC1-84FC-67A1B398D5C8")]
+public class AddMovementSpeedAttributesPlugIn075 : AddMovementSpeedAttributesPlugInBase
+{
+    /// <inheritdoc />
+    public override UpdateVersion Version => UpdateVersion.AddMovementSpeedAttributes075;
+
+    /// <inheritdoc />
+    public override string DataInitializationKey => Version075.DataInitialization.Id;
+
+    /// <inheritdoc />
+    protected override int MaximumItemLevel => Version075.Items.Constants.MaximumItemLevel;
+}

--- a/src/Persistence/Initialization/Updates/AddMovementSpeedAttributesPlugIn095D.cs
+++ b/src/Persistence/Initialization/Updates/AddMovementSpeedAttributesPlugIn095D.cs
@@ -1,4 +1,4 @@
-// <copyright file="AddMovementSpeedAttributesPlugIn095d.cs" company="MUnique">
+// <copyright file="AddMovementSpeedAttributesPlugIn095D.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
@@ -13,7 +13,7 @@ using MUnique.OpenMU.PlugIns;
 [PlugIn]
 [Display(Name = PlugInName, Description = PlugInDescription)]
 [Guid("7C38C30F-163B-4625-A82D-5C3A0A9ED883")]
-public class AddMovementSpeedAttributesPlugIn095d : AddMovementSpeedAttributesPlugInBase
+public class AddMovementSpeedAttributesPlugIn095D : AddMovementSpeedAttributesPlugInBase
 {
     /// <inheritdoc />
     public override UpdateVersion Version => UpdateVersion.AddMovementSpeedAttributes095d;

--- a/src/Persistence/Initialization/Updates/AddMovementSpeedAttributesPlugIn095d.cs
+++ b/src/Persistence/Initialization/Updates/AddMovementSpeedAttributesPlugIn095d.cs
@@ -1,0 +1,26 @@
+// <copyright file="AddMovementSpeedAttributesPlugIn095d.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Persistence.Initialization.Updates;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Adds movement speed attributes to 0.95d game configurations.
+/// </summary>
+[PlugIn]
+[Display(Name = PlugInName, Description = PlugInDescription)]
+[Guid("7C38C30F-163B-4625-A82D-5C3A0A9ED883")]
+public class AddMovementSpeedAttributesPlugIn095d : AddMovementSpeedAttributesPlugInBase
+{
+    /// <inheritdoc />
+    public override UpdateVersion Version => UpdateVersion.AddMovementSpeedAttributes095d;
+
+    /// <inheritdoc />
+    public override string DataInitializationKey => Version095d.DataInitialization.Id;
+
+    /// <inheritdoc />
+    protected override int MaximumItemLevel => Version095d.Items.Constants.MaximumItemLevel;
+}

--- a/src/Persistence/Initialization/Updates/AddMovementSpeedAttributesPlugInBase.cs
+++ b/src/Persistence/Initialization/Updates/AddMovementSpeedAttributesPlugInBase.cs
@@ -1,0 +1,317 @@
+// <copyright file="AddMovementSpeedAttributesPlugInBase.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Persistence.Initialization.Updates;
+
+using MUnique.OpenMU.AttributeSystem;
+using MUnique.OpenMU.DataModel;
+using MUnique.OpenMU.DataModel.Attributes;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.DataModel.Configuration.Items;
+using MUnique.OpenMU.GameLogic.Attributes;
+using MUnique.OpenMU.Persistence.Initialization.Items;
+using MUnique.OpenMU.Persistence.Initialization.Skills;
+using AtlansMap = MUnique.OpenMU.Persistence.Initialization.Version075.Maps.Atlans;
+using Doppelgaenger3Map = MUnique.OpenMU.Persistence.Initialization.VersionSeasonSix.Maps.Doppelgaenger3;
+using Kalima1Map = MUnique.OpenMU.Persistence.Initialization.VersionSeasonSix.Maps.Kalima1;
+using Kalima2Map = MUnique.OpenMU.Persistence.Initialization.VersionSeasonSix.Maps.Kalima2;
+using Kalima3Map = MUnique.OpenMU.Persistence.Initialization.VersionSeasonSix.Maps.Kalima3;
+using Kalima4Map = MUnique.OpenMU.Persistence.Initialization.VersionSeasonSix.Maps.Kalima4;
+using Kalima5Map = MUnique.OpenMU.Persistence.Initialization.VersionSeasonSix.Maps.Kalima5;
+using Kalima6Map = MUnique.OpenMU.Persistence.Initialization.VersionSeasonSix.Maps.Kalima6;
+using Kalima7Map = MUnique.OpenMU.Persistence.Initialization.VersionSeasonSix.Maps.Kalima7;
+
+/// <summary>
+/// Adds movement speed attributes and configuration values.
+/// </summary>
+public abstract class AddMovementSpeedAttributesPlugInBase : UpdatePlugInBase
+{
+    private const byte PetItemGroup = (byte)ItemGroups.Misc1;
+    private const byte UniriaNumber = 2;
+    private const byte DinorantNumber = 3;
+    private const byte DarkHorseNumber = 4;
+    private const byte WingsOfDragonNumber = 5;
+    private const byte WingOfStormNumber = 36;
+    private const byte FenrirNumber = 37;
+    private const string RunningMovementSpeedTableName = "Running Movement Speed";
+    private const int BlackFenrirMovementSpeedCombinationBonusNumber = 101;
+    private const int BlackFenrirUnderwaterMovementSpeedCombinationBonusNumber = 102;
+    private const int BlueFenrirMovementSpeedCombinationBonusNumber = 103;
+    private const int BlueFenrirUnderwaterMovementSpeedCombinationBonusNumber = 104;
+    private const int GoldFenrirMovementSpeedCombinationBonusNumber = 105;
+    private const int GoldFenrirUnderwaterMovementSpeedCombinationBonusNumber = 106;
+
+    private static readonly short[] UnderwaterMapNumbers =
+    [
+        AtlansMap.Number,
+        Kalima1Map.Number,
+        Kalima2Map.Number,
+        Kalima3Map.Number,
+        Kalima4Map.Number,
+        Kalima5Map.Number,
+        Kalima6Map.Number,
+        Kalima7Map.Number,
+        Doppelgaenger3Map.Number,
+    ];
+
+    /// <summary>
+    /// The plug in name.
+    /// </summary>
+    internal const string PlugInName = "Add Movement Speed Attributes";
+
+    /// <summary>
+    /// The plug in description.
+    /// </summary>
+    internal const string PlugInDescription = "Adds attribute-based movement speed configuration for players, monsters, items, effects, and underwater maps.";
+
+    /// <inheritdoc />
+    public override string Name => PlugInName;
+
+    /// <inheritdoc />
+    public override string Description => PlugInDescription;
+
+    /// <inheritdoc />
+    public override bool IsMandatory => true;
+
+    /// <inheritdoc />
+    public override DateTime CreatedAt => new(2026, 05, 15, 20, 0, 0, DateTimeKind.Utc);
+
+    /// <summary>
+    /// Gets the maximum item level of the target game version.
+    /// </summary>
+    protected abstract int MaximumItemLevel { get; }
+
+    /// <inheritdoc />
+    protected override ValueTask ApplyAsync(IContext context, GameConfiguration gameConfiguration)
+    {
+        AddStatIfNotExists(context, gameConfiguration, Stats.MaxMovementSpeed);
+        AddStatIfNotExists(context, gameConfiguration, Stats.MaxMovementSpeedUnderwater);
+        AddStatIfNotExists(context, gameConfiguration, Stats.MovementSpeedFactor);
+        AddStatIfNotExists(context, gameConfiguration, Stats.IsUnderwater);
+
+        this.AddGlobalMovementSpeedFactor(context, gameConfiguration);
+        this.AddEffectMovementSpeedFactors(context, gameConfiguration);
+        this.AddItemMovementSpeeds(context, gameConfiguration);
+        this.AddUnderwaterMapPowerUps(context, gameConfiguration);
+        return ValueTask.CompletedTask;
+    }
+
+    private void AddGlobalMovementSpeedFactor(IContext context, GameConfiguration gameConfiguration)
+    {
+        if (gameConfiguration.GlobalBaseAttributeValues.Any(a => a.Definition?.Id == Stats.MovementSpeedFactor.Id))
+        {
+            return;
+        }
+
+        gameConfiguration.GlobalBaseAttributeValues.Add(context.CreateNew<ConstValueAttribute>(1f, Stats.MovementSpeedFactor.GetPersistent(gameConfiguration)));
+    }
+
+    private void AddEffectMovementSpeedFactors(IContext context, GameConfiguration gameConfiguration)
+    {
+        foreach (var icedEffect in gameConfiguration.MagicEffects.Where(e => e.Number == (short)MagicEffectNumber.Iced))
+        {
+            this.AddMovementSpeedFactorPowerUp(context, gameConfiguration, icedEffect, MovementSpeedConstants.IcedMovementSpeedFactor);
+        }
+
+        var blowOfDestructionEffect = gameConfiguration.MagicEffects.FirstOrDefault(e => e.Number == (short)MagicEffectNumber.BlowOfDestruction);
+        if (blowOfDestructionEffect is null
+            && gameConfiguration.Skills.Any(s => s.Number == (short)SkillNumber.StrikeofDestruction))
+        {
+            new BlowOfDestructionEffectInitializer(context, gameConfiguration).Initialize();
+            blowOfDestructionEffect = gameConfiguration.MagicEffects.FirstOrDefault(e => e.Number == (short)MagicEffectNumber.BlowOfDestruction);
+        }
+
+        if (blowOfDestructionEffect is not null)
+        {
+            this.AddMovementSpeedFactorPowerUp(context, gameConfiguration, blowOfDestructionEffect, MovementSpeedConstants.BlowOfDestructionMovementSpeedFactor);
+            foreach (var skill in gameConfiguration.Skills.Where(s => s.Number == (short)SkillNumber.StrikeofDestruction))
+            {
+                skill.MagicEffectDef = blowOfDestructionEffect;
+            }
+        }
+    }
+
+    private void AddMovementSpeedFactorPowerUp(IContext context, GameConfiguration gameConfiguration, MagicEffectDefinition magicEffect, float value)
+    {
+        if (magicEffect.PowerUpDefinitions.Any(p => p.TargetAttribute?.Id == Stats.MovementSpeedFactor.Id))
+        {
+            return;
+        }
+
+        magicEffect.PowerUpDefinitions.Add(this.CreatePowerUpDefinition(context, gameConfiguration, Stats.MovementSpeedFactor, value, AggregateType.Multiplicate));
+    }
+
+    private void AddItemMovementSpeeds(IContext context, GameConfiguration gameConfiguration)
+    {
+        var runningMovementSpeedTable = this.GetOrCreateRunningMovementSpeedTable(context, gameConfiguration);
+
+        foreach (var boots in gameConfiguration.Items.Where(item => item.Group == (byte)ItemGroups.Boots))
+        {
+            this.AddItemBasePowerUp(context, gameConfiguration, boots, Stats.MaxMovementSpeed, 0, AggregateType.Maximum, runningMovementSpeedTable);
+        }
+
+        foreach (var gloves in gameConfiguration.Items.Where(item => item.Group == (byte)ItemGroups.Gloves))
+        {
+            this.AddItemBasePowerUp(context, gameConfiguration, gloves, Stats.MaxMovementSpeedUnderwater, 0, AggregateType.Maximum, runningMovementSpeedTable);
+        }
+
+        foreach (var wing in gameConfiguration.Items.Where(IsWingSlotItem))
+        {
+            this.AddMovementSpeedPowerUps(context, gameConfiguration, wing, GetWingMovementSpeed(wing));
+        }
+
+        foreach (var pet in gameConfiguration.Items.Where(item => item.Group == PetItemGroup))
+        {
+            var speed = GetPetMovementSpeed(pet);
+
+            if (speed > 0)
+            {
+                this.AddMovementSpeedPowerUps(context, gameConfiguration, pet, speed);
+            }
+        }
+
+        this.AddFenrirMovementSpeedCombinationBonuses(context, gameConfiguration);
+    }
+
+    private ItemLevelBonusTable GetOrCreateRunningMovementSpeedTable(IContext context, GameConfiguration gameConfiguration)
+    {
+        if (gameConfiguration.ItemLevelBonusTables.FirstOrDefault(t => t.Name == RunningMovementSpeedTableName) is { } existingTable)
+        {
+            return existingTable;
+        }
+
+        var table = context.CreateNew<ItemLevelBonusTable>();
+        gameConfiguration.ItemLevelBonusTables.Add(table);
+        table.Name = RunningMovementSpeedTableName;
+        table.Description = "Defines the running movement speed for boots and underwater gloves from item level 5.";
+        for (int level = MovementSpeedConstants.RunningGearMinimumLevel; level <= this.MaximumItemLevel; level++)
+        {
+            var levelBonus = context.CreateNew<LevelBonus>();
+            levelBonus.Level = level;
+            levelBonus.AdditionalValue = MovementSpeedConstants.RunningGearMovementSpeed;
+            table.BonusPerLevel.Add(levelBonus);
+        }
+
+        return table;
+    }
+
+    private static bool IsWingSlotItem(ItemDefinition item)
+    {
+        return item.ItemSlot?.ItemSlots.Contains(InventoryConstants.WingsSlot) ?? false;
+    }
+
+    private static float GetWingMovementSpeed(ItemDefinition wing)
+    {
+        return wing.Number is WingsOfDragonNumber or WingOfStormNumber
+            ? MovementSpeedConstants.FastWingMovementSpeed
+            : MovementSpeedConstants.DefaultWingMovementSpeed;
+    }
+
+    private static float GetPetMovementSpeed(ItemDefinition pet)
+    {
+        return pet.Number switch
+        {
+            UniriaNumber or DinorantNumber => MovementSpeedConstants.BasicMountMovementSpeed,
+            DarkHorseNumber or FenrirNumber => MovementSpeedConstants.HorseOrFenrirMovementSpeed,
+            _ => 0f,
+        };
+    }
+
+    private void AddMovementSpeedPowerUps(IContext context, GameConfiguration gameConfiguration, ItemDefinition item, float speed)
+    {
+        this.AddItemBasePowerUp(context, gameConfiguration, item, Stats.MaxMovementSpeed, speed, AggregateType.Maximum);
+        this.AddItemBasePowerUp(context, gameConfiguration, item, Stats.MaxMovementSpeedUnderwater, speed, AggregateType.Maximum);
+    }
+
+    private void AddItemBasePowerUp(
+        IContext context,
+        GameConfiguration gameConfiguration,
+        ItemDefinition item,
+        AttributeDefinition targetAttribute,
+        float value,
+        AggregateType aggregateType,
+        ItemLevelBonusTable? bonusPerLevelTable = null)
+    {
+        if (item.BasePowerUpAttributes.Any(p => p.TargetAttribute?.Id == targetAttribute.Id))
+        {
+            return;
+        }
+
+        var powerUp = context.CreateNew<ItemBasePowerUpDefinition>();
+        powerUp.TargetAttribute = targetAttribute.GetPersistent(gameConfiguration);
+        powerUp.BaseValue = value;
+        powerUp.AggregateType = aggregateType;
+        powerUp.BonusPerLevelTable = bonusPerLevelTable;
+        item.BasePowerUpAttributes.Add(powerUp);
+    }
+
+    private void AddFenrirMovementSpeedCombinationBonuses(IContext context, GameConfiguration gameConfiguration)
+    {
+        this.AddFenrirMovementSpeedCombinationBonus(context, gameConfiguration, ItemOptionTypes.BlackFenrir, BlackFenrirMovementSpeedCombinationBonusNumber, Stats.MaxMovementSpeed);
+        this.AddFenrirMovementSpeedCombinationBonus(context, gameConfiguration, ItemOptionTypes.BlackFenrir, BlackFenrirUnderwaterMovementSpeedCombinationBonusNumber, Stats.MaxMovementSpeedUnderwater);
+        this.AddFenrirMovementSpeedCombinationBonus(context, gameConfiguration, ItemOptionTypes.BlueFenrir, BlueFenrirMovementSpeedCombinationBonusNumber, Stats.MaxMovementSpeed);
+        this.AddFenrirMovementSpeedCombinationBonus(context, gameConfiguration, ItemOptionTypes.BlueFenrir, BlueFenrirUnderwaterMovementSpeedCombinationBonusNumber, Stats.MaxMovementSpeedUnderwater);
+        this.AddFenrirMovementSpeedCombinationBonus(context, gameConfiguration, ItemOptionTypes.GoldFenrir, GoldFenrirMovementSpeedCombinationBonusNumber, Stats.MaxMovementSpeed);
+        this.AddFenrirMovementSpeedCombinationBonus(context, gameConfiguration, ItemOptionTypes.GoldFenrir, GoldFenrirUnderwaterMovementSpeedCombinationBonusNumber, Stats.MaxMovementSpeedUnderwater);
+    }
+
+    private void AddFenrirMovementSpeedCombinationBonus(
+        IContext context,
+        GameConfiguration gameConfiguration,
+        ItemOptionType optionType,
+        int number,
+        AttributeDefinition targetAttribute)
+    {
+        if (gameConfiguration.ItemOptionTypes.FirstOrDefault(t => t == optionType) is not { } persistentOptionType)
+        {
+            return;
+        }
+
+        if (gameConfiguration.ItemOptionCombinationBonuses.Any(b =>
+                b.Bonus?.TargetAttribute?.Id == targetAttribute.Id
+                && b.Requirements.Any(r => r.OptionType == persistentOptionType)))
+        {
+            return;
+        }
+
+        var combinationBonus = context.CreateNew<ItemOptionCombinationBonus>();
+        combinationBonus.Number = number;
+        combinationBonus.Description = $"{persistentOptionType.Name}: {targetAttribute.Designation}";
+        combinationBonus.AppliesMultipleTimes = false;
+        combinationBonus.Requirements.Add(this.CreateFenrirMovementSpeedRequirement(context, persistentOptionType));
+        combinationBonus.Bonus = this.CreatePowerUpDefinition(context, gameConfiguration, targetAttribute, MovementSpeedConstants.UpgradedFenrirMovementSpeed, AggregateType.Maximum);
+        gameConfiguration.ItemOptionCombinationBonuses.Add(combinationBonus);
+    }
+
+    private CombinationBonusRequirement CreateFenrirMovementSpeedRequirement(IContext context, ItemOptionType optionType)
+    {
+        var requirement = context.CreateNew<CombinationBonusRequirement>();
+        requirement.OptionType = optionType;
+        requirement.MinimumCount = 1;
+        return requirement;
+    }
+
+    private void AddUnderwaterMapPowerUps(IContext context, GameConfiguration gameConfiguration)
+    {
+        foreach (var map in gameConfiguration.Maps.Where(m => UnderwaterMapNumbers.Contains(m.Number)))
+        {
+            if (map.CharacterPowerUpDefinitions.Any(p => p.TargetAttribute?.Id == Stats.IsUnderwater.Id))
+            {
+                continue;
+            }
+
+            map.CharacterPowerUpDefinitions.Add(this.CreatePowerUpDefinition(context, gameConfiguration, Stats.IsUnderwater, 1, AggregateType.AddRaw));
+        }
+    }
+
+    private PowerUpDefinition CreatePowerUpDefinition(IContext context, GameConfiguration gameConfiguration, AttributeDefinition targetAttribute, float value, AggregateType aggregateType)
+    {
+        var powerUp = context.CreateNew<PowerUpDefinition>();
+        powerUp.TargetAttribute = targetAttribute.GetPersistent(gameConfiguration);
+        powerUp.Boost = context.CreateNew<PowerUpDefinitionValue>();
+        powerUp.Boost.ConstantValue.Value = value;
+        powerUp.Boost.ConstantValue.AggregateType = aggregateType;
+        return powerUp;
+    }
+}

--- a/src/Persistence/Initialization/Updates/AddMovementSpeedAttributesPlugInBase.cs
+++ b/src/Persistence/Initialization/Updates/AddMovementSpeedAttributesPlugInBase.cs
@@ -114,20 +114,20 @@ public abstract class AddMovementSpeedAttributesPlugInBase : UpdatePlugInBase
             this.AddMovementSpeedFactorPowerUp(context, gameConfiguration, icedEffect, MovementSpeedConstants.IcedMovementSpeedFactor);
         }
 
-        var blowOfDestructionEffect = gameConfiguration.MagicEffects.FirstOrDefault(e => e.Number == (short)MagicEffectNumber.BlowOfDestruction);
-        if (blowOfDestructionEffect is null
+        var coldEffect = gameConfiguration.MagicEffects.FirstOrDefault(e => e.Number == (short)MagicEffectNumber.Cold);
+        if (coldEffect is null
             && gameConfiguration.Skills.Any(s => s.Number == (short)SkillNumber.StrikeofDestruction))
         {
-            new BlowOfDestructionEffectInitializer(context, gameConfiguration).Initialize();
-            blowOfDestructionEffect = gameConfiguration.MagicEffects.FirstOrDefault(e => e.Number == (short)MagicEffectNumber.BlowOfDestruction);
+            new ColdEffectInitializer(context, gameConfiguration).Initialize();
+            coldEffect = gameConfiguration.MagicEffects.FirstOrDefault(e => e.Number == (short)MagicEffectNumber.Cold);
         }
 
-        if (blowOfDestructionEffect is not null)
+        if (coldEffect is not null)
         {
-            this.AddMovementSpeedFactorPowerUp(context, gameConfiguration, blowOfDestructionEffect, MovementSpeedConstants.BlowOfDestructionMovementSpeedFactor);
+            this.AddMovementSpeedFactorPowerUp(context, gameConfiguration, coldEffect, MovementSpeedConstants.ColdMovementSpeedFactor);
             foreach (var skill in gameConfiguration.Skills.Where(s => s.Number == (short)SkillNumber.StrikeofDestruction))
             {
-                skill.MagicEffectDef = blowOfDestructionEffect;
+                skill.MagicEffectDef = coldEffect;
             }
         }
     }

--- a/src/Persistence/Initialization/Updates/AddMovementSpeedAttributesPlugInBase.cs
+++ b/src/Persistence/Initialization/Updates/AddMovementSpeedAttributesPlugInBase.cs
@@ -85,8 +85,8 @@ public abstract class AddMovementSpeedAttributesPlugInBase : UpdatePlugInBase
     /// <inheritdoc />
     protected override ValueTask ApplyAsync(IContext context, GameConfiguration gameConfiguration)
     {
-        AddStatIfNotExists(context, gameConfiguration, Stats.MaxMovementSpeed);
-        AddStatIfNotExists(context, gameConfiguration, Stats.MaxMovementSpeedUnderwater);
+        AddStatIfNotExists(context, gameConfiguration, Stats.MovementSpeed);
+        AddStatIfNotExists(context, gameConfiguration, Stats.MovementSpeedUnderwater);
         AddStatIfNotExists(context, gameConfiguration, Stats.MovementSpeedFactor);
         AddStatIfNotExists(context, gameConfiguration, Stats.IsUnderwater);
 
@@ -148,12 +148,12 @@ public abstract class AddMovementSpeedAttributesPlugInBase : UpdatePlugInBase
 
         foreach (var boots in gameConfiguration.Items.Where(item => item.Group == (byte)ItemGroups.Boots))
         {
-            this.AddItemBasePowerUp(context, gameConfiguration, boots, Stats.MaxMovementSpeed, 0, AggregateType.Maximum, runningMovementSpeedTable);
+            this.AddItemBasePowerUp(context, gameConfiguration, boots, Stats.MovementSpeed, 0, AggregateType.Maximum, runningMovementSpeedTable);
         }
 
         foreach (var gloves in gameConfiguration.Items.Where(item => item.Group == (byte)ItemGroups.Gloves))
         {
-            this.AddItemBasePowerUp(context, gameConfiguration, gloves, Stats.MaxMovementSpeedUnderwater, 0, AggregateType.Maximum, runningMovementSpeedTable);
+            this.AddItemBasePowerUp(context, gameConfiguration, gloves, Stats.MovementSpeedUnderwater, 0, AggregateType.Maximum, runningMovementSpeedTable);
         }
 
         foreach (var wing in gameConfiguration.Items.Where(IsWingSlotItem))
@@ -220,8 +220,8 @@ public abstract class AddMovementSpeedAttributesPlugInBase : UpdatePlugInBase
 
     private void AddMovementSpeedPowerUps(IContext context, GameConfiguration gameConfiguration, ItemDefinition item, float speed)
     {
-        this.AddItemBasePowerUp(context, gameConfiguration, item, Stats.MaxMovementSpeed, speed, AggregateType.Maximum);
-        this.AddItemBasePowerUp(context, gameConfiguration, item, Stats.MaxMovementSpeedUnderwater, speed, AggregateType.Maximum);
+        this.AddItemBasePowerUp(context, gameConfiguration, item, Stats.MovementSpeed, speed, AggregateType.Maximum);
+        this.AddItemBasePowerUp(context, gameConfiguration, item, Stats.MovementSpeedUnderwater, speed, AggregateType.Maximum);
     }
 
     private void AddItemBasePowerUp(
@@ -248,12 +248,12 @@ public abstract class AddMovementSpeedAttributesPlugInBase : UpdatePlugInBase
 
     private void AddFenrirMovementSpeedCombinationBonuses(IContext context, GameConfiguration gameConfiguration)
     {
-        this.AddFenrirMovementSpeedCombinationBonus(context, gameConfiguration, ItemOptionTypes.BlackFenrir, BlackFenrirMovementSpeedCombinationBonusNumber, Stats.MaxMovementSpeed);
-        this.AddFenrirMovementSpeedCombinationBonus(context, gameConfiguration, ItemOptionTypes.BlackFenrir, BlackFenrirUnderwaterMovementSpeedCombinationBonusNumber, Stats.MaxMovementSpeedUnderwater);
-        this.AddFenrirMovementSpeedCombinationBonus(context, gameConfiguration, ItemOptionTypes.BlueFenrir, BlueFenrirMovementSpeedCombinationBonusNumber, Stats.MaxMovementSpeed);
-        this.AddFenrirMovementSpeedCombinationBonus(context, gameConfiguration, ItemOptionTypes.BlueFenrir, BlueFenrirUnderwaterMovementSpeedCombinationBonusNumber, Stats.MaxMovementSpeedUnderwater);
-        this.AddFenrirMovementSpeedCombinationBonus(context, gameConfiguration, ItemOptionTypes.GoldFenrir, GoldFenrirMovementSpeedCombinationBonusNumber, Stats.MaxMovementSpeed);
-        this.AddFenrirMovementSpeedCombinationBonus(context, gameConfiguration, ItemOptionTypes.GoldFenrir, GoldFenrirUnderwaterMovementSpeedCombinationBonusNumber, Stats.MaxMovementSpeedUnderwater);
+        this.AddFenrirMovementSpeedCombinationBonus(context, gameConfiguration, ItemOptionTypes.BlackFenrir, BlackFenrirMovementSpeedCombinationBonusNumber, Stats.MovementSpeed);
+        this.AddFenrirMovementSpeedCombinationBonus(context, gameConfiguration, ItemOptionTypes.BlackFenrir, BlackFenrirUnderwaterMovementSpeedCombinationBonusNumber, Stats.MovementSpeedUnderwater);
+        this.AddFenrirMovementSpeedCombinationBonus(context, gameConfiguration, ItemOptionTypes.BlueFenrir, BlueFenrirMovementSpeedCombinationBonusNumber, Stats.MovementSpeed);
+        this.AddFenrirMovementSpeedCombinationBonus(context, gameConfiguration, ItemOptionTypes.BlueFenrir, BlueFenrirUnderwaterMovementSpeedCombinationBonusNumber, Stats.MovementSpeedUnderwater);
+        this.AddFenrirMovementSpeedCombinationBonus(context, gameConfiguration, ItemOptionTypes.GoldFenrir, GoldFenrirMovementSpeedCombinationBonusNumber, Stats.MovementSpeed);
+        this.AddFenrirMovementSpeedCombinationBonus(context, gameConfiguration, ItemOptionTypes.GoldFenrir, GoldFenrirUnderwaterMovementSpeedCombinationBonusNumber, Stats.MovementSpeedUnderwater);
     }
 
     private void AddFenrirMovementSpeedCombinationBonus(

--- a/src/Persistence/Initialization/Updates/AddMovementSpeedAttributesPlugInSeason6.cs
+++ b/src/Persistence/Initialization/Updates/AddMovementSpeedAttributesPlugInSeason6.cs
@@ -1,0 +1,28 @@
+// <copyright file="AddMovementSpeedAttributesPlugInSeason6.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Persistence.Initialization.Updates;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Adds movement speed attributes to season 6 game configurations.
+/// </summary>
+[PlugIn]
+[Display(Name = PlugInName, Description = PlugInDescription)]
+[Guid("1D4968DA-9C9C-42A7-AF80-D4811535EC63")]
+public class AddMovementSpeedAttributesPlugInSeason6 : AddMovementSpeedAttributesPlugInBase
+{
+    private const int SeasonSixMaximumItemLevel = 15;
+
+    /// <inheritdoc />
+    public override UpdateVersion Version => UpdateVersion.AddMovementSpeedAttributesSeason6;
+
+    /// <inheritdoc />
+    public override string DataInitializationKey => VersionSeasonSix.DataInitialization.Id;
+
+    /// <inheritdoc />
+    protected override int MaximumItemLevel => SeasonSixMaximumItemLevel;
+}

--- a/src/Persistence/Initialization/Updates/UpdateVersion.cs
+++ b/src/Persistence/Initialization/Updates/UpdateVersion.cs
@@ -429,7 +429,7 @@ public enum UpdateVersion
     AddMovementSpeedAttributes075 = 84,
 
     /// <summary>
-    /// The version of the <see cref="AddMovementSpeedAttributesPlugIn095d"/>.
+    /// The version of the <see cref="AddMovementSpeedAttributesPlugIn095D"/>.
     /// </summary>
     AddMovementSpeedAttributes095d = 85,
 

--- a/src/Persistence/Initialization/Updates/UpdateVersion.cs
+++ b/src/Persistence/Initialization/Updates/UpdateVersion.cs
@@ -422,4 +422,19 @@ public enum UpdateVersion
     /// The version of the <see cref="AddRandomExperienceConfigAttributesPlugInSeason6"/>.
     /// </summary>
     AddRandomExperienceConfigAttributesSeason6 = 83,
+
+    /// <summary>
+    /// The version of the <see cref="AddMovementSpeedAttributesPlugIn075"/>.
+    /// </summary>
+    AddMovementSpeedAttributes075 = 84,
+
+    /// <summary>
+    /// The version of the <see cref="AddMovementSpeedAttributesPlugIn095d"/>.
+    /// </summary>
+    AddMovementSpeedAttributes095d = 85,
+
+    /// <summary>
+    /// The version of the <see cref="AddMovementSpeedAttributesPlugInSeason6"/>.
+    /// </summary>
+    AddMovementSpeedAttributesSeason6 = 86,
 }

--- a/src/Persistence/Initialization/Version075/Items/Pets.cs
+++ b/src/Persistence/Initialization/Version075/Items/Pets.cs
@@ -33,7 +33,9 @@ public class Pets : InitializerBase
         this.AddItemToJewelItemDrop(angel);
         var imp = this.CreatePet(1, "Imp", 28, (Stats.AttackDamageIncrease, 1.3f, AggregateType.Multiplicate));
         this.AddItemToJewelItemDrop(imp);
-        var uniria = this.CreatePet(2, "Horn of Uniria", 25);
+        var uniria = this.CreatePet(2, "Horn of Uniria", 25,
+            (Stats.MaxMovementSpeed, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum),
+            (Stats.MaxMovementSpeedUnderwater, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum));
         this.AddItemToJewelItemDrop(uniria);
     }
 

--- a/src/Persistence/Initialization/Version075/Items/Pets.cs
+++ b/src/Persistence/Initialization/Version075/Items/Pets.cs
@@ -34,8 +34,8 @@ public class Pets : InitializerBase
         var imp = this.CreatePet(1, "Imp", 28, (Stats.AttackDamageIncrease, 1.3f, AggregateType.Multiplicate));
         this.AddItemToJewelItemDrop(imp);
         var uniria = this.CreatePet(2, "Horn of Uniria", 25,
-            (Stats.MaxMovementSpeed, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum),
-            (Stats.MaxMovementSpeedUnderwater, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum));
+            (Stats.MovementSpeed, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum),
+            (Stats.MovementSpeedUnderwater, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum));
         this.AddItemToJewelItemDrop(uniria);
     }
 

--- a/src/Persistence/Initialization/Version075/Items/Wings.cs
+++ b/src/Persistence/Initialization/Version075/Items/Wings.cs
@@ -118,8 +118,8 @@ public class Wings : WingsInitializerBase
         canFlyPowerUp.BaseValue = 1;
         wing.BasePowerUpAttributes.Add(canFlyPowerUp);
 
-        wing.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.MaxMovementSpeed, MovementSpeedConstants.DefaultWingMovementSpeed, AggregateType.Maximum));
-        wing.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.MaxMovementSpeedUnderwater, MovementSpeedConstants.DefaultWingMovementSpeed, AggregateType.Maximum));
+        wing.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.MovementSpeed, MovementSpeedConstants.DefaultWingMovementSpeed, AggregateType.Maximum));
+        wing.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.MovementSpeedUnderwater, MovementSpeedConstants.DefaultWingMovementSpeed, AggregateType.Maximum));
 
         return wing;
     }

--- a/src/Persistence/Initialization/Version075/Items/Wings.cs
+++ b/src/Persistence/Initialization/Version075/Items/Wings.cs
@@ -118,6 +118,9 @@ public class Wings : WingsInitializerBase
         canFlyPowerUp.BaseValue = 1;
         wing.BasePowerUpAttributes.Add(canFlyPowerUp);
 
+        wing.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.MaxMovementSpeed, MovementSpeedConstants.DefaultWingMovementSpeed, AggregateType.Maximum));
+        wing.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.MaxMovementSpeedUnderwater, MovementSpeedConstants.DefaultWingMovementSpeed, AggregateType.Maximum));
+
         return wing;
     }
 }

--- a/src/Persistence/Initialization/Version075/Maps/Atlans.cs
+++ b/src/Persistence/Initialization/Version075/Maps/Atlans.cs
@@ -40,6 +40,13 @@ internal class Atlans : BaseMapInitializer
     /// <inheritdoc/>
     protected override string MapName => Name;
 
+    /// <inheritdoc />
+    protected override void AdditionalInitialization(GameMapDefinition mapDefinition)
+    {
+        base.AdditionalInitialization(mapDefinition);
+        this.AddUnderwaterMovementPowerUp();
+    }
+
     /// <inheritdoc/>
     protected override IEnumerable<MonsterSpawnArea> CreateNpcSpawns()
     {

--- a/src/Persistence/Initialization/Version095d/Items/Pets.cs
+++ b/src/Persistence/Initialization/Version095d/Items/Pets.cs
@@ -35,14 +35,14 @@ public class Pets : InitializerBase
         var imp = this.CreatePet(1, 0, "Imp", 28, true, (Stats.AttackDamageIncrease, 1.3f, AggregateType.Multiplicate));
         this.AddItemToJewelItemDrop(imp);
         var uniria = this.CreatePet(2, 0, "Horn of Uniria", 25, true,
-            (Stats.MaxMovementSpeed, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum),
-            (Stats.MaxMovementSpeedUnderwater, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum));
+            (Stats.MovementSpeed, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum),
+            (Stats.MovementSpeedUnderwater, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum));
         this.AddItemToJewelItemDrop(uniria);
 
         var dinorant = this.CreatePet(3, SkillNumber.FireBreath, "Horn of Dinorant", 110, false,
             (Stats.IsDinorantEquipped, 1, AggregateType.AddRaw),
-            (Stats.MaxMovementSpeed, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum),
-            (Stats.MaxMovementSpeedUnderwater, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum),
+            (Stats.MovementSpeed, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum),
+            (Stats.MovementSpeedUnderwater, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum),
             (Stats.DamageReceiveDecrement, 0.9f, AggregateType.Multiplicate),
             (Stats.AttackDamageIncrease, 1.15f, AggregateType.Multiplicate));
         this.AddDinorantOptions(dinorant);

--- a/src/Persistence/Initialization/Version095d/Items/Pets.cs
+++ b/src/Persistence/Initialization/Version095d/Items/Pets.cs
@@ -78,11 +78,7 @@ public class Pets : InitializerBase
                 var powerUpDefinition = this.Context.CreateNew<ItemBasePowerUpDefinition>();
                 powerUpDefinition.TargetAttribute = basePowerUp.Item1.GetPersistent(this.GameConfiguration);
                 powerUpDefinition.BaseValue = basePowerUp.Item2;
-                if (basePowerUp.Item1 == Stats.MaxMovementSpeed || basePowerUp.Item1 == Stats.MaxMovementSpeedUnderwater)
-                {
-                    powerUpDefinition.AggregateType = basePowerUp.Item3;
-                }
-
+                powerUpDefinition.AggregateType = basePowerUp.Item3;
                 pet.BasePowerUpAttributes.Add(powerUpDefinition);
             }
         }

--- a/src/Persistence/Initialization/Version095d/Items/Pets.cs
+++ b/src/Persistence/Initialization/Version095d/Items/Pets.cs
@@ -34,10 +34,17 @@ public class Pets : InitializerBase
         this.AddItemToJewelItemDrop(angel);
         var imp = this.CreatePet(1, 0, "Imp", 28, true, (Stats.AttackDamageIncrease, 1.3f, AggregateType.Multiplicate));
         this.AddItemToJewelItemDrop(imp);
-        var uniria = this.CreatePet(2, 0, "Horn of Uniria", 25, true);
+        var uniria = this.CreatePet(2, 0, "Horn of Uniria", 25, true,
+            (Stats.MaxMovementSpeed, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum),
+            (Stats.MaxMovementSpeedUnderwater, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum));
         this.AddItemToJewelItemDrop(uniria);
 
-        var dinorant = this.CreatePet(3, SkillNumber.FireBreath, "Horn of Dinorant", 110, false, (Stats.IsDinorantEquipped, 1, AggregateType.AddRaw), (Stats.DamageReceiveDecrement, 0.9f, AggregateType.Multiplicate), (Stats.AttackDamageIncrease, 1.15f, AggregateType.Multiplicate));
+        var dinorant = this.CreatePet(3, SkillNumber.FireBreath, "Horn of Dinorant", 110, false,
+            (Stats.IsDinorantEquipped, 1, AggregateType.AddRaw),
+            (Stats.MaxMovementSpeed, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum),
+            (Stats.MaxMovementSpeedUnderwater, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum),
+            (Stats.DamageReceiveDecrement, 0.9f, AggregateType.Multiplicate),
+            (Stats.AttackDamageIncrease, 1.15f, AggregateType.Multiplicate));
         this.AddDinorantOptions(dinorant);
     }
 
@@ -71,6 +78,11 @@ public class Pets : InitializerBase
                 var powerUpDefinition = this.Context.CreateNew<ItemBasePowerUpDefinition>();
                 powerUpDefinition.TargetAttribute = basePowerUp.Item1.GetPersistent(this.GameConfiguration);
                 powerUpDefinition.BaseValue = basePowerUp.Item2;
+                if (basePowerUp.Item1 == Stats.MaxMovementSpeed || basePowerUp.Item1 == Stats.MaxMovementSpeedUnderwater)
+                {
+                    powerUpDefinition.AggregateType = basePowerUp.Item3;
+                }
+
                 pet.BasePowerUpAttributes.Add(powerUpDefinition);
             }
         }

--- a/src/Persistence/Initialization/Version095d/Items/Wings.cs
+++ b/src/Persistence/Initialization/Version095d/Items/Wings.cs
@@ -117,8 +117,8 @@ public class Wings : WingsInitializerBase
         canFlyPowerUp.BaseValue = 1;
         wing.BasePowerUpAttributes.Add(canFlyPowerUp);
 
-        wing.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.MaxMovementSpeed, MovementSpeedConstants.DefaultWingMovementSpeed, AggregateType.Maximum));
-        wing.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.MaxMovementSpeedUnderwater, MovementSpeedConstants.DefaultWingMovementSpeed, AggregateType.Maximum));
+        wing.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.MovementSpeed, MovementSpeedConstants.DefaultWingMovementSpeed, AggregateType.Maximum));
+        wing.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.MovementSpeedUnderwater, MovementSpeedConstants.DefaultWingMovementSpeed, AggregateType.Maximum));
 
         return wing;
     }

--- a/src/Persistence/Initialization/Version095d/Items/Wings.cs
+++ b/src/Persistence/Initialization/Version095d/Items/Wings.cs
@@ -117,6 +117,9 @@ public class Wings : WingsInitializerBase
         canFlyPowerUp.BaseValue = 1;
         wing.BasePowerUpAttributes.Add(canFlyPowerUp);
 
+        wing.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.MaxMovementSpeed, MovementSpeedConstants.DefaultWingMovementSpeed, AggregateType.Maximum));
+        wing.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.MaxMovementSpeedUnderwater, MovementSpeedConstants.DefaultWingMovementSpeed, AggregateType.Maximum));
+
         return wing;
     }
 }

--- a/src/Persistence/Initialization/VersionSeasonSix/Items/Pets.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Items/Pets.cs
@@ -20,6 +20,13 @@ using MUnique.OpenMU.Persistence.Initialization.Skills;
 /// <remarks>Pet system changed in Season 9. Reference: https://muonline.webzen.com/en/gameinfo/guide/detail/76 .</remarks>
 public class Pets : InitializerBase
 {
+    private const int BlackFenrirMovementSpeedCombinationBonusNumber = 101;
+    private const int BlackFenrirUnderwaterMovementSpeedCombinationBonusNumber = 102;
+    private const int BlueFenrirMovementSpeedCombinationBonusNumber = 103;
+    private const int BlueFenrirUnderwaterMovementSpeedCombinationBonusNumber = 104;
+    private const int GoldFenrirMovementSpeedCombinationBonusNumber = 105;
+    private const int GoldFenrirUnderwaterMovementSpeedCombinationBonusNumber = 106;
+
     private const string PetExperienceFormula = "level * level * level * 100 * (level + 10)";
 
     /// <summary>
@@ -43,17 +50,23 @@ public class Pets : InitializerBase
         var imp = this.CreatePet(1, 0, 1, 1, "Imp", 28, true, true,
             (Stats.AttackDamageIncrease, 1.3f, AggregateType.Multiplicate));
         this.AddItemToJewelItemDrop(imp);
-        var uniria = this.CreatePet(2, 0, 1, 1, "Horn of Uniria", 25, true, true);
+        var uniria = this.CreatePet(2, 0, 1, 1, "Horn of Uniria", 25, true, true,
+            (Stats.MaxMovementSpeed, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum),
+            (Stats.MaxMovementSpeedUnderwater, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum));
         this.AddItemToJewelItemDrop(uniria);
 
         var dinorant = this.CreatePet(3, SkillNumber.FireBreath, 1, 1, "Horn of Dinorant", 110, false, true,
             (Stats.IsDinorantEquipped, 1, AggregateType.AddRaw),
+            (Stats.MaxMovementSpeed, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum),
+            (Stats.MaxMovementSpeedUnderwater, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum),
             (Stats.DamageReceiveDecrement, 0.9f, AggregateType.Multiplicate),
             (Stats.AttackDamageIncrease, 1.15f, AggregateType.Multiplicate));
         this.AddDinorantOptions(dinorant);
 
         var darkHorse = this.CreatePet(4, SkillNumber.Earthshake, 1, 1, "Dark Horse", 218, false, false,
-            (Stats.IsHorseEquipped, 1, AggregateType.AddRaw));
+            (Stats.IsHorseEquipped, 1, AggregateType.AddRaw),
+            (Stats.MaxMovementSpeed, MovementSpeedConstants.HorseOrFenrirMovementSpeed, AggregateType.Maximum),
+            (Stats.MaxMovementSpeedUnderwater, MovementSpeedConstants.HorseOrFenrirMovementSpeed, AggregateType.Maximum));
         this.AddDarkHorseOptions(darkHorse);
         this.GameConfiguration.DetermineCharacterClasses(CharacterClasses.AllLords).ForEach(darkHorse.QualifiedCharacters.Add);
         darkHorse.PetExperienceFormula = PetExperienceFormula;
@@ -66,7 +79,9 @@ public class Pets : InitializerBase
         this.GameConfiguration.DetermineCharacterClasses(CharacterClasses.AllLords).ForEach(darkRaven.QualifiedCharacters.Add);
 
         var fenrir = this.CreatePet(37, SkillNumber.PlasmaStorm, 2, 2, "Horn of Fenrir", 300, false, true,
-            (Stats.CanFly, 1.0f, AggregateType.AddRaw));
+            (Stats.CanFly, 1.0f, AggregateType.AddRaw),
+            (Stats.MaxMovementSpeed, MovementSpeedConstants.HorseOrFenrirMovementSpeed, AggregateType.Maximum),
+            (Stats.MaxMovementSpeedUnderwater, MovementSpeedConstants.HorseOrFenrirMovementSpeed, AggregateType.Maximum));
         this.AddFenrirOptions(fenrir);
 
         this.CreatePet(64, 0, 1, 1, "Demon", 1, false, true,
@@ -306,6 +321,36 @@ public class Pets : InitializerBase
         fenrirOptionDefinition.PossibleOptions.Add(this.CreateRelatedPetOption(ItemOptionTypes.GoldFenrir, 4, Stats.WizardryBaseDmg, AggregateType.AddRaw, ItemOptionDefinitionNumbers.Fenrir, 0, (Stats.TotalLevel, 1f / 25f)));
 
         fenrir.PossibleItemOptions.Add(fenrirOptionDefinition);
+        this.AddFenrirMovementSpeedCombinationBonuses();
+    }
+
+    private void AddFenrirMovementSpeedCombinationBonuses()
+    {
+        this.AddFenrirMovementSpeedCombinationBonus(ItemOptionTypes.BlackFenrir, BlackFenrirMovementSpeedCombinationBonusNumber, Stats.MaxMovementSpeed);
+        this.AddFenrirMovementSpeedCombinationBonus(ItemOptionTypes.BlackFenrir, BlackFenrirUnderwaterMovementSpeedCombinationBonusNumber, Stats.MaxMovementSpeedUnderwater);
+        this.AddFenrirMovementSpeedCombinationBonus(ItemOptionTypes.BlueFenrir, BlueFenrirMovementSpeedCombinationBonusNumber, Stats.MaxMovementSpeed);
+        this.AddFenrirMovementSpeedCombinationBonus(ItemOptionTypes.BlueFenrir, BlueFenrirUnderwaterMovementSpeedCombinationBonusNumber, Stats.MaxMovementSpeedUnderwater);
+        this.AddFenrirMovementSpeedCombinationBonus(ItemOptionTypes.GoldFenrir, GoldFenrirMovementSpeedCombinationBonusNumber, Stats.MaxMovementSpeed);
+        this.AddFenrirMovementSpeedCombinationBonus(ItemOptionTypes.GoldFenrir, GoldFenrirUnderwaterMovementSpeedCombinationBonusNumber, Stats.MaxMovementSpeedUnderwater);
+    }
+
+    private void AddFenrirMovementSpeedCombinationBonus(ItemOptionType optionType, int number, AttributeDefinition targetAttribute)
+    {
+        var combinationBonus = this.Context.CreateNew<ItemOptionCombinationBonus>();
+        combinationBonus.Number = number;
+        combinationBonus.Description = $"{optionType.Name}: {targetAttribute.Designation}";
+        combinationBonus.AppliesMultipleTimes = false;
+        combinationBonus.Requirements.Add(this.CreateFenrirMovementSpeedRequirement(optionType));
+        combinationBonus.Bonus = this.CreatePowerUpDefinition(targetAttribute, MovementSpeedConstants.UpgradedFenrirMovementSpeed, AggregateType.Maximum);
+        this.GameConfiguration.ItemOptionCombinationBonuses.Add(combinationBonus);
+    }
+
+    private CombinationBonusRequirement CreateFenrirMovementSpeedRequirement(ItemOptionType optionType)
+    {
+        var requirement = this.Context.CreateNew<CombinationBonusRequirement>();
+        requirement.OptionType = this.GameConfiguration.ItemOptionTypes.First(t => t == optionType);
+        requirement.MinimumCount = 1;
+        return requirement;
     }
 
     private IncreasableItemOption CreateOption(ItemOptionType optionType, int number, AttributeDefinition attributeDefinition, float value, AggregateType aggregateType, short optionNumber)

--- a/src/Persistence/Initialization/VersionSeasonSix/Items/Pets.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Items/Pets.cs
@@ -51,22 +51,22 @@ public class Pets : InitializerBase
             (Stats.AttackDamageIncrease, 1.3f, AggregateType.Multiplicate));
         this.AddItemToJewelItemDrop(imp);
         var uniria = this.CreatePet(2, 0, 1, 1, "Horn of Uniria", 25, true, true,
-            (Stats.MaxMovementSpeed, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum),
-            (Stats.MaxMovementSpeedUnderwater, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum));
+            (Stats.MovementSpeed, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum),
+            (Stats.MovementSpeedUnderwater, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum));
         this.AddItemToJewelItemDrop(uniria);
 
         var dinorant = this.CreatePet(3, SkillNumber.FireBreath, 1, 1, "Horn of Dinorant", 110, false, true,
             (Stats.IsDinorantEquipped, 1, AggregateType.AddRaw),
-            (Stats.MaxMovementSpeed, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum),
-            (Stats.MaxMovementSpeedUnderwater, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum),
+            (Stats.MovementSpeed, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum),
+            (Stats.MovementSpeedUnderwater, MovementSpeedConstants.BasicMountMovementSpeed, AggregateType.Maximum),
             (Stats.DamageReceiveDecrement, 0.9f, AggregateType.Multiplicate),
             (Stats.AttackDamageIncrease, 1.15f, AggregateType.Multiplicate));
         this.AddDinorantOptions(dinorant);
 
         var darkHorse = this.CreatePet(4, SkillNumber.Earthshake, 1, 1, "Dark Horse", 218, false, false,
             (Stats.IsHorseEquipped, 1, AggregateType.AddRaw),
-            (Stats.MaxMovementSpeed, MovementSpeedConstants.HorseOrFenrirMovementSpeed, AggregateType.Maximum),
-            (Stats.MaxMovementSpeedUnderwater, MovementSpeedConstants.HorseOrFenrirMovementSpeed, AggregateType.Maximum));
+            (Stats.MovementSpeed, MovementSpeedConstants.HorseOrFenrirMovementSpeed, AggregateType.Maximum),
+            (Stats.MovementSpeedUnderwater, MovementSpeedConstants.HorseOrFenrirMovementSpeed, AggregateType.Maximum));
         this.AddDarkHorseOptions(darkHorse);
         this.GameConfiguration.DetermineCharacterClasses(CharacterClasses.AllLords).ForEach(darkHorse.QualifiedCharacters.Add);
         darkHorse.PetExperienceFormula = PetExperienceFormula;
@@ -80,8 +80,8 @@ public class Pets : InitializerBase
 
         var fenrir = this.CreatePet(37, SkillNumber.PlasmaStorm, 2, 2, "Horn of Fenrir", 300, false, true,
             (Stats.CanFly, 1.0f, AggregateType.AddRaw),
-            (Stats.MaxMovementSpeed, MovementSpeedConstants.HorseOrFenrirMovementSpeed, AggregateType.Maximum),
-            (Stats.MaxMovementSpeedUnderwater, MovementSpeedConstants.HorseOrFenrirMovementSpeed, AggregateType.Maximum));
+            (Stats.MovementSpeed, MovementSpeedConstants.HorseOrFenrirMovementSpeed, AggregateType.Maximum),
+            (Stats.MovementSpeedUnderwater, MovementSpeedConstants.HorseOrFenrirMovementSpeed, AggregateType.Maximum));
         this.AddFenrirOptions(fenrir);
 
         this.CreatePet(64, 0, 1, 1, "Demon", 1, false, true,
@@ -326,12 +326,12 @@ public class Pets : InitializerBase
 
     private void AddFenrirMovementSpeedCombinationBonuses()
     {
-        this.AddFenrirMovementSpeedCombinationBonus(ItemOptionTypes.BlackFenrir, BlackFenrirMovementSpeedCombinationBonusNumber, Stats.MaxMovementSpeed);
-        this.AddFenrirMovementSpeedCombinationBonus(ItemOptionTypes.BlackFenrir, BlackFenrirUnderwaterMovementSpeedCombinationBonusNumber, Stats.MaxMovementSpeedUnderwater);
-        this.AddFenrirMovementSpeedCombinationBonus(ItemOptionTypes.BlueFenrir, BlueFenrirMovementSpeedCombinationBonusNumber, Stats.MaxMovementSpeed);
-        this.AddFenrirMovementSpeedCombinationBonus(ItemOptionTypes.BlueFenrir, BlueFenrirUnderwaterMovementSpeedCombinationBonusNumber, Stats.MaxMovementSpeedUnderwater);
-        this.AddFenrirMovementSpeedCombinationBonus(ItemOptionTypes.GoldFenrir, GoldFenrirMovementSpeedCombinationBonusNumber, Stats.MaxMovementSpeed);
-        this.AddFenrirMovementSpeedCombinationBonus(ItemOptionTypes.GoldFenrir, GoldFenrirUnderwaterMovementSpeedCombinationBonusNumber, Stats.MaxMovementSpeedUnderwater);
+        this.AddFenrirMovementSpeedCombinationBonus(ItemOptionTypes.BlackFenrir, BlackFenrirMovementSpeedCombinationBonusNumber, Stats.MovementSpeed);
+        this.AddFenrirMovementSpeedCombinationBonus(ItemOptionTypes.BlackFenrir, BlackFenrirUnderwaterMovementSpeedCombinationBonusNumber, Stats.MovementSpeedUnderwater);
+        this.AddFenrirMovementSpeedCombinationBonus(ItemOptionTypes.BlueFenrir, BlueFenrirMovementSpeedCombinationBonusNumber, Stats.MovementSpeed);
+        this.AddFenrirMovementSpeedCombinationBonus(ItemOptionTypes.BlueFenrir, BlueFenrirUnderwaterMovementSpeedCombinationBonusNumber, Stats.MovementSpeedUnderwater);
+        this.AddFenrirMovementSpeedCombinationBonus(ItemOptionTypes.GoldFenrir, GoldFenrirMovementSpeedCombinationBonusNumber, Stats.MovementSpeed);
+        this.AddFenrirMovementSpeedCombinationBonus(ItemOptionTypes.GoldFenrir, GoldFenrirUnderwaterMovementSpeedCombinationBonusNumber, Stats.MovementSpeedUnderwater);
     }
 
     private void AddFenrirMovementSpeedCombinationBonus(ItemOptionType optionType, int number, AttributeDefinition targetAttribute)

--- a/src/Persistence/Initialization/VersionSeasonSix/Items/Wings.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Items/Wings.cs
@@ -230,8 +230,8 @@ public class Wings : WingsInitializerBase
         canFlyPowerUp.BaseValue = 1;
         wing.BasePowerUpAttributes.Add(canFlyPowerUp);
 
-        wing.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.MaxMovementSpeed, movementSpeed, AggregateType.Maximum));
-        wing.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.MaxMovementSpeedUnderwater, movementSpeed, AggregateType.Maximum));
+        wing.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.MovementSpeed, movementSpeed, AggregateType.Maximum));
+        wing.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.MovementSpeedUnderwater, movementSpeed, AggregateType.Maximum));
 
         return wing;
     }

--- a/src/Persistence/Initialization/VersionSeasonSix/Items/Wings.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Items/Wings.cs
@@ -79,7 +79,7 @@ public class Wings : WingsInitializerBase
         var secondWingOptions = this.CreateSecondClassWingOptions();
         this.CreateWing(3, 5, 3, "Wings of Spirits", 150, 30, 200, 215, 0, 0, 2, 0, 0, 0, 0, this.BuildOptions((0b10, OptionType.HealthRecover), (0b00, OptionType.PhysDamage)), 32, 25, this._damageIncreaseByLevelTableSecond, secondWingOptions);
         this.CreateWing(4, 5, 3, "Wings of Soul", 150, 30, 200, 215, 2, 0, 0, 0, 0, 0, 0, this.BuildOptions((0b00, OptionType.HealthRecover), (0b10, OptionType.WizDamage)), 32, 25, this._damageIncreaseByLevelTableSecond, secondWingOptions);
-        this.CreateWing(5, 3, 3, "Wings of Dragon", 150, 45, 200, 215, 0, 2, 0, 0, 0, 0, 0, this.BuildOptions((0b00, OptionType.HealthRecover), (0b10, OptionType.PhysDamage)), 32, 25, this._damageIncreaseByLevelTableSecond, secondWingOptions);
+        this.CreateWing(5, 3, 3, "Wings of Dragon", 150, 45, 200, 215, 0, 2, 0, 0, 0, 0, 0, this.BuildOptions((0b00, OptionType.HealthRecover), (0b10, OptionType.PhysDamage)), 32, 25, this._damageIncreaseByLevelTableSecond, secondWingOptions, movementSpeed: MovementSpeedConstants.FastWingMovementSpeed);
         this.CreateWing(6, 4, 2, "Wings of Darkness", 150, 40, 200, 215, 0, 0, 0, 1, 0, 0, 0, this.BuildOptions((0b00, OptionType.WizDamage), (0b10, OptionType.PhysDamage)), 32, 25, this._damageIncreaseByLevelTableSecond, secondWingOptions);
         this.CreateWing(42, 4, 3, "Wings of Despair", 150, 30, 200, 215, 0, 0, 0, 0, 0, 2, 0, this.BuildOptions((0b00, OptionType.CurseDamage), (0b10, OptionType.WizDamage)), 32, 25, this._damageIncreaseByLevelTableSecond, secondWingOptions);
 
@@ -95,7 +95,7 @@ public class Wings : WingsInitializerBase
 
         // Third class wings:
         var thirdWingOptions = this.CreateThirdClassWingOptions();
-        this.CreateWing(36, 4, 3, "Wing of Storm", 150, 60, 220, 400, 0, 3, 0, 0, 0, 0, 0, this.BuildOptions((0b00, OptionType.HealthRecover), (0b11, OptionType.PhysDamage), (0b10, OptionType.Defense)), 39, 39, this._damageIncreaseByLevelTable, thirdWingOptions);
+        this.CreateWing(36, 4, 3, "Wing of Storm", 150, 60, 220, 400, 0, 3, 0, 0, 0, 0, 0, this.BuildOptions((0b00, OptionType.HealthRecover), (0b11, OptionType.PhysDamage), (0b10, OptionType.Defense)), 39, 39, this._damageIncreaseByLevelTable, thirdWingOptions, movementSpeed: MovementSpeedConstants.FastWingMovementSpeed);
         this.CreateWing(37, 4, 3, "Wing of Eternal", 150, 45, 220, 400, 3, 0, 0, 0, 0, 0, 0, this.BuildOptions((0b00, OptionType.HealthRecover), (0b11, OptionType.WizDamage), (0b10, OptionType.Defense)), 39, 39, this._damageIncreaseByLevelTable, thirdWingOptions);
         this.CreateWing(38, 4, 3, "Wing of Illusion", 150, 45, 220, 400, 0, 0, 3, 0, 0, 0, 0, this.BuildOptions((0b00, OptionType.HealthRecover), (0b11, OptionType.PhysDamage), (0b10, OptionType.Defense)), 39, 39, this._damageIncreaseByLevelTable, thirdWingOptions);
         this.CreateWing(39, 4, 3, "Wing of Ruin", 150, 55, 220, 400, 0, 0, 0, 3, 0, 0, 0, this.BuildOptions((0b00, OptionType.HealthRecover), (0b11, OptionType.PhysDamage), (0b10, OptionType.WizDamage)), 39, 39, this._damageIncreaseByLevelTable, thirdWingOptions);
@@ -149,9 +149,9 @@ public class Wings : WingsInitializerBase
         this.GameConfiguration.Items.Add(feather);
     }
 
-    private ItemDefinition CreateWing(byte number, byte width, byte height, string name, byte dropLevel, int defense, byte durability, int levelRequirement, int darkWizardClassLevel, int darkKnightClassLevel, int elfClassLevel, int magicGladiatorClassLevel, int darkLordClassLevel, int summonerClassLevel, int ragefighterClassLevel, IEnumerable<IncreasableItemOption> possibleOptions, int damageIncreaseInitial, int damageAbsorbInitial, ItemLevelBonusTable damageIncreasePerLevel, ItemOptionDefinition? wingOptionDefinition)
+    private ItemDefinition CreateWing(byte number, byte width, byte height, string name, byte dropLevel, int defense, byte durability, int levelRequirement, int darkWizardClassLevel, int darkKnightClassLevel, int elfClassLevel, int magicGladiatorClassLevel, int darkLordClassLevel, int summonerClassLevel, int ragefighterClassLevel, IEnumerable<IncreasableItemOption> possibleOptions, int damageIncreaseInitial, int damageAbsorbInitial, ItemLevelBonusTable damageIncreasePerLevel, ItemOptionDefinition? wingOptionDefinition, float movementSpeed = MovementSpeedConstants.DefaultWingMovementSpeed)
     {
-        var wing = this.CreateWing(number, width, height, name, dropLevel, defense, durability, levelRequirement, darkWizardClassLevel, darkKnightClassLevel, elfClassLevel, magicGladiatorClassLevel, darkLordClassLevel, summonerClassLevel, ragefighterClassLevel);
+        var wing = this.CreateWing(number, width, height, name, dropLevel, defense, durability, levelRequirement, darkWizardClassLevel, darkKnightClassLevel, elfClassLevel, magicGladiatorClassLevel, darkLordClassLevel, summonerClassLevel, ragefighterClassLevel, movementSpeed);
         if (wingOptionDefinition != null)
         {
             wing.PossibleItemOptions.Add(wingOptionDefinition);
@@ -192,7 +192,7 @@ public class Wings : WingsInitializerBase
         return wing;
     }
 
-    private ItemDefinition CreateWing(byte number, byte width, byte height, string name, byte dropLevel, int defense, byte durability, int levelRequirement, int darkWizardClassLevel, int darkKnightClassLevel, int elfClassLevel, int magicGladiatorClassLevel, int darkLordClassLevel, int summonerClassLevel, int ragefighterClassLevel)
+    private ItemDefinition CreateWing(byte number, byte width, byte height, string name, byte dropLevel, int defense, byte durability, int levelRequirement, int darkWizardClassLevel, int darkKnightClassLevel, int elfClassLevel, int magicGladiatorClassLevel, int darkLordClassLevel, int summonerClassLevel, int ragefighterClassLevel, float movementSpeed = MovementSpeedConstants.DefaultWingMovementSpeed)
     {
         var wing = this.Context.CreateNew<ItemDefinition>();
         this.GameConfiguration.Items.Add(wing);
@@ -229,6 +229,9 @@ public class Wings : WingsInitializerBase
         canFlyPowerUp.TargetAttribute = Stats.CanFly.GetPersistent(this.GameConfiguration);
         canFlyPowerUp.BaseValue = 1;
         wing.BasePowerUpAttributes.Add(canFlyPowerUp);
+
+        wing.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.MaxMovementSpeed, movementSpeed, AggregateType.Maximum));
+        wing.BasePowerUpAttributes.Add(this.CreateItemBasePowerUpDefinition(Stats.MaxMovementSpeedUnderwater, movementSpeed, AggregateType.Maximum));
 
         return wing;
     }

--- a/src/Persistence/Initialization/VersionSeasonSix/Maps/Doppelgaenger3.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Maps/Doppelgaenger3.cs
@@ -36,4 +36,11 @@ internal class Doppelgaenger3 : BaseMapInitializer
 
     /// <inheritdoc />
     protected override string MapName => Name;
+
+    /// <inheritdoc />
+    protected override void AdditionalInitialization(GameMapDefinition mapDefinition)
+    {
+        base.AdditionalInitialization(mapDefinition);
+        this.AddUnderwaterMovementPowerUp();
+    }
 }

--- a/src/Persistence/Initialization/VersionSeasonSix/Maps/KalimaBase.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Maps/KalimaBase.cs
@@ -21,6 +21,13 @@ internal abstract class KalimaBase : BaseMapInitializer
     {
     }
 
+    /// <inheritdoc />
+    protected override void AdditionalInitialization(GameMapDefinition mapDefinition)
+    {
+        base.AdditionalInitialization(mapDefinition);
+        this.AddUnderwaterMovementPowerUp();
+    }
+
     /// <inheritdoc/>
     protected override IEnumerable<MonsterSpawnArea> CreateNpcSpawns()
     {

--- a/src/Persistence/Initialization/VersionSeasonSix/SkillsInitializer.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/SkillsInitializer.cs
@@ -71,7 +71,7 @@ internal class SkillsInitializer : SkillsInitializerBase
         { SkillNumber.Weakness, MagicEffectNumber.WeaknessSummoner },
         { SkillNumber.Innovation, MagicEffectNumber.Innovation },
         { SkillNumber.DamageReflection, MagicEffectNumber.Reflection },
-        { SkillNumber.StrikeofDestruction, MagicEffectNumber.BlowOfDestruction },
+        { SkillNumber.StrikeofDestruction, MagicEffectNumber.Cold },
         { SkillNumber.BeastUppercut, MagicEffectNumber.DefenseReductionBeastUppercut },
         { SkillNumber.PhoenixShot, MagicEffectNumber.DecreaseBlock },
         { SkillNumber.Explosion223, MagicEffectNumber.Explosion },
@@ -689,7 +689,7 @@ internal class SkillsInitializer : SkillsInitializerBase
         new WeaknessSummonerEffectInitializer(this.Context, this.GameConfiguration).Initialize();
         new InnovationEffectInitializer(this.Context, this.GameConfiguration).Initialize();
         new ReflectionEffectInitializer(this.Context, this.GameConfiguration).Initialize();
-        new BlowOfDestructionEffectInitializer(this.Context, this.GameConfiguration).Initialize();
+        new ColdEffectInitializer(this.Context, this.GameConfiguration).Initialize();
         new DefenseReductionBeastUppercutEffectInitializer(this.Context, this.GameConfiguration).Initialize();
         new DecreaseBlockEffectInitializer(this.Context, this.GameConfiguration).Initialize();
         new ExplosionEffectInitializer(this.Context, this.GameConfiguration).Initialize();

--- a/src/Persistence/Initialization/VersionSeasonSix/SkillsInitializer.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/SkillsInitializer.cs
@@ -71,6 +71,7 @@ internal class SkillsInitializer : SkillsInitializerBase
         { SkillNumber.Weakness, MagicEffectNumber.WeaknessSummoner },
         { SkillNumber.Innovation, MagicEffectNumber.Innovation },
         { SkillNumber.DamageReflection, MagicEffectNumber.Reflection },
+        { SkillNumber.StrikeofDestruction, MagicEffectNumber.BlowOfDestruction },
         { SkillNumber.BeastUppercut, MagicEffectNumber.DefenseReductionBeastUppercut },
         { SkillNumber.PhoenixShot, MagicEffectNumber.DecreaseBlock },
         { SkillNumber.Explosion223, MagicEffectNumber.Explosion },
@@ -688,6 +689,7 @@ internal class SkillsInitializer : SkillsInitializerBase
         new WeaknessSummonerEffectInitializer(this.Context, this.GameConfiguration).Initialize();
         new InnovationEffectInitializer(this.Context, this.GameConfiguration).Initialize();
         new ReflectionEffectInitializer(this.Context, this.GameConfiguration).Initialize();
+        new BlowOfDestructionEffectInitializer(this.Context, this.GameConfiguration).Initialize();
         new DefenseReductionBeastUppercutEffectInitializer(this.Context, this.GameConfiguration).Initialize();
         new DecreaseBlockEffectInitializer(this.Context, this.GameConfiguration).Initialize();
         new ExplosionEffectInitializer(this.Context, this.GameConfiguration).Initialize();


### PR DESCRIPTION
The current Walker implementation is not aligned to client-side movement- it uses wrong movement speeds and does not account for many parameters that client takes into account when calculating player/monster movement speed (safezones, boots, wings, pets, mounts, diagonal tiles, skill effects such as ice/strike of destruction etc). As a result, server and client positions of players/monsters frequently go out of sync, which causes the server to reject valid walk requests, and send forced move corrections back, causing a flaky movement experience overall.

This PR refines server-side player/monster movement by calculating walk delays per step accounting for movement speed modifiers (safe zones, wings, pets, boots, gloves, Fenrir, ice, strike of destruction, etc) instead of using one fixed inaccurate delay.

It also includes 2 other movement related minor fixes:
- Blocks player attacks when either side is protected by a safe zone.
- Stops sending walk direction data by default, since MuMain no longer uses it.
