### PR TITLE
Reset info in character details added

### DIFF
--- a/docs/Packets/C3-F3-03-CharacterInformationExtended_by-server.md
+++ b/docs/Packets/C3-F3-03-CharacterInformationExtended_by-server.md
@@ -13,7 +13,7 @@ The characters enters the game world.
 | Index | Length | Data Type | Value | Description |
 |-------|--------|-----------|-------|-------------|
 | 0 | 1 |   Byte   | 0xC3  | [Packet type](PacketTypes.md) |
-| 1 | 1 |    Byte   |   96   | Packet header - length of the packet |
+| 1 | 1 |    Byte   |   92   | Packet header - length of the packet |
 | 2 | 1 |    Byte   | 0xF3  | Packet header - packet type identifier |
 | 3 | 1 |    Byte   | 0x03  | Packet header - sub packet type identifier |
 | 4 | 1 | Byte |  | X |
@@ -46,6 +46,7 @@ The characters enters the game world.
 | 84 | 2 | ShortLittleEndian |  | MagicSpeed |
 | 86 | 2 | ShortLittleEndian |  | MaximumAttackSpeed |
 | 88 | 1 | Byte |  | InventoryExtensions |
+| 90 | 2 | ShortLittleEndian |  | Resets |
 
 ### CharacterHeroState Enum
 

--- a/src/GameServer/RemoteView/Character/UpdateCharacterStatsExtendedPlugIn.cs
+++ b/src/GameServer/RemoteView/Character/UpdateCharacterStatsExtendedPlugIn.cs
@@ -70,7 +70,7 @@ public class UpdateCharacterStatsExtendedPlugIn : IUpdateCharacterStatsPlugIn
                 (ushort)this._player.Attributes[Stats.MagicSpeed],
                 (ushort)maxAttackSpeed,
                 (byte)this._player.SelectedCharacter.InventoryExtensions,
-                (uint)this._player.Attributes[Stats.Resets])
+                (ushort)this._player.Attributes[Stats.Resets])
             .ConfigureAwait(false);
 
         if (this._player.SelectedCharacter.CharacterClass!.IsMasterClass)

--- a/src/GameServer/RemoteView/Character/UpdateCharacterStatsExtendedPlugIn.cs
+++ b/src/GameServer/RemoteView/Character/UpdateCharacterStatsExtendedPlugIn.cs
@@ -69,7 +69,8 @@ public class UpdateCharacterStatsExtendedPlugIn : IUpdateCharacterStatsPlugIn
                 (ushort)this._player.Attributes[Stats.AttackSpeed],
                 (ushort)this._player.Attributes[Stats.MagicSpeed],
                 (ushort)maxAttackSpeed,
-                (byte)this._player.SelectedCharacter.InventoryExtensions)
+                (byte)this._player.SelectedCharacter.InventoryExtensions,
+                (uint)this._player.Attributes[Stats.Resets])
             .ConfigureAwait(false);
 
         if (this._player.SelectedCharacter.CharacterClass!.IsMasterClass)

--- a/src/GameServer/RemoteView/Character/UpdateCharacterStatsPlugIn.cs
+++ b/src/GameServer/RemoteView/Character/UpdateCharacterStatsPlugIn.cs
@@ -65,8 +65,7 @@ public class UpdateCharacterStatsPlugIn : IUpdateCharacterStatsPlugIn
             (ushort)this._player.Attributes[Stats.BaseLeadership],
             (ushort)this._player.SelectedCharacter.UsedNegFruitPoints,
             this._player.SelectedCharacter.GetMaximumFruitPoints(),
-            (byte)this._player.SelectedCharacter.InventoryExtensions,
-            (uint)this._player.Attributes[Stats.Resets])
+            (byte)this._player.SelectedCharacter.InventoryExtensions)
             .ConfigureAwait(false);
 
         if (this._player.SelectedCharacter.CharacterClass!.IsMasterClass)

--- a/src/GameServer/RemoteView/Character/UpdateCharacterStatsPlugIn.cs
+++ b/src/GameServer/RemoteView/Character/UpdateCharacterStatsPlugIn.cs
@@ -65,7 +65,8 @@ public class UpdateCharacterStatsPlugIn : IUpdateCharacterStatsPlugIn
             (ushort)this._player.Attributes[Stats.BaseLeadership],
             (ushort)this._player.SelectedCharacter.UsedNegFruitPoints,
             this._player.SelectedCharacter.GetMaximumFruitPoints(),
