### PR TITLE
Feature: Add auto accept party request from friends and guild members

### DIFF
--- a/src/Dapr/FriendServer.Host/FriendServerController.cs
+++ b/src/Dapr/FriendServer.Host/FriendServerController.cs
@@ -78,6 +78,17 @@ public class FriendServerController : ControllerBase
     }
 
     /// <summary>
+    /// Determines whether two players are friends.
+    /// </summary>
+    /// <param name="data">The data.</param>
+    /// <returns>True if the two players are friends; otherwise false.</returns>
+    [HttpPost(nameof(IFriendServer.IsFriendAsync))]
+    public async Task<bool> IsFriendAsync([FromBody] RequestArguments data)
+    {
+        return await this._friendServer.IsFriendAsync(data.Requester, data.Receiver).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Sends a friend request to the friend, and adds a new friend view item to the players friend list.
     /// </summary>
     /// <param name="data">The data.</param>

--- a/src/Dapr/ServerClients/FriendServer.cs
+++ b/src/Dapr/ServerClients/FriendServer.cs
@@ -83,6 +83,20 @@ public class FriendServer : IFriendServer
     }
 
     /// <inheritdoc />
+    public async ValueTask<bool> IsFriendAsync(string characterName, string friendName)
+    {
+        try
+        {
+            return await this._daprClient.InvokeMethodAsync<RequestArguments, bool>(this._targetAppId, nameof(this.IsFriendAsync), new RequestArguments(characterName, friendName)).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            this._logger.LogError(ex, "Unexpected error when checking friendship.");
+            return false;
+        }
+    }
+
+    /// <inheritdoc />
     public async ValueTask<bool> FriendRequestAsync(string playerName, string friendName)
     {
         try

--- a/src/FriendServer/FriendServer.cs
+++ b/src/FriendServer/FriendServer.cs
@@ -84,15 +84,31 @@ public class FriendServer : IFriendServer
     }
 
     /// <inheritdoc/>
+    public async ValueTask<bool> IsFriendAsync(string characterName, string friendName)
+    {
+        if (this.OnlineFriends.TryGetValue(characterName, out var player)
+            && this.OnlineFriends.TryGetValue(friendName, out var friend))
+        {
+            return player.HasSubscriber(friend);
+        }
+
+        using var context = this._persistenceContextProvider.CreateNewFriendServerContext();
+        var friendEntry = await context.GetFriendByNamesAsync(characterName, friendName).ConfigureAwait(false);
+        return friendEntry?.Accepted == true;
+    }
+
+    /// <inheritdoc/>
     public async ValueTask DeleteFriendAsync(string playerName, string friendName)
     {
         if (this.OnlineFriends.TryGetValue(playerName, out var player) && this.OnlineFriends.TryGetValue(friendName, out var friend))
         {
             player.RemoveSubscriber(friend);
+            friend.RemoveSubscriber(player);
         }
 
         using var context = this._persistenceContextProvider.CreateNewFriendServerContext();
         await context.DeleteAsync(playerName, friendName).ConfigureAwait(false);
+        await context.DeleteAsync(friendName, playerName).ConfigureAwait(false);
         await context.SaveChangesAsync().ConfigureAwait(false);
     }
 

--- a/src/GameLogic/MuHelper/IMuHelperSettings.cs
+++ b/src/GameLogic/MuHelper/IMuHelperSettings.cs
@@ -141,13 +141,13 @@ public interface IMuHelperSettings
     /// <summary>Gets a value indicating whether to repair items.</summary>
     bool RepairItem { get; }
 
-    /// <summary>Gets a value indicating whether to automatically defend against nearby monsters attacking the character.</summary>
+    /// <summary>Gets a value indicating whether to automatically defend against players attacking the character.</summary>
     bool UseSelfDefense { get; }
 
-    /// <summary>Gets a value indicating whether to automatically accept friend requests.</summary>
+    /// <summary>Gets a value indicating whether to automatically accept requests from friends.</summary>
     bool AutoAcceptFriend { get; }
 
-    /// <summary>Gets a value indicating whether to automatically accept guild join requests.</summary>
+    /// <summary>Gets a value indicating whether to automatically accept requests from guild.</summary>
     bool AutoAcceptGuild { get; }
 
     /// <summary>Gets a value indicating whether to use basic attack as fallback when the configured skill cannot be used.</summary>

--- a/src/GameLogic/MuHelper/IMuHelperSettings.cs
+++ b/src/GameLogic/MuHelper/IMuHelperSettings.cs
@@ -140,4 +140,16 @@ public interface IMuHelperSettings
 
     /// <summary>Gets a value indicating whether to repair items.</summary>
     bool RepairItem { get; }
+
+    /// <summary>Gets a value indicating whether to automatically defend against nearby monsters attacking the character.</summary>
+    bool UseSelfDefense { get; }
+
+    /// <summary>Gets a value indicating whether to automatically accept friend requests.</summary>
+    bool AutoAcceptFriend { get; }
+
+    /// <summary>Gets a value indicating whether to automatically accept guild join requests.</summary>
+    bool AutoAcceptGuild { get; }
+
+    /// <summary>Gets a value indicating whether to use basic attack as fallback when the configured skill cannot be used.</summary>
+    bool FallbackBasicAttack { get; }
 }

