### PR TITLE
Dark mode for Admin Panel

### DIFF
--- a/src/Web/AdminPanel/Components/App.razor
+++ b/src/Web/AdminPanel/Components/App.razor
@@ -1,7 +1,16 @@
 @using MUnique.OpenMU.Web.AdminPanel.Components.Layout
+@using MUnique.OpenMU.Web.Shared.Services
+
+@code {
+    [CascadingParameter]
+    public HttpContext? HttpContext { get; set; }
+
+    private string CurrentTheme =>
+        ThemeController.NormalizeTheme(this.HttpContext?.Request.Cookies[ThemeController.CookieName]);
+}
 
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="@this.CurrentTheme">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/src/Web/AdminPanel/Components/Layout/ConfigurationSearch.razor.css
+++ b/src/Web/AdminPanel/Components/Layout/ConfigurationSearch.razor.css
@@ -36,7 +36,7 @@
 
 .configuration-search__result-path {
     font-size: 0.78rem;
-    color: #5f6368;
+    color: var(--omu-text-muted);
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
@@ -45,7 +45,7 @@
 
 .configuration-search__result:hover .configuration-search__result-path,
 .configuration-search__result:focus .configuration-search__result-path {
-    color: rgba(0, 0, 0, 0.7);
+    color: var(--omu-text);
 }
 
 @media (max-width: 640.98px) {

--- a/src/Web/AdminPanel/Components/Layout/CreationPanel.razor.css
+++ b/src/Web/AdminPanel/Components/Layout/CreationPanel.razor.css
@@ -6,8 +6,9 @@
     flex-shrink: 0;
     display: flex;
     flex-direction: row;
-    background-color: #fff;
-    border-left: 1px solid #d6d5d5;
+    background-color: var(--omu-surface-2);
+    color: var(--omu-text);
+    border-left: 1px solid var(--omu-border);
     box-shadow: -2px 0 5px rgba(0, 0, 0, 0.08);
     overflow: hidden;
     z-index: 2;
@@ -22,14 +23,14 @@
     width: 1.75rem;
     padding: 0;
     border: none;
-    border-right: 1px solid #d6d5d5;
-    background-color: #f7f7f7;
+    border-right: 1px solid var(--omu-border);
+    background-color: var(--omu-surface-muted);
     cursor: pointer;
-    color: #333;
+    color: var(--omu-text);
 }
 
 .collapse-toggle:hover {
-    background-color: #e9e9e9;
+    background-color: var(--omu-surface-hover);
 }
 
 .creation-panel-body {

--- a/src/Web/AdminPanel/Components/Layout/MainLayout.razor
+++ b/src/Web/AdminPanel/Components/Layout/MainLayout.razor
@@ -1,6 +1,17 @@
 @using MUnique.OpenMU.Web.AdminPanel.Properties
+@using MUnique.OpenMU.Web.Shared.Services
 
 @inherits LayoutComponentBase
+
+@code {
+    [CascadingParameter]
+    public HttpContext? HttpContext { get; set; }
+
+    private bool IsDarkTheme => string.Equals(
+        this.HttpContext?.Request.Cookies[ThemeController.CookieName],
+        "dark",
+        StringComparison.OrdinalIgnoreCase);
+}
 
 <div class="page">
     <div class="sidebar">
@@ -14,14 +25,15 @@
                     <div class="header-search flex-grow-1">
                         <ConfigurationSearch />
                     </div>
-                    <div class="header-actions ml-3">
-                        <a href="https://munique.net" target="_blank" class="text-secondary small">@Resources.About</a>
+                    <div class="header-actions ml-3 d-flex align-items-center">
+                        <ThemeSelector IsDark="@this.IsDarkTheme" />
+                        <a href="https://munique.net" target="_blank" class="text-secondary small ml-3">@Resources.About</a>
                     </div>
                 </div>
             </div>
         </header>
 
-        <div class="breadcrumb-bar bg-white border-bottom px-4 py-3">
+        <div class="breadcrumb-bar border-bottom px-4 py-3">
             <div class="d-flex align-items-center">
                 <BreadcrumbNavigation />
             </div>

--- a/src/Web/AdminPanel/Components/Layout/MainLayout.razor.css
+++ b/src/Web/AdminPanel/Components/Layout/MainLayout.razor.css
@@ -9,7 +9,7 @@ main {
 }
 
 .sidebar {
-    background-image: linear-gradient(180deg, rgb(5, 39, 103) 0%, #3a0647 70%);
+    background-image: var(--omu-sidebar-gradient);
 }
 
 .header-search {
@@ -24,6 +24,7 @@ main {
 
 .breadcrumb-bar {
     min-height: 2.5rem;
+    background-color: var(--omu-surface-2);
 }
 
 .breadcrumb-bar ::deep .breadcrumb-nav {
@@ -58,8 +59,8 @@ main {
 }
 
 #blazor-error-ui {
-    color-scheme: light only;
-    background: lightyellow;
+    background: var(--omu-error-bg);
+    color: var(--omu-error-text);
     bottom: 0;
     box-shadow: 0 -1px 2px rgba(0, 0, 0, 0.2);
     box-sizing: border-box;

--- a/src/Web/AdminPanel/_Imports.razor
+++ b/src/Web/AdminPanel/_Imports.razor
@@ -5,6 +5,7 @@
 @using Microsoft.AspNetCore.Components.Forms
 @using Microsoft.AspNetCore.Components.Routing
 @using Microsoft.AspNetCore.Components.Web
+@using Microsoft.AspNetCore.Http
 @using static Microsoft.AspNetCore.Components.Web.RenderMode
 @using Microsoft.AspNetCore.Components.Web.Virtualization
 @using Microsoft.JSInterop

--- a/src/Web/Shared/Components/Form/AutoForm.razor.css
+++ b/src/Web/Shared/Components/Form/AutoForm.razor.css
@@ -1,6 +1,7 @@
 .auto-form {
-    background: #fff;
-    border: 1px solid #dee2e6;
+    background: var(--omu-surface-2);
+    color: var(--omu-text);
+    border: 1px solid var(--omu-border);
     border-radius: 0.375rem;
     padding: 1.5rem;
     margin-bottom: 1rem;
@@ -9,9 +10,9 @@
 .form-actions {
     position: sticky;
     bottom: 0;
-    background-color: #fff;
+    background-color: var(--omu-surface-2);
     margin: 1rem 0 0 0;
-    border-top: 1px solid #dee2e6;
+    border-top: 1px solid var(--omu-border);
     display: flex;
     gap: 0.5rem;
     justify-content: flex-start;
@@ -38,6 +39,6 @@
     left: 0.75rem;
     top: 50%;
     transform: translateY(-50%);
-    color: #6c757d;
+    color: var(--omu-text-muted);
     pointer-events: none;
 }

--- a/src/Web/Shared/Components/Form/Typeahead.razor.css
+++ b/src/Web/Shared/Components/Form/Typeahead.razor.css
@@ -13,16 +13,17 @@
     padding: 0.375rem 2.2rem;
     min-height: calc(1.5em + 0.75rem + 2px);
     cursor: text;
-    border: 1px solid #ced4da;
+    border: 1px solid var(--omu-border);
     border-radius: 0.25rem;
-    background-color: #fff;
+    background-color: var(--omu-surface-2);
+    color: var(--omu-text);
     transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 }
 
 .typeahead-controls:focus-within {
-    color: #495057;
-    background-color: #fff;
-    border-color: #80bdff;
+    color: var(--omu-text);
+    background-color: var(--omu-surface-2);
+    border-color: var(--omu-link);
     outline: 0;
     box-shadow: 0 0 0 0.2rem rgba(0, 123, 255, 0.25);
 }
@@ -39,8 +40,9 @@
 .typeahead-multi-value {
     display: inline-flex;
     align-items: center;
-    background-color: #e9ecef;
-    border: 1px solid #ced4da;
+    background-color: var(--omu-surface-hover);
+    color: var(--omu-text);
+    border: 1px solid var(--omu-border);
     border-radius: 0.2rem;
     padding: 0.1rem 0.4rem;
     font-size: 0.875rem;
@@ -51,7 +53,7 @@
 .typeahead-multi-value-remove {
     background: none;
     border: none;
-    color: #6c757d;
+    color: var(--omu-text-muted);
     cursor: pointer;
     font-size: 1rem;
     font-weight: bold;
@@ -93,7 +95,7 @@
     left: 0.75rem;
     top: 50%;
     transform: translateY(-50%);
-    color: #6c757d;
+    color: var(--omu-text-muted);
     pointer-events: none;
     font-size: 0.9rem;
 }

--- a/src/Web/Shared/Components/ThemeSelector.razor
+++ b/src/Web/Shared/Components/ThemeSelector.razor
@@ -1,0 +1,20 @@
+@*
+    A simple toggle that switches the UI between the "light" and "dark" themes.
+    Persists the selection by calling the ThemeController (cookie-based, same pattern as CultureSelector).
+*@
+@using MUnique.OpenMU.Web.Shared.Properties
+
+<button type="button"
+        class="theme-selector btn btn-link p-0"
+        title="@(this.EffectiveIsDark ? Resources.SwitchToLightMode : Resources.SwitchToDarkMode)"
+        aria-label="@Resources.ToggleTheme"
+        @onclick="this.Toggle">
+    @if (this.EffectiveIsDark)
+    {
+        <span class="oi oi-sun theme-selector__icon" aria-hidden="true"></span>
+    }
+    else
+    {
+        <span class="oi oi-moon theme-selector__icon" aria-hidden="true"></span>
+    }
+</button>

--- a/src/Web/Shared/Components/ThemeSelector.razor.cs
+++ b/src/Web/Shared/Components/ThemeSelector.razor.cs
@@ -1,0 +1,110 @@
+// <copyright file="ThemeSelector.razor.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Web.Shared.Components;
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.JSInterop;
+
+/// <summary>
+/// A toggle component which switches between the light and dark UI themes.
+/// Persists the selection by calling the <see cref="MUnique.OpenMU.Web.Shared.Services.ThemeController"/>
+/// (cookie-based, mirrors the <see cref="CultureSelector"/> approach).
+/// </summary>
+public partial class ThemeSelector : IAsyncDisposable
+{
+    private static readonly string JsModulePath =
+        $"./_content/{typeof(ThemeSelector).Assembly.GetName().Name}/themeSelector.js";
+
+    private readonly NavigationManager _navigationManager;
+
+    private IJSObjectReference? _jsModule;
+
+    private bool _isDarkInternal;
+
+    private bool _hydrated;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ThemeSelector"/> class.
+    /// </summary>
+    /// <param name="navigationManager">The navigation manager used for the post-toggle redirect.</param>
+    public ThemeSelector(NavigationManager navigationManager)
+    {
+        this._navigationManager = navigationManager;
+    }
+
+    /// <summary>
+    /// Gets or sets the current dark-mode state as seen by the server-side renderer.
+    /// </summary>
+    /// <remarks>
+    /// Only used until the first interactive render hydrates the value from the live DOM
+    /// (the cascading HttpContext is null during interactive updates so this parameter
+    /// would otherwise flip back to false even when the cookie is "dark").
+    /// </remarks>
+    [Parameter]
+    public bool IsDark { get; set; }
+
+    /// <summary>
+    /// Gets or sets the JS runtime used to load the theme reader module.
+    /// </summary>
+    [Inject]
+    private IJSRuntime JS { get; set; } = null!;
+
+    private bool EffectiveIsDark => this._hydrated ? this._isDarkInternal : this.IsDark;
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (this._jsModule is not null)
+        {
+            try
+            {
+                await this._jsModule.DisposeAsync().ConfigureAwait(false);
+            }
+            catch (JSDisconnectedException)
+            {
+                // Ignore: circuit already gone.
+            }
+        }
+    }
+
+    /// <inheritdoc />
+    protected override async Task OnAfterRenderAsync(bool firstRender)
+    {
+        await base.OnAfterRenderAsync(firstRender).ConfigureAwait(true);
+        if (!firstRender)
+        {
+            return;
+        }
+
+        try
+        {
+            this._jsModule = await this.JS
+                .InvokeAsync<IJSObjectReference>("import", JsModulePath)
+                .ConfigureAwait(true);
+            var theme = await this._jsModule
+                .InvokeAsync<string?>("current")
+                .ConfigureAwait(true);
+            this._isDarkInternal = string.Equals(theme, "dark", StringComparison.OrdinalIgnoreCase);
+            this._hydrated = true;
+            this.StateHasChanged();
+        }
+        catch
+        {
+            // Fall back to the SSR parameter if JS is unavailable.
+        }
+    }
+
+    private void Toggle()
+    {
+        var next = this.EffectiveIsDark ? "light" : "dark";
+        var uri = new Uri(this._navigationManager.Uri)
+            .GetComponents(UriComponents.PathAndQuery, UriFormat.Unescaped);
+        var themeEscaped = Uri.EscapeDataString(next);
+        var uriEscaped = Uri.EscapeDataString(uri);
+
+        var fullUri = $"Theme/Set?theme={themeEscaped}&redirectUri={uriEscaped}";
+        this._navigationManager.NavigateTo(fullUri, forceLoad: true);
+    }
+}

--- a/src/Web/Shared/Components/ThemeSelector.razor.cs
+++ b/src/Web/Shared/Components/ThemeSelector.razor.cs
@@ -17,22 +17,11 @@ public partial class ThemeSelector : IAsyncDisposable
     private static readonly string JsModulePath =
         $"./_content/{typeof(ThemeSelector).Assembly.GetName().Name}/themeSelector.js";
 
-    private readonly NavigationManager _navigationManager;
-
     private IJSObjectReference? _jsModule;
 
     private bool _isDarkInternal;
 
     private bool _hydrated;
-
-    /// <summary>
-    /// Initializes a new instance of the <see cref="ThemeSelector"/> class.
-    /// </summary>
-    /// <param name="navigationManager">The navigation manager used for the post-toggle redirect.</param>
-    public ThemeSelector(NavigationManager navigationManager)
-    {
-        this._navigationManager = navigationManager;
-    }
 
     /// <summary>
     /// Gets or sets the current dark-mode state as seen by the server-side renderer.
@@ -44,6 +33,12 @@ public partial class ThemeSelector : IAsyncDisposable
     /// </remarks>
     [Parameter]
     public bool IsDark { get; set; }
+
+    /// <summary>
+    /// Gets or sets the navigation manager used for the post-toggle redirect.
+    /// </summary>
+    [Inject]
+    private NavigationManager NavigationManager { get; set; } = null!;
 
     /// <summary>
     /// Gets or sets the JS runtime used to load the theme reader module.
@@ -99,12 +94,12 @@ public partial class ThemeSelector : IAsyncDisposable
     private void Toggle()
     {
         var next = this.EffectiveIsDark ? "light" : "dark";
-        var uri = new Uri(this._navigationManager.Uri)
+        var uri = new Uri(this.NavigationManager.Uri)
             .GetComponents(UriComponents.PathAndQuery, UriFormat.Unescaped);
         var themeEscaped = Uri.EscapeDataString(next);
         var uriEscaped = Uri.EscapeDataString(uri);
 
-        var fullUri = $"Theme/Set?theme={themeEscaped}&redirectUri={uriEscaped}";
-        this._navigationManager.NavigateTo(fullUri, forceLoad: true);
+        var fullUri = $"/Theme/Set?theme={themeEscaped}&redirectUri={uriEscaped}";
+        this.NavigationManager.NavigateTo(fullUri, forceLoad: true);
     }
 }

--- a/src/Web/Shared/Components/ThemeSelector.razor.css
+++ b/src/Web/Shared/Components/ThemeSelector.razor.css
@@ -1,0 +1,22 @@
+.theme-selector {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2rem;
+    height: 2rem;
+    line-height: 1;
+    color: inherit;
+    text-decoration: none;
+    border-radius: 999px;
+}
+
+.theme-selector:hover,
+.theme-selector:focus {
+    background-color: rgba(0, 0, 0, 0.06);
+    text-decoration: none;
+    color: inherit;
+}
+
+.theme-selector__icon {
+    font-size: 1.1rem;
+}

--- a/src/Web/Shared/Exports.cs
+++ b/src/Web/Shared/Exports.cs
@@ -48,6 +48,7 @@ public static class Exports
         get
         {
             yield return $"{Prefix}/css/shared.css";
+            yield return $"{Prefix}/css/theme.css";
         }
     }
 }

--- a/src/Web/Shared/Properties/Resources.Designer.cs
+++ b/src/Web/Shared/Properties/Resources.Designer.cs
@@ -356,5 +356,23 @@ namespace MUnique.OpenMU.Web.Shared.Properties {
                 return ResourceManager.GetString("Refresh", resourceCulture);
             }
         }
+
+        public static string ToggleTheme {
+            get {
+                return ResourceManager.GetString("ToggleTheme", resourceCulture);
+            }
+        }
+
+        public static string SwitchToDarkMode {
+            get {
+                return ResourceManager.GetString("SwitchToDarkMode", resourceCulture);
+            }
+        }
+
+        public static string SwitchToLightMode {
+            get {
+                return ResourceManager.GetString("SwitchToLightMode", resourceCulture);
+            }
+        }
     }
 }

