### PR TITLE
Apply monster attribute changes instantly on the game server

### DIFF
--- a/src/GameLogic/Attributes/MonsterAttributeHolder.cs
+++ b/src/GameLogic/Attributes/MonsterAttributeHolder.cs
@@ -35,9 +35,9 @@ public class MonsterAttributeHolder : IAttributeSystem
 
     private readonly AttackableNpcBase _monster;
 
-    private readonly IDictionary<AttributeDefinition, float> _statAttributes;
-
     private readonly object _attributesLock = new();
+
+    private IDictionary<AttributeDefinition, float> _statAttributes;
 
     /// <summary>
     /// Attribute dictionary of a monster instance.
@@ -158,11 +158,27 @@ public class MonsterAttributeHolder : IAttributeSystem
         throw new NotImplementedException();
     }
 
+    /// <summary>
+    /// Reloads the stat attributes from the (possibly changed) <see cref="MonsterDefinition"/>,
+    /// so that configuration changes take effect on the running game server.
+    /// </summary>
+    public void ApplyChanges()
+    {
+        var statAttributes = BuildStatAttributes(this._monster.Definition);
+        MonsterStatAttributesCache[this._monster.Definition] = statAttributes;
+        this._statAttributes = statAttributes;
+    }
+
     private static IDictionary<AttributeDefinition, float> GetStatAttributeOfMonster(MonsterDefinition monsterDefinition)
     {
-        return MonsterStatAttributesCache.GetOrAdd(monsterDefinition, monsterDef => monsterDef.Attributes.ToDictionary(
-                m => m.AttributeDefinition ?? throw Error.NotInitializedProperty(m, nameof(m.AttributeDefinition)),
-                m => m.Value));
+        return MonsterStatAttributesCache.GetOrAdd(monsterDefinition, BuildStatAttributes);
+    }
+
+    private static IDictionary<AttributeDefinition, float> BuildStatAttributes(MonsterDefinition monsterDefinition)
+    {
+        return monsterDefinition.Attributes.ToDictionary(
+            m => m.AttributeDefinition ?? throw Error.NotInitializedProperty(m, nameof(m.AttributeDefinition)),
+            m => m.Value);
     }
 
     private IDictionary<AttributeDefinition, IComposableAttribute> GetAttributeDictionary()

