### PR TITLE
Proposed fix drop zen in party

### DIFF
--- a/src/GameLogic/DroppedMoney.cs
+++ b/src/GameLogic/DroppedMoney.cs
@@ -6,6 +6,7 @@ namespace MUnique.OpenMU.GameLogic;
 
 using System.Diagnostics;
 using System.Threading;
+using MUnique.OpenMU.GameLogic.Attributes;
 using MUnique.OpenMU.Pathfinding;
 using Nito.AsyncEx;
 
@@ -67,8 +68,7 @@ public sealed class DroppedMoney : AsyncDisposable, ILocateable
     public async ValueTask<bool> TryPickUpByAsync(Player player)
     {
         player.Logger.LogDebug("Player {0} tries to pick up {1}", player, this);
-        int amountToAdd = 0;
-        var clampMoneyOnPickup = player.GameContext?.Configuration?.ClampMoneyOnPickup ?? false;
+
         using (await this._pickupLock.LockAsync())
         {
             if (!this._availableToPick)
@@ -77,12 +77,33 @@ public sealed class DroppedMoney : AsyncDisposable, ILocateable
                 return false;
             }
 
+            this._availableToPick = false;
+        }
+
+        if (player.Party is { } party)
+        {
+            var partyMembers = party.PartyList
+                .OfType<Player>()
+                .Where(p => p.CurrentMap == player.CurrentMap && !p.IsAtSafezone() && p.Attributes is { })
+                .ToList();
+
+            if (partyMembers.Count > 0)
+            {
+                var share = (int)(this.Amount / partyMembers.Count);
+                foreach (var member in partyMembers)
+                {
+                    member.TryAddMoney((int)(share * member.Attributes![Stats.MoneyAmountRate]));
+                }
+            }
+        }
+        else
+        {
+            var clampMoneyOnPickup = player.GameContext?.Configuration?.ClampMoneyOnPickup ?? false;
             if (clampMoneyOnPickup)
             {
-                // Calculate how much can actually be added (clamp to max)
                 var maxMoney = player.GameContext?.Configuration?.MaximumInventoryMoney ?? int.MaxValue;
                 var currentMoney = player.Money;
-                amountToAdd = (int)Math.Min(this.Amount, (uint)Math.Max(0, maxMoney - currentMoney));
+                var amountToAdd = (int)Math.Min(this.Amount, (uint)Math.Max(0, maxMoney - currentMoney));
 
                 if (amountToAdd <= 0)
                 {
@@ -90,7 +111,6 @@ public sealed class DroppedMoney : AsyncDisposable, ILocateable
                     return false;
                 }
 
-                // Add the clamped amount
                 if (!player.TryAddMoney(amountToAdd))
                 {
                     player.Logger.LogDebug("Money could not be added to the inventory, Player {0}, Money {1}", player, this);
@@ -99,26 +119,12 @@ public sealed class DroppedMoney : AsyncDisposable, ILocateable
             }
             else
             {
-                // Original behavior: fail if it would exceed the maximum
                 if (!player.TryAddMoney((int)this.Amount))
                 {
                     player.Logger.LogDebug("Money could not be added to the inventory, Player {0}, Money {1}", player, this);
                     return false;
                 }
-
-                amountToAdd = (int)this.Amount;
             }
-
-            this._availableToPick = false;
-        }
-
-        if (clampMoneyOnPickup && amountToAdd < this.Amount)
-        {
-            player.Logger.LogDebug("Money '{0}' was partially picked up by player '{1}' - added {2} out of {3} (player at max limit).", this, player, amountToAdd, this.Amount);
-        }
-        else
-        {
-            player.Logger.LogDebug("Money '{0}' was picked up by player '{1}' and added to his inventory.", this, player);
         }
 
         await this.DisposeAsync().ConfigureAwait(false);

--- a/src/GameLogic/NPC/AttackableNpcBase.cs
+++ b/src/GameLogic/NPC/AttackableNpcBase.cs
@@ -373,15 +373,7 @@ public abstract class AttackableNpcBase : NonPlayerCharacter, IAttackable
             return;
         }
 
-        var partySize = killer.Party?.PartyList
-            .OfType<Player>()
-            .Count(p => p.CurrentMap == killer.CurrentMap && !p.IsAtSafezone() && p.Attributes is { }) ?? 1;
-        if (partySize > 1)
-        {
-            amount /= (uint)partySize;
-        }
-
-        var droppedMoney = new DroppedMoney((uint)(amount * killer.Attributes![Stats.MoneyAmountRate]), this.Position, this.CurrentMap);
+        var droppedMoney = new DroppedMoney((uint)(amount * (killer.Attributes?[Stats.MoneyAmountRate] ?? 1.0f)), this.Position, this.CurrentMap);
         await this.CurrentMap.AddAsync(droppedMoney).ConfigureAwait(false);
     }
 