--- a/src/GameLogic/MuHelper/PartyRequestHandler.cs
+++ b/src/GameLogic/MuHelper/PartyRequestHandler.cs
@@ -1,0 +1,98 @@
+// <copyright file="PartyRequestHandler.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.MuHelper;
+
+using MUnique.OpenMU.Interfaces;
+
+/// <summary>
+/// Handles auto-accepting incoming party requests from friends and guild members
+/// based on the player's MU Helper settings flags.
+/// </summary>
+public static class PartyRequestHandler
+{
+    /// <summary>
+    /// Automatically accepts a party request if the receiver has the relevant flag enabled.
+    /// </summary>
+    /// <param name="receiver">The player receiving the party request.</param>
+    /// <param name="requester">The player who sent the party request.</param>
+    /// <returns>True if the request was auto-accepted and the players are in a party; false otherwise.</returns>
+    public static async ValueTask<bool> TryAutoAcceptPartyRequestAsync(Player receiver, Player requester)
+    {
+        var settings = receiver.MuHelperSettings;
+        if (settings is null)
+        {
+            return false;
+        }
+
+        if (settings.AutoAcceptGuild && AreGuildMembers(receiver, requester))
+        {
+            return await AcceptPartyRequestAsync(receiver, requester).ConfigureAwait(false);
+        }
+
+        if (settings.AutoAcceptFriend && await AreFriendsAsync(receiver, requester).ConfigureAwait(false))
+        {
+            return await AcceptPartyRequestAsync(receiver, requester).ConfigureAwait(false);
+        }
+
+        return false;
+    }
+
+    private static bool AreGuildMembers(Player receiver, Player requester)
+    {
+        return receiver.GuildStatus?.GuildId != null
+            && receiver.GuildStatus.GuildId == requester.GuildStatus?.GuildId;
+    }
+
+    private static async ValueTask<bool> AreFriendsAsync(Player receiver, Player requester)
+    {
+        if (receiver.SelectedCharacter is null || requester.SelectedCharacter is null)
+        {
+            return false;
+        }
+
+        var friendServer = (receiver.GameContext as IGameServerContext)?.FriendServer;
+        if (friendServer is null)
+        {
+            return false;
+        }
+
+        return await friendServer.IsFriendAsync(receiver.SelectedCharacter.Name, requester.SelectedCharacter.Name).ConfigureAwait(false);
+    }
+
+    private static async ValueTask<bool> AcceptPartyRequestAsync(Player receiver, Player requester)
+    {
+        bool success = false;
+        try
+        {
+            if (receiver.Party != null)
+            {
+                if (requester.Party == null)
+                {
+                    // Receiver is the offline party master; add the solo requester to the existing party.
+                    success = await receiver.Party.AddAsync(requester).ConfigureAwait(false);
+                }
+            }
+            else if (requester.Party != null)
+            {
+                // Requester already has a party; add the offline receiver to it.
+                success = await requester.Party.AddAsync(receiver).ConfigureAwait(false);
+            }
+            else
+            {
+                // Neither side has a party; create a new one.
+                var party = receiver.GameContext.PartyManager.CreateParty();
+                success = await party.AddAsync(requester).ConfigureAwait(false)
+                    && await party.AddAsync(receiver).ConfigureAwait(false);
+            }
+        }
+        finally
+        {
+            await receiver.PlayerState.TryAdvanceToAsync(PlayerState.EnteredWorld).ConfigureAwait(false);
+            receiver.LastPartyRequester = null;
+        }
+
+        return success;
+    }
+}

--- a/src/GameLogic/MuHelper/PartyRequestHandler.cs
+++ b/src/GameLogic/MuHelper/PartyRequestHandler.cs
@@ -17,7 +17,7 @@ public static class PartyRequestHandler
     /// </summary>
     /// <param name="receiver">The player receiving the party request.</param>
     /// <param name="requester">The player who sent the party request.</param>
