### PR TITLE
Seed sphere creation fix

### DIFF
--- a/src/GameLogic/PlayerActions/Items/MoveItemAction.cs
+++ b/src/GameLogic/PlayerActions/Items/MoveItemAction.cs
@@ -421,7 +421,7 @@ public class MoveItemAction
             Storages.ChaosCardMaster => state == PlayerState.NpcDialogOpened && openedWindow == NpcWindow.ChaosCardCombination,
             Storages.CherryBlossomSpirit => state == PlayerState.NpcDialogOpened && openedWindow == NpcWindow.CherryBlossomBranchesAssembly,
             Storages.SeedCrafting => state == PlayerState.NpcDialogOpened && openedWindow == NpcWindow.SeedMaster,
-            Storages.SeedSphereCrafting => state == PlayerState.NpcDialogOpened && openedWindow == NpcWindow.SeedResearcher,
+            Storages.SeedSphereCrafting => state == PlayerState.NpcDialogOpened && openedWindow == NpcWindow.SeedMaster,
             Storages.SeedMountCrafting => state == PlayerState.NpcDialogOpened && openedWindow == NpcWindow.SeedResearcher,
             Storages.SeedUnmountCrafting => state == PlayerState.NpcDialogOpened && openedWindow == NpcWindow.SeedResearcher,
             _ => false,


### PR DESCRIPTION
Fixes: https://github.com/MUnique/OpenMU/issues/767

BUG: Seed Sphere Assembly does not allow placing items

Description:
When a player talks to the Seed Master NPC in Elveland and selects "Seed Sphere
Assembly" (Seed Sphere Creation, crafting 43), then tries to put the required
items (Seed, Sphere, Jewel of Creation, Jewel of Chaos) into the crafting
dialog, the NPC does not allow placing any items.

Root cause:
In MoveItemAction.cs, method IsStorageContextAllowed, the SeedSphereCrafting
storage is checked against NpcWindow.SeedResearcher. However, the "Seed Sphere
Assembly" dialog is opened by the Seed Master NPC (NpcWindow.SeedMaster), not
by the Seed Researcher.

As a result, when the player has the Seed Master window open (correct for this
dialog) and tries to move an item to the SeedSphereCrafting storage, the server
rejects the move because it expects the Seed Researcher window to be open.

The SocketSystem.cs initialization confirms the crafting assignments:
  - Seed Master (NpcWindow.SeedMaster) has crafting 42 (Seed Creation)
    and crafting 43 (Seed Sphere Creation)
  - Seed Researcher (NpcWindow.SeedResearcher) has crafting 44
    (Mount Seed Sphere) and crafting 45 (Remove Seed Sphere)

In MoveItemAction.cs, line 424:
  Storages.SeedCrafting => ... NpcWindow.SeedMaster        // correct
  Storages.SeedSphereCrafting => ... NpcWindow.SeedResearcher // BUG!

Fix:
In src/GameLogic/PlayerActions/Items/MoveItemAction.cs, line 424, change:
  NpcWindow.SeedResearcher -> NpcWindow.SeedMaster

After the fix:
  Storages.SeedSphereCrafting => state == PlayerState.NpcDialogOpened
                                 && openedWindow == NpcWindow.SeedMaster,
