### PR TITLE
Fix QuestProgressExtended packet header overflow (C1 to C2)

### DIFF
--- a/src/Network/Packets/ServerToClient/ServerToClientPackets.cs
+++ b/src/Network/Packets/ServerToClient/ServerToClientPackets.cs
@@ -28733,7 +28733,7 @@ public readonly struct QuestProgressExtended
             var header = this.Header;
             header.Type = HeaderType;
             header.Code = Code;
-            header.Length = (byte)Math.Min(data.Length, Length);
+            header.Length = (ushort)Math.Min(data.Length, Length);
             header.SubCode = SubCode;
         }
     }
@@ -28741,7 +28741,7 @@ public readonly struct QuestProgressExtended
     /// <summary>
     /// Gets the header type of this data packet.
     /// </summary>
-    public static byte HeaderType => 0xC1;
+    public static byte HeaderType => 0xC2;
 
     /// <summary>
     /// Gets the operation code of this data packet.
@@ -28762,7 +28762,7 @@ public readonly struct QuestProgressExtended
     /// <summary>
     /// Gets the header of this packet.
     /// </summary>
-    public C1HeaderWithSubCode Header => new (this._data);
+    public C2HeaderWithSubCode Header => new (this._data);
 
     /// <summary>
     /// Gets or sets the condition count.

--- a/src/Network/Packets/ServerToClient/ServerToClientPackets.xml
+++ b/src/Network/Packets/ServerToClient/ServerToClientPackets.xml
@@ -10294,7 +10294,7 @@
       </Fields>
     </Packet>
     <Packet>
-      <HeaderType>C1HeaderWithSubCode</HeaderType>
+      <HeaderType>C2HeaderWithSubCode</HeaderType>
       <Code>F6</Code>
       <SubCode>0C</SubCode>
       <Name>QuestProgressExtended</Name>

--- a/src/Network/Packets/ServerToClient/ServerToClientPacketsRef.cs
+++ b/src/Network/Packets/ServerToClient/ServerToClientPacketsRef.cs
@@ -27342,7 +27342,7 @@ public readonly ref struct QuestProgressExtendedRef
             var header = this.Header;
             header.Type = HeaderType;
             header.Code = Code;
-            header.Length = (byte)Math.Min(data.Length, Length);
+            header.Length = (ushort)Math.Min(data.Length, Length);
             header.SubCode = SubCode;
         }
     }
@@ -27350,7 +27350,7 @@ public readonly ref struct QuestProgressExtendedRef
     /// <summary>
     /// Gets the header type of this data packet.
     /// </summary>
-    public static byte HeaderType => 0xC1;
+    public static byte HeaderType => 0xC2;
 
     /// <summary>
     /// Gets the operation code of this data packet.
@@ -27371,7 +27371,7 @@ public readonly ref struct QuestProgressExtendedRef
     /// <summary>
     /// Gets the header of this packet.
     /// </summary>
-    public C1HeaderWithSubCodeRef Header => new (this._data);
+    public C2HeaderWithSubCodeRef Header => new (this._data);
 
     /// <summary>
     /// Gets or sets the condition count.


### PR DESCRIPTION
The QuestProgressExtended packet (0xF6, 0x0C) is 272 bytes but was declared with a C1 header. A C1 header stores its length in a single byte, so it cannot represent sizes above 255: the length was written as 272 & 0xFF = 16. Clients therefore framed only 16 bytes, the remaining 256 desynced the packet stream, and the connection dropped when a quest was started or its progress was shown.

Switch the header to C2HeaderWithSubCode, matching the identically sized QuestStateExtended packet and every other server packet larger than 255 bytes. The 2-byte C2 length encodes 272 correctly. Field offsets are unchanged; the generated struct definitions are updated to match the packet definition.

This is the server part for https://github.com/sven-n/MuMain/pull/425

Closes #779 