-    /// <returns>True if the request was auto-accepted and the players are in a party; false otherwise.</returns>
+    /// <returns>True if the criteria matched (auto-accept was attempted, regardless of success); false if no criteria matched.</returns>
     public static async ValueTask<bool> TryAutoAcceptPartyRequestAsync(Player receiver, Player requester)
     {
         var settings = receiver.MuHelperSettings;
@@ -28,12 +28,14 @@ public static class PartyRequestHandler
 
         if (settings.AutoAcceptGuild && AreGuildMembers(receiver, requester))
         {
-            return await AcceptPartyRequestAsync(receiver, requester).ConfigureAwait(false);
+            await AcceptPartyRequestAsync(receiver, requester).ConfigureAwait(false);
+            return true;
         }
 
         if (settings.AutoAcceptFriend && await AreFriendsAsync(receiver, requester).ConfigureAwait(false))
         {
-            return await AcceptPartyRequestAsync(receiver, requester).ConfigureAwait(false);
+            await AcceptPartyRequestAsync(receiver, requester).ConfigureAwait(false);
+            return true;
         }
 
         return false;

--- a/src/GameLogic/Offline/CombatHandler.cs
+++ b/src/GameLogic/Offline/CombatHandler.cs
@@ -18,15 +18,16 @@ using MUnique.OpenMU.Pathfinding;
 public sealed class CombatHandler
 {
     private const byte DefaultRange = 1;
+    private const byte BowRange = 6;
     private const int ComboFinisherDelayTicks = 3;
     private const int InterSkillDelayTicks = 1;
     private const int MinComboSkillCount = 3;
 
-    private static readonly TargetedSkillDefaultPlugin DefaultPlugin = new();
-
     private const short DrainLifeBaseSkillId = 214;
     private const short DrainLifeStrengthenerSkillId = 458;
     private const short DrainLifeMasterySkillId = 462;
+
+    private static readonly TargetedSkillDefaultPlugin DefaultPlugin = new();
 
     private readonly OfflinePlayer _player;
     private readonly IMuHelperSettings? _config;
@@ -517,7 +518,7 @@ public sealed class CombatHandler
         if (this._player.Attributes is { } attributes
             && (attributes[Stats.IsBowEquipped] > 0 || attributes[Stats.IsCrossBowEquipped] > 0))
         {
-            return 6;
+            return BowRange;
         }
 
         return DefaultRange;

--- a/src/GameLogic/Offline/CombatHandler.cs
+++ b/src/GameLogic/Offline/CombatHandler.cs
@@ -31,7 +31,6 @@ public sealed class CombatHandler
     private readonly OfflinePlayer _player;
     private readonly IMuHelperSettings? _config;
     private readonly MovementHandler _movementHandler;
-    private readonly BuffHandler _buffHandler;
     private readonly Point _originPosition;
     private readonly ConditionalSkillSlot[] _conditionalSkillSlots;
 
@@ -46,14 +45,12 @@ public sealed class CombatHandler
     /// <param name="player">The offline player.</param>
     /// <param name="config">The MU helper settings.</param>
     /// <param name="movementHandler">The movement handler.</param>
-    /// <param name="buffHandler">The buff handler.</param>
     /// <param name="originPosition">The original position to hunt around.</param>
-    public CombatHandler(OfflinePlayer player, IMuHelperSettings? config, MovementHandler movementHandler, BuffHandler buffHandler, Point originPosition)
+    public CombatHandler(OfflinePlayer player, IMuHelperSettings? config, MovementHandler movementHandler, Point originPosition)
     {
         this._player = player;
         this._config = config;
         this._movementHandler = movementHandler;
-        this._buffHandler = buffHandler;
         this._originPosition = originPosition;
         this._conditionalSkillSlots = config is null ? [] :
         [
@@ -163,14 +160,9 @@ public sealed class CombatHandler
     private async ValueTask ExecuteAttackAsync(IAttackable target)
     {
         var skill = this.SelectAttackSkill();
-        if (skill == null)
+        if (skill == null && this._config?.FallbackBasicAttack != true)
         {
-            // Do not attack if there are buffs configured to handle buff-only classes.
-            var buffs = this._buffHandler.ConfiguredBuffIds;
-            if (buffs.Any(id => id > 0))
-            {
-                return;
-            }
+            return;
         }
 
         await this.ExecuteAttackAsync(target, skill, false).ConfigureAwait(false);
@@ -520,6 +512,12 @@ public sealed class CombatHandler
             {
                 return (byte)ranges.Min();
             }
+        }
+
+        if (this._player.Attributes is { } attributes
+            && (attributes[Stats.IsBowEquipped] > 0 || attributes[Stats.IsCrossBowEquipped] > 0))
+        {
+            return 6;
         }
 
         return DefaultRange;

--- a/src/GameLogic/Offline/OfflinePlayerMuHelper.cs
+++ b/src/GameLogic/Offline/OfflinePlayerMuHelper.cs
@@ -54,7 +54,7 @@ public sealed class OfflinePlayerMuHelper : AsyncDisposable
         this._healingHandler = new HealingHandler(player, config);
         this._itemPickupHandler = new ItemPickupHandler(player, config);
         this._movementHandler = new MovementHandler(player, config, originalPosition);
-        this._combatHandler = new CombatHandler(player, config, this._movementHandler, this._buffHandler, originalPosition);
+        this._combatHandler = new CombatHandler(player, config, this._movementHandler, originalPosition);
         this._repairHandler = new RepairHandler(player, config);
         this._zenHandler = new ZenConsumptionHandler(player);
         this._petHandler = new PetHandler(player, config);

--- a/src/GameLogic/PlayerActions/Party/PartyRequestAction.cs
+++ b/src/GameLogic/PlayerActions/Party/PartyRequestAction.cs
@@ -1,9 +1,10 @@
-﻿// <copyright file="PartyRequestAction.cs" company="MUnique">
+// <copyright file="PartyRequestAction.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
 namespace MUnique.OpenMU.GameLogic.PlayerActions.Party;
 
+using MUnique.OpenMU.GameLogic.MuHelper;
 using MUnique.OpenMU.GameLogic.Views.Party;
 
 /// <summary>
@@ -27,6 +28,14 @@ public class PartyRequestAction
 
         if (toRequest.Party != null || toRequest.LastPartyRequester != null)
         {
+            if (toRequest.Party != null && Equals(toRequest.Party.PartyMaster, toRequest))
+            {
+                if (await PartyRequestHandler.TryAutoAcceptPartyRequestAsync(toRequest, player).ConfigureAwait(false))
+                {
+                    return;
+                }
+            }
+
             await player.ShowLocalizedBlueMessageAsync(nameof(PlayerMessage.PlayerIsAlreadyInParty), toRequest.Name).ConfigureAwait(false);
             return;
         }
@@ -34,6 +43,17 @@ public class PartyRequestAction
         if (isPartyMember)
         {
             await player.ShowLocalizedBlueMessageAsync(nameof(PlayerMessage.YouAreNotPartyMaster)).ConfigureAwait(false);
+            return;
+        }
+
+        if (toRequest is Offline.OfflinePlayer)
+        {
+            if (await PartyRequestHandler.TryAutoAcceptPartyRequestAsync(toRequest, player).ConfigureAwait(false))
+            {
+                return;
+            }
+
+            await player.ShowLocalizedBlueMessageAsync(nameof(PlayerMessage.PlayerIsAlreadyInParty), toRequest.Name).ConfigureAwait(false);
             return;
         }
 
@@ -52,6 +72,15 @@ public class PartyRequestAction
         }
 
         toRequest.LastPartyRequester = requester;
+
+        if (toRequest is Player receiver && requester is Player requesterPlayer)
+        {
+            if (await PartyRequestHandler.TryAutoAcceptPartyRequestAsync(receiver, requesterPlayer).ConfigureAwait(false))
+            {
+                return;
+            }
+        }
+
         await toRequest.InvokeViewPlugInAsync<IShowPartyRequestPlugIn>(p => p.ShowPartyRequestAsync(requester)).ConfigureAwait(false);
     }
 }

--- a/src/GameServer/MessageHandler/MuHelper/MuHelperSaveDataRequestHandlerPlugin.cs
+++ b/src/GameServer/MessageHandler/MuHelper/MuHelperSaveDataRequestHandlerPlugin.cs
@@ -8,6 +8,7 @@ using System.Buffers;
 using System.Runtime.InteropServices;
 using MUnique.OpenMU.GameLogic;
 using MUnique.OpenMU.GameLogic.PlayerActions.MuHelper;
+using MUnique.OpenMU.GameServer.RemoteView.MuHelper;
 using MUnique.OpenMU.Network.Packets.ClientToServer;
 using MUnique.OpenMU.PlugIns;
 
@@ -36,5 +37,9 @@ public class MuHelperSaveDataRequestHandlerPlugin : IPacketHandlerPlugIn
         var memory = memoryOwner.Memory[..dataSize];
         message.HelperData.CopyTo(memory.Span);
         await this._updateMuBotConfigurationAction.SaveDataAsync(player, memory).ConfigureAwait(false);
+        if (player.SelectedCharacter?.MuHelperConfiguration is { } configuration)
+        {
+            player.MuHelperSettings = MuHelperSettingsSerializer.TryDeserialize(configuration);
+        }
     }
 }