--- a/src/Web/Shared/Properties/Resources.resx
+++ b/src/Web/Shared/Properties/Resources.resx
@@ -273,4 +273,13 @@
   <data name="Refresh" xml:space="preserve">
     <value>Refresh</value>
   </data>
+  <data name="ToggleTheme" xml:space="preserve">
+    <value>Toggle theme</value>
+  </data>
+  <data name="SwitchToDarkMode" xml:space="preserve">
+    <value>Switch to dark mode</value>
+  </data>
+  <data name="SwitchToLightMode" xml:space="preserve">
+    <value>Switch to light mode</value>
+  </data>
 </root>

--- a/src/Web/Shared/Services/ThemeController.cs
+++ b/src/Web/Shared/Services/ThemeController.cs
@@ -1,0 +1,56 @@
+// <copyright file="ThemeController.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Web.Shared.Services;
+
+using Microsoft.AspNetCore.Mvc;
+
+/// <summary>
+/// A controller which writes the UI theme preference to a cookie and redirects to the specified uri.
+/// </summary>
+[Route("[controller]/[action]")]
+public class ThemeController : Controller
+{
+    /// <summary>
+    /// The name of the cookie that stores the selected theme.
+    /// </summary>
+    public const string CookieName = "OpenMU.Theme";
+
+    /// <summary>
+    /// The default theme used when no cookie is present.
+    /// </summary>
+    public const string DefaultTheme = "light";
+
+    /// <summary>
+    /// Sets the UI theme by writing the theme cookie and redirects to the specified URI.
+    /// </summary>
+    /// <param name="theme">The theme to set, e.g. &quot;light&quot; or &quot;dark&quot;.</param>
+    /// <param name="redirectUri">The URI to redirect to after the cookie has been set.</param>
+    /// <returns>A local redirect to <paramref name="redirectUri"/>.</returns>
+    public IActionResult Set(string? theme, string redirectUri)
+    {
+        var normalized = NormalizeTheme(theme);
+        this.HttpContext.Response.Cookies.Append(
+            CookieName,
+            normalized,
+            new Microsoft.AspNetCore.Http.CookieOptions
+            {
+                Expires = DateTimeOffset.UtcNow.AddYears(1),
+                IsEssential = true,
+                SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Lax,
+            });
+
+        return this.LocalRedirect(redirectUri);
+    }
+
+    /// <summary>
+    /// Normalizes the supplied theme value to a known token.
+    /// </summary>
+    /// <param name="theme">The raw value from the request.</param>
+    /// <returns>Either &quot;dark&quot; or &quot;light&quot;.</returns>
+    public static string NormalizeTheme(string? theme)
+    {
+        return string.Equals(theme, "dark", StringComparison.OrdinalIgnoreCase) ? "dark" : "light";
+    }
+}