@@ -393,17 +385,9 @@ public abstract class AttackableNpcBase : NonPlayerCharacter, IAttackable
         // derived from this experience value, party money drops were dramatically
         // lower than solo drops. We recalculate the experience for money purposes
         // using the solo formula so money is consistent regardless of party state.
-        if (killer.Party is not null && killer.SelectedCharacter?.CharacterClass is { } characterClass)
+        if (killer.Party is not null)
         {
-            var baseExp = this.CalculateBaseExperience(killer.Attributes![Stats.TotalLevel]);
-            var isMaster = characterClass.IsMasterClass
-                           && (short)killer.Attributes[Stats.Level] == killer.GameContext.Configuration.MaximumLevel;
-            var expRateAttr = isMaster ? Stats.MasterExperienceRate : Stats.ExperienceRate;
-            var gameRate = isMaster ? killer.GameContext.MasterExperienceRate : killer.GameContext.ExperienceRate;
-
-            var experience = baseExp * gameRate * (killer.Attributes[expRateAttr] + killer.Attributes[Stats.BonusExperienceRate]);
-            experience *= killer.CurrentMap?.Definition.ExpMultiplier ?? 1;
-            exp = Rand.NextInt((int)(experience * 0.8), (int)(experience * 1.2));
+            exp = killer.CalculateExpAfterKill(this);
         }
 
         var (generatedItems, droppedMoney) = await this._dropGenerator.GenerateItemDropsAsync(this.Definition, exp, killer).ConfigureAwait(false);

--- a/src/GameLogic/NPC/AttackableNpcBase.cs
+++ b/src/GameLogic/NPC/AttackableNpcBase.cs
@@ -373,12 +373,39 @@ public abstract class AttackableNpcBase : NonPlayerCharacter, IAttackable
             return;
         }
 
+        var partySize = killer.Party?.PartyList
+            .OfType<Player>()
+            .Count(p => p.CurrentMap == killer.CurrentMap && !p.IsAtSafezone() && p.Attributes is { }) ?? 1;
+        if (partySize > 1)
+        {
+            amount /= (uint)partySize;
+        }
+
         var droppedMoney = new DroppedMoney((uint)(amount * killer.Attributes![Stats.MoneyAmountRate]), this.Position, this.CurrentMap);
         await this.CurrentMap.AddAsync(droppedMoney).ConfigureAwait(false);
     }
 
     private async ValueTask DropItemAsync(int exp, Player killer)
     {
+        // When the killer is in a party, DistributeExperienceAfterKillAsync returns a
+        // total party experience that does NOT include game rate (ExperienceRate) or
+        // personal experience rate multipliers. Since the money drop amount is
+        // derived from this experience value, party money drops were dramatically
+        // lower than solo drops. We recalculate the experience for money purposes
+        // using the solo formula so money is consistent regardless of party state.
+        if (killer.Party is not null && killer.SelectedCharacter?.CharacterClass is { } characterClass)
+        {
+            var baseExp = this.CalculateBaseExperience(killer.Attributes![Stats.TotalLevel]);
+            var isMaster = characterClass.IsMasterClass
+                           && (short)killer.Attributes[Stats.Level] == killer.GameContext.Configuration.MaximumLevel;
+            var expRateAttr = isMaster ? Stats.MasterExperienceRate : Stats.ExperienceRate;
+            var gameRate = isMaster ? killer.GameContext.MasterExperienceRate : killer.GameContext.ExperienceRate;
+
+            var experience = baseExp * gameRate * (killer.Attributes[expRateAttr] + killer.Attributes[Stats.BonusExperienceRate]);
+            experience *= killer.CurrentMap?.Definition.ExpMultiplier ?? 1;
+            exp = Rand.NextInt((int)(experience * 0.8), (int)(experience * 1.2));
+        }
+
         var (generatedItems, droppedMoney) = await this._dropGenerator.GenerateItemDropsAsync(this.Definition, exp, killer).ConfigureAwait(false);
         if (droppedMoney > 0)
         {

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -1184,29 +1184,55 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
             return 0;
         }
 
+        var experience = this.CalculateExpAfterKill(killedObject);
+        if (experience == 0)
+        {
+            return 0;
+        }
+
         var addMasterExperience = characterClass.IsMasterClass
                             && (short)this.Attributes![Stats.Level] == this.GameContext.Configuration.MaximumLevel;
-        var expRateAttribute = addMasterExperience ? Stats.MasterExperienceRate : Stats.ExperienceRate;
-        var gameRate = addMasterExperience ? this.GameContext.MasterExperienceRate : this.GameContext.ExperienceRate;
-
-        var experience = killedObject.CalculateBaseExperience(this.Attributes![Stats.TotalLevel]);
-        experience *= gameRate;
-        experience *= this.Attributes[expRateAttribute] + this.Attributes[Stats.BonusExperienceRate];
-        experience *= this.CurrentMap?.Definition.ExpMultiplier ?? 1;
-        experience = Rand.NextInt((int)(experience * 0.8), (int)(experience * 1.2));
-
         if (addMasterExperience)
         {
-            await this.AddMasterExperienceAsync((int)experience, killedObject).ConfigureAwait(false);
+            await this.AddMasterExperienceAsync(experience, killedObject).ConfigureAwait(false);
         }
         else
         {
-            await this.AddExperienceAsync((int)experience, killedObject).ConfigureAwait(false);
+            await this.AddExperienceAsync(experience, killedObject).ConfigureAwait(false);
         }
 
         await this.AddPetExperienceAsync(experience).ConfigureAwait(false);
 
-        return (int)experience;
+        return experience;
+    }
+
+    /// <summary>
+    /// Calculates the amount of experience gained after a kill, without applying it to the character.
+    /// </summary>
+    /// <param name="killedObject">The killed monster.</param>
+    /// <returns>The calculated experience amount.</returns>
+    public int CalculateExpAfterKill(IAttackable killedObject)
+    {
+        if (this.SelectedCharacter?.CharacterClass is not { } characterClass)
+        {
+            return 0;
+        }
+
+        if (this.Attributes is not { } attributes)
+        {
+            return 0;
+        }
+
+        var addMasterExperience = characterClass.IsMasterClass
+                            && (short)attributes[Stats.Level] == this.GameContext.Configuration.MaximumLevel;
+        var expRateAttribute = addMasterExperience ? Stats.MasterExperienceRate : Stats.ExperienceRate;
+        var gameRate = addMasterExperience ? this.GameContext.MasterExperienceRate : this.GameContext.ExperienceRate;
+
+        var experience = killedObject.CalculateBaseExperience(attributes[Stats.TotalLevel]);
+        experience *= gameRate;
+        experience *= attributes[expRateAttribute] + attributes[Stats.BonusExperienceRate];
+        experience *= this.CurrentMap?.Definition.ExpMultiplier ?? 1;
+        return Rand.NextInt((int)(experience * 0.8), (int)(experience * 1.2));
     }
 
     /// <summary>