--- a/src/GameServer/RemoteView/MuHelper/MuHelperSettings.cs
+++ b/src/GameServer/RemoteView/MuHelper/MuHelperSettings.cs
@@ -26,10 +26,10 @@ public sealed class MuHelperSettings : IMuHelperSettings
     /// <summary>Gets the timer interval (seconds) for ActivationSkill2 when Skill2Delay is set.</summary>
     public int DelayMinSkill2 { get; init; }
 
-    /// <summary>Gets a value indicating whether to use timer for the skill 1.</summary>
+    /// <summary>Gets a value indicating whether to use a timer for skill 1.</summary>
     public bool Skill1UseTimer { get; init; }
 
-    /// <summary>Gets a value indicating whether to use condition for the skill 1.</summary>
+    /// <summary>Gets a value indicating whether to use a condition for skill 1.</summary>
     public bool Skill1UseCondition { get; init; }
 
     /// <summary>Gets a value indicating whether to use the precondition for Skill1 (false = nearby, true = attacking).</summary>
@@ -38,10 +38,10 @@ public sealed class MuHelperSettings : IMuHelperSettings
     /// <summary>Gets the mob count threshold for Skill1 condition: 0=2+, 1=3+, 2=4+, 3=5+.</summary>
     public int Skill1SubCondition { get; init; }
 
-    /// <summary>Gets a value indicating whether to use timer for the skill 2.</summary>
+    /// <summary>Gets a value indicating whether to use a timer for skill 2.</summary>
     public bool Skill2UseTimer { get; init; }
 
-    /// <summary>Gets a value indicating whether to use condition for the skill 2.</summary>
+    /// <summary>Gets a value indicating whether to use a condition for skill 2.</summary>
     public bool Skill2UseCondition { get; init; }
 
     /// <summary>Gets a value indicating whether to use the precondition for Skill2 (false = nearby, true = attacking).</summary>
@@ -56,13 +56,13 @@ public sealed class MuHelperSettings : IMuHelperSettings
     /// <summary>Gets the hunting range nibble (0-15); multiply to get tile distance.</summary>
     public int HuntingRange { get; init; }
 
-    /// <summary>Gets the max seconds away from original position before regrouping.</summary>
+    /// <summary>Gets the max seconds away from the original position before regrouping.</summary>
     public int MaxSecondsAway { get; init; }
 
     /// <summary>Gets a value indicating whether to counter-attack enemies that attack from long range.</summary>
     public bool LongRangeCounterAttack { get; init; }
 
-    /// <summary>Gets a value indicating whether to return to original spawn position when away too long.</summary>
+    /// <summary>Gets a value indicating whether to return to the original spawn position when away too long.</summary>
     public bool ReturnToOriginalPosition { get; init; }
 
     /// <summary>Gets the Buff 0 skill id.</summary>
@@ -74,10 +74,10 @@ public sealed class MuHelperSettings : IMuHelperSettings
     /// <summary>Gets the Buff 2 skill id.</summary>
     public int BuffSkill2Id { get; init; }
 
-    /// <summary>Gets a value indicating whether apply buffs based on duration (i.e. when the buff expires).</summary>
+    /// <summary>Gets a value indicating whether to apply buffs based on duration (i.e. when the buff expires).</summary>
     public bool BuffOnDuration { get; init; }
 
-    /// <summary>Gets a value indicating whether apply buff duration logic to party members too.</summary>
+    /// <summary>Gets a value indicating whether to apply buff duration logic to party members too.</summary>
     public bool BuffDurationForParty { get; init; }
 
     /// <summary>Gets the buff cast interval in seconds (0 = disabled).</summary>
@@ -92,13 +92,13 @@ public sealed class MuHelperSettings : IMuHelperSettings
     /// <summary>Gets a value indicating whether to use drain life.</summary>
     public bool UseDrainLife { get; init; }
 
-    /// <summary>Gets a value indicating whether to use healing potion.</summary>
+    /// <summary>Gets a value indicating whether to use a healing potion.</summary>
     public bool UseHealPotion { get; init; }
 
     /// <summary>Gets the potion use threshold (% HP).</summary>
     public int PotionThresholdPercent { get; init; }
 
-    /// <summary>Gets a value indicating whether to support party.</summary>
+    /// <summary>Gets a value indicating whether to support a party.</summary>
     public bool SupportParty { get; init; }
 
     /// <summary>Gets a value indicating whether to auto heal party.</summary>
@@ -110,31 +110,31 @@ public sealed class MuHelperSettings : IMuHelperSettings
     /// <summary>Gets a value indicating whether to use dark raven.</summary>
     public bool UseDarkRaven { get; init; }
 