--- a/src/Web/Shared/Services/ThemeController.cs
+++ b/src/Web/Shared/Services/ThemeController.cs
@@ -13,14 +13,14 @@ using Microsoft.AspNetCore.Mvc;
 public class ThemeController : Controller
 {
     /// <summary>
-    /// The name of the cookie that stores the selected theme.
+    /// Gets the name of the cookie that stores the selected theme.
     /// </summary>
-    public const string CookieName = "OpenMU.Theme";
+    public static string CookieName { get; } = "OpenMU.Theme";
 
     /// <summary>
-    /// The default theme used when no cookie is present.
+    /// Gets the default theme used when no cookie is present.
     /// </summary>
-    public const string DefaultTheme = "light";
+    public static string DefaultTheme { get; } = "light";
 
     /// <summary>
     /// Sets the UI theme by writing the theme cookie and redirects to the specified URI.

--- a/src/Web/Shared/Services/ThemeController.cs
+++ b/src/Web/Shared/Services/ThemeController.cs
@@ -26,9 +26,9 @@ public class ThemeController : Controller
     /// Sets the UI theme by writing the theme cookie and redirects to the specified URI.
     /// </summary>
     /// <param name="theme">The theme to set, e.g. &quot;light&quot; or &quot;dark&quot;.</param>
-    /// <param name="redirectUri">The URI to redirect to after the cookie has been set.</param>
-    /// <returns>A local redirect to <paramref name="redirectUri"/>.</returns>
-    public IActionResult Set(string? theme, string redirectUri)
+    /// <param name="redirectUri">The URI to redirect to after the cookie has been set. Must be a local URL; otherwise the user is sent to the application root.</param>
+    /// <returns>A local redirect to <paramref name="redirectUri"/>, or to &quot;/&quot; if the URI is missing or non-local.</returns>
+    public IActionResult Set(string? theme, string? redirectUri)
     {
         var normalized = NormalizeTheme(theme);
         this.HttpContext.Response.Cookies.Append(
@@ -40,6 +40,13 @@ public class ThemeController : Controller
                 IsEssential = true,
                 SameSite = Microsoft.AspNetCore.Http.SameSiteMode.Lax,
             });
+
+        // LocalRedirect throws InvalidOperationException (-> 500) on empty / non-local URIs.
+        // Fall back to the app root so a malformed request never crashes the response.
+        if (string.IsNullOrEmpty(redirectUri) || !this.Url.IsLocalUrl(redirectUri))
+        {
+            return this.LocalRedirect("/");
+        }
 
         return this.LocalRedirect(redirectUri);
     }