### PR DESCRIPTION
Party Zen Drop Fix
==================

Problem
-------
When a player killed a monster in a party, the zen (money) drop amount was
dramatically lower than when playing solo. With a high experience rate server,
a solo player could get ~1,000,000 zen per kill, while a party member would
only see ~3,000 zen. Additionally, the zen was not shared among party members.

Root Cause
----------
The zen drop amount is calculated as `gainedExperience + BaseMoneyDrop (7)` in
`DefaultDropGenerator.GenerateItemDropOrMoney`. The `gainedExperience` value
comes from `AttackableNpcBase.OnDeathAsync`, which uses different formulas for
solo and party play:

  Solo: `player.AddExpAfterKillAsync()`
    → baseExp * gameRate * personalRate * mapMultiplier * random

  Party: `party.DistributeExperienceAfterKillAsync()`
    → baseExp * count * 1.05^(count-1) * mapMultiplier * random

The party formula does NOT include the game rate (e.g. 100x) or personal
experience rate bonuses, making the zen amount orders of magnitude smaller.

Changes
-------
Three files modified on branch `zen-drop-party-fix`:

1. `src/GameLogic/Player.cs` — new `CalculateExpAfterKill()` method
   Extracts the experience calculation logic from `AddExpAfterKillAsync` into
   a separate public method that returns the calculated value without applying
   it to the character. `AddExpAfterKillAsync` now calls this shared method.
   This avoids duplicating the experience formula when it's needed for other
   purposes (like zen calculation).

2. `src/GameLogic/NPC/AttackableNpcBase.cs` — `DropItemAsync()`
   When the killer is in a party, uses `player.CalculateExpAfterKill(this)`
   to get the correct experience value for zen calculation instead of using
   the party-distributed value (which lacks game rate and personal bonuses).
   Also uses null-conditional access for `Attributes` instead of `!`.

3. `src/GameLogic/DroppedMoney.cs` — `TryPickUpByAsync()`
   When a player in a party picks up money from the ground, it is now
   distributed equally among all eligible party members (same map, not in
   safezone). Solo pickup behavior is unchanged.

Result
------
- Solo: 1,000,000 zen drops on the ground → picked up by one player → gets 1,000,000
- Party of 2: 1,000,000 zen drops on the ground → picked up → each gets 500,000
- Party of 5: 1,000,000 zen drops on the ground → picked up → each gets 200,000