### PR TITLE
DbUpdateConcurrencyException on periodic player saves

### DIFF
--- a/src/GameServer/GameServer.cs
+++ b/src/GameServer/GameServer.cs
@@ -468,7 +468,6 @@ public sealed class GameServer : IGameServer, IDisposable, IGameServerContextPro
     {
         if (!remotePlayer.IsTemplatePlayer)
         {
-            await this.SaveSessionOfPlayerAsync(remotePlayer).ConfigureAwait(false);
             await this.SetOfflineAtLoginServerAsync(remotePlayer).ConfigureAwait(false);
         }
 

--- a/src/Persistence/EntityFramework/EntityFrameworkContextBase.cs
+++ b/src/Persistence/EntityFramework/EntityFrameworkContextBase.cs
@@ -117,6 +117,19 @@ internal class EntityFrameworkContextBase : IContext
     /// <inheritdoc />
     public bool Detach(object item)
     {
+        using var l = this._lock.Lock();
+        return this.DetachInternal(item);
+    }
+
+    /// <inheritdoc />
+    public void Attach(object item)
+    {
+        using var l = this._lock.Lock();
+        this.Context.Attach(item);
+    }
+
+    private bool DetachInternal(object item)
+    {
         var entry = this.Context.Entry(item);
         if (entry is null)
         {
@@ -125,15 +138,9 @@ internal class EntityFrameworkContextBase : IContext
 
         var previousState = entry.State;
         entry.State = EntityState.Detached;
-        this.ForEachAggregate(item, obj => this.Detach(obj));
+        this.ForEachAggregate(item, obj => this.DetachInternal(obj));
 
         return previousState != EntityState.Added;
-    }
-
-    /// <inheritdoc />
-    public void Attach(object item)
-    {
-        this.Context.Attach(item);
     }
 
     /// <inheritdoc />

--- a/src/Persistence/EntityFramework/EntityFrameworkContextBase.cs
+++ b/src/Persistence/EntityFramework/EntityFrameworkContextBase.cs
@@ -181,7 +181,7 @@ internal class EntityFrameworkContextBase : IContext
             case EntityState.Detached:
                 return true;
             case EntityState.Added:
-                this.Detach(obj);
+                this.DetachInternal(obj);
                 break;
             default:
                 this.Context.Remove(obj);

--- a/src/Persistence/EntityFramework/GameConfigurationRepository.cs
+++ b/src/Persistence/EntityFramework/GameConfigurationRepository.cs
@@ -45,7 +45,7 @@ internal class GameConfigurationRepository : GenericRepository<GameConfiguration
         {
             if (await this._objectLoader.LoadObjectAsync<GameConfiguration>(id, currentContext.Context, cancellationToken).ConfigureAwait(false) is { } config)
             {
-                currentContext.Attach(config);
+                currentContext.Context.Attach(config);
                 return config;
             }
 
@@ -71,7 +71,7 @@ internal class GameConfigurationRepository : GenericRepository<GameConfiguration
         try
         {
             var configs = (await this._objectLoader.LoadAllObjectsAsync<GameConfiguration>(currentContext.Context, cancellationToken).ConfigureAwait(false)).ToList();
-            configs.ForEach(currentContext.Attach);
+            configs.ForEach(c => currentContext.Context.Attach(c));
             return configs;
         }
         finally


### PR DESCRIPTION
Releated to this bug:  [bug.txt](https://github.com/user-attachments/files/27778895/bug.txt)

What changes are proposed:
Fix DbUpdateConcurrencyException on periodic player saves

Root cause: Race condition in EntityFrameworkContextBase. SaveChangesAsync had
an AsyncLock, but Attach/Detach did not. Game logic (trades, item drops, NPC buys)
calls Attach/Detach on the player's context while PeriodicSaveProgressPlugIn is
executing SaveChangesAsync, corrupting EF Core's change tracker state. This caused
UPDATE statements to affect 0 rows, throwing DbUpdateConcurrencyException and
triggering a player save rollback.

Fix 1: src/Persistence/EntityFramework/EntityFrameworkContextBase.cs
  - Added AsyncLock to Attach() and Detach()
  - Detach is recursive (ForEachAggregate), so extracted a DetachInternal()
    method without lock for recursive calls to avoid deadlock

Fix 2: src/GameServer/GameServer.cs
  - Removed redundant SaveSessionOfPlayerAsync() call from OnPlayerDisconnectedAsync
  - SaveProgressAsync is already called in Player.RemoveFromGameAsync() before the
    disconnect event fires. The second save hit a stale/empty change tracker.
  - Offline player path (OfflinePlayerManager.TransitionToOfflineAsync) is unaffected
    because it uses SuppressDisconnectedEvent() so the event never fires.

Fix 3: src/Persistence/EntityFramework/GameConfigurationRepository.cs
Fix: Replaced currentContext.Attach(config) with currentContext.Context.Attach(config) in both GetAllAsync() and GetByIdAsync(). The custom Attach() method only wraps DbContext.Attach() in the AsyncLock, so calling DbContext.Attach directly is functionally identical but bypasses the lock entirely. This is safe because the lock is already held by the outer GetAsync<T>() scope, so concurrent access is already prevented at that level.
