### PR TITLE
Plugin that allows reset stats via chat command

### DIFF
--- a/src/GameLogic/Properties/PlayerMessage.Designer.cs
+++ b/src/GameLogic/Properties/PlayerMessage.Designer.cs
@@ -1679,5 +1679,86 @@ namespace MUnique.OpenMU.GameLogic.Properties {
                 return ResourceManager.GetString("OfflineLevelingMuHelperNotRunning", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Stat reset is not enabled..
+        /// </summary>
+        public static string StatResetNotEnabled {
+            get {
+                return ResourceManager.GetString("StatResetNotEnabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Stat reset is not configured..
+        /// </summary>
+        public static string StatResetNotConfigured {
+            get {
+                return ResourceManager.GetString("StatResetNotConfigured", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Required level for stat reset is {0}..
+        /// </summary>
+        public static string RequiredLevelForStatReset {
+            get {
+                return ResourceManager.GetString("RequiredLevelForStatReset", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You don&apos;t have enough money for stat reset, required zen is {0}..
+        /// </summary>
+        public static string NotEnoughMoneyForStatReset {
+            get {
+                return ResourceManager.GetString("NotEnoughMoneyForStatReset", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You don&apos;t have enough required items for stat reset, required {0} x {1}..
+        /// </summary>
+        public static string NotEnoughItemsForStatReset {
+            get {
+                return ResourceManager.GetString("NotEnoughItemsForStatReset", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Stat reset is only possible in a safezone..
+        /// </summary>
+        public static string CantResetStatsNotInSafezone {
+            get {
+                return ResourceManager.GetString("CantResetStatsNotInSafezone", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Cannot reset stats with any windows opened..
+        /// </summary>
+        public static string CantResetStatsWithOpenedWindows {
+            get {
+                return ResourceManager.GetString("CantResetStatsWithOpenedWindows", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The /resetstats command is disabled..
+        /// </summary>
+        public static string StatResetChatCommandDisabled {
+            get {
+                return ResourceManager.GetString("StatResetChatCommandDisabled", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Your stats have been reset. You have {0} level-up points available..
+        /// </summary>
+        public static string StatsResetSuccessfully {
+            get {
+                return ResourceManager.GetString("StatsResetSuccessfully", resourceCulture);
+            }
+        }
     }
 }

--- a/src/GameLogic/Properties/PlayerMessage.resx
+++ b/src/GameLogic/Properties/PlayerMessage.resx
@@ -657,4 +657,31 @@
   <data name="OfflineLevelingMuHelperNotRunning" xml:space="preserve">
     <value>MU Helper must be running to start offline leveling.</value>
   </data>
+  <data name="StatResetNotEnabled" xml:space="preserve">
+    <value>Stat reset is not enabled.</value>
+  </data>
+  <data name="StatResetNotConfigured" xml:space="preserve">
+    <value>Stat reset is not configured.</value>
+  </data>
+  <data name="RequiredLevelForStatReset" xml:space="preserve">
+    <value>Required level for stat reset is {0}.</value>
+  </data>
+  <data name="NotEnoughMoneyForStatReset" xml:space="preserve">
+    <value>You don't have enough money for stat reset, required zen is {0}.</value>
+  </data>
+  <data name="NotEnoughItemsForStatReset" xml:space="preserve">
+    <value>You don't have enough required items for stat reset, required {0} x {1}.</value>
+  </data>
+  <data name="CantResetStatsNotInSafezone" xml:space="preserve">
+    <value>Stat reset is only possible in a safezone.</value>
+  </data>
+  <data name="CantResetStatsWithOpenedWindows" xml:space="preserve">
+    <value>Cannot reset stats with any windows opened.</value>
+  </data>
+  <data name="StatResetChatCommandDisabled" xml:space="preserve">
+    <value>The /resetstats command is disabled.</value>
+  </data>
+  <data name="StatsResetSuccessfully" xml:space="preserve">
+    <value>Your stats have been reset. You have {0} level-up points available.</value>
+  </data>
 </root>

--- a/src/GameLogic/Properties/PlugInResources.Designer.cs
+++ b/src/GameLogic/Properties/PlugInResources.Designer.cs
@@ -3238,5 +3238,86 @@ namespace MUnique.OpenMU.GameLogic.Properties {
                 return ResourceManager.GetString("MonsterAttributeScaler_Name", resourceCulture);
             }
         }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Provides configuration for the stat reset feature..
+        /// </summary>
+        public static string StatResetFeaturePlugIn_Description {
+            get {
+                return ResourceManager.GetString("StatResetFeaturePlugIn_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Stat Reset Feature.
+        /// </summary>
+        public static string StatResetFeaturePlugIn_Name {
+            get {
+                return ResourceManager.GetString("StatResetFeaturePlugIn_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Handles the chat command &apos;/resetstats&apos;..
+        /// </summary>
+        public static string ResetStatsChatCommandPlugIn_Description {
+            get {
+                return ResourceManager.GetString("ResetStatsChatCommandPlugIn_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Reset Stats chat command.
+        /// </summary>
+        public static string ResetStatsChatCommandPlugIn_Name {
+            get {
+                return ResourceManager.GetString("ResetStatsChatCommandPlugIn_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Required level.
+        /// </summary>
+        public static string StatResetConfiguration_RequiredLevel_Name {
+            get {
+                return ResourceManager.GetString("StatResetConfiguration_RequiredLevel_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Required money.
+        /// </summary>
+        public static string StatResetConfiguration_RequiredMoney_Name {
+            get {
+                return ResourceManager.GetString("StatResetConfiguration_RequiredMoney_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Chat command enabled.
+        /// </summary>
+        public static string StatResetConfiguration_ChatCommandEnabled_Name {
+            get {
+                return ResourceManager.GetString("StatResetConfiguration_ChatCommandEnabled_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Move home.
+        /// </summary>
+        public static string StatResetConfiguration_MoveHome_Name {
+            get {
+                return ResourceManager.GetString("StatResetConfiguration_MoveHome_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Log out.
+        /// </summary>
+        public static string StatResetConfiguration_LogOut_Name {
+            get {
+                return ResourceManager.GetString("StatResetConfiguration_LogOut_Name", resourceCulture);
+            }
+        }
     }
 }

--- a/src/GameLogic/Properties/PlugInResources.Designer.cs
+++ b/src/GameLogic/Properties/PlugInResources.Designer.cs
@@ -3294,6 +3294,15 @@ namespace MUnique.OpenMU.GameLogic.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Required reset item.
+        /// </summary>
+        public static string StatResetConfiguration_RequiredResetItem_Name {
+            get {
+                return ResourceManager.GetString("StatResetConfiguration_RequiredResetItem_Name", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Chat command enabled.
         /// </summary>
         public static string StatResetConfiguration_ChatCommandEnabled_Name {

--- a/src/GameLogic/Properties/PlugInResources.resx
+++ b/src/GameLogic/Properties/PlugInResources.resx
@@ -1194,6 +1194,9 @@
   <data name="StatResetConfiguration_RequiredMoney_Name" xml:space="preserve">
     <value>Required money</value>
   </data>
+  <data name="StatResetConfiguration_RequiredResetItem_Name" xml:space="preserve">
+    <value>Required reset item</value>
+  </data>
   <data name="StatResetConfiguration_ChatCommandEnabled_Name" xml:space="preserve">
     <value>Chat command enabled</value>
   </data>

--- a/src/GameLogic/Properties/PlugInResources.resx
+++ b/src/GameLogic/Properties/PlugInResources.resx
@@ -1176,4 +1176,31 @@
   <data name="MonsterAttributeScaler_Description" xml:space="preserve">
     <value>Increases all monster base stats by a configurable percentage.</value>
   </data>
+  <data name="StatResetFeaturePlugIn_Name" xml:space="preserve">
+    <value>Stat Reset Feature</value>
+  </data>
+  <data name="StatResetFeaturePlugIn_Description" xml:space="preserve">
+    <value>Provides configuration for the stat reset feature.</value>
+  </data>
+  <data name="ResetStatsChatCommandPlugIn_Name" xml:space="preserve">
+    <value>Reset Stats chat command</value>
+  </data>
+  <data name="ResetStatsChatCommandPlugIn_Description" xml:space="preserve">
+    <value>Handles the chat command '/resetstats'.</value>
+  </data>
+  <data name="StatResetConfiguration_RequiredLevel_Name" xml:space="preserve">
+    <value>Required level</value>
+  </data>
+  <data name="StatResetConfiguration_RequiredMoney_Name" xml:space="preserve">
+    <value>Required money</value>
+  </data>
+  <data name="StatResetConfiguration_ChatCommandEnabled_Name" xml:space="preserve">
+    <value>Chat command enabled</value>
+  </data>
+  <data name="StatResetConfiguration_MoveHome_Name" xml:space="preserve">
+    <value>Move home</value>
+  </data>
+  <data name="StatResetConfiguration_LogOut_Name" xml:space="preserve">
+    <value>Log out</value>
+  </data>
 </root>

--- a/src/GameLogic/Resets/ResetStatsAction.cs
+++ b/src/GameLogic/Resets/ResetStatsAction.cs
@@ -98,10 +98,15 @@ public class ResetStatsAction
 
         foreach (var statDef in selectedCharacter.CharacterClass!.StatAttributes.Where(s => s.IncreasableByPlayer))
         {
-            var currentValue = (int)this._player.Attributes![statDef.Attribute!];
+            if (statDef.Attribute is not { } attribute)
+            {
+                continue;
+            }
+
+            var currentValue = (int)this._player.Attributes![attribute];
             var baseValue = (int)statDef.BaseValue;
-            investedPoints += currentValue - baseValue;
-            this._player.Attributes[statDef.Attribute] = baseValue;
+            investedPoints += Math.Max(0, currentValue - baseValue);
+            this._player.Attributes[attribute] = baseValue;
         }
 
         selectedCharacter.LevelUpPoints += investedPoints;
@@ -109,29 +114,21 @@ public class ResetStatsAction
 
     private async ValueTask<bool> TryConsumeCostsAsync(StatResetConfiguration configuration)
     {
-        if (configuration.RequiredResetItem is null)
+        if (this._player.Money < configuration.RequiredMoney)
         {
-            if (this._player.Money < configuration.RequiredMoney)
-            {
-                await this.ShowMessageAsync(nameof(PlayerMessage.NotEnoughMoneyForStatReset), configuration.RequiredMoney).ConfigureAwait(false);
-                return false;
-            }
-
-            if (configuration.RequiredMoney > 0 && !this._player.TryRemoveMoney(configuration.RequiredMoney))
-            {
-                await this.ShowMessageAsync(nameof(PlayerMessage.NotEnoughMoneyForStatReset), configuration.RequiredMoney).ConfigureAwait(false);
-                return false;
-            }
+            await this.ShowMessageAsync(nameof(PlayerMessage.NotEnoughMoneyForStatReset), configuration.RequiredMoney).ConfigureAwait(false);
+            return false;
         }
-        else
+
+        Item? requiredItem = null;
+        if (configuration.RequiredResetItem is { } requiredDefinition)
         {
             if (this._player.Inventory is null)
             {
                 return false;
             }
 
-            var requiredDefinition = configuration.RequiredResetItem;
-            var requiredItem = this._player.Inventory.Items
+            requiredItem = this._player.Inventory.Items
                 .FirstOrDefault(item => item.Definition is { } definition
                                         && definition.Group == requiredDefinition.Group
                                         && definition.Number == requiredDefinition.Number);
@@ -141,19 +138,16 @@ public class ResetStatsAction
                 await this.ShowMessageAsync(nameof(PlayerMessage.NotEnoughItemsForStatReset), 1, requiredDefinition.Name).ConfigureAwait(false);
                 return false;
             }
+        }
 
-            if (this._player.Money < configuration.RequiredMoney)
-            {
-                await this.ShowMessageAsync(nameof(PlayerMessage.NotEnoughMoneyForStatReset), configuration.RequiredMoney).ConfigureAwait(false);
-                return false;
-            }
+        if (configuration.RequiredMoney > 0 && !this._player.TryRemoveMoney(configuration.RequiredMoney))
+        {
+            await this.ShowMessageAsync(nameof(PlayerMessage.NotEnoughMoneyForStatReset), configuration.RequiredMoney).ConfigureAwait(false);
+            return false;
+        }
 
-            if (configuration.RequiredMoney > 0 && !this._player.TryRemoveMoney(configuration.RequiredMoney))
-            {
-                await this.ShowMessageAsync(nameof(PlayerMessage.NotEnoughMoneyForStatReset), configuration.RequiredMoney).ConfigureAwait(false);
-                return false;
-            }
-
+        if (requiredItem is not null)
+        {
             await this._player.DestroyInventoryItemAsync(requiredItem).ConfigureAwait(false);
         }
 
@@ -166,16 +160,14 @@ public class ResetStatsAction
         if (homeMapDef is { }
             && await this._player.GameContext.GetMapAsync((ushort)homeMapDef.Number).ConfigureAwait(false) is { SafeZoneSpawnGate: { } spawnGate })
         {
-            this._player.SelectedCharacter.PositionX = (byte)Rand.NextInt(spawnGate.X1, spawnGate.X2);
-            this._player.SelectedCharacter.PositionY = (byte)Rand.NextInt(spawnGate.Y1, spawnGate.Y2);
-            this._player.SelectedCharacter.CurrentMap = spawnGate.Map;
-            this._player.Rotation = spawnGate.Direction;
+            await this._player.WarpToAsync(spawnGate).ConfigureAwait(false);
         }
     }
 
     private async ValueTask UpdateClientStatsAsync()
     {
         await this._player.InvokeViewPlugInAsync<IUpdateCharacterBaseStatsPlugIn>(p => p.UpdateCharacterBaseStatsAsync()).ConfigureAwait(false);
+        await this._player.InvokeViewPlugInAsync<IUpdateCharacterStatsPlugIn>(p => p.UpdateCharacterStatsAsync()).ConfigureAwait(false);
     }
 
     private async ValueTask ShowMessageAsync(string messageKey, params object?[] args)

--- a/src/GameLogic/Resets/ResetStatsAction.cs
+++ b/src/GameLogic/Resets/ResetStatsAction.cs
@@ -74,7 +74,7 @@ public class ResetStatsAction
             return;
         }
 
-        this.ResetAttributes(configuration);
+        this.ResetAttributes();
 
         if (configuration.MoveHome)
         {
@@ -91,7 +91,7 @@ public class ResetStatsAction
         }
     }
 
-    private void ResetAttributes(StatResetConfiguration configuration)
+    private void ResetAttributes()
     {
         var selectedCharacter = this._player.SelectedCharacter!;
         var investedPoints = 0;

--- a/src/GameLogic/Resets/ResetStatsAction.cs
+++ b/src/GameLogic/Resets/ResetStatsAction.cs
@@ -1,0 +1,186 @@
+// <copyright file="ResetStatsAction.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Resets;
+
+using MUnique.OpenMU.GameLogic.NPC;
+using MUnique.OpenMU.GameLogic.PlayerActions;
+using MUnique.OpenMU.GameLogic.Views.Character;
+using MUnique.OpenMU.GameLogic.Views.Login;
+
+/// <summary>
+/// Action to reset a character's stats back to base values and refund the invested points.
+/// </summary>
+public class ResetStatsAction
+{
+    private readonly Player _player;
+    private readonly LogoutAction _logoutAction = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ResetStatsAction"/> class.
+    /// </summary>
+    /// <param name="player">Player to reset stats for.</param>
+    public ResetStatsAction(Player player)
+    {
+        this._player = player;
+    }
+
+    /// <summary>
+    /// Resets the character stats to base values and refunds invested points.
+    /// </summary>
+    public async ValueTask ResetStatsAsync()
+    {
+        var statResetFeature = this._player.GameContext.FeaturePlugIns.GetPlugIn<StatResetFeaturePlugIn>();
+        if (statResetFeature is null)
+        {
+            await this.ShowMessageAsync(nameof(PlayerMessage.StatResetNotEnabled)).ConfigureAwait(false);
+            return;
+        }
+
+        if (this._player.PlayerState.CurrentState != PlayerState.EnteredWorld)
+        {
+            await this.ShowMessageAsync(nameof(PlayerMessage.CantResetStatsWithOpenedWindows)).ConfigureAwait(false);
+            return;
+        }
+
+        if (this._player.Attributes is null || this._player.SelectedCharacter is null)
+        {
+            await this.ShowMessageAsync(nameof(PlayerMessage.NotEnteredTheGame)).ConfigureAwait(false);
+            return;
+        }
+
+        var configuration = statResetFeature.Configuration;
+        if (configuration is null)
+        {
+            await this.ShowMessageAsync(nameof(PlayerMessage.StatResetNotConfigured)).ConfigureAwait(false);
+            return;
+        }
+
+        if (!this._player.IsAtSafezone())
+        {
+            await this.ShowMessageAsync(nameof(PlayerMessage.CantResetStatsNotInSafezone)).ConfigureAwait(false);
+            return;
+        }
+
+        if (this._player.Level < configuration.RequiredLevel)
+        {
+            await this.ShowMessageAsync(nameof(PlayerMessage.RequiredLevelForStatReset), configuration.RequiredLevel).ConfigureAwait(false);
+            return;
+        }
+
+        if (!await this.TryConsumeCostsAsync(configuration).ConfigureAwait(false))
+        {
+            return;
+        }
+
+        this.ResetAttributes(configuration);
+
+        if (configuration.MoveHome)
+        {
+            await this.MoveHomeAsync().ConfigureAwait(false);
+        }
+
+        if (configuration.LogOut)
+        {
+            await this._logoutAction.LogoutAsync(this._player, LogoutType.BackToCharacterSelection).ConfigureAwait(false);
+        }
+        else
+        {
+            await this.UpdateClientStatsAsync().ConfigureAwait(false);
+        }
+    }
+
+    private void ResetAttributes(StatResetConfiguration configuration)
+    {
+        var selectedCharacter = this._player.SelectedCharacter!;
+        var investedPoints = 0;
+
+        foreach (var statDef in selectedCharacter.CharacterClass!.StatAttributes.Where(s => s.IncreasableByPlayer))
+        {
+            var currentValue = (int)this._player.Attributes![statDef.Attribute!];
+            var baseValue = (int)statDef.BaseValue;
+            investedPoints += currentValue - baseValue;
+            this._player.Attributes[statDef.Attribute] = baseValue;
+        }
+
+        selectedCharacter.LevelUpPoints += investedPoints;
+    }
+
+    private async ValueTask<bool> TryConsumeCostsAsync(StatResetConfiguration configuration)
+    {
+        if (configuration.RequiredResetItem is null)
+        {
+            if (this._player.Money < configuration.RequiredMoney)
+            {
+                await this.ShowMessageAsync(nameof(PlayerMessage.NotEnoughMoneyForStatReset), configuration.RequiredMoney).ConfigureAwait(false);
+                return false;
+            }
+
+            if (configuration.RequiredMoney > 0 && !this._player.TryRemoveMoney(configuration.RequiredMoney))
+            {
+                await this.ShowMessageAsync(nameof(PlayerMessage.NotEnoughMoneyForStatReset), configuration.RequiredMoney).ConfigureAwait(false);
+                return false;
+            }
+        }
+        else
+        {
+            if (this._player.Inventory is null)
+            {
+                return false;
+            }
+
+            var requiredDefinition = configuration.RequiredResetItem;
+            var requiredItem = this._player.Inventory.Items
+                .FirstOrDefault(item => item.Definition is { } definition
+                                        && definition.Group == requiredDefinition.Group
+                                        && definition.Number == requiredDefinition.Number);
+
+            if (requiredItem is null)
+            {
+                await this.ShowMessageAsync(nameof(PlayerMessage.NotEnoughItemsForStatReset), 1, requiredDefinition.Name).ConfigureAwait(false);
+                return false;
+            }
+
+            if (this._player.Money < configuration.RequiredMoney)
+            {
+                await this.ShowMessageAsync(nameof(PlayerMessage.NotEnoughMoneyForStatReset), configuration.RequiredMoney).ConfigureAwait(false);
+                return false;
+            }
+
+            if (configuration.RequiredMoney > 0 && !this._player.TryRemoveMoney(configuration.RequiredMoney))
+            {
+                await this.ShowMessageAsync(nameof(PlayerMessage.NotEnoughMoneyForStatReset), configuration.RequiredMoney).ConfigureAwait(false);
+                return false;
+            }
+
+            await this._player.DestroyInventoryItemAsync(requiredItem).ConfigureAwait(false);
+        }
+
+        return true;
+    }
+
+    private async ValueTask MoveHomeAsync()
+    {
+        var homeMapDef = this._player.SelectedCharacter!.CharacterClass!.HomeMap;
+        if (homeMapDef is { }
+            && await this._player.GameContext.GetMapAsync((ushort)homeMapDef.Number).ConfigureAwait(false) is { SafeZoneSpawnGate: { } spawnGate })
+        {
+            this._player.SelectedCharacter.PositionX = (byte)Rand.NextInt(spawnGate.X1, spawnGate.X2);
+            this._player.SelectedCharacter.PositionY = (byte)Rand.NextInt(spawnGate.Y1, spawnGate.Y2);
+            this._player.SelectedCharacter.CurrentMap = spawnGate.Map;
+            this._player.Rotation = spawnGate.Direction;
+        }
+    }
+
+    private async ValueTask UpdateClientStatsAsync()
+    {
+        await this._player.InvokeViewPlugInAsync<IUpdateCharacterBaseStatsPlugIn>(p => p.UpdateCharacterBaseStatsAsync()).ConfigureAwait(false);
+    }
+
+    private async ValueTask ShowMessageAsync(string messageKey, params object?[] args)
+    {
+        var message = this._player.GetLocalizedMessage(messageKey, args);
+        await this._player.ShowBlueMessageAsync(message).ConfigureAwait(false);
+    }
+}

--- a/src/GameLogic/Resets/ResetStatsChatCommandPlugIn.cs
+++ b/src/GameLogic/Resets/ResetStatsChatCommandPlugIn.cs
@@ -1,0 +1,41 @@
+// <copyright file="ResetStatsChatCommandPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Resets;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic.PlugIns.ChatCommands;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// A chat command plugin which handles the stat reset command.
+/// </summary>
+[Guid("A1B2C3D4-E5F6-7890-ABCD-EF1234567891")]
+[PlugIn]
+[Display(Name = nameof(PlugInResources.ResetStatsChatCommandPlugIn_Name), Description = nameof(PlugInResources.ResetStatsChatCommandPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[ChatCommandHelp(Command, "Resets your character stats to base values and refunds all invested points.", null)]
+public class ResetStatsChatCommandPlugIn : IChatCommandPlugIn
+{
+    private const string Command = "/resetstats";
+
+    /// <inheritdoc />
+    public string Key => Command;
+
+    /// <inheritdoc />
+    public CharacterStatus MinCharacterStatusRequirement => CharacterStatus.Normal;
+
+    /// <inheritdoc />
+    public async ValueTask HandleCommandAsync(Player player, string command)
+    {
+        var statResetFeature = player.GameContext.FeaturePlugIns.GetPlugIn<StatResetFeaturePlugIn>();
+        if (statResetFeature?.Configuration is { } configuration && !configuration.ChatCommandEnabled)
+        {
+            await player.ShowLocalizedBlueMessageAsync(PlayerMessage.StatResetChatCommandDisabled).ConfigureAwait(false);
+            return;
+        }
+
+        var resetAction = new ResetStatsAction(player);
+        await resetAction.ResetStatsAsync().ConfigureAwait(false);
+    }
+}

--- a/src/GameLogic/Resets/StatResetConfiguration.cs
+++ b/src/GameLogic/Resets/StatResetConfiguration.cs
@@ -16,7 +16,7 @@ public class StatResetConfiguration
     /// Gets or sets the required level for a stat reset.
     /// </summary>
     [Display(ResourceType = typeof(PlugInResources), Name = nameof(PlugInResources.StatResetConfiguration_RequiredLevel_Name))]
-    public int RequiredLevel { get; set; } = 0;
+    public int RequiredLevel { get; set; }
 
     /// <summary>
     /// Gets or sets the required money for a stat reset.

--- a/src/GameLogic/Resets/StatResetConfiguration.cs
+++ b/src/GameLogic/Resets/StatResetConfiguration.cs
@@ -27,7 +27,7 @@ public class StatResetConfiguration
     /// <summary>
     /// Gets or sets the required item for a stat reset.
     /// </summary>
-    [Display(Name = "Required reset item")]
+    [Display(ResourceType = typeof(PlugInResources), Name = nameof(PlugInResources.StatResetConfiguration_RequiredResetItem_Name))]
     public ItemDefinition? RequiredResetItem { get; set; }
 
     /// <summary>

--- a/src/GameLogic/Resets/StatResetConfiguration.cs
+++ b/src/GameLogic/Resets/StatResetConfiguration.cs
@@ -1,0 +1,50 @@
+// <copyright file="StatResetConfiguration.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Resets;
+
+using MUnique.OpenMU.DataModel.Composition;
+using MUnique.OpenMU.DataModel.Configuration.Items;
+
+/// <summary>
+/// Configuration of the Stat Reset System.
+/// </summary>
+public class StatResetConfiguration
+{
+    /// <summary>
+    /// Gets or sets the required level for a stat reset.
+    /// </summary>
+    [Display(ResourceType = typeof(PlugInResources), Name = nameof(PlugInResources.StatResetConfiguration_RequiredLevel_Name))]
+    public int RequiredLevel { get; set; } = 0;
+
+    /// <summary>
+    /// Gets or sets the required money for a stat reset.
+    /// </summary>
+    [Display(ResourceType = typeof(PlugInResources), Name = nameof(PlugInResources.StatResetConfiguration_RequiredMoney_Name))]
+    public int RequiredMoney { get; set; } = 1000000;
+
+    /// <summary>
+    /// Gets or sets the required item for a stat reset.
+    /// </summary>
+    [Display(Name = "Required reset item")]
+    public ItemDefinition? RequiredResetItem { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the chat command is enabled.
+    /// </summary>
+    [Display(ResourceType = typeof(PlugInResources), Name = nameof(PlugInResources.StatResetConfiguration_ChatCommandEnabled_Name))]
+    public bool ChatCommandEnabled { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether a stat reset moves the player home (safe zone).
+    /// </summary>
+    [Display(ResourceType = typeof(PlugInResources), Name = nameof(PlugInResources.StatResetConfiguration_MoveHome_Name))]
+    public bool MoveHome { get; set; } = true;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether a stat reset logs the player out back to character selection.
+    /// </summary>
+    [Display(ResourceType = typeof(PlugInResources), Name = nameof(PlugInResources.StatResetConfiguration_LogOut_Name))]
+    public bool LogOut { get; set; } = true;
+}

--- a/src/GameLogic/Resets/StatResetFeaturePlugIn.cs
+++ b/src/GameLogic/Resets/StatResetFeaturePlugIn.cs
@@ -1,0 +1,23 @@
+// <copyright file="StatResetFeaturePlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Resets;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Feature plugin which provides the configuration for the stat reset feature.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.StatResetFeaturePlugIn_Name), Description = nameof(PlugInResources.StatResetFeaturePlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("0F1E2D3C-4B5A-6978-8C7D-6E5F4A3B2C1D")]
+public class StatResetFeaturePlugIn : IFeaturePlugIn, ISupportCustomConfiguration<StatResetConfiguration>, ISupportDefaultCustomConfiguration, IDisabledByDefault
+{
+    /// <inheritdoc/>
+    public StatResetConfiguration? Configuration { get; set; }
+
+    /// <inheritdoc/>
+    public object CreateDefaultConfig() => new StatResetConfiguration();
+}


### PR DESCRIPTION
# Stat Reset Plugin for OpenMU

A plugin that allows players to reset their character's stats back to base values and refund all invested points.

## Features

- Resets all increasable character attributes to their base values
- Refunds all invested stat points as level-up points
- Configurable requirements (level, money, item)
- Chat command `/resetstats` (toggleable)
- Optional teleport to home safezone after reset
- Optional logout to character selection after reset
- Disabled by default, requires explicit activation

## Configuration

| Setting | Description | Default |
|---------|-------------|---------|
| RequiredLevel | Minimum character level | 0 |
| RequiredMoney | Zen cost | 1,000,000 |
| RequiredResetItem | Required item (optional) | null |
| ChatCommandEnabled | Allow `/resetstats` command | true |
| MoveHome | Teleport to safezone after reset | true |
| LogOut | Log out to character selection | true |

## Files

- `GameLogic/Resets/StatResetFeaturePlugIn.cs` - Feature plugin (implements `IFeaturePlugIn`)
- `GameLogic/Resets/StatResetConfiguration.cs` - Configuration model
- `GameLogic/Resets/ResetStatsAction.cs` - Core reset logic
- `GameLogic/Resets/ResetStatsChatCommandPlugIn.cs` - `/resetstats` chat command handler
- `GameLogic/Properties/PlayerMessage.Designer.cs` + `.resx` - Localized player messages
- `GameLogic/Properties/PlugInResources.Designer.cs` + `.resx` - Localized plugin display names