-    /// <summary>Gets the dark raven mode 0 = cease, 1 = auto-attack, 2 = attack with owner.</summary>
+    /// <summary>Gets the dark raven mode 0 = cease, 1 = auto-attack, 2 = attack with an owner.</summary>
     public int DarkRavenMode { get; init; }
 
-    /// <summary>Gets the obtain range.</summary>
+    /// <summary>Gets the range to obtain.</summary>
     public int ObtainRange { get; init; }
 
-    /// <summary>Gets a value indicating whether pickup all items.</summary>
+    /// <summary>Gets a value indicating whether to pick up all items.</summary>
     public bool PickAllItems { get; init; }
 
-    /// <summary>Gets a value indicating whether pickup selected items.</summary>
+    /// <summary>Gets a value indicating whether to pick up selected items.</summary>
     public bool PickSelectItems { get; init; }
 
-    /// <summary>Gets a value indicating whether pickup jewels.</summary>
+    /// <summary>Gets a value indicating whether to pick up jewels.</summary>
     public bool PickJewel { get; init; }
 
-    /// <summary>Gets a value indicating whether pickup zen.</summary>
+    /// <summary>Gets a value indicating whether to pick up zen.</summary>
     public bool PickZen { get; init; }
 
-    /// <summary>Gets a value indicating whether pickup ancient items.</summary>
+    /// <summary>Gets a value indicating whether to pick up ancient items.</summary>
     public bool PickAncient { get; init; }
 
-    /// <summary>Gets a value indicating whether pickup excellent items.</summary>
+    /// <summary>Gets a value indicating whether to pick up excellent items.</summary>
     public bool PickExcellent { get; init; }
 
-    /// <summary>Gets a value indicating whether pickup extra items.</summary>
+    /// <summary>Gets a value indicating whether to pick up extra items.</summary>
     public bool PickExtraItems { get; init; }
 
     /// <summary>Gets the extra item names. Up to 12 item name substrings; pick any dropped item whose name contains one of these.</summary>
@@ -146,10 +146,10 @@ public sealed class MuHelperSettings : IMuHelperSettings
     /// <summary>Gets a value indicating whether to automatically defend against nearby monsters attacking the character.</summary>
     public bool UseSelfDefense { get; init; }
 
-    /// <summary>Gets a value indicating whether to automatically accept friend requests.</summary>
+    /// <summary>Gets a value indicating whether to automatically accept requests from friends.</summary>
     public bool AutoAcceptFriend { get; init; }
 
-    /// <summary>Gets a value indicating whether to automatically accept guild join requests.</summary>
+    /// <summary>Gets a value indicating whether to automatically accept requests from guild.</summary>
     public bool AutoAcceptGuild { get; init; }
 
     /// <summary>Gets a value indicating whether to use basic attack as fallback when the configured skill cannot be used.</summary>

--- a/src/GameServer/RemoteView/MuHelper/MuHelperSettings.cs
+++ b/src/GameServer/RemoteView/MuHelper/MuHelperSettings.cs
@@ -143,6 +143,18 @@ public sealed class MuHelperSettings : IMuHelperSettings
     /// <summary>Gets a value indicating whether to repair items.</summary>
     public bool RepairItem { get; init; }
 
+    /// <summary>Gets a value indicating whether to automatically defend against nearby monsters attacking the character.</summary>
+    public bool UseSelfDefense { get; init; }
+
+    /// <summary>Gets a value indicating whether to automatically accept friend requests.</summary>
+    public bool AutoAcceptFriend { get; init; }
+
+    /// <summary>Gets a value indicating whether to automatically accept guild join requests.</summary>
+    public bool AutoAcceptGuild { get; init; }
+
+    /// <summary>Gets a value indicating whether to use basic attack as fallback when the configured skill cannot be used.</summary>
+    public bool FallbackBasicAttack { get; init; }
+
     /// <inheritdoc />
     public override string ToString()
     {

--- a/src/GameServer/RemoteView/MuHelper/MuHelperSettings.cs
+++ b/src/GameServer/RemoteView/MuHelper/MuHelperSettings.cs
@@ -143,7 +143,7 @@ public sealed class MuHelperSettings : IMuHelperSettings
     /// <summary>Gets a value indicating whether to repair items.</summary>
     public bool RepairItem { get; init; }
 
-    /// <summary>Gets a value indicating whether to automatically defend against nearby monsters attacking the character.</summary>
+    /// <summary>Gets a value indicating whether to automatically defend against players attacking the character.</summary>
     public bool UseSelfDefense { get; init; }
 
     /// <summary>Gets a value indicating whether to automatically accept requests from friends.</summary>

--- a/src/GameServer/RemoteView/MuHelper/MuHelperSettingsSerializer.cs
+++ b/src/GameServer/RemoteView/MuHelper/MuHelperSettingsSerializer.cs
@@ -34,7 +34,8 @@ using MUnique.OpenMU.GameLogic.MuHelper;
 ///  27     [Skill2Delay:1][Skill2Con:1][Skill2PreCon:1][Skill2SubCon:2]
 ///         [RepairItem:1][PickAllNearItems:1][PickSelectedItems:1]
 ///  28     PetAttack (BYTE: 0=cease, 1=auto, 2=together)
-///  29-64  _UnusedPadding[36]
+///  29     [UseSelfDefense:1][AutoAcceptFriend:1][AutoAcceptGuild:1][FallbackBasicAttack:1][Unused:4]
+///  30-64  _UnusedPadding[35]
 ///  65-244 ExtraItems[12][15]  (null-terminated ASCII item name filters)
 ///  245-256 (trailing padding, ignored)
 /// </code>
@@ -61,10 +62,16 @@ public static class MuHelperSettingsSerializer
     private const int Skill1FlagsOffset = 26;
     private const int Skill2FlagsOffset = 27;
     private const int PetAttackOffset = 28;
+    private const int HelperFlagsOffset = 29;
     private const int ExtraItemsOffset = 65;
     private const int ExtraItemsEndOffset = 245;
     private const int ExtraItemSlotCount = 12;
     private const int ExtraItemSlotLength = 15;
+
+    private const int UseSelfDefenseFlag = 1 << 0;
+    private const int AutoAcceptFriendFlag = 1 << 1;
+    private const int AutoAcceptGuildFlag = 1 << 2;
+    private const int FallbackBasicAttackFlag = 1 << 3;
 
     private const int PickJewelFlag = 1 << 3;
     private const int PickSetItemFlag = 1 << 4;
@@ -180,6 +187,12 @@ public static class MuHelperSettingsSerializer
 
         int petAttack = blob[PetAttackOffset];
 
+        byte helperFlags = blob[HelperFlagsOffset];
+        bool useSelfDefense = (helperFlags & UseSelfDefenseFlag) != 0;
+        bool autoAcceptFriend = (helperFlags & AutoAcceptFriendFlag) != 0;
+        bool autoAcceptGuild = (helperFlags & AutoAcceptGuildFlag) != 0;
+        bool fallbackBasicAttack = (helperFlags & FallbackBasicAttackFlag) != 0;
+
         var extraNames = new List<string>();
         if (blob.Length >= ExtraItemsEndOffset)
         {
@@ -245,6 +258,10 @@ public static class MuHelperSettingsSerializer
             PickExtraItems = extraItem,
             ExtraItemNames = extraNames,
             RepairItem = repairItem,
+            UseSelfDefense = useSelfDefense,
+            AutoAcceptFriend = autoAcceptFriend,
+            AutoAcceptGuild = autoAcceptGuild,
+            FallbackBasicAttack = fallbackBasicAttack,
         };
     }
 