-            (byte)this._player.SelectedCharacter.InventoryExtensions)
+            (byte)this._player.SelectedCharacter.InventoryExtensions,
+            (ushort)this._player.Attributes[Stats.Resets])
             .ConfigureAwait(false);
 
         if (this._player.SelectedCharacter.CharacterClass!.IsMasterClass)

--- a/src/GameServer/RemoteView/Character/UpdateCharacterStatsPlugIn.cs
+++ b/src/GameServer/RemoteView/Character/UpdateCharacterStatsPlugIn.cs
@@ -66,7 +66,7 @@ public class UpdateCharacterStatsPlugIn : IUpdateCharacterStatsPlugIn
             (ushort)this._player.SelectedCharacter.UsedNegFruitPoints,
             this._player.SelectedCharacter.GetMaximumFruitPoints(),
             (byte)this._player.SelectedCharacter.InventoryExtensions,
-            (ushort)this._player.Attributes[Stats.Resets])
+            (uint)this._player.Attributes[Stats.Resets])
             .ConfigureAwait(false);
 
         if (this._player.SelectedCharacter.CharacterClass!.IsMasterClass)

--- a/src/Network/Packets/ServerToClient/ConnectionExtensions.cs
+++ b/src/Network/Packets/ServerToClient/ConnectionExtensions.cs
@@ -3385,6 +3385,7 @@ public static class ConnectionExtensions
     /// <param name="magicSpeed">The magic speed.</param>
     /// <param name="maximumAttackSpeed">The maximum attack speed.</param>
     /// <param name="inventoryExtensions">The inventory extensions.</param>
+    /// <param name="resets">The resets.</param>
     /// <remarks>
     /// Is sent by the server when: After the character was selected by the player and entered the game.
     /// Causes reaction on client side: The characters enters the game world.

--- a/src/Network/Packets/ServerToClient/ConnectionExtensions.cs
+++ b/src/Network/Packets/ServerToClient/ConnectionExtensions.cs
@@ -3260,7 +3260,7 @@ public static class ConnectionExtensions
     /// Is sent by the server when: After the character was selected by the player and entered the game.
     /// Causes reaction on client side: The characters enters the game world.
     /// </remarks>