--- a/src/GameLogic/Attributes/MonsterAttributeHolder.cs
+++ b/src/GameLogic/Attributes/MonsterAttributeHolder.cs
@@ -164,6 +164,15 @@ public class MonsterAttributeHolder : IAttributeSystem
     /// </summary>
     public void ApplyChanges()
     {
+        // When many instances of the same monster are spawned, all of them get notified about the
+        // same change. The first one rebuilds the shared cache; the others just adopt the new one.
+        if (MonsterStatAttributesCache.TryGetValue(this._monster.Definition, out var cached)
+            && !ReferenceEquals(cached, this._statAttributes))
+        {
+            this._statAttributes = cached;
+            return;
+        }
+
         var statAttributes = BuildStatAttributes(this._monster.Definition);
         MonsterStatAttributesCache[this._monster.Definition] = statAttributes;
         this._statAttributes = statAttributes;

--- a/src/GameLogic/MapInitializer.cs
+++ b/src/GameLogic/MapInitializer.cs
@@ -271,17 +271,20 @@ public class MapInitializer : IMapInitializer
     private void RegisterForConfigChanges(GameMap createdMap, MonsterSpawnArea spawnArea, NonPlayerCharacter spawnedObject)
     {
         // Apply changes of the monster definition (e.g. its attributes) instantly to the
-        // already spawned instance, without having to re-spawn it.
-        var definitionRegistration = spawnedObject is AttackableNpcBase
-            ? this._configurationChangeMediator?.RegisterObject(
+        // already spawned instance, without having to re-spawn it. The registration is owned
+        // by the NPC, so it gets disposed whenever the NPC is disposed.
+        if (spawnedObject is AttackableNpcBase attackableNpc
+            && this._configurationChangeMediator?.RegisterObject(
                 spawnedObject.Definition,
-                spawnedObject,
+                attackableNpc,
                 (_, _, o) =>
                 {
-                    (o as AttackableNpcBase)?.ReloadAttributes();
+                    o.ReloadAttributes();
                     return ValueTask.CompletedTask;
-                })
-            : null;
+                }) is { } definitionRegistration)
+        {
+            attackableNpc.RegisterDisposable(definitionRegistration);
+        }
 
         this._configurationChangeMediator?.RegisterObject(
             spawnArea,
@@ -290,7 +293,6 @@ public class MapInitializer : IMapInitializer
             {
                 if (area.Quantity < o.SpawnIndex + 1)
                 {
-                    definitionRegistration?.Dispose();
                     await o.DisposeAsync().ConfigureAwait(false);
                     unregisterAction();
                     this._spawnedMonsters.AddOrUpdate(spawnArea, spawnArea.Quantity, (_, _) => spawnArea.Quantity);
@@ -301,7 +303,6 @@ public class MapInitializer : IMapInitializer
                 // because MonsterAttributeHolder caches stats from the definition at construction time.
                 if (area.MonsterDefinition != o.Definition)
                 {
-                    definitionRegistration?.Dispose();
                     await o.DisposeAsync().ConfigureAwait(false);
                     unregisterAction();
                     var newNpc = await this.InitializeSpawnAsync(o.SpawnIndex, createdMap, area).ConfigureAwait(false);
@@ -331,7 +332,6 @@ public class MapInitializer : IMapInitializer
             },
             async (_, o) =>
             {
-                definitionRegistration?.Dispose();
                 await o.DisposeAsync().ConfigureAwait(false);
                 this._spawnedMonsters.TryRemove(spawnArea, out var _);
             });

--- a/src/GameLogic/MapInitializer.cs
+++ b/src/GameLogic/MapInitializer.cs
@@ -270,6 +270,19 @@ public class MapInitializer : IMapInitializer
 
     private void RegisterForConfigChanges(GameMap createdMap, MonsterSpawnArea spawnArea, NonPlayerCharacter spawnedObject)
     {
+        // Apply changes of the monster definition (e.g. its attributes) instantly to the
+        // already spawned instance, without having to re-spawn it.
+        var definitionRegistration = spawnedObject is AttackableNpcBase
+            ? this._configurationChangeMediator?.RegisterObject(
+                spawnedObject.Definition,
+                spawnedObject,
+                (_, _, o) =>
+                {
+                    (o as AttackableNpcBase)?.ReloadAttributes();
+                    return ValueTask.CompletedTask;
+                })
+            : null;
+
         this._configurationChangeMediator?.RegisterObject(
             spawnArea,
             spawnedObject,
@@ -277,6 +290,7 @@ public class MapInitializer : IMapInitializer
             {
                 if (area.Quantity < o.SpawnIndex + 1)
                 {
+                    definitionRegistration?.Dispose();
                     await o.DisposeAsync().ConfigureAwait(false);
                     unregisterAction();
                     this._spawnedMonsters.AddOrUpdate(spawnArea, spawnArea.Quantity, (_, _) => spawnArea.Quantity);
@@ -287,6 +301,7 @@ public class MapInitializer : IMapInitializer
                 // because MonsterAttributeHolder caches stats from the definition at construction time.
                 if (area.MonsterDefinition != o.Definition)
                 {
+                    definitionRegistration?.Dispose();
                     await o.DisposeAsync().ConfigureAwait(false);
                     unregisterAction();
                     var newNpc = await this.InitializeSpawnAsync(o.SpawnIndex, createdMap, area).ConfigureAwait(false);
@@ -316,6 +331,7 @@ public class MapInitializer : IMapInitializer
             },
             async (_, o) =>
             {
+                definitionRegistration?.Dispose();
                 await o.DisposeAsync().ConfigureAwait(false);
                 this._spawnedMonsters.TryRemove(spawnArea, out var _);
             });

--- a/src/GameLogic/NPC/AttackableNpcBase.cs
+++ b/src/GameLogic/NPC/AttackableNpcBase.cs
@@ -24,6 +24,7 @@ public abstract class AttackableNpcBase : NonPlayerCharacter, IAttackable
     private readonly IEventStateProvider? _eventStateProvider;
     private readonly IDropGenerator _dropGenerator;
     private readonly PlugInManager _plugInManager;
+    private readonly List<IDisposable> _registrations = new();
 
     private int _health;
 
@@ -170,6 +171,16 @@ public abstract class AttackableNpcBase : NonPlayerCharacter, IAttackable
         (this.Attributes as MonsterAttributeHolder)?.ApplyChanges();
     }
 
+    /// <summary>
+    /// Registers a disposable (e.g. a configuration change registration) to be disposed
+    /// together with this instance.
+    /// </summary>
+    /// <param name="disposable">The disposable.</param>
+    public void RegisterDisposable(IDisposable disposable)
+    {
+        this._registrations.Add(disposable);
+    }
+
     /// <inheritdoc/>
     protected override void Dispose(bool managed)
     {
@@ -177,6 +188,12 @@ public abstract class AttackableNpcBase : NonPlayerCharacter, IAttackable
         {
             this.Died = null;
             this.IsAlive = false;
+            foreach (var registration in this._registrations)
+            {
+                registration.Dispose();
+            }
+
+            this._registrations.Clear();
         }
 
         base.Dispose(managed);

--- a/src/GameLogic/NPC/AttackableNpcBase.cs
+++ b/src/GameLogic/NPC/AttackableNpcBase.cs
@@ -161,6 +161,15 @@ public abstract class AttackableNpcBase : NonPlayerCharacter, IAttackable
         this.IsAlive = true;
     }
 
+    /// <summary>
+    /// Reloads the attributes from the <see cref="NonPlayerCharacter.Definition"/>, so that changes
+    /// to the monster definition take effect on this already spawned instance.
+    /// </summary>
+    public void ReloadAttributes()
+    {
+        (this.Attributes as MonsterAttributeHolder)?.ApplyChanges();
+    }
+
     /// <inheritdoc/>
     protected override void Dispose(bool managed)
     {

--- a/tests/MUnique.OpenMU.Tests/MonsterAttributeReloadTests.cs
+++ b/tests/MUnique.OpenMU.Tests/MonsterAttributeReloadTests.cs
@@ -1,0 +1,104 @@
+// <copyright file="MonsterAttributeReloadTests.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Tests;
+
+using Moq;
+using MUnique.OpenMU.AttributeSystem;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.Attributes;
+using MUnique.OpenMU.GameLogic.NPC;
+using MUnique.OpenMU.Pathfinding;
+using MonsterDefinition = MUnique.OpenMU.Persistence.BasicModel.MonsterDefinition;
+using MonsterAttribute = MUnique.OpenMU.Persistence.BasicModel.MonsterAttribute;
+
+/// <summary>
+/// Tests for applying changes of a <see cref="MonsterDefinition"/> to an already spawned
+/// <see cref="AttackableNpcBase"/> via <see cref="AttackableNpcBase.ReloadAttributes"/>.
+/// </summary>
+[TestFixture]
+public class MonsterAttributeReloadTests
+{
+    private IGameContext _gameContext = null!;
+
+    /// <summary>
+    /// Sets up a fresh game context before each test.
+    /// </summary>
+    [SetUp]
+    public void SetUp()
+    {
+        this._gameContext = GameContextTestHelper.CreateGameContext();
+    }
+
+    /// <summary>
+    /// Tests that changing a value of a <see cref="MonsterAttribute"/> takes effect on an
+    /// already spawned monster after <see cref="AttackableNpcBase.ReloadAttributes"/> is called.
+    /// </summary>
+    [Test]
+    public async ValueTask ReloadAttributesAppliesChangedValueAsync()
+    {
+        var monster = await this.CreateMonsterAsync().ConfigureAwait(false);
+        var maximumHealthAttribute = monster.Definition.Attributes.First(a => a.AttributeDefinition == Stats.MaximumHealth);
+
+        Assert.That(monster.Attributes[Stats.MaximumHealth], Is.EqualTo(1000));
+
+        maximumHealthAttribute.Value = 2000;
+        monster.ReloadAttributes();
+
+        Assert.That(monster.Attributes[Stats.MaximumHealth], Is.EqualTo(2000));
+    }
+
+    /// <summary>
+    /// Tests that adding a new <see cref="MonsterAttribute"/> takes effect on an already spawned
+    /// monster after <see cref="AttackableNpcBase.ReloadAttributes"/> is called.
+    /// </summary>
+    [Test]
+    public async ValueTask ReloadAttributesAppliesAddedAttributeAsync()
+    {
+        var monster = await this.CreateMonsterAsync().ConfigureAwait(false);
+
+        Assert.That(monster.Attributes[Stats.AttackRatePvm], Is.EqualTo(0));
+
+        monster.Definition.Attributes.Add(new MonsterAttribute { AttributeDefinition = Stats.AttackRatePvm, Value = 50 });
+        monster.ReloadAttributes();
+
+        Assert.That(monster.Attributes[Stats.AttackRatePvm], Is.EqualTo(50));
+    }
+
+    private async ValueTask<Monster> CreateMonsterAsync()
+    {
+        var monsterDefinition = new MonsterDefinition
+        {
+            ObjectKind = NpcObjectKind.Monster,
+        };
+        monsterDefinition.Attributes.Add(new MonsterAttribute { AttributeDefinition = Stats.MaximumHealth, Value = 1000 });
+        monsterDefinition.Attributes.Add(new MonsterAttribute { AttributeDefinition = Stats.DefenseBase, Value = 100 });
+
+        var map = await this._gameContext.GetMapAsync(0).ConfigureAwait(false);
+        var spawnArea = new MonsterSpawnArea
+        {
+            MonsterDefinition = monsterDefinition,
+            GameMap = map!.Definition,
+            X1 = 100,
+            Y1 = 100,
+            X2 = 100,
+            Y2 = 100,
+            Quantity = 1,
+        };
+
+        var monster = new Monster(
+            spawnArea,
+            monsterDefinition,
+            map,
+            NullDropGenerator.Instance,
+            new Mock<INpcIntelligence>().Object,
+            this._gameContext.PlugInManager,
+            this._gameContext.PathFinderPool);
+
+        monster.Initialize();
+
+        return monster;
+    }
+}

--- a/tests/MUnique.OpenMU.Tests/MonsterAttributeReloadTests.cs
+++ b/tests/MUnique.OpenMU.Tests/MonsterAttributeReloadTests.cs
@@ -67,7 +67,26 @@ public class MonsterAttributeReloadTests
         Assert.That(monster.Attributes[Stats.AttackRatePvm], Is.EqualTo(50));
     }
 
-    private async ValueTask<Monster> CreateMonsterAsync()
+    /// <summary>
+    /// Tests that all spawned instances of the same monster definition pick up an attribute change.
+    /// </summary>
+    [Test]
+    public async ValueTask ReloadAttributesAppliesToAllInstancesOfDefinitionAsync()
+    {
+        var monsterDefinition = CreateMonsterDefinition();
+        var monster1 = await this.CreateMonsterAsync(monsterDefinition).ConfigureAwait(false);
+        var monster2 = await this.CreateMonsterAsync(monsterDefinition).ConfigureAwait(false);
+        var maximumHealthAttribute = monsterDefinition.Attributes.First(a => a.AttributeDefinition == Stats.MaximumHealth);
+
+        maximumHealthAttribute.Value = 2000;
+        monster1.ReloadAttributes();
+        monster2.ReloadAttributes();
+
+        Assert.That(monster1.Attributes[Stats.MaximumHealth], Is.EqualTo(2000));
+        Assert.That(monster2.Attributes[Stats.MaximumHealth], Is.EqualTo(2000));
+    }
+
+    private static MonsterDefinition CreateMonsterDefinition()
     {
         var monsterDefinition = new MonsterDefinition
         {
@@ -75,7 +94,16 @@ public class MonsterAttributeReloadTests
         };
         monsterDefinition.Attributes.Add(new MonsterAttribute { AttributeDefinition = Stats.MaximumHealth, Value = 1000 });
         monsterDefinition.Attributes.Add(new MonsterAttribute { AttributeDefinition = Stats.DefenseBase, Value = 100 });
+        return monsterDefinition;
+    }
 
+    private ValueTask<Monster> CreateMonsterAsync()
+    {
+        return this.CreateMonsterAsync(CreateMonsterDefinition());
+    }
+
+    private async ValueTask<Monster> CreateMonsterAsync(MonsterDefinition monsterDefinition)
+    {
         var map = await this._gameContext.GetMapAsync(0).ConfigureAwait(false);
         var spawnArea = new MonsterSpawnArea
         {


### PR DESCRIPTION
## Summary
Closes #784.

Changing a monster's attributes (e.g. via the admin panel) previously had no effect until a server restart, because `MonsterAttributeHolder` snapshots the monster's stats from its `MonsterDefinition` at construction time into a static cache and never refreshed them.

This change hooks into the existing `ConfigurationChangeMediator`: whenever a `MonsterAttribute` is added/removed/modified, the infrastructure publishes a parent-level change for its `MonsterDefinition`. Each spawned attackable NPC now registers for those changes and reloads its cached stat attributes in place — no re-spawn, so health and position are preserved.

## Changes
- **`MonsterAttributeHolder`**: added `ApplyChanges()`, which rebuilds the stat dictionary from the (already updated in place) `MonsterDefinition.Attributes`, refreshes the shared static cache, and atomically swaps in the new dictionary.
- **`AttackableNpcBase`**: added `ReloadAttributes()` forwarding to the holder.
- **`MapInitializer.RegisterForConfigChanges`**: each spawned attackable NPC registers for changes to its `MonsterDefinition`; the registration is disposed alongside the NPC in all existing teardown paths.

## Known limitation
Stats that currently have a per-instance composable element applied (e.g. an active magic effect, or the disabled-by-default `MonsterAttributeScaler`) won't reflect a base-value change until that element is removed/re-added, since composable attributes snapshot their base at add time. This matches existing system behavior.

## Test plan
- [x] New unit tests in `MonsterAttributeReloadTests` cover changing an existing attribute value and adding a new attribute; both confirm the value takes effect after `ReloadAttributes()`.
- [x] Manual verification: edit a monster's attribute in the admin panel on a running server and confirm immediate effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)