--- a/src/Web/Shared/wwwroot/css/theme.css
+++ b/src/Web/Shared/wwwroot/css/theme.css
@@ -291,3 +291,131 @@ body {
     background-color: var(--omu-surface) !important;
     border-top: 1px solid var(--omu-border) !important;
 }
+
+/* Sticky "Add New" bar in EditConfigGrid (hardcoded #fff / #dee2e6 in EditConfigGrid.razor.css, added in #788) */
+[data-theme="dark"] .add-new-bar {
+    background-color: var(--omu-surface) !important;
+    border-top: 1px solid var(--omu-border) !important;
+}
+
+/* Blazored.Modal panel (NuGet package hardcodes background-color: #fff in blazored.modal.bundle.scp.css) */
+[data-theme="dark"] .blazored-modal {
+    background-color: var(--omu-surface) !important;
+    border-color: var(--omu-border) !important;
+    color: var(--omu-text);
+}
+
+/* MultiLookupField (used in Plugins modal, ItemEdit excellent/wing options, etc.) */
+[data-theme="dark"] .multi-lookup-field__selected-items {
+    background: var(--omu-surface-2);
+    border-color: var(--omu-border);
+    color: var(--omu-text);
+}
+
+[data-theme="dark"] .multi-lookup-field__tag {
+    background-color: var(--omu-surface-hover);
+    border-color: var(--omu-border);
+    color: var(--omu-text);
+}
+
+[data-theme="dark"] .multi-lookup-field__tag-remove {
+    color: var(--omu-text-muted);
+}
+
+[data-theme="dark"] .multi-lookup-field__dropdown {
+    background: var(--omu-surface-2);
+    border-color: var(--omu-border);
+}
+
+[data-theme="dark"] .multi-lookup-field__dropdown-item {
+    color: var(--omu-text);
+}
+
+[data-theme="dark"] .multi-lookup-field__dropdown-item:hover,
+[data-theme="dark"] .multi-lookup-field__dropdown-item--selected {
+    background-color: var(--omu-surface-hover);
+}
+
+[data-theme="dark"] .multi-lookup-field__dropdown-item--selected:hover {
+    background-color: var(--omu-surface-muted);
+}
+
+[data-theme="dark"] .multi-lookup-field__dropdown-item--loading,
+[data-theme="dark"] .multi-lookup-field__dropdown-item--empty {
+    color: var(--omu-text-muted);
+}
+
+/*
+ * QuickGrid column header. shared.css applies `button { color: #212529 }` globally;
+ * `.col-title` is a bare <button>, so the header text inherits the dark color.
+ * Narrow target — don't touch `.btn-*` variants (they have their own explicit color).
+ */
+[data-theme="dark"] button.col-title,
+[data-theme="dark"] .col-title-text {
+    color: var(--omu-text);
+}
+
+/*
+ * QuickGrid sort indicator and paginator buttons render their arrows as SVG
+ * data-URIs in `background-image` with no `fill` attribute, so the paths default
+ * to black. We can't override the SVG fill from outside, so invert the element
+ * to flip black -> white in dark mode.
+ */
+[data-theme="dark"] .sort-indicator,
+[data-theme="dark"] .go-first,
+[data-theme="dark"] .go-previous,
+[data-theme="dark"] .go-next,
+[data-theme="dark"] .go-last {
+    filter: invert(1);
+}
+
+/*
+ * Bootstrap alert variants — used on the Updates and Install pages. The light
+ * backgrounds are illegible on dark mode. Match the variant's accent hue with a
+ * subtle tint over the dark surface (15% bg, 40% border).
+ * `.alert-secondary` already overridden above; not redefined here.
+ */
+[data-theme="dark"] .alert-primary {
+    background-color: rgba(46, 134, 214, 0.15);
+    color: #8ec5ff;
+    border-color: rgba(46, 134, 214, 0.4);
+}
+
+[data-theme="dark"] .alert-success {
+    background-color: rgba(40, 167, 69, 0.15);
+    color: #7dd87d;
+    border-color: rgba(40, 167, 69, 0.4);
+}
+
+[data-theme="dark"] .alert-info {
+    background-color: rgba(23, 162, 184, 0.15);
+    color: #6fc3d1;
+    border-color: rgba(23, 162, 184, 0.4);
+}
+
+[data-theme="dark"] .alert-warning {
+    background-color: rgba(255, 193, 7, 0.15);
+    color: #ffd96b;
+    border-color: rgba(255, 193, 7, 0.4);
+}
+
+[data-theme="dark"] .alert-danger {
+    background-color: rgba(220, 53, 69, 0.15);
+    color: #ef8993;
+    border-color: rgba(220, 53, 69, 0.4);
+}
+
+[data-theme="dark"] .alert-light {
+    background-color: var(--omu-surface);
+    color: var(--omu-text);
+    border-color: var(--omu-border);
+}
+
+/*
+ * Bootstrap sets per-variant <hr> border colors that are bright tints of the
+ * alert hue (e.g. .alert-primary hr -> rgb(158,204,255)); too loud over our
+ * dark alert backgrounds. One neutral muted line for all variants.
+ */
+[data-theme="dark"] .alert hr {
+    border-top-color: rgba(255, 255, 255, 0.15) !important;
+}