--- a/src/Interfaces/IFriendServer.cs
+++ b/src/Interfaces/IFriendServer.cs
@@ -69,6 +69,14 @@ public interface IFriendServer
     ValueTask SetPlayerVisibilityStateAsync(byte serverId, Guid characterId, string characterName, bool isVisible);
 
     /// <summary>
+    /// Determines whether two players are friends (accepted friend relationship).
+    /// </summary>
+    /// <param name="characterName">The character name of the first player.</param>
+    /// <param name="friendName">The character name of the second player.</param>
+    /// <returns>True if the two players are friends; otherwise false.</returns>
+    ValueTask<bool> IsFriendAsync(string characterName, string friendName);
+
+    /// <summary>
     /// Sends a friend request to the friend, and adds a new friend view item to the players friend list.
     /// </summary>
     /// <param name="playerName">The name of the requesting player.</param>

--- a/src/Persistence/EntityFramework/FriendServerContext.cs
+++ b/src/Persistence/EntityFramework/FriendServerContext.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="FriendServerContext.cs" company="MUnique">
+// <copyright file="FriendServerContext.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 

--- a/src/Persistence/InMemory/FriendServerInMemoryContext.cs
+++ b/src/Persistence/InMemory/FriendServerInMemoryContext.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="FriendServerInMemoryContext.cs" company="MUnique">
+// <copyright file="FriendServerInMemoryContext.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 

--- a/tests/MUnique.OpenMU.Tests/Offline/CombatHandlerTests.cs
+++ b/tests/MUnique.OpenMU.Tests/Offline/CombatHandlerTests.cs
@@ -51,9 +51,8 @@ public class CombatHandlerTests
 
         var config = new MuHelperSettings { HuntingRange = 10 };
         var movementHandler = new MovementHandler(player, config, this._origin);
-        var buffHandler = new BuffHandler(player, config);
 
-        var handler = new CombatHandler(player, config, movementHandler, buffHandler, this._origin);
+        var handler = new CombatHandler(player, config, movementHandler, this._origin);
 
         // Act
         await handler.PerformAttackAsync().ConfigureAwait(false);
@@ -95,9 +94,8 @@ public class CombatHandlerTests
         await player.SkillList!.AddLearnedSkillAsync(drainSkill).ConfigureAwait(false);
 
         var movementHandler = new MovementHandler(player, config, this._origin);
-        var buffHandler = new BuffHandler(player, config);
 
-        var handler = new CombatHandler(player, config, movementHandler, buffHandler, this._origin);
+        var handler = new CombatHandler(player, config, movementHandler, this._origin);
 
         // Act
         await handler.PerformDrainLifeRecoveryAsync().ConfigureAwait(false);

--- a/tests/MUnique.OpenMU.Tests/Party/PartyTest.cs
+++ b/tests/MUnique.OpenMU.Tests/Party/PartyTest.cs
@@ -8,8 +8,12 @@ using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using MUnique.OpenMU.DataModel.Configuration;
 using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.MuHelper;
 using MUnique.OpenMU.GameLogic.PlayerActions.Party;
 using MUnique.OpenMU.GameLogic.Views.Party;
+using MUnique.OpenMU.GameServer;
+using MUnique.OpenMU.Interfaces;
+using MUnique.OpenMU.Pathfinding;
 using MUnique.OpenMU.Persistence.InMemory;
 using MUnique.OpenMU.PlugIns;
 
@@ -180,6 +184,194 @@ public class PartyTest
         Assert.That(player.LastPartyRequester, Is.Null);
         Assert.That(requester.Party, Is.Null);
         Mock.Get(player.ViewPlugIns.GetPlugIn<IShowPartyRequestPlugIn>()!).Verify(v => v!.ShowPartyRequestAsync(requester), Times.Never);
