### PR TITLE
Monster Attribute Scaler Plugin

### DIFF
--- a/src/GameLogic/PlugIns/MonsterAttributeScaler.cs
+++ b/src/GameLogic/PlugIns/MonsterAttributeScaler.cs
@@ -1,0 +1,136 @@
+// <copyright file="MonsterAttributeScaler.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.PlugIns;
+
+using System.Collections.Concurrent;
+using System.ComponentModel.DataAnnotations;
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.AttributeSystem;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.Attributes;
+using MUnique.OpenMU.GameLogic.NPC;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// A feature plugin which scales all monster base stats by a configurable percentage.
+/// Uses multiplicative IElement instances applied per-monster. A server restart is
+/// required for configuration changes to take effect.
+/// </summary>
+[PlugIn]
+[Display(Name = "Monster Attribute Scaler", Description = "Increases all monster base stats by a configurable percentage.")]
+[Guid("59E5B45F-0A3D-4BAF-8B6C-9E1D2F3A4B5C")]
+public class MonsterAttributeScaler : IFeaturePlugIn, IObjectAddedToMapPlugIn, IObjectRemovedFromMapPlugIn,
+    ISupportCustomConfiguration<MonsterAttributeScalerConfiguration>,
+    ISupportDefaultCustomConfiguration,
+    IDisabledByDefault
+{
+    private MonsterAttributeScalerConfiguration? _configuration;
+
+    private readonly ConcurrentDictionary<IAttackable, List<(AttributeDefinition Attribute, IElement Element)>> _scaledMonsters = new();
+
+    private readonly ConcurrentDictionary<int, byte> _loggedMonsterTypes = new();
+
+    private static readonly HashSet<AttributeDefinition> ScalableStatsExceptHealth =
+    [
+        Stats.MinimumPhysBaseDmg,
+        Stats.MaximumPhysBaseDmg,
+        Stats.AttackRatePvm,
+        Stats.DefenseRatePvm,
+        Stats.DefenseBase,
+    ];
+
+    /// <inheritdoc />
+    public MonsterAttributeScalerConfiguration? Configuration
+    {
+        get => this._configuration;
+        set => this._configuration = value;
+    }
+
+    /// <inheritdoc />
+    public object CreateDefaultConfig() => new MonsterAttributeScalerConfiguration();
+
+    /// <summary>
+    /// Applies configured scaling to newly spawned monsters.
+    /// </summary>
+    public ValueTask ObjectAddedToMapAsync(GameMap map, ILocateable addedObject)
+    {
+        if (addedObject is not AttackableNpcBase monster)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        if (this.Configuration is not { Percentage: > 0 } config)
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        if (!this._scaledMonsters.ContainsKey(monster))
+        {
+            var multiplier = 1.0f + config.Percentage / 100.0f;
+            this.ApplyScaling(monster, multiplier);
+
+            if (this._loggedMonsterTypes.TryAdd(monster.Definition.Number, 0))
+            {
+                Console.WriteLine($"[MonsterAttributeScaler] Scaled monster type {monster.Definition.Number} by {config.Percentage}%");
+            }
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// Cleans up the tracking dictionary when a monster is removed from a map.
+    /// </summary>
+    public ValueTask ObjectRemovedFromMapAsync(GameMap map, ILocateable removedObject)
+    {
+        if (removedObject is IAttackable attackable)
+        {
+            this._scaledMonsters.TryRemove(attackable, out _);
+        }
+
+        return ValueTask.CompletedTask;
+    }
+
+    private void ApplyScaling(IAttackable monster, float multiplier)
+    {
+        this.RemoveScaling(monster);
+
+        var tracker = this._scaledMonsters.GetOrAdd(monster, _ => new List<(AttributeDefinition, IElement)>());
+
+        foreach (var stat in ScalableStatsExceptHealth)
+        {
+            var element = new SimpleElement(multiplier, AggregateType.Multiplicate);
+            monster.Attributes.AddElement(element, stat);
+            tracker.Add((stat, element));
+        }
+
+        if (monster is AttackableNpcBase npc)
+        {
+            var healthElement = new SimpleElement(multiplier, AggregateType.Multiplicate);
+            monster.Attributes.AddElement(healthElement, Stats.MaximumHealth);
+            tracker.Add((Stats.MaximumHealth, healthElement));
+
+            npc.Health = Math.Max(1, (int)(npc.Health * multiplier));
+        }
+    }
+
+    private void RemoveScaling(IAttackable monster)
+    {
+        if (!this._scaledMonsters.TryRemove(monster, out var tracker))
+        {
+            return;
+        }
+
+        foreach (var (attribute, element) in tracker)
+        {
+            monster.Attributes.RemoveElement(element, attribute);
+        }
+
+        if (monster is AttackableNpcBase npc)
+        {
+            npc.Health = Math.Max(1, (int)monster.Attributes[Stats.MaximumHealth]);
+        }
+    }
+}

--- a/src/GameLogic/PlugIns/MonsterAttributeScaler.cs
+++ b/src/GameLogic/PlugIns/MonsterAttributeScaler.cs
@@ -87,7 +87,7 @@ public class MonsterAttributeScaler : IFeaturePlugIn, IObjectAddedToMapPlugIn, I
     {
         if (removedObject is IAttackable attackable)
         {
-            this._scaledMonsters.TryRemove(attackable, out _);
+            this.RemoveScaling(attackable);
         }
 
         return ValueTask.CompletedTask;
@@ -123,6 +123,16 @@ public class MonsterAttributeScaler : IFeaturePlugIn, IObjectAddedToMapPlugIn, I
             return;
         }
 
+        float healthPercentage = 0f;
+        if (monster is AttackableNpcBase { IsAlive: true } npc)
+        {
+            var maxHealth = monster.Attributes[Stats.MaximumHealth];
+            if (maxHealth > 0)
+            {
+                healthPercentage = (float)npc.Health / maxHealth;
+            }
+        }
+
         foreach (var (attribute, element) in tracker)
         {
             monster.Attributes.RemoveElement(element, attribute);
@@ -130,7 +140,15 @@ public class MonsterAttributeScaler : IFeaturePlugIn, IObjectAddedToMapPlugIn, I
 
         if (monster is AttackableNpcBase npc)
         {
-            npc.Health = Math.Max(1, (int)monster.Attributes[Stats.MaximumHealth]);
+            if (npc.IsAlive)
+            {
+                var newMaxHealth = monster.Attributes[Stats.MaximumHealth];
+                npc.Health = Math.Max(1, (int)(newMaxHealth * healthPercentage));
+            }
+            else
+            {
+                npc.Health = 0;
+            }
         }
     }
 }

--- a/src/GameLogic/PlugIns/MonsterAttributeScaler.cs
+++ b/src/GameLogic/PlugIns/MonsterAttributeScaler.cs
@@ -37,8 +37,14 @@ public class MonsterAttributeScaler : IFeaturePlugIn, IObjectAddedToMapPlugIn, I
         set
         {
             this._configuration = value;
+
             if (value is null)
             {
+                this._damageMultiplier.Value = 1.0f;
+                this._attackRateMultiplier.Value = 1.0f;
+                this._defenseRateMultiplier.Value = 1.0f;
+                this._defenseMultiplier.Value = 1.0f;
+                this._healthMultiplier.Value = 1.0f;
                 return;
             }
 
@@ -53,17 +59,10 @@ public class MonsterAttributeScaler : IFeaturePlugIn, IObjectAddedToMapPlugIn, I
     /// <inheritdoc />
     public object CreateDefaultConfig()
     {
-        return CreateDefaultConfiguration();
+        return new MonsterAttributeScalerConfiguration();
     }
 
-    private static MonsterAttributeScalerConfiguration CreateDefaultConfiguration()
-    {
-        return new();
-    }
-
-    /// <summary>
-    /// Applies configured scaling to newly spawned monsters.
-    /// </summary>
+    /// <inheritdoc />
     public ValueTask ObjectAddedToMapAsync(GameMap map, ILocateable addedObject)
     {
         if (addedObject is not AttackableNpcBase monster)
@@ -81,9 +80,7 @@ public class MonsterAttributeScaler : IFeaturePlugIn, IObjectAddedToMapPlugIn, I
         return ValueTask.CompletedTask;
     }
 
-    /// <summary>
-    /// Removes the shared elements when a monster is removed from a map.
-    /// </summary>
+    /// <inheritdoc />
     public ValueTask ObjectRemovedFromMapAsync(GameMap map, ILocateable removedObject)
     {
         if (removedObject is not AttackableNpcBase monster)

--- a/src/GameLogic/PlugIns/MonsterAttributeScaler.cs
+++ b/src/GameLogic/PlugIns/MonsterAttributeScaler.cs
@@ -5,10 +5,8 @@
 namespace MUnique.OpenMU.GameLogic.PlugIns;
 
 using System.Collections.Concurrent;
-using System.ComponentModel.DataAnnotations;
 using System.Runtime.InteropServices;
 using MUnique.OpenMU.AttributeSystem;
-using MUnique.OpenMU.GameLogic;
 using MUnique.OpenMU.GameLogic.Attributes;
 using MUnique.OpenMU.GameLogic.NPC;
 using MUnique.OpenMU.PlugIns;
@@ -19,18 +17,14 @@ using MUnique.OpenMU.PlugIns;
 /// required for configuration changes to take effect.
 /// </summary>
 [PlugIn]
-[Display(Name = "Monster Attribute Scaler", Description = "Increases all monster base stats by a configurable percentage.")]
+[Display(Name = nameof(PlugInResources.MonsterAttributeScaler_Name), Description = nameof(PlugInResources.MonsterAttributeScaler_Description), ResourceType = typeof(PlugInResources))]
 [Guid("59E5B45F-0A3D-4BAF-8B6C-9E1D2F3A4B5C")]
 public class MonsterAttributeScaler : IFeaturePlugIn, IObjectAddedToMapPlugIn, IObjectRemovedFromMapPlugIn,
     ISupportCustomConfiguration<MonsterAttributeScalerConfiguration>,
     ISupportDefaultCustomConfiguration,
     IDisabledByDefault
 {
-    private MonsterAttributeScalerConfiguration? _configuration;
-
     private readonly ConcurrentDictionary<IAttackable, List<(AttributeDefinition Attribute, IElement Element)>> _scaledMonsters = new();
-
-    private readonly ConcurrentDictionary<int, byte> _loggedMonsterTypes = new();
 
     private static readonly HashSet<AttributeDefinition> ScalableStatsExceptHealth =
     [
@@ -42,14 +36,18 @@ public class MonsterAttributeScaler : IFeaturePlugIn, IObjectAddedToMapPlugIn, I
     ];
 
     /// <inheritdoc />
-    public MonsterAttributeScalerConfiguration? Configuration
-    {
-        get => this._configuration;
-        set => this._configuration = value;
-    }
+    public MonsterAttributeScalerConfiguration? Configuration { get; set; }
 
     /// <inheritdoc />
-    public object CreateDefaultConfig() => new MonsterAttributeScalerConfiguration();
+    public object CreateDefaultConfig()
+    {
+        return CreateDefaultConfiguration();
+    }
+
+    private static MonsterAttributeScalerConfiguration CreateDefaultConfiguration()
+    {
+        return new();
+    }
 
     /// <summary>
     /// Applies configured scaling to newly spawned monsters.
@@ -61,20 +59,16 @@ public class MonsterAttributeScaler : IFeaturePlugIn, IObjectAddedToMapPlugIn, I
             return ValueTask.CompletedTask;
         }
 
-        if (this.Configuration is not { Percentage: > 0 } config)
+        var configuration = this.Configuration ??= CreateDefaultConfiguration();
+        if (configuration.Percentage <= 0)
         {
             return ValueTask.CompletedTask;
         }
 
         if (!this._scaledMonsters.ContainsKey(monster))
         {
-            var multiplier = 1.0f + config.Percentage / 100.0f;
+            var multiplier = 1.0f + configuration.Percentage / 100.0f;
             this.ApplyScaling(monster, multiplier);
-
-            if (this._loggedMonsterTypes.TryAdd(monster.Definition.Number, 0))
-            {
-                Console.WriteLine($"[MonsterAttributeScaler] Scaled monster type {monster.Definition.Number} by {config.Percentage}%");
-            }
         }
 
         return ValueTask.CompletedTask;
@@ -123,8 +117,9 @@ public class MonsterAttributeScaler : IFeaturePlugIn, IObjectAddedToMapPlugIn, I
             return;
         }
 
+        var npc = monster as AttackableNpcBase;
         float healthPercentage = 0f;
-        if (monster is AttackableNpcBase { IsAlive: true } npc)
+        if (npc is { IsAlive: true })
         {
             var maxHealth = monster.Attributes[Stats.MaximumHealth];
             if (maxHealth > 0)
@@ -138,7 +133,7 @@ public class MonsterAttributeScaler : IFeaturePlugIn, IObjectAddedToMapPlugIn, I
             monster.Attributes.RemoveElement(element, attribute);
         }
 
-        if (monster is AttackableNpcBase npc)
+        if (npc is not null)
         {
             if (npc.IsAlive)
             {

--- a/src/GameLogic/PlugIns/MonsterAttributeScaler.cs
+++ b/src/GameLogic/PlugIns/MonsterAttributeScaler.cs
@@ -4,7 +4,6 @@
 
 namespace MUnique.OpenMU.GameLogic.PlugIns;
 
-using System.Collections.Concurrent;
 using System.Runtime.InteropServices;
 using MUnique.OpenMU.AttributeSystem;
 using MUnique.OpenMU.GameLogic.Attributes;
@@ -13,8 +12,7 @@ using MUnique.OpenMU.PlugIns;
 
 /// <summary>
 /// A feature plugin which scales all monster base stats by a configurable percentage.
-/// Uses multiplicative IElement instances applied per-monster. A server restart is
-/// required for configuration changes to take effect.
+/// Uses shared multiplicative IElement instances. Configuration changes take effect immediately.
 /// </summary>
 [PlugIn]
 [Display(Name = nameof(PlugInResources.MonsterAttributeScaler_Name), Description = nameof(PlugInResources.MonsterAttributeScaler_Description), ResourceType = typeof(PlugInResources))]
@@ -24,19 +22,33 @@ public class MonsterAttributeScaler : IFeaturePlugIn, IObjectAddedToMapPlugIn, I
     ISupportDefaultCustomConfiguration,
     IDisabledByDefault
 {
-    private readonly ConcurrentDictionary<IAttackable, List<(AttributeDefinition Attribute, IElement Element)>> _scaledMonsters = new();
+    private readonly SimpleElement _damageMultiplier = new(1.0f, AggregateType.Multiplicate);
+    private readonly SimpleElement _attackRateMultiplier = new(1.0f, AggregateType.Multiplicate);
+    private readonly SimpleElement _defenseRateMultiplier = new(1.0f, AggregateType.Multiplicate);
+    private readonly SimpleElement _defenseMultiplier = new(1.0f, AggregateType.Multiplicate);
+    private readonly SimpleElement _healthMultiplier = new(1.0f, AggregateType.Multiplicate);
 
-    private static readonly HashSet<AttributeDefinition> ScalableStatsExceptHealth =
-    [
-        Stats.MinimumPhysBaseDmg,
-        Stats.MaximumPhysBaseDmg,
-        Stats.AttackRatePvm,
-        Stats.DefenseRatePvm,
-        Stats.DefenseBase,
-    ];
+    private MonsterAttributeScalerConfiguration? _configuration;
 
     /// <inheritdoc />
-    public MonsterAttributeScalerConfiguration? Configuration { get; set; }
+    public MonsterAttributeScalerConfiguration? Configuration
+    {
+        get => this._configuration;
+        set
+        {
+            this._configuration = value;
+            if (value is null)
+            {
+                return;
+            }
+
+            this._damageMultiplier.Value = value.DamagePercentage > 0 ? 1.0f + value.DamagePercentage / 100.0f : 1.0f;
+            this._attackRateMultiplier.Value = value.AttackRatePercentage > 0 ? 1.0f + value.AttackRatePercentage / 100.0f : 1.0f;
+            this._defenseRateMultiplier.Value = value.DefenseRatePercentage > 0 ? 1.0f + value.DefenseRatePercentage / 100.0f : 1.0f;
+            this._defenseMultiplier.Value = value.DefensePercentage > 0 ? 1.0f + value.DefensePercentage / 100.0f : 1.0f;
+            this._healthMultiplier.Value = value.HealthPercentage > 0 ? 1.0f + value.HealthPercentage / 100.0f : 1.0f;
+        }
+    }
 
     /// <inheritdoc />
     public object CreateDefaultConfig()
@@ -59,91 +71,33 @@ public class MonsterAttributeScaler : IFeaturePlugIn, IObjectAddedToMapPlugIn, I
             return ValueTask.CompletedTask;
         }
 
-        var configuration = this.Configuration ??= CreateDefaultConfiguration();
-        if (configuration.Percentage <= 0)
-        {
-            return ValueTask.CompletedTask;
-        }
-
-        if (!this._scaledMonsters.ContainsKey(monster))
-        {
-            var multiplier = 1.0f + configuration.Percentage / 100.0f;
-            this.ApplyScaling(monster, multiplier);
-        }
+        monster.Attributes.AddElement(this._damageMultiplier, Stats.MinimumPhysBaseDmg);
+        monster.Attributes.AddElement(this._damageMultiplier, Stats.MaximumPhysBaseDmg);
+        monster.Attributes.AddElement(this._attackRateMultiplier, Stats.AttackRatePvm);
+        monster.Attributes.AddElement(this._defenseRateMultiplier, Stats.DefenseRatePvm);
+        monster.Attributes.AddElement(this._defenseMultiplier, Stats.DefenseBase);
+        monster.Attributes.AddElement(this._healthMultiplier, Stats.MaximumHealth);
 
         return ValueTask.CompletedTask;
     }
 
     /// <summary>
-    /// Cleans up the tracking dictionary when a monster is removed from a map.
+    /// Removes the shared elements when a monster is removed from a map.
     /// </summary>
     public ValueTask ObjectRemovedFromMapAsync(GameMap map, ILocateable removedObject)
     {
-        if (removedObject is IAttackable attackable)
+        if (removedObject is not AttackableNpcBase monster)
         {
-            this.RemoveScaling(attackable);
+            return ValueTask.CompletedTask;
         }
+
+        monster.Attributes.RemoveElement(this._damageMultiplier, Stats.MinimumPhysBaseDmg);
+        monster.Attributes.RemoveElement(this._damageMultiplier, Stats.MaximumPhysBaseDmg);
+        monster.Attributes.RemoveElement(this._attackRateMultiplier, Stats.AttackRatePvm);
+        monster.Attributes.RemoveElement(this._defenseRateMultiplier, Stats.DefenseRatePvm);
+        monster.Attributes.RemoveElement(this._defenseMultiplier, Stats.DefenseBase);
+        monster.Attributes.RemoveElement(this._healthMultiplier, Stats.MaximumHealth);
 
         return ValueTask.CompletedTask;
-    }
-
-    private void ApplyScaling(IAttackable monster, float multiplier)
-    {
-        this.RemoveScaling(monster);
-
-        var tracker = this._scaledMonsters.GetOrAdd(monster, _ => new List<(AttributeDefinition, IElement)>());
-
-        foreach (var stat in ScalableStatsExceptHealth)
-        {
-            var element = new SimpleElement(multiplier, AggregateType.Multiplicate);
-            monster.Attributes.AddElement(element, stat);
-            tracker.Add((stat, element));
-        }
-
-        if (monster is AttackableNpcBase npc)
-        {
-            var healthElement = new SimpleElement(multiplier, AggregateType.Multiplicate);
-            monster.Attributes.AddElement(healthElement, Stats.MaximumHealth);
-            tracker.Add((Stats.MaximumHealth, healthElement));
-
-            npc.Health = Math.Max(1, (int)(npc.Health * multiplier));
-        }
-    }
-
-    private void RemoveScaling(IAttackable monster)
-    {
-        if (!this._scaledMonsters.TryRemove(monster, out var tracker))
-        {
-            return;
-        }
-
-        var npc = monster as AttackableNpcBase;
-        float healthPercentage = 0f;
-        if (npc is { IsAlive: true })
-        {
-            var maxHealth = monster.Attributes[Stats.MaximumHealth];
-            if (maxHealth > 0)
-            {
-                healthPercentage = (float)npc.Health / maxHealth;
-            }
-        }
-
-        foreach (var (attribute, element) in tracker)
-        {
-            monster.Attributes.RemoveElement(element, attribute);
-        }
-
-        if (npc is not null)
-        {
-            if (npc.IsAlive)
-            {
-                var newMaxHealth = monster.Attributes[Stats.MaximumHealth];
-                npc.Health = Math.Max(1, (int)(newMaxHealth * healthPercentage));
-            }
-            else
-            {
-                npc.Health = 0;
-            }
-        }
     }
 }

--- a/src/GameLogic/PlugIns/MonsterAttributeScalerConfiguration.cs
+++ b/src/GameLogic/PlugIns/MonsterAttributeScalerConfiguration.cs
@@ -9,9 +9,94 @@ namespace MUnique.OpenMU.GameLogic.PlugIns;
 /// </summary>
 public class MonsterAttributeScalerConfiguration
 {
+    private float _scaleAllPercentage;
+    private float _damagePercentage = 25.0f;
+    private float _attackRatePercentage = 25.0f;
+    private float _defenseRatePercentage = 25.0f;
+    private float _defensePercentage = 25.0f;
+    private float _healthPercentage = 25.0f;
+
+    private bool ScaleAllActive => this._scaleAllPercentage > 0;
+
     /// <summary>
-    /// Gets or sets the percentage by which all monster base stats
-    /// (attack rate, defense, defense rate, damage, health) are increased.
+    /// Gets or sets the percentage applied to all stats at once.
+    /// When set above 0, cascades to all individual fields.
     /// </summary>
-    public float Percentage { get; set; } = 25.0f;
+    public float ScaleAllPercentage
+    {
+        get => this._scaleAllPercentage;
+        set
+        {
+            this._scaleAllPercentage = value;
+            if (value > 0)
+            {
+                this._damagePercentage = value;
+                this._attackRatePercentage = value;
+                this._defenseRatePercentage = value;
+                this._defensePercentage = value;
+                this._healthPercentage = value;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets or sets the percentage by which monster damage (MinPhysBaseDmg, MaxPhysBaseDmg) is increased.
+    /// </summary>
+    public float DamagePercentage
+    {
+        get => this.ScaleAllActive ? this._scaleAllPercentage : this._damagePercentage;
+        set => this.SetIndividualField(ref this._damagePercentage, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the percentage by which monster attack rate is increased.
+    /// </summary>
+    public float AttackRatePercentage
+    {
+        get => this.ScaleAllActive ? this._scaleAllPercentage : this._attackRatePercentage;
+        set => this.SetIndividualField(ref this._attackRatePercentage, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the percentage by which monster defense rate is increased.
+    /// </summary>
+    public float DefenseRatePercentage
+    {
+        get => this.ScaleAllActive ? this._scaleAllPercentage : this._defenseRatePercentage;
+        set => this.SetIndividualField(ref this._defenseRatePercentage, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the percentage by which monster defense is increased.
+    /// </summary>
+    public float DefensePercentage
+    {
+        get => this.ScaleAllActive ? this._scaleAllPercentage : this._defensePercentage;
+        set => this.SetIndividualField(ref this._defensePercentage, value);
+    }
+
+    /// <summary>
+    /// Gets or sets the percentage by which monster maximum health is increased.
+    /// </summary>
+    public float HealthPercentage
+    {
+        get => this.ScaleAllActive ? this._scaleAllPercentage : this._healthPercentage;
+        set => this.SetIndividualField(ref this._healthPercentage, value);
+    }
+
+    private void SetIndividualField(ref float field, float value)
+    {
+        if (this.ScaleAllActive)
+        {
+            if (Math.Abs(value - this._scaleAllPercentage) > 0.01f)
+            {
+                this._scaleAllPercentage = 0;
+                field = value;
+            }
+
+            return;
+        }
+
+        field = value;
+    }
 }

--- a/src/GameLogic/PlugIns/MonsterAttributeScalerConfiguration.cs
+++ b/src/GameLogic/PlugIns/MonsterAttributeScalerConfiguration.cs
@@ -1,0 +1,17 @@
+// <copyright file="MonsterAttributeScalerConfiguration.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.PlugIns;
+
+/// <summary>
+/// Configuration for the <see cref="MonsterAttributeScaler"/>.
+/// </summary>
+public class MonsterAttributeScalerConfiguration
+{
+    /// <summary>
+    /// Gets or sets the percentage by which all monster base stats
+    /// (attack rate, defense, defense rate, damage, health) are increased.
+    /// </summary>
+    public float Percentage { get; set; } = 25.0f;
+}

--- a/src/GameLogic/PlugIns/MonsterAttributeScalerConfiguration.cs
+++ b/src/GameLogic/PlugIns/MonsterAttributeScalerConfiguration.cs
@@ -88,12 +88,6 @@ public class MonsterAttributeScalerConfiguration
     {
         if (this.ScaleAllActive)
         {
-            if (Math.Abs(value - this._scaleAllPercentage) > 0.01f)
-            {
-                this._scaleAllPercentage = 0;
-                field = value;
-            }
-
             return;
         }
 

--- a/src/GameLogic/Properties/PlugInResources.Designer.cs
+++ b/src/GameLogic/Properties/PlugInResources.Designer.cs
@@ -3220,5 +3220,23 @@ namespace MUnique.OpenMU.GameLogic.Properties {
                 return ResourceManager.GetString("WeatherUpdatePlugIn_Name", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Increases all monster base stats by a configurable percentage..
+        /// </summary>
+        public static string MonsterAttributeScaler_Description {
+            get {
+                return ResourceManager.GetString("MonsterAttributeScaler_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Monster Attribute Scaler.
+        /// </summary>
+        public static string MonsterAttributeScaler_Name {
+            get {
+                return ResourceManager.GetString("MonsterAttributeScaler_Name", resourceCulture);
+            }
+        }
     }
 }

--- a/src/GameLogic/Properties/PlugInResources.resx
+++ b/src/GameLogic/Properties/PlugInResources.resx
@@ -1170,4 +1170,10 @@
   <data name="PartyAutoRejoinPlugIn_Description" xml:space="preserve">
     <value>Automatically rejoins players to their previous party upon entering the world.</value>
   </data>
+  <data name="MonsterAttributeScaler_Name" xml:space="preserve">
+    <value>Monster Attribute Scaler</value>
+  </data>
+  <data name="MonsterAttributeScaler_Description" xml:space="preserve">
+    <value>Increases all monster base stats by a configurable percentage.</value>
+  </data>
 </root>

--- a/src/Startup/ConfigurationChangeHandler.cs
+++ b/src/Startup/ConfigurationChangeHandler.cs
@@ -111,18 +111,19 @@ public class ConfigurationChangeHandler : IConfigurationChangePublisher
             return;
         }
 
-        var currentlyActive = plugInManager.IsPlugInActive(id);
+        var typeId = plugInConfiguration.TypeId;
+        var currentlyActive = plugInManager.IsPlugInActive(typeId);
         if (currentlyActive && !plugInConfiguration.IsActive)
         {
-            plugInManager.DeactivatePlugIn(id);
+            plugInManager.DeactivatePlugIn(typeId);
         }
         else if (!currentlyActive && plugInConfiguration.IsActive)
         {
-            plugInManager.ActivatePlugIn(id);
+            plugInManager.ActivatePlugIn(typeId);
         }
         else
         {
-            plugInManager.ConfigurePlugIn(id, plugInConfiguration);
+            plugInManager.ConfigurePlugIn(typeId, plugInConfiguration);
         }
     }
 }


### PR DESCRIPTION
Monster Attribute Scaler Plugin
-------------------------------

What it does:
A feature plugin that scales monster base stats by a configurable percentage.
Each stat group (Damage, AttackRate, DefenseRate, Defense, Health) has its own
percentage setting. Default: +25% to MinimumPhysBaseDmg, MaximumPhysBaseDmg,
AttackRatePvm, DefenseRatePvm, DefenseBase, and MaximumHealth. Supports a
"Scale All" option that sets all stat groups at once. Starts disabled by default.

How it works:
The plugin uses shared multiplicative IElement instances, one per stat group,
added to all monsters at spawn time via IObjectAddedToMapPlugIn and removed
on despawn via IObjectRemovedFromMapPlugIn. Configuration changes in the
Admin Panel take effect immediately by mutating the shared element values,
which propagate to all active monsters through the attribute system's
ValueChanged event. The configuration class handles ScaleAll cascading and
individual field isolation at the property level.

Bug fix — ConfigurationChangeHandler (not plugin-specific, but required for live updates):
The OnPlugInConfigurationChanged method passed the entity primary key (Id)
instead of plugInConfiguration.TypeId to all PlugInManager calls. This caused
ActivatePlugIn, DeactivatePlugIn, and ConfigurePlugIn to silently no-op because
PlugInManager looks up plugins by their [Guid] TypeId, not by the database entity
PK. Fix: replaced 'id' with 'plugInConfiguration.TypeId' in all four calls.

Files modified for this plugin:
OpenMU/src/GameLogic/Properties/PlugInResources.resx
OpenMU/src/GameLogic/Properties/PlugInResources.Designer.cs

Files modified (bug fix, required for live updates):
OpenMU/src/Startup/ConfigurationChangeHandler.cs

Files added for this plugin:
OpenMU/src/GameLogic/PlugIns/MonsterAttributeScaler.cs
OpenMU/src/GameLogic/PlugIns/MonsterAttributeScalerConfiguration.cs