--- a/src/Web/Shared/wwwroot/css/theme.css
+++ b/src/Web/Shared/wwwroot/css/theme.css
@@ -32,6 +32,12 @@
 }
 
 [data-theme="dark"] {
+    /*
+     * Tell the browser to render native form controls (checkbox, radio,
+     * scrollbars, date pickers, native select arrows) in their dark variant
+     * so unchecked checkboxes/radios don't render as bright white tiles.
+     */
+    color-scheme: dark;
     --omu-bg: #121417;
     --omu-surface: #1c1f24;
     --omu-surface-2: #1a1d22;
@@ -56,6 +62,14 @@ html,
 body {
     background-color: var(--omu-bg);
     color: var(--omu-text);
+}
+
+/*
+ * shared.css has the light gradient hardcoded on .sidebar > nav (Navigation.scss).
+ * Recolor it in dark mode so nav matches body/sidebar gradient.
+ */
+[data-theme="dark"] .sidebar > nav {
+    background-image: var(--omu-sidebar-gradient);
 }
 
 /* ===== Dark-mode overrides for Bootstrap 4 surfaces ===== */
@@ -270,4 +284,10 @@ body {
 [data-theme="dark"] #blazor-error-ui {
     background: var(--omu-error-bg);
     color: var(--omu-error-text);
+}
+
+/* CreationPanel sticky form-actions footer (hardcoded #fff / #dee2e6 in CreationPanel.razor.css) */
+[data-theme="dark"] .creation-panel-body .form-actions {
+    background-color: var(--omu-surface) !important;
+    border-top: 1px solid var(--omu-border) !important;
 }

--- a/src/Web/Shared/wwwroot/css/theme.css
+++ b/src/Web/Shared/wwwroot/css/theme.css
@@ -1,0 +1,273 @@
+/*
+ * Theme tokens for the admin panel (light + dark).
+ *
+ * Loaded as a separate stylesheet via Exports.Stylesheets so it does NOT depend
+ * on Dart Sass being available at build time (the SCSS -> shared.css pipeline
+ * is skipped in Docker / CI builds where ci=true).
+ *
+ * Active theme is selected by the [data-theme] attribute on <html>, set in
+ * App.razor from the OpenMU.Theme cookie (written by ThemeController).
+ */
+
+:root,
+[data-theme="light"] {
+    --omu-bg: #ffffff;
+    --omu-surface: #f8f9fa;
+    --omu-surface-2: #ffffff;
+    --omu-surface-muted: #f7f7f7;
+    --omu-surface-hover: #e9e9e9;
+    --omu-text: #212529;
+    --omu-text-muted: #5f6368;
+    --omu-text-secondary: #6c757d;
+    --omu-border: #d6d5d5;
+    --omu-link: #0366d6;
+    --omu-link-primary: #1b6ec2;
+    --omu-link-primary-border: #1861ac;
+    --omu-mark-bg: #ffff00;
+    --omu-error-bg: lightyellow;
+    --omu-error-text: #212529;
+    --omu-sidebar-gradient: linear-gradient(180deg, rgb(5, 39, 103) 0%, #3a0647 70%);
+    --omu-nav-link: #d7d7d7;
+    --omu-spinner-dot: rgb(5, 39, 103);
+}
+
+[data-theme="dark"] {
+    --omu-bg: #121417;
+    --omu-surface: #1c1f24;
+    --omu-surface-2: #1a1d22;
+    --omu-surface-muted: #23272d;
+    --omu-surface-hover: #2a2f36;
+    --omu-text: #e6e6e6;
+    --omu-text-muted: #a0a4ab;
+    --omu-text-secondary: #b0b4bb;
+    --omu-border: #2a2f36;
+    --omu-link: #66b2ff;
+    --omu-link-primary: #2e86d6;
+    --omu-link-primary-border: #1f6fb8;
+    --omu-mark-bg: #6b5e00;
+    --omu-error-bg: #3a2f00;
+    --omu-error-text: #f5e9b3;
+    --omu-sidebar-gradient: linear-gradient(180deg, #0a1330 0%, #1a0322 70%);
+    --omu-nav-link: #d7d7d7;
+    --omu-spinner-dot: #66b2ff;
+}
+
+html,
+body {
+    background-color: var(--omu-bg);
+    color: var(--omu-text);
+}
+
+/* ===== Dark-mode overrides for Bootstrap 4 surfaces ===== */
+[data-theme="dark"] .bg-light,
+[data-theme="dark"] .navbar-light,
+[data-theme="dark"] .breadcrumb,
+[data-theme="dark"] .breadcrumb-bar,
+[data-theme="dark"] .bg-white {
+    background-color: var(--omu-surface) !important;
+    color: var(--omu-text);
+}
+
+[data-theme="dark"] .border-bottom,
+[data-theme="dark"] .border-top,
+[data-theme="dark"] .border-left,
+[data-theme="dark"] .border-right,
+[data-theme="dark"] .border {
+    border-color: var(--omu-border) !important;
+}
+
+[data-theme="dark"] .text-secondary,
+[data-theme="dark"] small.text-secondary {
+    color: var(--omu-text-secondary) !important;
+}
+
+[data-theme="dark"] .navbar-light .navbar-text,
+[data-theme="dark"] .navbar-light .navbar-brand,
+[data-theme="dark"] .navbar-light .navbar-nav .nav-link {
+    color: var(--omu-text);
+}
+
+/* Tables (used everywhere via @extend .table .table-striped .table-hover in Tables.scss) */
+[data-theme="dark"] .table,
+[data-theme="dark"] table {
+    color: var(--omu-text);
+    background-color: transparent;
+}
+
+[data-theme="dark"] .table-striped tbody tr:nth-of-type(odd),
+[data-theme="dark"] table tbody tr:nth-of-type(odd) {
+    background-color: rgba(255, 255, 255, 0.04);
+    color: var(--omu-text);
+}
+
+[data-theme="dark"] .table-hover tbody tr:hover,
+[data-theme="dark"] table tbody tr:hover {
+    background-color: rgba(255, 255, 255, 0.08);
+    color: var(--omu-text);
+}
+
+[data-theme="dark"] .table th,
+[data-theme="dark"] .table td,
+[data-theme="dark"] table th,
+[data-theme="dark"] table td {
+    border-color: var(--omu-border);
+}
+
+/* Form controls */
+[data-theme="dark"] .form-control,
+[data-theme="dark"] .custom-select,
+[data-theme="dark"] .custom-select-sm,
+[data-theme="dark"] input:not([type="checkbox"]):not([type="radio"]),
+[data-theme="dark"] select,
+[data-theme="dark"] textarea {
+    background-color: var(--omu-surface-muted);
+    color: var(--omu-text);
+    border-color: var(--omu-border);
+}
+
+[data-theme="dark"] .form-control:focus,
+[data-theme="dark"] .custom-select:focus,
+[data-theme="dark"] input:focus,
+[data-theme="dark"] select:focus,
+[data-theme="dark"] textarea:focus {
+    background-color: var(--omu-surface-muted);
+    color: var(--omu-text);
+    border-color: var(--omu-link);
+    box-shadow: 0 0 0 0.2rem rgba(102, 178, 255, 0.25);
+}
+
+[data-theme="dark"] .input-group-text {
+    background-color: var(--omu-surface-hover);
+    color: var(--omu-text);
+    border-color: var(--omu-border);
+}
+
+/* Dropdowns / popovers */
+[data-theme="dark"] .dropdown-menu {
+    background-color: var(--omu-surface);
+    color: var(--omu-text);
+    border-color: var(--omu-border);
+}
+
+[data-theme="dark"] .dropdown-item {
+    color: var(--omu-text);
+}
+
+[data-theme="dark"] .dropdown-item:hover,
+[data-theme="dark"] .dropdown-item:focus {
+    background-color: var(--omu-surface-hover);
+    color: var(--omu-text);
+}
+
+/* Modals */
+[data-theme="dark"] .modal-content {
+    background-color: var(--omu-surface);
+    color: var(--omu-text);
+    border-color: var(--omu-border);
+}
+
+[data-theme="dark"] .modal-header,
+[data-theme="dark"] .modal-footer {
+    border-color: var(--omu-border);
+}
+
+[data-theme="dark"] .close {
+    color: var(--omu-text);
+    text-shadow: none;
+}
+
+/* Alerts / cards / list groups */
+[data-theme="dark"] .alert-secondary {
+    background-color: var(--omu-surface-hover);
+    color: var(--omu-text);
+    border-color: var(--omu-border);
+}
+
+[data-theme="dark"] .card,
+[data-theme="dark"] .list-group-item {
+    background-color: var(--omu-surface);
+    color: var(--omu-text);
+    border-color: var(--omu-border);
+}
+
+[data-theme="dark"] .btn-secondary {
+    background-color: #3a3f47;
+    border-color: #3a3f47;
+    color: var(--omu-text);
+}
+
+[data-theme="dark"] .btn-light {
+    background-color: var(--omu-surface-hover);
+    border-color: var(--omu-border);
+    color: var(--omu-text);
+}
+
+/*
+ * Link color in dark mode — narrow the `a` selector to skip anchors styled as
+ * buttons (Bootstrap pattern `<a class="btn btn-info">`, used by
+ * EditConfigGrid.razor and ItemTable.razor for Edit links). Without :not(.btn)
+ * our --omu-link (#66b2ff) would beat .btn-info's white text and tank contrast.
+ * .btn-link is intentionally still recolored — its semantics is a link.
+ */
+[data-theme="dark"] a:not(.btn),
+[data-theme="dark"] .btn-link {
+    color: var(--omu-link);
+}
+
+[data-theme="dark"] .btn-primary {
+    background-color: var(--omu-link-primary);
+    border-color: var(--omu-link-primary-border);
+    color: #fff;
+}
+
+/* Open-Iconic glyphs sometimes inherit black; force visible color in dark mode */
+[data-theme="dark"] .oi {
+    color: inherit;
+}
+
+/* Sidebar gradient — overrides hard-coded gradient in shared.css when dark */
+[data-theme="dark"] .sidebar > nav {
+    background-image: var(--omu-sidebar-gradient);
+}
+
+/*
+ * Sidebar dropdown (Game Configuration submenu).
+ * Navigation.scss uses `@extend .dropdown-menu` so the actual element does NOT carry
+ * the `.dropdown-menu` class — it shares styles via the compound selector. So we have
+ * to target the SCSS selector directly to recolor it.
+ */
+[data-theme="dark"] .sidebar > nav > div > ul > li.dropdown > div {
+    background-color: var(--omu-surface);
+    color: var(--omu-text);
+    border-color: var(--omu-border);
+}
+
+[data-theme="dark"] .sidebar > nav > div > ul > li.dropdown > div > a {
+    color: var(--omu-text);
+}
+
+[data-theme="dark"] .sidebar > nav > div > ul > li.dropdown > div > a:hover,
+[data-theme="dark"] .sidebar > nav > div > ul > li.dropdown > div > a:focus {
+    background-color: var(--omu-surface-hover);
+    color: var(--omu-text);
+}
+
+[data-theme="dark"] .sidebar > nav > div > ul > li.dropdown > div > a.active {
+    background-color: var(--omu-surface-hover);
+    color: var(--omu-text);
+}
+
+[data-theme="dark"] .sidebar > nav > div > ul > li.dropdown > div hr {
+    border-color: var(--omu-border);
+}
+
+/* Breadcrumb bar (used in MainLayout) */
+[data-theme="dark"] .breadcrumb-bar {
+    background-color: var(--omu-surface) !important;
+}
+
+/* Blazor error banner */
+[data-theme="dark"] #blazor-error-ui {
+    background: var(--omu-error-bg);
+    color: var(--omu-error-text);
+}

--- a/src/Web/Shared/wwwroot/css/theme.css
+++ b/src/Web/Shared/wwwroot/css/theme.css
@@ -64,14 +64,6 @@ body {
     color: var(--omu-text);
 }
 
-/*
- * shared.css has the light gradient hardcoded on .sidebar > nav (Navigation.scss).
- * Recolor it in dark mode so nav matches body/sidebar gradient.
- */
-[data-theme="dark"] .sidebar > nav {
-    background-image: var(--omu-sidebar-gradient);
-}
-
 /* ===== Dark-mode overrides for Bootstrap 4 surfaces ===== */
 [data-theme="dark"] .bg-light,
 [data-theme="dark"] .navbar-light,

--- a/src/Web/Shared/wwwroot/themeSelector.js
+++ b/src/Web/Shared/wwwroot/themeSelector.js
@@ -1,0 +1,17 @@
+// <copyright file="themeSelector.js" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+/**
+ * Returns the active UI theme from the <html> element's data-theme attribute
+ * (set by App.razor from the OpenMU.Theme cookie). Used by ThemeSelector to
+ * hydrate its toggle state after the interactive Blazor circuit takes over,
+ * because the cascading HttpContext is null in interactive renders.
+ *
+ * Lives in wwwroot/ (not colocated as ThemeSelector.razor.js) because
+ * the *.razor.js colocation static-web-asset publishing is broken in this
+ * project's build pipeline; wwwroot/ is the reliable path for static assets.
+ */
+export function current() {
+    return document.documentElement.getAttribute("data-theme");
+}


### PR DESCRIPTION
Dark mode for Admin Panel

---

## Summary

Adds a dark-mode toggle to the admin panel with persistence across sessions and page reloads. Implementation mirrors the existing `CultureSelector` pattern (cookie-based, no SignalR state), so the architectural footprint is minimal and the mental model is consistent with what already exists in the codebase.

The toggle lives in the panel header next to the "About" link. State is stored in an `OpenMU.Theme` cookie. A `[data-theme]` attribute on `<html>` drives all styling via CSS custom properties.

## What's in

**New files**
- `src/Web/Shared/Services/ThemeController.cs` — MVC controller endpoint `Theme/Set?theme=…&redirectUri=…` (1:1 with `CultureController`)
- `src/Web/Shared/Components/ThemeSelector.razor` + `.razor.cs` + `.razor.css` — toggle button with moon/sun icons from open-iconic
- `src/Web/Shared/wwwroot/themeSelector.js` — tiny `export function current()` reading `document.documentElement.dataset.theme` for hydration after the Blazor interactive circuit takes over
- `src/Web/Shared/wwwroot/css/theme.css` — theme tokens (`:root`/`[data-theme="dark"]`) and Bootstrap 4 surface overrides (`.bg-light`, tables, forms, dropdowns, modals, sidebar dropdown submenu)

**Modified files**
- `src/Web/AdminPanel/Components/App.razor` — sets `<html data-theme="…">` from the cookie via `[CascadingParameter] HttpContext`
- `src/Web/AdminPanel/Components/Layout/MainLayout.razor` + `.razor.css` — adds the `<ThemeSelector>` to the header, recolors sidebar gradient/breadcrumb/`#blazor-error-ui` via CSS variables
- `src/Web/AdminPanel/Components/Layout/CreationPanel.razor.css`, `ConfigurationSearch.razor.css` — surface colors switched to CSS variables
- `src/Web/Shared/Components/Form/AutoForm.razor.css` — Save/Refresh action bar background switched to CSS variables (fixes light panel under buttons on every config edit page)
- `src/Web/Shared/Exports.cs` — `theme.css` added to `Stylesheets`
- `src/Web/Shared/Properties/Resources.resx` + `Resources.Designer.cs` — three new strings: `ToggleTheme`, `SwitchToDarkMode`, `SwitchToLightMode`
- `src/Web/AdminPanel/_Imports.razor` — `@using Microsoft.AspNetCore.Http` so the cascading `HttpContext` resolves

## Design decisions

**Cookie + reload (not localStorage + JS swap).** Identical pattern to `CultureSelector`. Keeps SSR honest — the first paint matches the active theme, no flash-of-light-content. Cost: one full reload per toggle, accepted in admin tooling (low traffic, infrequent action).

**CSS variables in a separate `theme.css`, not in the SCSS pipeline.** The Dockerfile runs `dotnet build -p:ci=true`, which skips the `CompileSass` MSBuild target. SCSS edits never reach the published `shared.css` in containerized builds. `theme.css` is a plain static asset loaded via `Exports.Stylesheets` and works on every host.

**Bootstrap 4 surface overrides (not an upgrade to BS5).** Bootstrap 5 ships native dark-mode via `data-bs-theme`, but the migration is a separate, much larger effort. Overriding the specific BS4 classes the panel uses (`.bg-light`, `.table-striped`, `.dropdown-menu`, `.form-control`, `.modal-content`, …) is the smallest viable change.

**JS hydration via `wwwroot/themeSelector.js` as an ES module, not colocated `.razor.js`.** Colocated `*.razor.js` files are 404 in this project's build pipeline (verified — `ReconnectModal.razor.js` is also 404; see related issues). `wwwroot/` is the reliable static-asset path, same as `shared.css` and our new `theme.css`. The hydration reads `data-theme` from `<html>` after the interactive circuit connects, because `[CascadingParameter] HttpContext` is null in interactive renders — without this, the toggle would get stuck in dark mode (the icon would flip back to "moon" while the cookie stayed `dark`).

**Icon convention: action-affordance.** Moon icon shown in light mode (click → go dark), sun icon shown in dark mode (click → go light). Same convention as iOS, GitHub, Stripe Dashboard, Material Design. Tooltip ("Switch to dark mode" / "Switch to light mode") reinforces the affordance.

## Known limitations / out-of-scope

- **Brief icon flicker** on the first SSR→interactive transition (~50–200 ms) when reload happens while already in dark mode. The SSR renders the correct icon, the first interactive re-render briefly shows the wrong one (cascading HttpContext is null in interactive), then JS hydration corrects it. Fixable with `PersistentComponentState`; not worth the boilerplate for an admin tool.
- **Per-culture translations** of the three new resource strings — only English defaults added. Project doesn't have per-culture `.resx` files yet, so consistent with existing convention.
- **`MUnique.OpenMU.Web.AdminPanel.csproj` SDK reference chain** — not touched. Pre-existing static-web-asset path-doubling issue (`_content/AdminPanel/_content/<pkg>/…` 404s) and the `ReconnectModal.razor.js` 404 are pre-existing bugs unrelated to dark mode, surfaced in the same DevTools sweep. Tracked separately (see related issues).

## Test plan

- [x] Build the all-in-one Docker container, hit `localhost:8082`, confirm panel loads in light mode by default
- [x] Click the moon icon in the header → page reloads → background turns dark, icon becomes sun
- [x] Click the sun icon → page reloads → back to light mode, icon becomes moon
- [x] Navigate to **Game Configuration → General** — `AutoForm` panel and the sticky Save/Refresh bar are dark
- [x] Navigate to **Game Configuration → Monsters** — Edit button (rendered as `<a class="btn btn-info">`) has white text on teal background, readable
- [x] Navigate to **Game Configuration → Merchant Stores** — Edit button (rendered as `<button class="btn-info">`) is consistent
- [x] Open the Game Configuration dropdown in the sidebar — submenu has dark surface, links contrast cleanly
- [x] Open any modal (e.g. ItemEdit) — dark modal background, dark form fields
- [x] Open a table-based view (Accounts, Servers) — striped rows and hover state visible in dark mode
- [x] Verify cookie `OpenMU.Theme = dark` is set in DevTools → Application → Cookies after toggling
- [x] Verify `<html data-theme="dark">` is set in DevTools → Elements after toggling
- [x] Reload the page in dark mode → state persists, icon shows sun on first paint (no flicker on cold load)

Preview:
<img width="1920" height="1080" alt="1" src="https://github.com/user-attachments/assets/997a8b50-d55d-449f-8bdd-5d9549b30af6" />
<img width="1910" height="871" alt="2" src="https://github.com/user-attachments/assets/28ed9847-ec9e-4bae-8399-50eb51ee9433" />
<img width="1920" height="1080" alt="3" src="https://github.com/user-attachments/assets/11c570f7-7227-44e5-ac4d-a853e4883782" />