+    }
+
+    /// <summary>
+    /// Tests if a party request is auto-accepted when <see cref="IMuHelperSettings.AutoAcceptFriend"/> is true
+    /// and the requester is a friend.
+    /// </summary>
+    [Test]
+    public async ValueTask PartyRequestAutoAcceptByFriendAsync()
+    {
+        var friendServer = new Mock<IFriendServer>();
+        friendServer.Setup(f => f.IsFriendAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(true);
+        var gameContext = PartyTest.CreateGameServerContext(friendServer.Object);
+        var player = await PlayerTestHelper.CreatePlayerAsync(gameContext).ConfigureAwait(false);
+        var toRequest = await PlayerTestHelper.CreatePlayerAsync(gameContext).ConfigureAwait(false);
+        player.SelectedCharacter!.Name = "Requester";
+        toRequest.SelectedCharacter!.Name = "Receiver";
+        player.Observers.Add(toRequest);
+
+        var settingsMock = new Mock<IMuHelperSettings>();
+        settingsMock.Setup(s => s.AutoAcceptFriend).Returns(true);
+        toRequest.MuHelperSettings = settingsMock.Object;
+
+        var handler = new PartyRequestAction();
+        await handler.HandlePartyRequestAsync(player, toRequest).ConfigureAwait(false);
+
+        Assert.That(player.Party, Is.Not.Null);
+        Assert.That(toRequest.Party, Is.SameAs(player.Party));
+        Mock.Get(toRequest.ViewPlugIns.GetPlugIn<IShowPartyRequestPlugIn>()!).Verify(v => v!.ShowPartyRequestAsync(player), Times.Never);
+    }
+
+    /// <summary>
+    /// Tests if a party request still shows the dialog when <see cref="IMuHelperSettings.AutoAcceptFriend"/>
+    /// is true but the requester is not a friend.
+    /// </summary>
+    [Test]
+    public async ValueTask PartyRequestAutoAcceptByFriendNotFriendAsync()
+    {
+        var friendServer = new Mock<IFriendServer>();
+        friendServer.Setup(f => f.IsFriendAsync(It.IsAny<string>(), It.IsAny<string>())).ReturnsAsync(false);
+        var gameContext = PartyTest.CreateGameServerContext(friendServer.Object);
+        var player = await PlayerTestHelper.CreatePlayerAsync(gameContext).ConfigureAwait(false);
+        var toRequest = await PlayerTestHelper.CreatePlayerAsync(gameContext).ConfigureAwait(false);
+        player.SelectedCharacter!.Name = "Requester";
+        toRequest.SelectedCharacter!.Name = "Receiver";
+        player.Observers.Add(toRequest);
+
+        var settingsMock = new Mock<IMuHelperSettings>();
+        settingsMock.Setup(s => s.AutoAcceptFriend).Returns(true);
+        toRequest.MuHelperSettings = settingsMock.Object;
+
+        var handler = new PartyRequestAction();
+        await handler.HandlePartyRequestAsync(player, toRequest).ConfigureAwait(false);
+
+        Assert.That(player.Party, Is.Null);
+        Mock.Get(toRequest.ViewPlugIns.GetPlugIn<IShowPartyRequestPlugIn>()!).Verify(v => v!.ShowPartyRequestAsync(player), Times.Once);
+    }
+
+    /// <summary>
+    /// Tests if a party request is auto-accepted when <see cref="IMuHelperSettings.AutoAcceptGuild"/> is true
+    /// and both players are members of the same guild.
+    /// </summary>
+    [Test]
+    public async ValueTask PartyRequestAutoAcceptByGuildAsync()
+    {
+        var gameContext = GameContextTestHelper.CreateGameContext();
+        var player = await PlayerTestHelper.CreatePlayerAsync(gameContext).ConfigureAwait(false);
+        var toRequest = await PlayerTestHelper.CreatePlayerAsync(gameContext).ConfigureAwait(false);
+        player.Observers.Add(toRequest);
+
+        var guildId = 1u;
+        player.GuildStatus = new GuildMemberStatus(guildId, GuildPosition.GuildMaster);
+        toRequest.GuildStatus = new GuildMemberStatus(guildId, GuildPosition.NormalMember);
+
+        var settingsMock = new Mock<IMuHelperSettings>();
+        settingsMock.Setup(s => s.AutoAcceptGuild).Returns(true);
+        toRequest.MuHelperSettings = settingsMock.Object;
+
+        var handler = new PartyRequestAction();
+        await handler.HandlePartyRequestAsync(player, toRequest).ConfigureAwait(false);
+
+        Assert.That(player.Party, Is.Not.Null);
+        Assert.That(toRequest.Party, Is.SameAs(player.Party));
+        Mock.Get(toRequest.ViewPlugIns.GetPlugIn<IShowPartyRequestPlugIn>()!).Verify(v => v!.ShowPartyRequestAsync(player), Times.Never);
+    }
+
+    /// <summary>
+    /// Tests if a party request still shows the dialog when <see cref="IMuHelperSettings.AutoAcceptGuild"/>
+    /// is true but the players are in different guilds.
+    /// </summary>
+    [Test]
+    public async ValueTask PartyRequestAutoAcceptByGuildDifferentGuildAsync()
+    {
+        var gameContext = GameContextTestHelper.CreateGameContext();
+        var player = await PlayerTestHelper.CreatePlayerAsync(gameContext).ConfigureAwait(false);
+        var toRequest = await PlayerTestHelper.CreatePlayerAsync(gameContext).ConfigureAwait(false);
+        player.Observers.Add(toRequest);
+
+        player.GuildStatus = new GuildMemberStatus(1u, GuildPosition.GuildMaster);
+        toRequest.GuildStatus = new GuildMemberStatus(2u, GuildPosition.NormalMember);
+
+        var settingsMock = new Mock<IMuHelperSettings>();
+        settingsMock.Setup(s => s.AutoAcceptGuild).Returns(true);
+        toRequest.MuHelperSettings = settingsMock.Object;
+
+        var handler = new PartyRequestAction();
+        await handler.HandlePartyRequestAsync(player, toRequest).ConfigureAwait(false);
+
+        Assert.That(player.Party, Is.Null);
+        Mock.Get(toRequest.ViewPlugIns.GetPlugIn<IShowPartyRequestPlugIn>()!).Verify(v => v!.ShowPartyRequestAsync(player), Times.Once);
+    }
+
+    /// <summary>
+    /// Tests that a party request is not auto-accepted when no relevant flags are set.
+    /// </summary>
+    [Test]
+    public async ValueTask PartyRequestAutoAcceptNoFlagsAsync()
+    {
+        var friendServer = new Mock<IFriendServer>();
+        var gameContext = PartyTest.CreateGameServerContext(friendServer.Object);
+        var player = await PlayerTestHelper.CreatePlayerAsync(gameContext).ConfigureAwait(false);
+        var toRequest = await PlayerTestHelper.CreatePlayerAsync(gameContext).ConfigureAwait(false);
+        player.SelectedCharacter!.Name = "Requester";
+        toRequest.SelectedCharacter!.Name = "Receiver";
+        player.Observers.Add(toRequest);
+
+        var settingsMock = new Mock<IMuHelperSettings>();
+        toRequest.MuHelperSettings = settingsMock.Object;
+
+        var handler = new PartyRequestAction();
+        await handler.HandlePartyRequestAsync(player, toRequest).ConfigureAwait(false);
+
+        Assert.That(player.Party, Is.Null);
+        Mock.Get(toRequest.ViewPlugIns.GetPlugIn<IShowPartyRequestPlugIn>()!).Verify(v => v!.ShowPartyRequestAsync(player), Times.Once);
+    }
+
+    /// <summary>
+    /// Tests that a party request is not auto-accepted when MuHelperSettings is null.
+    /// </summary>
+    [Test]
+    public async ValueTask PartyRequestAutoAcceptNoSettingsAsync()
+    {
+        var friendServer = new Mock<IFriendServer>();
+        var gameContext = PartyTest.CreateGameServerContext(friendServer.Object);
+        var player = await PlayerTestHelper.CreatePlayerAsync(gameContext).ConfigureAwait(false);
+        var toRequest = await PlayerTestHelper.CreatePlayerAsync(gameContext).ConfigureAwait(false);
+        player.Observers.Add(toRequest);
+
+        var handler = new PartyRequestAction();
+        await handler.HandlePartyRequestAsync(player, toRequest).ConfigureAwait(false);
+
+        Assert.That(player.Party, Is.Null);
+        Mock.Get(toRequest.ViewPlugIns.GetPlugIn<IShowPartyRequestPlugIn>()!).Verify(v => v!.ShowPartyRequestAsync(player), Times.Once);
+    }
+
+    private static IGameServerContext CreateGameServerContext(IFriendServer friendServer)
+    {
+        var contextProvider = new InMemoryPersistenceContextProvider();
+        var context = contextProvider.CreateNewContext();
+        var gameConfiguration = context.CreateNew<MUnique.OpenMU.Persistence.BasicModel.GameConfiguration>();
+        gameConfiguration.MaximumPartySize = 5;
+        gameConfiguration.RecoveryInterval = int.MaxValue;
+        gameConfiguration.MaximumInventoryMoney = int.MaxValue;
+        var mapDef = context.CreateNew<MUnique.OpenMU.Persistence.BasicModel.GameMapDefinition>();
+        mapDef.Number = 0;
+        mapDef.TerrainData = new byte[ushort.MaxValue + 3];
+        gameConfiguration.Maps.Add(mapDef);
+
+        var mapInitializer = new MapInitializer(gameConfiguration, new NullLogger<MapInitializer>(), NullDropGenerator.Instance, null);
+
+        var gameServer = new GameServerContext(
+            new GameServerDefinition
+            {
+                GameConfiguration = gameConfiguration,
+                ServerConfiguration = new GameServerConfiguration(),
+            },
+            new Mock<IGuildServer>().Object,
+            new Mock<IEventPublisher>().Object,
+            new Mock<ILoginServer>().Object,
+            friendServer,
+            new InMemoryPersistenceContextProvider(),
+            mapInitializer,
+            new NullLoggerFactory(),
+            new PlugInManager(new List<PlugInConfiguration>(), new NullLoggerFactory(), null, null),
+            NullDropGenerator.Instance,
+            new ConfigurationChangeMediator());
+        mapInitializer.PlugInManager = gameServer.PlugInManager;
+        mapInitializer.PathFinderPool = gameServer.PathFinderPool;
+        return gameServer;
     }
 
     private async ValueTask<Player> CreatePartyMemberAsync()


### PR DESCRIPTION
## MU Helper: new flags, party auto-accept, combat update

**New MU Helper flags** — `UseSelfDefense`, `AutoAcceptFriend`, `AutoAcceptGuild`, `FallbackBasicAttack` added to the 257-byte client blob deserialization, `IMuHelperSettings` interface, and model class.

**Party auto-accept** — `PartyRequestHandler.TryAutoAcceptPartyRequestAsync` automatically accepts party requests when the receiver has `AutoAcceptFriend` (checked via `IFriendServer.IsFriendAsync`) or `AutoAcceptGuild` (same guild ID) enabled.

**CombatHandler** — removed buff-based early return. `FallbackBasicAttack` flag controls whether basic attack is performed when no skill is configured.

**Friend server** — added `IsFriendAsync` to `IFriendServer` (in-memory + Dapr). `DeleteFriendAsync` now cleans up both directions (subscribers + persistence).

**Immediate effect** — MU Helper config saves (0xAE packet) re-deserialize `player.MuHelperSettings` so flag changes apply without relog.

**Tests** — 6 party auto-accept tests, CombatHandlerTests updated.