-    public static async ValueTask SendCharacterInformationAsync(this IConnection? connection, byte @x, byte @y, ushort @mapId, ulong @currentExperience, ulong @experienceForNextLevel, ushort @levelUpPoints, ushort @strength, ushort @agility, ushort @vitality, ushort @energy, ushort @currentHealth, ushort @maximumHealth, ushort @currentMana, ushort @maximumMana, ushort @currentShield, ushort @maximumShield, ushort @currentAbility, ushort @maximumAbility, uint @money, CharacterHeroState @heroState, CharacterStatus @status, ushort @usedFruitPoints, ushort @maxFruitPoints, ushort @leadership, ushort @usedNegativeFruitPoints, ushort @maxNegativeFruitPoints, byte @inventoryExtensions, uint @resets)
+    public static async ValueTask SendCharacterInformationAsync(this IConnection? connection, byte @x, byte @y, ushort @mapId, ulong @currentExperience, ulong @experienceForNextLevel, ushort @levelUpPoints, ushort @strength, ushort @agility, ushort @vitality, ushort @energy, ushort @currentHealth, ushort @maximumHealth, ushort @currentMana, ushort @maximumMana, ushort @currentShield, ushort @maximumShield, ushort @currentAbility, ushort @maximumAbility, uint @money, CharacterHeroState @heroState, CharacterStatus @status, ushort @usedFruitPoints, ushort @maxFruitPoints, ushort @leadership, ushort @usedNegativeFruitPoints, ushort @maxNegativeFruitPoints, byte @inventoryExtensions)
     {
         if (connection is null)
         {
@@ -3298,7 +3298,6 @@ public static class ConnectionExtensions
             packet.UsedNegativeFruitPoints = @usedNegativeFruitPoints;
             packet.MaxNegativeFruitPoints = @maxNegativeFruitPoints;
             packet.InventoryExtensions = @inventoryExtensions;
-            packet.Resets = @resets;
 
             return packet.Header.Length;
         }
@@ -3390,7 +3389,7 @@ public static class ConnectionExtensions
     /// Is sent by the server when: After the character was selected by the player and entered the game.
     /// Causes reaction on client side: The characters enters the game world.
     /// </remarks>
-    public static async ValueTask SendCharacterInformationExtendedAsync(this IConnection? connection, byte @x, byte @y, ushort @mapId, ulong @currentExperience, ulong @experienceForNextLevel, ushort @levelUpPoints, ushort @strength, ushort @agility, ushort @vitality, ushort @energy, ushort @leadership, uint @currentHealth, uint @maximumHealth, uint @currentMana, uint @maximumMana, uint @currentShield, uint @maximumShield, uint @currentAbility, uint @maximumAbility, uint @money, CharacterHeroState @heroState, CharacterStatus @status, ushort @usedFruitPoints, ushort @maxFruitPoints, ushort @usedNegativeFruitPoints, ushort @maxNegativeFruitPoints, ushort @attackSpeed, ushort @magicSpeed, ushort @maximumAttackSpeed, byte @inventoryExtensions, uint @resets)
+    public static async ValueTask SendCharacterInformationExtendedAsync(this IConnection? connection, byte @x, byte @y, ushort @mapId, ulong @currentExperience, ulong @experienceForNextLevel, ushort @levelUpPoints, ushort @strength, ushort @agility, ushort @vitality, ushort @energy, ushort @leadership, uint @currentHealth, uint @maximumHealth, uint @currentMana, uint @maximumMana, uint @currentShield, uint @maximumShield, uint @currentAbility, uint @maximumAbility, uint @money, CharacterHeroState @heroState, CharacterStatus @status, ushort @usedFruitPoints, ushort @maxFruitPoints, ushort @usedNegativeFruitPoints, ushort @maxNegativeFruitPoints, ushort @attackSpeed, ushort @magicSpeed, ushort @maximumAttackSpeed, byte @inventoryExtensions, ushort @resets)
     {
         if (connection is null)
         {

--- a/src/Network/Packets/ServerToClient/ConnectionExtensions.cs
+++ b/src/Network/Packets/ServerToClient/ConnectionExtensions.cs
@@ -3260,7 +3260,7 @@ public static class ConnectionExtensions
     /// Is sent by the server when: After the character was selected by the player and entered the game.
     /// Causes reaction on client side: The characters enters the game world.
     /// </remarks>
-    public static async ValueTask SendCharacterInformationAsync(this IConnection? connection, byte @x, byte @y, ushort @mapId, ulong @currentExperience, ulong @experienceForNextLevel, ushort @levelUpPoints, ushort @strength, ushort @agility, ushort @vitality, ushort @energy, ushort @currentHealth, ushort @maximumHealth, ushort @currentMana, ushort @maximumMana, ushort @currentShield, ushort @maximumShield, ushort @currentAbility, ushort @maximumAbility, uint @money, CharacterHeroState @heroState, CharacterStatus @status, ushort @usedFruitPoints, ushort @maxFruitPoints, ushort @leadership, ushort @usedNegativeFruitPoints, ushort @maxNegativeFruitPoints, byte @inventoryExtensions, ushort @resets)
+    public static async ValueTask SendCharacterInformationAsync(this IConnection? connection, byte @x, byte @y, ushort @mapId, ulong @currentExperience, ulong @experienceForNextLevel, ushort @levelUpPoints, ushort @strength, ushort @agility, ushort @vitality, ushort @energy, ushort @currentHealth, ushort @maximumHealth, ushort @currentMana, ushort @maximumMana, ushort @currentShield, ushort @maximumShield, ushort @currentAbility, ushort @maximumAbility, uint @money, CharacterHeroState @heroState, CharacterStatus @status, ushort @usedFruitPoints, ushort @maxFruitPoints, ushort @leadership, ushort @usedNegativeFruitPoints, ushort @maxNegativeFruitPoints, byte @inventoryExtensions, uint @resets)
     {
         if (connection is null)
         {

--- a/src/Network/Packets/ServerToClient/ConnectionExtensions.cs
+++ b/src/Network/Packets/ServerToClient/ConnectionExtensions.cs
@@ -3260,7 +3260,7 @@ public static class ConnectionExtensions
     /// Is sent by the server when: After the character was selected by the player and entered the game.
     /// Causes reaction on client side: The characters enters the game world.
     /// </remarks>
-    public static async ValueTask SendCharacterInformationAsync(this IConnection? connection, byte @x, byte @y, ushort @mapId, ulong @currentExperience, ulong @experienceForNextLevel, ushort @levelUpPoints, ushort @strength, ushort @agility, ushort @vitality, ushort @energy, ushort @currentHealth, ushort @maximumHealth, ushort @currentMana, ushort @maximumMana, ushort @currentShield, ushort @maximumShield, ushort @currentAbility, ushort @maximumAbility, uint @money, CharacterHeroState @heroState, CharacterStatus @status, ushort @usedFruitPoints, ushort @maxFruitPoints, ushort @leadership, ushort @usedNegativeFruitPoints, ushort @maxNegativeFruitPoints, byte @inventoryExtensions)
+    public static async ValueTask SendCharacterInformationAsync(this IConnection? connection, byte @x, byte @y, ushort @mapId, ulong @currentExperience, ulong @experienceForNextLevel, ushort @levelUpPoints, ushort @strength, ushort @agility, ushort @vitality, ushort @energy, ushort @currentHealth, ushort @maximumHealth, ushort @currentMana, ushort @maximumMana, ushort @currentShield, ushort @maximumShield, ushort @currentAbility, ushort @maximumAbility, uint @money, CharacterHeroState @heroState, CharacterStatus @status, ushort @usedFruitPoints, ushort @maxFruitPoints, ushort @leadership, ushort @usedNegativeFruitPoints, ushort @maxNegativeFruitPoints, byte @inventoryExtensions, ushort @resets)
     {
         if (connection is null)
         {
@@ -3298,6 +3298,7 @@ public static class ConnectionExtensions
             packet.UsedNegativeFruitPoints = @usedNegativeFruitPoints;
             packet.MaxNegativeFruitPoints = @maxNegativeFruitPoints;
             packet.InventoryExtensions = @inventoryExtensions;
+            packet.Resets = @resets;
 
             return packet.Header.Length;
         }
@@ -3389,7 +3390,7 @@ public static class ConnectionExtensions
     /// Is sent by the server when: After the character was selected by the player and entered the game.
     /// Causes reaction on client side: The characters enters the game world.
     /// </remarks>
-    public static async ValueTask SendCharacterInformationExtendedAsync(this IConnection? connection, byte @x, byte @y, ushort @mapId, ulong @currentExperience, ulong @experienceForNextLevel, ushort @levelUpPoints, ushort @strength, ushort @agility, ushort @vitality, ushort @energy, ushort @leadership, uint @currentHealth, uint @maximumHealth, uint @currentMana, uint @maximumMana, uint @currentShield, uint @maximumShield, uint @currentAbility, uint @maximumAbility, uint @money, CharacterHeroState @heroState, CharacterStatus @status, ushort @usedFruitPoints, ushort @maxFruitPoints, ushort @usedNegativeFruitPoints, ushort @maxNegativeFruitPoints, ushort @attackSpeed, ushort @magicSpeed, ushort @maximumAttackSpeed, byte @inventoryExtensions)
+    public static async ValueTask SendCharacterInformationExtendedAsync(this IConnection? connection, byte @x, byte @y, ushort @mapId, ulong @currentExperience, ulong @experienceForNextLevel, ushort @levelUpPoints, ushort @strength, ushort @agility, ushort @vitality, ushort @energy, ushort @leadership, uint @currentHealth, uint @maximumHealth, uint @currentMana, uint @maximumMana, uint @currentShield, uint @maximumShield, uint @currentAbility, uint @maximumAbility, uint @money, CharacterHeroState @heroState, CharacterStatus @status, ushort @usedFruitPoints, ushort @maxFruitPoints, ushort @usedNegativeFruitPoints, ushort @maxNegativeFruitPoints, ushort @attackSpeed, ushort @magicSpeed, ushort @maximumAttackSpeed, byte @inventoryExtensions, uint @resets)
     {
         if (connection is null)
         {
@@ -3430,6 +3431,7 @@ public static class ConnectionExtensions
             packet.MagicSpeed = @magicSpeed;
             packet.MaximumAttackSpeed = @maximumAttackSpeed;
             packet.InventoryExtensions = @inventoryExtensions;
+            packet.Resets = @resets;
 
             return packet.Header.Length;
         }

--- a/src/Network/Packets/ServerToClient/ServerToClientPackets.cs
+++ b/src/Network/Packets/ServerToClient/ServerToClientPackets.cs
@@ -17141,7 +17141,7 @@ public readonly struct CharacterInformationExtended
     /// <summary>
     /// Gets the initial length of this data packet. When the size is dynamic, this value may be bigger than actually needed.
     /// </summary>
-    public static int Length => 96;
+    public static int Length => 92;
 
     /// <summary>
     /// Gets the header of this packet.
@@ -17416,6 +17416,15 @@ public readonly struct CharacterInformationExtended
     {
         get => this._data.Span[88];
         set => this._data.Span[88] = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the resets.
+    /// </summary>
+    public ushort Resets
+    {
+        get => ReadUInt16LittleEndian(this._data.Span[90..]);
+        set => WriteUInt16LittleEndian(this._data.Span[90..], value);
     }
 
     /// <summary>

--- a/src/Network/Packets/ServerToClient/ServerToClientPackets.xml
+++ b/src/Network/Packets/ServerToClient/ServerToClientPackets.xml
@@ -6322,7 +6322,7 @@
       <Code>F3</Code>
       <SubCode>03</SubCode>
       <Name>CharacterInformationExtended</Name>
-      <Length>96</Length>
+      <Length>92</Length>
       <Direction>ServerToClient</Direction>
       <SentWhen>After the character was selected by the player and entered the game.</SentWhen>
       <CausedReaction>The characters enters the game world.</CausedReaction>
@@ -6479,8 +6479,9 @@
           <Type>Byte</Type>
           <Name>InventoryExtensions</Name>
         </Field>
+        <!-- 1 spare byte here -->
         <Field>
-          <Index>89</Index>
+          <Index>90</Index>
           <Type>ShortLittleEndian</Type>
           <Name>Resets</Name>
         </Field>

--- a/src/Network/Packets/ServerToClient/ServerToClientPackets.xml
+++ b/src/Network/Packets/ServerToClient/ServerToClientPackets.xml
@@ -6479,6 +6479,11 @@
           <Type>Byte</Type>
           <Name>InventoryExtensions</Name>
         </Field>
+        <Field>
+          <Index>89</Index>
+          <Type>ShortLittleEndian</Type>
+          <Name>Resets</Name>
+        </Field>
       </Fields>
     </Packet>
     <Packet>

--- a/src/Network/Packets/ServerToClient/ServerToClientPacketsRef.cs
+++ b/src/Network/Packets/ServerToClient/ServerToClientPacketsRef.cs
@@ -16053,6 +16053,15 @@ public readonly ref struct CharacterInformationRef
     }
 
     /// <summary>
+    /// Gets or sets the resets.
+    /// </summary>
+    public ushort Resets
+    {
+        get => ReadUInt16LittleEndian(this._data[69..]);
+        set => WriteUInt16LittleEndian(this._data[69..], value);
+    }
+
+    /// <summary>
     /// Performs an implicit conversion from a Span of bytes to a <see cref="CharacterInformation"/>.
     /// </summary>
     /// <param name="packet">The packet as span.</param>
@@ -16564,6 +16573,15 @@ public readonly ref struct CharacterInformationExtendedRef
     {
         get => this._data[88];
         set => this._data[88] = value;
+    }
+
+    /// <summary>
+    /// Gets or sets the resets.
+    /// </summary>
+    public uint Resets
+    {
+        get => ReadUInt32LittleEndian(this._data[89..]);
+        set => WriteUInt32LittleEndian(this._data[89..], value);
     }
 
     /// <summary>

--- a/src/Network/Packets/ServerToClient/ServerToClientPacketsRef.cs
+++ b/src/Network/Packets/ServerToClient/ServerToClientPacketsRef.cs
@@ -16289,7 +16289,7 @@ public readonly ref struct CharacterInformationExtendedRef
     /// <summary>
     /// Gets the initial length of this data packet. When the size is dynamic, this value may be bigger than actually needed.
     /// </summary>
-    public static int Length => 96;
+    public static int Length => 92;
 
     /// <summary>
     /// Gets the header of this packet.
@@ -16571,8 +16571,8 @@ public readonly ref struct CharacterInformationExtendedRef
     /// </summary>
     public ushort Resets
     {
-        get => ReadUInt16LittleEndian(this._data[89..]);
-        set => WriteUInt16LittleEndian(this._data[89..], value);
+        get => ReadUInt16LittleEndian(this._data[90..]);
+        set => WriteUInt16LittleEndian(this._data[90..], value);
     }
 
     /// <summary>

--- a/src/Network/Packets/ServerToClient/ServerToClientPacketsRef.cs
+++ b/src/Network/Packets/ServerToClient/ServerToClientPacketsRef.cs
@@ -15802,7 +15802,7 @@ public readonly ref struct CharacterInformationRef
     /// <summary>
     /// Gets the initial length of this data packet. When the size is dynamic, this value may be bigger than actually needed.
     /// </summary>
-    public static int Length => 72;
+    public static int Length => 73;
 
     /// <summary>
     /// Gets the header of this packet.
@@ -16055,10 +16055,10 @@ public readonly ref struct CharacterInformationRef
     /// <summary>
     /// Gets or sets the resets.
     /// </summary>
-    public ushort Resets
+    public uint Resets
     {
-        get => ReadUInt16LittleEndian(this._data[69..]);
-        set => WriteUInt16LittleEndian(this._data[69..], value);
+        get => ReadUInt32LittleEndian(this._data[69..]);
+        set => WriteUInt32LittleEndian(this._data[69..], value);
     }
 
     /// <summary>

--- a/src/Network/Packets/ServerToClient/ServerToClientPacketsRef.cs
+++ b/src/Network/Packets/ServerToClient/ServerToClientPacketsRef.cs
@@ -15802,7 +15802,7 @@ public readonly ref struct CharacterInformationRef
     /// <summary>
     /// Gets the initial length of this data packet. When the size is dynamic, this value may be bigger than actually needed.
     /// </summary>
-    public static int Length => 73;
+    public static int Length => 72;
 
     /// <summary>
     /// Gets the header of this packet.
@@ -16050,15 +16050,6 @@ public readonly ref struct CharacterInformationRef
     {
         get => this._data[68];
         set => this._data[68] = value;
-    }
-
-    /// <summary>
-    /// Gets or sets the resets.
-    /// </summary>
-    public uint Resets
-    {
-        get => ReadUInt32LittleEndian(this._data[69..]);
-        set => WriteUInt32LittleEndian(this._data[69..], value);
     }
 
     /// <summary>
@@ -16578,10 +16569,10 @@ public readonly ref struct CharacterInformationExtendedRef
     /// <summary>
     /// Gets or sets the resets.
     /// </summary>
-    public uint Resets
+    public ushort Resets
     {
-        get => ReadUInt32LittleEndian(this._data[89..]);
-        set => WriteUInt32LittleEndian(this._data[89..], value);
+        get => ReadUInt16LittleEndian(this._data[89..]);
+        set => WriteUInt16LittleEndian(this._data[89..], value);
     }
 
     /// <summary>

--- a/tests/MUnique.OpenMU.Network.Packets.Tests/ServerToClientPacketTests.cs
+++ b/tests/MUnique.OpenMU.Network.Packets.Tests/ServerToClientPacketTests.cs
@@ -3423,7 +3423,7 @@ public class PacketStructureTests
     public void CharacterInformationExtended_PacketSizeValidation()
     {
         // Fixed-length packet validation
-        const int expectedLength = 96;
+        const int expectedLength = 92;
         var actualLength = CharacterInformationExtendedRef.Length;
         
         Assert.That(actualLength, Is.EqualTo(expectedLength), 
@@ -3548,6 +3548,10 @@ public class PacketStructureTests
         // Validate field 'InventoryExtensions' boundary
         Assert.That(88 + 1, Is.LessThanOrEqualTo(expectedLength), 
             "Field 'InventoryExtensions' exceeds packet boundary");
+        
+        // Validate field 'Resets' boundary
+        Assert.That(90 + 2, Is.LessThanOrEqualTo(expectedLength), 
+            "Field 'Resets' exceeds packet boundary");
     }
 
     /// <summary>


### PR DESCRIPTION
<!-- Thanks for contributing! Please fill in the sections below. -->

## Summary
This PR adds reset info in character details.

<img width="1074" height="855" alt="mumain_resets" src="https://github.com/user-attachments/assets/f97fbb67-6405-4f15-895c-ec0ed3f4f31d" />

<!-- What does this PR do, and why? -->

## Related issues
https://github.com/sven-n/MuMain/issues/361

<!-- e.g. Closes #123 -->