### PR TITLE
Chore: fix low effort warnings on build

### DIFF
--- a/src/ChatServer/ExDbConnector/Program.cs
+++ b/src/ChatServer/ExDbConnector/Program.cs
@@ -9,12 +9,12 @@ using System.IO;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
-using Serilog;
-using Serilog.Debugging;
 using MUnique.OpenMU.ChatServer;
 using MUnique.OpenMU.Network;
 using MUnique.OpenMU.Network.PlugIns;
 using MUnique.OpenMU.PlugIns;
+using Serilog;
+using Serilog.Debugging;
 
 /// <summary>
 /// The main entry class of the application.

--- a/src/ConnectServer/Client.cs
+++ b/src/ConnectServer/Client.cs
@@ -8,10 +8,10 @@ using System.Buffers;
 using System.Net;
 using System.Threading;
 using Microsoft.Extensions.Logging;
-using Nito.AsyncEx.Synchronous;
 using MUnique.OpenMU.ConnectServer.PacketHandler;
 using MUnique.OpenMU.Network;
 using MUnique.OpenMU.Network.Packets.ConnectServer;
+using Nito.AsyncEx.Synchronous;
 
 /// <summary>
 /// The client which connected to the connect server.

--- a/src/ConnectServer/ClientListener.cs
+++ b/src/ConnectServer/ClientListener.cs
@@ -6,10 +6,10 @@ namespace MUnique.OpenMU.ConnectServer;
 
 using System.Net;
 using Microsoft.Extensions.Logging;
-using Nito.AsyncEx;
 using MUnique.OpenMU.ConnectServer.PacketHandler;
 using MUnique.OpenMU.Interfaces;
 using MUnique.OpenMU.Network;
+using Nito.AsyncEx;
 
 /// <summary>
 /// The listener which is waiting for new connecting clients.

--- a/src/ConnectServer/ServerListItem.cs
+++ b/src/ConnectServer/ServerListItem.cs
@@ -45,7 +45,7 @@ internal class ServerListItem : IGameServerEntry
     public ushort ServerId { get; set; }
 
     /// <summary>
-    /// Gets or sets the server load (usage rate).
+    /// Gets the server load (usage rate).
     /// </summary>
     public byte ServerLoadPercentage
     {

--- a/src/Dapr/AdminPanel.Host/DockerConnectServerInstanceManager.cs
+++ b/src/Dapr/AdminPanel.Host/DockerConnectServerInstanceManager.cs
@@ -2,9 +2,9 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
-using MUnique.OpenMU.Interfaces;
-
 namespace MUnique.OpenMU.AdminPanel.Host;
+
+using MUnique.OpenMU.Interfaces;
 
 /// <summary>
 /// An implementation of <see cref="IConnectServerInstanceManager"/>.
@@ -14,7 +14,7 @@ public class DockerConnectServerInstanceManager : IConnectServerInstanceManager
     private readonly IServerProvider _serverProvider;
 
     /// <summary>
-    /// Initializes a new instance of the <see cref="DockerGameServerInstanceManager"/> class.
+    /// Initializes a new instance of the <see cref="DockerConnectServerInstanceManager"/> class.
     /// </summary>
     /// <param name="serverProvider">The server provider.</param>
     public DockerConnectServerInstanceManager(IServerProvider serverProvider)

--- a/src/Dapr/AdminPanel.Host/DockerGameServerInstanceManager.cs
+++ b/src/Dapr/AdminPanel.Host/DockerGameServerInstanceManager.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ServerRestarter.cs" company="MUnique">
+﻿// <copyright file="DockerGameServerInstanceManager.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 

--- a/src/Dapr/ConnectServer.Host/GameServerRegistry.cs
+++ b/src/Dapr/ConnectServer.Host/GameServerRegistry.cs
@@ -7,8 +7,8 @@ namespace MUnique.OpenMU.ConnectServer.Host;
 using System.Net;
 using System.Threading;
 using Microsoft.Extensions.Logging;
-using Nito.AsyncEx;
 using MUnique.OpenMU.Interfaces;
+using Nito.AsyncEx;
 
 /// <summary>
 /// A registry which keeps track of available <see cref="IGameServer"/>s.

--- a/src/Dapr/LoginServer.Host/GameServerRegistry.cs
+++ b/src/Dapr/LoginServer.Host/GameServerRegistry.cs
@@ -6,8 +6,8 @@ namespace MUnique.OpenMU.LoginServer.Host;
 
 using System.Threading;
 using Microsoft.Extensions.Logging;
-using Nito.AsyncEx;
 using MUnique.OpenMU.PlugIns;
+using Nito.AsyncEx;
 
 /// <summary>
 /// The registry for game servers.

--- a/src/Dapr/ServerClients/FriendServer.cs
+++ b/src/Dapr/ServerClients/FriendServer.cs
@@ -4,8 +4,8 @@
 
 namespace MUnique.OpenMU.ServerClients;
 
-using Microsoft.Extensions.Logging;
 using Dapr.Client;
+using Microsoft.Extensions.Logging;
 using MUnique.OpenMU.Interfaces;
 
 /// <summary>

--- a/src/Dapr/ServerClients/LoginServer.cs
+++ b/src/Dapr/ServerClients/LoginServer.cs
@@ -4,8 +4,8 @@
 
 namespace MUnique.OpenMU.ServerClients;
 
-using Microsoft.Extensions.Logging;
 using Dapr.Client;
+using Microsoft.Extensions.Logging;
 using MUnique.OpenMU.Interfaces;
 
 /// <summary>

--- a/src/Dapr/ServerClients/PlayerLoggedInArguments.cs
+++ b/src/Dapr/ServerClients/PlayerLoggedInArguments.cs
@@ -7,6 +7,6 @@ namespace MUnique.OpenMU.ServerClients;
 using MUnique.OpenMU.Interfaces;
 
 /// <summary>
-/// Arguments for <see cref="IGameServer.PlayerAlreadyLoggedInAsync"/>
+/// Arguments for <see cref="IGameServer.PlayerAlreadyLoggedInAsync"/>.
 /// </summary>
 public record PlayerLoggedInArguments(byte ServerId, string LoginName);

--- a/src/DataModel/Configuration/Items/CombinationBonusRequirement.cs
+++ b/src/DataModel/Configuration/Items/CombinationBonusRequirement.cs
@@ -30,6 +30,6 @@ public partial class CombinationBonusRequirement
     /// <inheritdoc />
     public override string ToString()
     {
-        return $"{OptionType}: SubOption Type {this.SubOptionType}, Min. Count {this.MinimumCount}";
+        return $"{this.OptionType}: SubOption Type {this.SubOptionType}, Min. Count {this.MinimumCount}";
     }
 }

--- a/src/DataModel/Configuration/Items/ItemOfItemSet.cs
+++ b/src/DataModel/Configuration/Items/ItemOfItemSet.cs
@@ -4,8 +4,8 @@
 
 namespace MUnique.OpenMU.DataModel.Configuration.Items;
 
-using MUnique.OpenMU.Annotations;
 using System.Text.Json.Serialization;
+using MUnique.OpenMU.Annotations;
 
 /// <summary>
 /// Defines additional bonus options for this item of a set.

--- a/src/DataModel/Configuration/MonsterDefinition.cs
+++ b/src/DataModel/Configuration/MonsterDefinition.cs
@@ -193,7 +193,7 @@ public enum NpcObjectKind
     Trap,
 
     /// <summary>
-    /// The npc is a gate
+    /// The npc is a gate.
     /// </summary>
     Gate,
 

--- a/src/DataModel/Configuration/SystemConfiguration.cs
+++ b/src/DataModel/Configuration/SystemConfiguration.cs
@@ -56,7 +56,7 @@ public partial class SystemConfiguration
     /// Gets or sets a value indicating whether to automatically update the
     /// database schema when the server process starts.
     /// Only applicable to the All-In-One Startup. In a distributed deployment,
-    /// the user must start the update manually over the admin panel
+    /// the user must start the update manually over the admin panel.
     /// </summary>
     [Display(
         Order = 4,

--- a/src/DataModel/Entities/Account.cs
+++ b/src/DataModel/Entities/Account.cs
@@ -2,10 +2,9 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
-using System.ComponentModel;
-
 namespace MUnique.OpenMU.DataModel.Entities;
 
+using System.ComponentModel;
 using MUnique.OpenMU.AttributeSystem;
 using MUnique.OpenMU.DataModel.Configuration;
 

--- a/src/DataModel/InventoryConstants.cs
+++ b/src/DataModel/InventoryConstants.cs
@@ -112,7 +112,7 @@ public static class InventoryConstants
     /// <summary>
     /// Index of the first personal store slot.
     /// 12 = number of wearable item slots
-    /// 64 = number of inventory slots
+    /// 64 = number of inventory slots.
     /// </summary>
     public static readonly byte FirstExtensionItemSlotIndex = (byte)(
         EquippableSlotsCount + // 12

--- a/src/DataModel/ItemExtensions.cs
+++ b/src/DataModel/ItemExtensions.cs
@@ -72,14 +72,14 @@ public static class ItemExtensions
 
     /// <summary>
     /// Gets the dark raven leadership requirement, based on pet level.
-    /// TODO: Make somehow configurable?
+    /// TODO: Make somehow configurable?.
     /// </summary>
     /// <param name="item">The item.</param>
     /// <param name="petLevel">The pet level.</param>
     /// <returns>The required leadership.</returns>
     public static int GetDarkRavenLeadershipRequirement(this Item item, int petLevel)
     {
-        return petLevel * 15 + 185;
+        return (petLevel * 15) + 185;
     }
 
     /// <summary>

--- a/src/DataModel/ModelResourceProvider.cs
+++ b/src/DataModel/ModelResourceProvider.cs
@@ -1,4 +1,8 @@
-﻿namespace MUnique.OpenMU.DataModel;
+﻿// <copyright file="ModelResourceProvider.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.DataModel;
 
 using System;
 using System.Collections.Concurrent;

--- a/src/FriendServer/OnlineFriend.cs
+++ b/src/FriendServer/OnlineFriend.cs
@@ -2,11 +2,10 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
-using Nito.AsyncEx.Synchronous;
-
 namespace MUnique.OpenMU.FriendServer;
 
 using System.Threading;
+using Nito.AsyncEx.Synchronous;
 
 /// <summary>
 /// Represents an online friend who can observe his other friends, and be subscribed by other friends.
@@ -56,7 +55,7 @@ public sealed class OnlineFriend : IObservable<OnlineFriend>, IObserver<OnlineFr
     public int ServerId { get; set; }
 
     /// <summary>
-    /// Gets a value indicating this friend is invisible or offline.
+    /// Gets a value indicating whether gets a value indicating this friend is invisible or offline.
     /// </summary>
     public bool IsInvisibleOrOffline => this.ServerId == FriendServer.InvisibleServerId || this.ServerId == FriendServer.OfflineServerId;
 

--- a/src/FriendServer/OnlineFriend.cs
+++ b/src/FriendServer/OnlineFriend.cs
@@ -55,7 +55,7 @@ public sealed class OnlineFriend : IObservable<OnlineFriend>, IObserver<OnlineFr
     public int ServerId { get; set; }
 
     /// <summary>
-    /// Gets a value indicating whether gets a value indicating this friend is invisible or offline.
+    /// Gets a value indicating whether this friend is invisible or offline.
     /// </summary>
     public bool IsInvisibleOrOffline => this.ServerId == FriendServer.InvisibleServerId || this.ServerId == FriendServer.OfflineServerId;
 

--- a/src/GameLogic/AttackableExtensions.cs
+++ b/src/GameLogic/AttackableExtensions.cs
@@ -33,15 +33,15 @@ public static class AttackableExtensions
         /// <summary>
         /// Gets a value indicating whether this instance is a summoned monster.
         /// </summary>
-        public bool IsSummonedMonster => this.attackable is Monster { SummonedBy: not null };
+        public bool IsSummonedMonster => attackable is Monster { SummonedBy: not null };
     }
 
     /// <summary>
-    /// Calculates the damage, using a skill.
+    /// Calculates the damage using a skill.
     /// </summary>
-    /// <param name="attacker">The object which is attacking.</param>
-    /// <param name="defender">The object which is defending.</param>
-    /// <param name="skill">The skill which is used.</param>
+    /// <param name="attacker">The object that is attacking.</param>
+    /// <param name="defender">The object that is defending.</param>
+    /// <param name="skill">The skill that is used.</param>
     /// <param name="isCombo">If set to <c>true</c>, the damage gets increased by a combo bonus.</param>
     /// <param name="damageFactor">The damage factor.</param>
     /// <returns>
@@ -806,7 +806,7 @@ public static class AttackableExtensions
                 maximumBaseDamage = (int)attackerStats[Stats.FenrirBaseDmg] + skillMaximumDamage;
                 break;
             default:
-                // the skill has some other damage type defined which is not applicable to this calculation
+                // the skill has some other damage type defined that is not applicable to this calculation
                 break;
         }
 

--- a/src/GameLogic/AttackableExtensions.cs
+++ b/src/GameLogic/AttackableExtensions.cs
@@ -33,7 +33,7 @@ public static class AttackableExtensions
         /// <summary>
         /// Gets a value indicating whether this instance is a summoned monster.
         /// </summary>
-        public bool IsSummonedMonster => attackable is Monster { SummonedBy: not null };
+        public bool IsSummonedMonster => this.attackable is Monster { SummonedBy: not null };
     }
 
     /// <summary>

--- a/src/GameLogic/INpcIntelligence.cs
+++ b/src/GameLogic/INpcIntelligence.cs
@@ -18,7 +18,7 @@ public interface INpcIntelligence
     NonPlayerCharacter Npc { get; set; }
 
     /// <summary>
-    /// Gets or sets a value indicating whether this instance can walk on safezone.
+    /// Gets a value indicating whether this instance can walk on safezone.
     /// </summary>
     /// <value>
     ///   <c>true</c> if this instance can walk on safezone; otherwise, <c>false</c>.

--- a/src/GameLogic/ITrader.cs
+++ b/src/GameLogic/ITrader.cs
@@ -4,9 +4,9 @@
 
 namespace MUnique.OpenMU.GameLogic;
 
+using System.Threading;
 using MUnique.OpenMU.Interfaces;
 using MUnique.OpenMU.Persistence;
-using System.Threading;
 
 /// <summary>
 /// Interface of a trader.

--- a/src/GameLogic/ItemEventArgs.cs
+++ b/src/GameLogic/ItemEventArgs.cs
@@ -14,7 +14,7 @@ public class ItemEventArgs : EventArgs
     /// Initializes a new instance of the <see cref="ItemEventArgs"/> class.
     /// </summary>
     /// <param name="item">The item.</param>
-    /// <param name="isEquipped">Whether equipped or not</param>
+    /// <param name="isEquipped">Whether equipped or not.</param>
     public ItemEventArgs(Item item, bool isEquipped)
     {
         this.Item = item;

--- a/src/GameLogic/PlayerActions/Items/MoveItemAction.cs
+++ b/src/GameLogic/PlayerActions/Items/MoveItemAction.cs
@@ -5,8 +5,8 @@
 namespace MUnique.OpenMU.GameLogic.PlayerActions.Items;
 
 using System.ComponentModel;
-using MUnique.OpenMU.DataModel.Configuration;
 using Microsoft.Extensions.Logging;
+using MUnique.OpenMU.DataModel.Configuration;
 using MUnique.OpenMU.DataModel.Configuration.Items;
 using MUnique.OpenMU.GameLogic.PlugIns;
 using MUnique.OpenMU.GameLogic.Views.Inventory;

--- a/src/GameLogic/PlayerActions/Skills/FrustumBasedTargetFilter.cs
+++ b/src/GameLogic/PlayerActions/Skills/FrustumBasedTargetFilter.cs
@@ -143,8 +143,8 @@ public record FrustumBasedTargetFilter
         // The frustum has Y pointing forward and X pointing right
         var cos = Math.Cos(-rotationRad);
         var sin = Math.Sin(-rotationRad);
-        var rotatedX = dx * cos - dy * sin;
-        var rotatedY = dx * sin + dy * cos;
+        var rotatedX = (dx * cos) - (dy * sin);
+        var rotatedY = (dx * sin) + (dy * cos);
 
         // If target is behind us or too close, return 0
         if (rotatedY <= 0)
@@ -155,7 +155,7 @@ public record FrustumBasedTargetFilter
         // Calculate the frustum width at the target's distance
         // Linear interpolation between start and end width
         var distanceRatio = Math.Min(rotatedY / this.Distance, 1.0);
-        var frustumWidthAtDistance = this.StartWidth + (this.EndWidth - this.StartWidth) * distanceRatio;
+        var frustumWidthAtDistance = this.StartWidth + ((this.EndWidth - this.StartWidth) * distanceRatio);
 
         // Normalize the X position by the frustum width at that distance
         // Result will be in range [-1, 1] where -1 is left edge, 0 is center, 1 is right edge

--- a/src/GameLogic/PlugIns/MonsterAttributeScaler.cs
+++ b/src/GameLogic/PlugIns/MonsterAttributeScaler.cs
@@ -48,11 +48,11 @@ public class MonsterAttributeScaler : IFeaturePlugIn, IObjectAddedToMapPlugIn, I
                 return;
             }
 
-            this._damageMultiplier.Value = value.DamagePercentage > 0 ? 1.0f + value.DamagePercentage / 100.0f : 1.0f;
-            this._attackRateMultiplier.Value = value.AttackRatePercentage > 0 ? 1.0f + value.AttackRatePercentage / 100.0f : 1.0f;
-            this._defenseRateMultiplier.Value = value.DefenseRatePercentage > 0 ? 1.0f + value.DefenseRatePercentage / 100.0f : 1.0f;
-            this._defenseMultiplier.Value = value.DefensePercentage > 0 ? 1.0f + value.DefensePercentage / 100.0f : 1.0f;
-            this._healthMultiplier.Value = value.HealthPercentage > 0 ? 1.0f + value.HealthPercentage / 100.0f : 1.0f;
+            this._damageMultiplier.Value = value.DamagePercentage > 0 ? 1.0f + (value.DamagePercentage / 100.0f) : 1.0f;
+            this._attackRateMultiplier.Value = value.AttackRatePercentage > 0 ? 1.0f + (value.AttackRatePercentage / 100.0f) : 1.0f;
+            this._defenseRateMultiplier.Value = value.DefenseRatePercentage > 0 ? 1.0f + (value.DefenseRatePercentage / 100.0f) : 1.0f;
+            this._defenseMultiplier.Value = value.DefensePercentage > 0 ? 1.0f + (value.DefensePercentage / 100.0f) : 1.0f;
+            this._healthMultiplier.Value = value.HealthPercentage > 0 ? 1.0f + (value.HealthPercentage / 100.0f) : 1.0f;
         }
     }
 

--- a/src/GameLogic/Views/IConsumeSpecialItemPlugIn.cs
+++ b/src/GameLogic/Views/IConsumeSpecialItemPlugIn.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="IDrinkAlcoholPlugIn.cs" company="MUnique">
+﻿// <copyright file="IConsumeSpecialItemPlugIn.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 

--- a/src/GameServer/MessageHandler/Guild/GuildRelationshipChangeHandlerPlugIn.cs
+++ b/src/GameServer/MessageHandler/Guild/GuildRelationshipChangeHandlerPlugIn.cs
@@ -10,8 +10,8 @@ using MUnique.OpenMU.GameLogic.PlayerActions.Guild;
 using MUnique.OpenMU.GameLogic.Views;
 using MUnique.OpenMU.Network.Packets.ClientToServer;
 using MUnique.OpenMU.PlugIns;
-using ViewGuildRelationshipType = MUnique.OpenMU.GameLogic.Views.Guild.GuildRelationshipType;
 using ViewGuildRelationshipRequestType = MUnique.OpenMU.GameLogic.Views.Guild.GuildRelationshipRequestType;
+using ViewGuildRelationshipType = MUnique.OpenMU.GameLogic.Views.Guild.GuildRelationshipType;
 
 /// <summary>
 /// Handler for guild relationship change request packets (C1 E5).

--- a/src/GameServer/MessageHandler/Guild/GuildRelationshipChangeResponseHandlerPlugIn.cs
+++ b/src/GameServer/MessageHandler/Guild/GuildRelationshipChangeResponseHandlerPlugIn.cs
@@ -9,8 +9,8 @@ using MUnique.OpenMU.GameLogic;
 using MUnique.OpenMU.GameLogic.PlayerActions.Guild;
 using MUnique.OpenMU.Network.Packets.ClientToServer;
 using MUnique.OpenMU.PlugIns;
-using ViewGuildRelationshipType = MUnique.OpenMU.GameLogic.Views.Guild.GuildRelationshipType;
 using ViewGuildRelationshipRequestType = MUnique.OpenMU.GameLogic.Views.Guild.GuildRelationshipRequestType;
+using ViewGuildRelationshipType = MUnique.OpenMU.GameLogic.Views.Guild.GuildRelationshipType;
 
 /// <summary>
 /// Handler for guild relationship change response packets (C1 E6) — the target guild master's answer.

--- a/src/GameServer/MessageHandler/Items/JewelMixHandlerPlugIn.cs
+++ b/src/GameServer/MessageHandler/Items/JewelMixHandlerPlugIn.cs
@@ -56,7 +56,7 @@ internal class JewelMixHandlerPlugIn : IPacketHandlerPlugIn
             LahapJewelMixRequest.StackSize.Ten => 10,
             LahapJewelMixRequest.StackSize.Twenty => 20,
             LahapJewelMixRequest.StackSize.Thirty => 30,
-            _ => throw new InvalidEnumArgumentException(nameof(stackSize), (int)stackSize, typeof(LahapJewelMixRequest.StackSize))
+            _ => throw new InvalidEnumArgumentException(nameof(stackSize), (int)stackSize, typeof(LahapJewelMixRequest.StackSize)),
         };
     }
 }

--- a/src/GameServer/RemoteView/AppearanceSerializer095.cs
+++ b/src/GameServer/RemoteView/AppearanceSerializer095.cs
@@ -85,7 +85,6 @@ public class AppearanceSerializer095 : IAppearanceSerializer
     /// </summary>
     /// <param name="target">The target.</param>
     /// <param name="appearanceData">The appearance data.</param>
-    /// <returns></returns>
     private void WritePreviewCharSet(Span<byte> target, IAppearanceData appearanceData)
     {
         ItemAppearance?[] itemArray = new ItemAppearance[InventoryConstants.EquippableSlotsCount];

--- a/src/GameServer/RemoteView/AppearanceSerializerExtended.cs
+++ b/src/GameServer/RemoteView/AppearanceSerializerExtended.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AppearanceSerializer.cs" company="MUnique">
+﻿// <copyright file="AppearanceSerializerExtended.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
@@ -92,15 +92,15 @@ public class AppearanceSerializerExtended : IAppearanceSerializer
         }
 
         var items = target[2..];
-        SetShinyItem(items[0..3], itemArray[InventoryConstants.LeftHandSlot]);
-        SetShinyItem(items[3..6], itemArray[InventoryConstants.RightHandSlot]);
-        SetShinyItem(items[6..9], itemArray[InventoryConstants.HelmSlot]);
-        SetShinyItem(items[9..12], itemArray[InventoryConstants.ArmorSlot]);
-        SetShinyItem(items[12..15], itemArray[InventoryConstants.PantsSlot]);
-        SetShinyItem(items[15..18], itemArray[InventoryConstants.GlovesSlot]);
-        SetShinyItem(items[18..21], itemArray[InventoryConstants.BootsSlot]);
-        SetUnshinyItem(items[21..23], itemArray[InventoryConstants.WingsSlot]);
-        SetUnshinyItem(items[23..25], itemArray[InventoryConstants.PetSlot]);
+        this.SetShinyItem(items[0..3], itemArray[InventoryConstants.LeftHandSlot]);
+        this.SetShinyItem(items[3..6], itemArray[InventoryConstants.RightHandSlot]);
+        this.SetShinyItem(items[6..9], itemArray[InventoryConstants.HelmSlot]);
+        this.SetShinyItem(items[9..12], itemArray[InventoryConstants.ArmorSlot]);
+        this.SetShinyItem(items[12..15], itemArray[InventoryConstants.PantsSlot]);
+        this.SetShinyItem(items[15..18], itemArray[InventoryConstants.GlovesSlot]);
+        this.SetShinyItem(items[18..21], itemArray[InventoryConstants.BootsSlot]);
+        this.SetUnshinyItem(items[21..23], itemArray[InventoryConstants.WingsSlot]);
+        this.SetUnshinyItem(items[23..25], itemArray[InventoryConstants.PetSlot]);
 
         var pet = itemArray[InventoryConstants.PetSlot];
         if (pet is not null)
@@ -174,7 +174,7 @@ public class AppearanceSerializerExtended : IAppearanceSerializer
     ///     Number: 12 bit
     ///     Level:  4 bit
     ///     IsExc:  1 bit
-    ///     IsAnc:  1 bit
+    ///     IsAnc:  1 bit.
     /// </summary>
     private readonly ref struct ShinyItem(Span<byte> data)
     {
@@ -254,7 +254,7 @@ public class AppearanceSerializerExtended : IAppearanceSerializer
     /// <summary>
     /// Unshiny Item: (2 bytes)
     ///     Group:  4 bit
-    ///     Number: 12 bit
+    ///     Number: 12 bit.
     /// </summary>
     private readonly ref struct UnshinyItem(Span<byte> data)
     {

--- a/src/GameServer/RemoteView/Character/UpdateStatsBasePlugIn.cs
+++ b/src/GameServer/RemoteView/Character/UpdateStatsBasePlugIn.cs
@@ -10,7 +10,7 @@ using System.Threading;
 using MUnique.OpenMU.AttributeSystem;
 using MUnique.OpenMU.GameLogic;
 using MUnique.OpenMU.GameLogic.Views.Character;
-using UpdateAction = Func<RemotePlayer, ValueTask>;
+using UpdateAction = System.Func<MUnique.OpenMU.GameServer.RemoteView.RemotePlayer, System.Threading.Tasks.ValueTask>;
 
 /// <summary>
 /// The default implementation of the <see cref="IUpdateStatsPlugIn"/> which is forwarding everything to the game client with specific data packets.

--- a/src/GameServer/RemoteView/Quest/QuestStateResponseExtendedPlugIn.cs
+++ b/src/GameServer/RemoteView/Quest/QuestStateResponseExtendedPlugIn.cs
@@ -27,7 +27,8 @@ public class QuestStateResponseExtendedPlugIn : QuestStateResponsePlugIn, IQuest
     /// Initializes a new instance of the <see cref="QuestStateResponseExtendedPlugIn"/> class.
     /// </summary>
     /// <param name="player">The player.</param>
-    public QuestStateResponseExtendedPlugIn(RemotePlayer player) : base(player)
+    public QuestStateResponseExtendedPlugIn(RemotePlayer player)
+        : base(player)
     {
         this._player = player;
     }

--- a/src/GameServer/RemoteView/World/ObjectMovedPlugInExtended.cs
+++ b/src/GameServer/RemoteView/World/ObjectMovedPlugInExtended.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="ObjectMovedPlugIn.cs" company="MUnique">
+﻿// <copyright file="ObjectMovedPlugInExtended.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 

--- a/src/Interfaces/IFriendServer.cs
+++ b/src/Interfaces/IFriendServer.cs
@@ -65,7 +65,7 @@ public interface IFriendServer
     /// <param name="serverId">The server identifier.</param>
     /// <param name="characterId">Id of the character.</param>
     /// <param name="characterName">Name of the character.</param>
-    /// <param name="isVisible">If set to <c>true</c>, the character is visible as online. Otherwise, it appears as offline for other players, but is still online</param>
+    /// <param name="isVisible">If set to <c>true</c>, the character is visible as online. Otherwise, it appears as offline for other players, but is still online.</param>
     ValueTask SetPlayerVisibilityStateAsync(byte serverId, Guid characterId, string characterName, bool isVisible);
 
     /// <summary>

--- a/src/Interfaces/IGameServerInstanceManager.cs
+++ b/src/Interfaces/IGameServerInstanceManager.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="IGameServerInitializer.cs" company="MUnique">
+﻿// <copyright file="IGameServerInstanceManager.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 

--- a/src/LoginServer/LoginServer.cs
+++ b/src/LoginServer/LoginServer.cs
@@ -4,8 +4,8 @@
 
 namespace MUnique.OpenMU.LoginServer;
 
-using Nito.AsyncEx;
 using MUnique.OpenMU.Interfaces;
+using Nito.AsyncEx;
 
 /// <summary>
 /// The login server which keeps track of connected accounts in-memory.

--- a/src/Network/Analyzer/MainForm.cs
+++ b/src/Network/Analyzer/MainForm.cs
@@ -59,7 +59,7 @@ public partial class MainForm : Form
         this._analyzer = new PacketAnalyzer();
         this.Disposed += (_, _) => this._analyzer.Dispose();
 
-        this.clientVersionComboBox.SelectedIndexChanged += OnSelectedClientVersionChanged;
+        this.clientVersionComboBox.SelectedIndexChanged += this.OnSelectedClientVersionChanged;
         this.clientVersionComboBox.DataSource = new BindingSource(this._clientVersions, string.Empty);
         this.clientVersionComboBox.DisplayMember = "Value";
         this.clientVersionComboBox.ValueMember = "Key";

--- a/src/Network/Analyzer/Packet.cs
+++ b/src/Network/Analyzer/Packet.cs
@@ -117,7 +117,7 @@ public sealed class Packet : INotifyPropertyChanged
                 this._message = request.Message;
                 this._analyzedByVersion = request.ClientVersion;
                 this._definition = request.Definition;
-                this.RaisePropertyChanged(nameof(DisplayCode));
+                this.RaisePropertyChanged(nameof(this.DisplayCode));
             }
 
             return this._message ?? string.Empty;
@@ -142,7 +142,7 @@ public sealed class Packet : INotifyPropertyChanged
     /// <summary>
     /// Gets the protocol version which was applied when analyzing.
     /// </summary>
-    public ClientVersion AnalyzedByVersion => _analyzedByVersion;
+    public ClientVersion AnalyzedByVersion => this._analyzedByVersion;
 
     /// <inheritdoc />
     public override string ToString()
@@ -159,12 +159,12 @@ public sealed class Packet : INotifyPropertyChanged
         this._definition = null;
         this._displayCode = null;
         this._message = null;
-        this.RaisePropertyChanged(nameof(Message));
+        this.RaisePropertyChanged(nameof(this.Message));
     }
 
     private void RaisePropertyChanged([CallerMemberName] string? propertyName = null)
     {
-        PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
     }
 
     /// <summary>
@@ -178,7 +178,7 @@ public sealed class Packet : INotifyPropertyChanged
         /// <param name="data">The data.</param>
         public AnalyzingRequestedEventArgs(Packet data)
         {
-            Packet = data;
+            this.Packet = data;
         }
 
         /// <summary>

--- a/src/Network/Analyzer/PacketAnalyzer.cs
+++ b/src/Network/Analyzer/PacketAnalyzer.cs
@@ -20,7 +20,7 @@ public sealed class PacketAnalyzer : IDisposable
     private const string ServerToClientPacketsFile = "ServerToClientPackets.xml";
     private const string CommonFile = "CommonEnums.xml";
     private const int DefaultVersionValue = 100;
-    private const int ExtendedVersionValue = 106 * 100 + 3;
+    private const int ExtendedVersionValue = (106 * 100) + 3;
 
     private readonly IList<IDisposable> _watchers = new List<IDisposable>();
     private PacketDefinitions? _clientPacketDefinitions;
@@ -49,7 +49,7 @@ public sealed class PacketAnalyzer : IDisposable
         set
         {
             this._clientVersion = value;
-            this._clientVersionValue = value.Season * 100 + value.Episode;
+            this._clientVersionValue = (value.Season * 100) + value.Episode;
         }
     }
 
@@ -352,7 +352,7 @@ public sealed class PacketAnalyzer : IDisposable
         }
 
         var typeLength = elementType.Length > 0 ? elementType.Length : this.DetermineFixedStructLength(data, arrayField, elementType, count);
-        var fixedLengthByCount = CalcFixStructLengthBySizeAndCount(data, arrayField, elementType, count);
+        var fixedLengthByCount = this.CalcFixStructLengthBySizeAndCount(data, arrayField, elementType, count);
         var stringBuilder = new StringBuilder();
         var restData = data[arrayField.Index..];
 
@@ -439,12 +439,12 @@ public sealed class PacketAnalyzer : IDisposable
             && type.Fields.FirstOrDefault(f => f.Type == FieldType.Binary) is { } binaryField
             && binaryField.Name?.EndsWith("ItemData") is true)
         {
-            return binaryField.Index + DetermineItemSize(restData, binaryField);
+            return binaryField.Index + this.DetermineItemSize(restData, binaryField);
         }
 
         if (type.Fields.MaxBy(f => f.Index) is { Type: not (FieldType.Binary or FieldType.StructureArray) } lastField)
         {
-            return lastField.Index + FieldSize(lastField.Type);
+            return lastField.Index + this.FieldSize(lastField.Type);
         }
 
         return null;

--- a/src/Network/ConfigurableIpResolver.cs
+++ b/src/Network/ConfigurableIpResolver.cs
@@ -28,7 +28,7 @@ public class ConfigurableIpResolver : IIpAddressResolver
     /// <param name="allowRuntimeReconfiguration">
     /// If set to <c>false</c>, calls to <see cref="Configure"/> are ignored after construction.
     /// </param>
-    /// <exception cref="System.ArgumentException">When using a custom resolver type, a parameter with an IP or host name is required. - parameter</exception>
+    /// <exception cref="System.ArgumentException">When using a custom resolver type, a parameter with an IP or host name is required. - parameter.</exception>
     public ConfigurableIpResolver(IpResolverType resolverType, string? parameter, ILoggerFactory loggerFactory, bool allowRuntimeReconfiguration = true)
     {
         this._loggerFactory = loggerFactory;
@@ -101,7 +101,7 @@ public class ConfigurableIpResolver : IIpAddressResolver
             case IpResolverType.Auto:
             case IpResolverType.Public:
             default:
-                return new PublicIpResolver(_loggerFactory.CreateLogger<PublicIpResolver>());
+                return new PublicIpResolver(this._loggerFactory.CreateLogger<PublicIpResolver>());
         }
     }
 }

--- a/src/Network/Connection.cs
+++ b/src/Network/Connection.cs
@@ -2,21 +2,20 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
-using Nito.AsyncEx;
-
 namespace MUnique.OpenMU.Network;
 
+using System.Buffers;
 using System.Diagnostics;
 using System.Diagnostics.Metrics;
-using System.Buffers;
 using System.IO.Pipelines;
 using System.Net;
 using System.Threading;
 using Microsoft.Extensions.Logging;
-using Pipelines.Sockets.Unofficial;
-using Nito.AsyncEx.Synchronous;
 using MUnique.OpenMU.Network.SimpleModulus;
 using MUnique.OpenMU.PlugIns;
+using Nito.AsyncEx;
+using Nito.AsyncEx.Synchronous;
+using Pipelines.Sockets.Unofficial;
 
 /// <summary>
 /// A connection which works on <see cref="IDuplexPipe"/>.

--- a/src/Network/DuplexPipe.cs
+++ b/src/Network/DuplexPipe.cs
@@ -13,6 +13,7 @@ using System.IO.Pipelines;
 public class DuplexPipe : IDuplexPipe
 {
     /// <summary>
+    /// Initializes a new instance of the <see cref="DuplexPipe"/> class.
     /// Initializes a new instance of <see cref="DuplexPipe"/>.
     /// </summary>
     /// <param name="options">The optional pipe options. If null, the default options are applied.</param>

--- a/src/Network/DuplexPipe.cs
+++ b/src/Network/DuplexPipe.cs
@@ -14,7 +14,6 @@ public class DuplexPipe : IDuplexPipe
 {
     /// <summary>
     /// Initializes a new instance of the <see cref="DuplexPipe"/> class.
-    /// Initializes a new instance of <see cref="DuplexPipe"/>.
     /// </summary>
     /// <param name="options">The optional pipe options. If null, the default options are applied.</param>
     public DuplexPipe(PipeOptions? options = null)

--- a/src/Network/IConnection.cs
+++ b/src/Network/IConnection.cs
@@ -7,8 +7,8 @@ namespace MUnique.OpenMU.Network;
 using System.Buffers;
 using System.IO.Pipelines;
 using System.Net;
-using Nito.AsyncEx;
 using MUnique.OpenMU.PlugIns;
+using Nito.AsyncEx;
 
 /// <summary>
 /// Interface for a connection.

--- a/src/Network/IpResolverType.cs
+++ b/src/Network/IpResolverType.cs
@@ -1,4 +1,8 @@
-﻿namespace MUnique.OpenMU.Network;
+﻿// <copyright file="IpResolverType.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Network;
 
 using System.ComponentModel.DataAnnotations;
 

--- a/src/Network/Listener.cs
+++ b/src/Network/Listener.cs
@@ -8,8 +8,8 @@ using System.IO.Pipelines;
 using System.Net;
 using System.Net.Sockets;
 using Microsoft.Extensions.Logging;
-using Pipelines.Sockets.Unofficial;
 using MUnique.OpenMU.PlugIns;
+using Pipelines.Sockets.Unofficial;
 
 /// <summary>
 /// A tcp listener which automatically creates instances of <see cref="Connection"/>s for accepted clients.

--- a/src/Network/PlugIns/OpenSourceClientNetworkEncryptionFactoryPlugIn.cs
+++ b/src/Network/PlugIns/OpenSourceClientNetworkEncryptionFactoryPlugIn.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="Season106Episode3NetworkEncryptionFactoryPlugIn.cs" company="MUnique">
+﻿// <copyright file="OpenSourceClientNetworkEncryptionFactoryPlugIn.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
@@ -13,7 +13,7 @@ using MUnique.OpenMU.Network.Xor;
 using MUnique.OpenMU.PlugIns;
 
 /// <summary>
-/// A plugin which provides network encryptors and decryptors for the english open source game clients of season 6 episode 3, version 2.04d
+/// A plugin which provides network encryptors and decryptors for the english open source game clients of season 6 episode 3, version 2.04d.
 /// </summary>
 [PlugIn]
 [Display(Name = nameof(PlugInResources.OpenSourceClientNetworkEncryptionFactoryPlugIn_Name), Description = nameof(PlugInResources.OpenSourceClientNetworkEncryptionFactoryPlugIn_Description), ResourceType = typeof(PlugInResources))]

--- a/src/Persistence/AccountDataSource.cs
+++ b/src/Persistence/AccountDataSource.cs
@@ -43,7 +43,7 @@ public sealed class AccountDataSource : DataSourceBase<Account>
         IDataSource<GameConfiguration> gameConfigurationSource)
         : base(logger, persistenceContextProvider)
     {
-        _gameConfigurationSource = gameConfigurationSource;
+        this._gameConfigurationSource = gameConfigurationSource;
     }
 
     /// <inheritdoc />
@@ -52,7 +52,7 @@ public sealed class AccountDataSource : DataSourceBase<Account>
     /// <inheritdoc />
     protected override async ValueTask<IContext> CreateNewContextAsync()
     {
-        var gameConfiguration = await _gameConfigurationSource.GetOwnerAsync(Guid.Empty).ConfigureAwait(false);
+        var gameConfiguration = await this._gameConfigurationSource.GetOwnerAsync(Guid.Empty).ConfigureAwait(false);
         return this.ContextProvider.CreateNewPlayerContext(gameConfiguration);
     }
 }

--- a/src/Persistence/BasicModel/AttributeDefinition.Custom.cs
+++ b/src/Persistence/BasicModel/AttributeDefinition.Custom.cs
@@ -27,7 +27,7 @@ public partial class AttributeDefinition :
     {
         if (other is AttributeSystem.AttributeDefinition typedOther)
         {
-            AssignValuesOf(typedOther, gameConfiguration);
+            this.AssignValuesOf(typedOther, gameConfiguration);
         }
     }
 

--- a/src/Persistence/DataSourceBase.cs
+++ b/src/Persistence/DataSourceBase.cs
@@ -96,7 +96,7 @@ public abstract class DataSourceBase<TOwner> : IDataSource<TOwner>
         }
         else
         {
-            owner = (await context.GetByIdAsync<TOwner>(ownerId, cancellationToken).ConfigureAwait(false));
+            owner = await context.GetByIdAsync<TOwner>(ownerId, cancellationToken).ConfigureAwait(false);
         }
 
         this._owner = owner;
@@ -109,7 +109,7 @@ public abstract class DataSourceBase<TOwner> : IDataSource<TOwner>
     /// <inheritdoc />
     public async ValueTask DiscardChangesAsync()
     {
-        using var l = await _loadLock.LockAsync().ConfigureAwait(false);
+        using var l = await this._loadLock.LockAsync().ConfigureAwait(false);
         if (this._context?.HasChanges is true)
         {
             // next time, we have to load again.
@@ -121,7 +121,7 @@ public abstract class DataSourceBase<TOwner> : IDataSource<TOwner>
     /// <inheritdoc />
     public async ValueTask ForceDiscardChangesAsync()
     {
-        using var l = await _loadLock.LockAsync().ConfigureAwait(false);
+        using var l = await this._loadLock.LockAsync().ConfigureAwait(false);
         this.Reset();
     }
 
@@ -136,18 +136,18 @@ public abstract class DataSourceBase<TOwner> : IDataSource<TOwner>
     {
         var gameConfiguration = this._owner ?? throw new InvalidOperationException("config is not loaded.");
 
-        if (TypeToEnumerables.TryGetValue(type, out var getter))
+        if (this.TypeToEnumerables.TryGetValue(type, out var getter))
         {
             return getter(gameConfiguration);
         }
 
-        throw new ArgumentOutOfRangeException($"The type {type} is not registered as child of the {nameof(Owner)}", nameof(type));
+        throw new ArgumentOutOfRangeException($"The type {type} is not registered as child of the {nameof(this.Owner)}", nameof(type));
     }
 
     /// <inheritdoc />
     public IIdentifiable? Get(Guid id)
     {
-        using var l = _loadLock.Lock();
+        using var l = this._loadLock.Lock();
         if (this.SubObjects.TryGetValue(id, out var obj))
         {
             return obj;
@@ -177,7 +177,7 @@ public abstract class DataSourceBase<TOwner> : IDataSource<TOwner>
 
         var result = new Dictionary<Guid, IIdentifiable>();
 
-        foreach (var (type, objects) in TypeToEnumerables)
+        foreach (var (type, objects) in this.TypeToEnumerables)
         {
             foreach (var obj in objects(owner).OfType<IIdentifiable>())
             {

--- a/src/Persistence/EntityFramework/AccountRepository.cs
+++ b/src/Persistence/EntityFramework/AccountRepository.cs
@@ -4,13 +4,13 @@
 
 namespace MUnique.OpenMU.Persistence.EntityFramework;
 
+using System.Linq;
+using System.Threading;
 using BCrypt.Net;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using MUnique.OpenMU.Persistence.EntityFramework.Json;
 using MUnique.OpenMU.Persistence.EntityFramework.Model;
-using System.Linq;
-using System.Threading;
 
 /// <summary>
 /// Repository for accounts.

--- a/src/Persistence/EntityFramework/CacheAwareRepositoryProvider.cs
+++ b/src/Persistence/EntityFramework/CacheAwareRepositoryProvider.cs
@@ -2,12 +2,11 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
-using MUnique.OpenMU.DataModel.Configuration;
-
 namespace MUnique.OpenMU.Persistence.EntityFramework;
 
 using Microsoft.Extensions.Logging;
 using MUnique.OpenMU.DataModel;
+using MUnique.OpenMU.DataModel.Configuration;
 using MUnique.OpenMU.Interfaces;
 
 /// <summary>

--- a/src/Persistence/EntityFramework/CachingEntityFrameworkContext.cs
+++ b/src/Persistence/EntityFramework/CachingEntityFrameworkContext.cs
@@ -2,12 +2,11 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
-using MUnique.OpenMU.Interfaces;
-
 namespace MUnique.OpenMU.Persistence.EntityFramework;
 
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
+using MUnique.OpenMU.Interfaces;
 
 /// <summary>
 /// Implementation of <see cref="IContext"/> for the entity framework <see cref="PersistenceContextProvider"/>.

--- a/src/Persistence/EntityFramework/CachingGameConfigurationRepository.cs
+++ b/src/Persistence/EntityFramework/CachingGameConfigurationRepository.cs
@@ -2,10 +2,9 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
-using System.Threading;
-
 namespace MUnique.OpenMU.Persistence.EntityFramework;
 
+using System.Threading;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using MUnique.OpenMU.Persistence.EntityFramework.Json;

--- a/src/Persistence/EntityFramework/ConfigurationChangeListener.cs
+++ b/src/Persistence/EntityFramework/ConfigurationChangeListener.cs
@@ -4,11 +4,11 @@
 
 namespace MUnique.OpenMU.Persistence.EntityFramework;
 
+using System.IO;
 using Microsoft.EntityFrameworkCore.Metadata;
 using MUnique.OpenMU.DataModel;
 using MUnique.OpenMU.DataModel.Configuration;
 using MUnique.OpenMU.Interfaces;
-using System.IO;
 
 /// <summary>
 /// Class which listens to changes within the <see cref="GameConfiguration"/>,

--- a/src/Persistence/EntityFramework/ConfigurationTypeRepository.cs
+++ b/src/Persistence/EntityFramework/ConfigurationTypeRepository.cs
@@ -111,7 +111,7 @@ internal class ConfigurationTypeRepository<T> : IRepository<T>, IConfigurationTy
 
     /// <summary>
     /// Ensures the cache for the current configuration.
-    /// TODO: Call this at a better place and time - so that we can remove this check before every GetById
+    /// TODO: Call this at a better place and time - so that we can remove this check before every GetById.
     /// </summary>
     public void EnsureCacheForCurrentConfiguration()
     {

--- a/src/Persistence/EntityFramework/EntityFrameworkContextBase.cs
+++ b/src/Persistence/EntityFramework/EntityFrameworkContextBase.cs
@@ -2,13 +2,11 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
-using System.Threading;
-using Nito.Disposables;
-
 namespace MUnique.OpenMU.Persistence.EntityFramework;
 
 using System.Collections;
 using System.Reflection;
+using System.Threading;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Metadata;
@@ -16,6 +14,7 @@ using Microsoft.Extensions.Logging;
 using MUnique.OpenMU.DataModel.Composition;
 using MUnique.OpenMU.DataModel.Configuration;
 using Nito.AsyncEx;
+using Nito.Disposables;
 
 /// <summary>
 /// Abstract base class for an <see cref="IContext"/> which uses an <see cref="DbContext"/>.

--- a/src/Persistence/EntityFramework/GameConfigurationRepository.cs
+++ b/src/Persistence/EntityFramework/GameConfigurationRepository.cs
@@ -4,11 +4,11 @@
 
 namespace MUnique.OpenMU.Persistence.EntityFramework;
 
+using System.Threading;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using MUnique.OpenMU.Persistence.EntityFramework.Json;
 using MUnique.OpenMU.Persistence.EntityFramework.Model;
-using System.Threading;
 
 /// <summary>
 /// The game configuration repository, which loads the configuration by using the

--- a/src/Persistence/EntityFramework/GameServerDefinitionRepository.cs
+++ b/src/Persistence/EntityFramework/GameServerDefinitionRepository.cs
@@ -2,10 +2,9 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
-using System.Threading;
-
 namespace MUnique.OpenMU.Persistence.EntityFramework;
 
+using System.Threading;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 using Microsoft.Extensions.Logging;

--- a/src/Persistence/EntityFramework/Json/JsonObjectDeserializer.cs
+++ b/src/Persistence/EntityFramework/Json/JsonObjectDeserializer.cs
@@ -4,8 +4,8 @@
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Json;
 
-using MUnique.OpenMU.PlugIns;
 using System.Text.Json;
+using MUnique.OpenMU.PlugIns;
 
 /// <summary>
 /// A deserializer which parses the json retrieved from the postgres database by using a query built by the <see cref="JsonQueryBuilder"/>.

--- a/src/Persistence/EntityFramework/Json/JsonObjectLoader.cs
+++ b/src/Persistence/EntityFramework/Json/JsonObjectLoader.cs
@@ -2,12 +2,11 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
-using System.Threading;
-
 namespace MUnique.OpenMU.Persistence.EntityFramework.Json;
 
 using System.Data;
 using System.Text.Json.Serialization;
+using System.Threading;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata;
 

--- a/src/Persistence/EntityFramework/LetterBodyRepository.cs
+++ b/src/Persistence/EntityFramework/LetterBodyRepository.cs
@@ -4,10 +4,10 @@
 
 namespace MUnique.OpenMU.Persistence.EntityFramework;
 
+using System.Threading;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using MUnique.OpenMU.Persistence.EntityFramework.Model;
-using System.Threading;
 
 /// <summary>
 /// Repository which is able to load <see cref="LetterBody"/>s for a specific letter header.

--- a/src/Persistence/EntityFramework/Migrations/00000000000000_Initial.cs
+++ b/src/Persistence/EntityFramework/Migrations/00000000000000_Initial.cs
@@ -1,12 +1,17 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="00000000000000_Initial.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using System;
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     public partial class Initial : Migration
     {
+        /// <inheritdoc/>
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.EnsureSchema(
@@ -32,7 +37,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     MaximumConnections = table.Column<int>(type: "integer", nullable: false),
                     ClientTimeout = table.Column<TimeSpan>(type: "interval", nullable: false),
                     ClientCleanUpInterval = table.Column<TimeSpan>(type: "interval", nullable: false),
-                    RoomCleanUpInterval = table.Column<TimeSpan>(type: "interval", nullable: false)
+                    RoomCleanUpInterval = table.Column<TimeSpan>(type: "interval", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -48,7 +53,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     CharacterId = table.Column<Guid>(type: "uuid", nullable: false),
                     FriendId = table.Column<Guid>(type: "uuid", nullable: false),
                     Accepted = table.Column<bool>(type: "boolean", nullable: false),
-                    RequestOpen = table.Column<bool>(type: "boolean", nullable: false)
+                    RequestOpen = table.Column<bool>(type: "boolean", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -67,7 +72,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     Language = table.Column<int>(type: "integer", nullable: false),
                     Version = table.Column<byte[]>(type: "bytea", nullable: true),
                     Serial = table.Column<byte[]>(type: "bytea", nullable: true),
-                    Description = table.Column<string>(type: "text", nullable: false)
+                    Description = table.Column<string>(type: "text", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -98,7 +103,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     ShouldDropMoney = table.Column<bool>(type: "boolean", nullable: false),
                     DamagePerOneItemDurability = table.Column<double>(type: "double precision", nullable: false),
                     DamagePerOnePetDurability = table.Column<double>(type: "double precision", nullable: false),
-                    HitsPerOneItemDurability = table.Column<double>(type: "double precision", nullable: false)
+                    HitsPerOneItemDurability = table.Column<double>(type: "double precision", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -111,7 +116,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 columns: table => new
                 {
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
-                    MaximumPlayers = table.Column<short>(type: "smallint", nullable: false)
+                    MaximumPlayers = table.Column<short>(type: "smallint", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -129,7 +134,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     Name = table.Column<string>(type: "character varying(8)", maxLength: 8, nullable: false),
                     Logo = table.Column<byte[]>(type: "bytea", nullable: true),
                     Score = table.Column<int>(type: "integer", nullable: false),
-                    Notice = table.Column<string>(type: "text", nullable: true)
+                    Notice = table.Column<string>(type: "text", nullable: true),
                 },
                 constraints: table =>
                 {
@@ -154,7 +159,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 columns: table => new
                 {
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
-                    Money = table.Column<int>(type: "integer", nullable: false)
+                    Money = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -168,7 +173,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 {
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     Value = table.Column<float>(type: "real", nullable: false),
-                    AggregateType = table.Column<int>(type: "integer", nullable: false)
+                    AggregateType = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -184,7 +189,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     X1 = table.Column<byte>(type: "smallint", nullable: false),
                     Y1 = table.Column<byte>(type: "smallint", nullable: false),
                     X2 = table.Column<byte>(type: "smallint", nullable: false),
-                    Y2 = table.Column<byte>(type: "smallint", nullable: false)
+                    Y2 = table.Column<byte>(type: "smallint", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -210,7 +215,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     ResultItemLuckOptionChance = table.Column<byte>(type: "smallint", nullable: false),
                     ResultItemSkillChance = table.Column<byte>(type: "smallint", nullable: false),
                     ResultItemExcellentOptionChance = table.Column<byte>(type: "smallint", nullable: false),
-                    ResultItemMaxExcOptionCount = table.Column<byte>(type: "smallint", nullable: false)
+                    ResultItemMaxExcOptionCount = table.Column<byte>(type: "smallint", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -225,7 +230,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     ClientId = table.Column<Guid>(type: "uuid", nullable: true),
                     ChatServerDefinitionId = table.Column<Guid>(type: "uuid", nullable: true),
-                    NetworkPort = table.Column<int>(type: "integer", nullable: false)
+                    NetworkPort = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -265,7 +270,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     ListenerBacklog = table.Column<int>(type: "integer", nullable: false),
                     MaxFtpRequests = table.Column<int>(type: "integer", nullable: false),
                     MaxIpRequests = table.Column<int>(type: "integer", nullable: false),
-                    MaxServerListRequests = table.Column<int>(type: "integer", nullable: false)
+                    MaxServerListRequests = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -286,7 +291,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     GameConfigurationId = table.Column<Guid>(type: "uuid", nullable: true),
                     Designation = table.Column<string>(type: "text", nullable: true),
-                    Description = table.Column<string>(type: "text", nullable: true)
+                    Description = table.Column<string>(type: "text", nullable: true),
                 },
                 constraints: table =>
                 {
@@ -307,7 +312,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     GameConfigurationId = table.Column<Guid>(type: "uuid", nullable: true),
                     Name = table.Column<string>(type: "text", nullable: false),
-                    Description = table.Column<string>(type: "text", nullable: false)
+                    Description = table.Column<string>(type: "text", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -330,7 +335,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     Name = table.Column<string>(type: "text", nullable: false),
                     AddsRandomly = table.Column<bool>(type: "boolean", nullable: false),
                     AddChance = table.Column<float>(type: "real", nullable: false),
-                    MaximumOptionsPerItem = table.Column<int>(type: "integer", nullable: false)
+                    MaximumOptionsPerItem = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -352,7 +357,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     GameConfigurationId = table.Column<Guid>(type: "uuid", nullable: true),
                     Name = table.Column<string>(type: "text", nullable: false),
                     Description = table.Column<string>(type: "text", nullable: false),
-                    IsVisible = table.Column<bool>(type: "boolean", nullable: false)
+                    IsVisible = table.Column<bool>(type: "boolean", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -376,7 +381,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     AlwaysApplies = table.Column<bool>(type: "boolean", nullable: false),
                     CountDistinct = table.Column<bool>(type: "boolean", nullable: false),
                     MinimumItemCount = table.Column<int>(type: "integer", nullable: false),
-                    SetLevel = table.Column<int>(type: "integer", nullable: false)
+                    SetLevel = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -397,7 +402,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     ItemSlots = table.Column<string>(type: "text", nullable: true),
                     GameConfigurationId = table.Column<Guid>(type: "uuid", nullable: true),
-                    Description = table.Column<string>(type: "text", nullable: false)
+                    Description = table.Column<string>(type: "text", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -417,7 +422,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 {
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     GameConfigurationId = table.Column<Guid>(type: "uuid", nullable: true),
-                    Name = table.Column<string>(type: "text", nullable: false)
+                    Name = table.Column<string>(type: "text", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -441,7 +446,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     IsActive = table.Column<bool>(type: "boolean", nullable: false),
                     CustomPlugInSource = table.Column<string>(type: "text", nullable: true),
                     ExternalAssemblyName = table.Column<string>(type: "text", nullable: true),
-                    CustomConfiguration = table.Column<string>(type: "text", nullable: true)
+                    CustomConfiguration = table.Column<string>(type: "text", nullable: true),
                 },
                 constraints: table =>
                 {
@@ -464,7 +469,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     GameConfigurationId = table.Column<Guid>(type: "uuid", nullable: true),
                     ServerID = table.Column<byte>(type: "smallint", nullable: false),
                     Description = table.Column<string>(type: "text", nullable: false),
-                    ExperienceRate = table.Column<float>(type: "real", nullable: false)
+                    ExperienceRate = table.Column<float>(type: "real", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -498,7 +503,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     State = table.Column<int>(type: "integer", nullable: false),
                     TimeZone = table.Column<short>(type: "smallint", nullable: false),
                     VaultPassword = table.Column<string>(type: "text", nullable: false),
-                    IsVaultExtended = table.Column<bool>(type: "boolean", nullable: false)
+                    IsVaultExtended = table.Column<bool>(type: "boolean", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -524,7 +529,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     SubType = table.Column<byte>(type: "smallint", nullable: false),
                     InformObservers = table.Column<bool>(type: "boolean", nullable: false),
                     StopByDeath = table.Column<bool>(type: "boolean", nullable: false),
-                    SendDuration = table.Column<bool>(type: "boolean", nullable: false)
+                    SendDuration = table.Column<bool>(type: "boolean", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -556,7 +561,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     LeftTeamSpawnPointX = table.Column<byte>(type: "smallint", nullable: true),
                     LeftTeamSpawnPointY = table.Column<byte>(type: "smallint", nullable: false),
                     RightTeamSpawnPointX = table.Column<byte>(type: "smallint", nullable: true),
-                    RightTeamSpawnPointY = table.Column<byte>(type: "smallint", nullable: false)
+                    RightTeamSpawnPointY = table.Column<byte>(type: "smallint", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -596,7 +601,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     FailResult = table.Column<int>(type: "integer", nullable: false),
                     NpcPriceDivisor = table.Column<int>(type: "integer", nullable: false),
                     AddPercentage = table.Column<byte>(type: "smallint", nullable: false),
-                    Reference = table.Column<byte>(type: "smallint", nullable: false)
+                    Reference = table.Column<byte>(type: "smallint", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -617,7 +622,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     ItemLevelBonusTableId = table.Column<Guid>(type: "uuid", nullable: true),
                     Level = table.Column<int>(type: "integer", nullable: false),
-                    AdditionalValue = table.Column<float>(type: "real", nullable: false)
+                    AdditionalValue = table.Column<float>(type: "real", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -639,7 +644,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     ClientId = table.Column<Guid>(type: "uuid", nullable: true),
                     GameServerDefinitionId = table.Column<Guid>(type: "uuid", nullable: true),
                     NetworkPort = table.Column<int>(type: "integer", nullable: false),
-                    AlternativePublishedPort = table.Column<int>(type: "integer", nullable: false)
+                    AlternativePublishedPort = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -666,7 +671,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     TargetAttributeId = table.Column<Guid>(type: "uuid", nullable: true),
                     BoostId = table.Column<Guid>(type: "uuid", nullable: true),
-                    MagicEffectDefinitionId = table.Column<Guid>(type: "uuid", nullable: true)
+                    MagicEffectDefinitionId = table.Column<Guid>(type: "uuid", nullable: true),
                 },
                 constraints: table =>
                 {
@@ -704,7 +709,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     Name = table.Column<string>(type: "text", nullable: false),
                     TerrainData = table.Column<byte[]>(type: "bytea", nullable: true),
                     ExpMultiplier = table.Column<double>(type: "double precision", nullable: false),
-                    Discriminator = table.Column<int>(type: "integer", nullable: false)
+                    Discriminator = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -735,7 +740,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 columns: table => new
                 {
                     ItemCraftingRequiredItemId = table.Column<Guid>(type: "uuid", nullable: false),
-                    ItemOptionTypeId = table.Column<Guid>(type: "uuid", nullable: false)
+                    ItemOptionTypeId = table.Column<Guid>(type: "uuid", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -768,7 +773,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     ItemSetGroupId = table.Column<Guid>(type: "uuid", nullable: true),
                     Number = table.Column<int>(type: "integer", nullable: false),
                     SubOptionType = table.Column<int>(type: "integer", nullable: false),
-                    LevelType = table.Column<int>(type: "integer", nullable: false)
+                    LevelType = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -809,7 +814,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     GameConfigurationId = table.Column<Guid>(type: "uuid", nullable: true),
                     Description = table.Column<string>(type: "text", nullable: false),
                     Number = table.Column<int>(type: "integer", nullable: false),
-                    AppliesMultipleTimes = table.Column<bool>(type: "boolean", nullable: false)
+                    AppliesMultipleTimes = table.Column<bool>(type: "boolean", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -844,7 +849,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     CreationAllowedFlag = table.Column<byte>(type: "smallint", nullable: false),
                     IsMasterClass = table.Column<bool>(type: "boolean", nullable: false),
                     LevelWarpRequirementReductionPercent = table.Column<int>(type: "integer", nullable: false),
-                    FruitCalculation = table.Column<int>(type: "integer", nullable: false)
+                    FruitCalculation = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -881,7 +886,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     X2 = table.Column<byte>(type: "smallint", nullable: false),
                     Y2 = table.Column<byte>(type: "smallint", nullable: false),
                     Direction = table.Column<int>(type: "integer", nullable: false),
-                    IsSpawnGate = table.Column<bool>(type: "boolean", nullable: false)
+                    IsSpawnGate = table.Column<bool>(type: "boolean", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -900,7 +905,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 columns: table => new
                 {
                     GameServerConfigurationId = table.Column<Guid>(type: "uuid", nullable: false),
-                    GameMapDefinitionId = table.Column<Guid>(type: "uuid", nullable: false)
+                    GameMapDefinitionId = table.Column<Guid>(type: "uuid", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -930,7 +935,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     PowerUpDefinitionId = table.Column<Guid>(type: "uuid", nullable: true),
                     IncreasableItemOptionId = table.Column<Guid>(type: "uuid", nullable: true),
                     Level = table.Column<int>(type: "integer", nullable: false),
-                    RequiredItemLevel = table.Column<int>(type: "integer", nullable: false)
+                    RequiredItemLevel = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -958,7 +963,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     OptionTypeId = table.Column<Guid>(type: "uuid", nullable: true),
                     ItemOptionCombinationBonusId = table.Column<Guid>(type: "uuid", nullable: true),
                     SubOptionType = table.Column<int>(type: "integer", nullable: false),
-                    MinimumCount = table.Column<int>(type: "integer", nullable: false)
+                    MinimumCount = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -983,7 +988,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 columns: table => new
                 {
                     AccountId = table.Column<Guid>(type: "uuid", nullable: false),
-                    CharacterClassId = table.Column<Guid>(type: "uuid", nullable: false)
+                    CharacterClassId = table.Column<Guid>(type: "uuid", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1012,7 +1017,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     CharacterClassId = table.Column<Guid>(type: "uuid", nullable: true),
                     Pose = table.Column<byte>(type: "smallint", nullable: false),
-                    FullAncientSetEquipped = table.Column<bool>(type: "boolean", nullable: false)
+                    FullAncientSetEquipped = table.Column<bool>(type: "boolean", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1036,7 +1041,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     CharacterClassId = table.Column<Guid>(type: "uuid", nullable: true),
                     PowerUpDefinitionValueId = table.Column<Guid>(type: "uuid", nullable: true),
                     InputOperator = table.Column<int>(type: "integer", nullable: false),
-                    InputOperand = table.Column<float>(type: "real", nullable: false)
+                    InputOperand = table.Column<float>(type: "real", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1094,7 +1099,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     UsedFruitPoints = table.Column<int>(type: "integer", nullable: false),
                     UsedNegFruitPoints = table.Column<int>(type: "integer", nullable: false),
                     InventoryExtensions = table.Column<int>(type: "integer", nullable: false),
-                    KeyConfiguration = table.Column<byte[]>(type: "bytea", nullable: true)
+                    KeyConfiguration = table.Column<byte[]>(type: "bytea", nullable: true),
                 },
                 constraints: table =>
                 {
@@ -1135,7 +1140,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     DefinitionId = table.Column<Guid>(type: "uuid", nullable: true),
                     CharacterClassId = table.Column<Guid>(type: "uuid", nullable: false),
-                    Value = table.Column<float>(type: "real", nullable: false)
+                    Value = table.Column<float>(type: "real", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1164,7 +1169,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     AttributeId = table.Column<Guid>(type: "uuid", nullable: true),
                     CharacterClassId = table.Column<Guid>(type: "uuid", nullable: true),
                     BaseValue = table.Column<float>(type: "real", nullable: false),
-                    IncreasableByPlayer = table.Column<bool>(type: "boolean", nullable: false)
+                    IncreasableByPlayer = table.Column<bool>(type: "boolean", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1196,7 +1201,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     X2 = table.Column<byte>(type: "smallint", nullable: false),
                     Y2 = table.Column<byte>(type: "smallint", nullable: false),
                     LevelRequirement = table.Column<short>(type: "smallint", nullable: false),
-                    Number = table.Column<short>(type: "smallint", nullable: false)
+                    Number = table.Column<short>(type: "smallint", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1226,7 +1231,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     Index = table.Column<int>(type: "integer", nullable: false),
                     Name = table.Column<string>(type: "text", nullable: false),
                     Costs = table.Column<int>(type: "integer", nullable: false),
-                    LevelRequirement = table.Column<int>(type: "integer", nullable: false)
+                    LevelRequirement = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1252,7 +1257,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 {
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     GuildId = table.Column<Guid>(type: "uuid", nullable: false),
-                    Status = table.Column<byte>(type: "smallint", nullable: false)
+                    Status = table.Column<byte>(type: "smallint", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1283,7 +1288,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     SenderName = table.Column<string>(type: "text", nullable: true),
                     Subject = table.Column<string>(type: "text", nullable: true),
                     LetterDate = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
-                    ReadFlag = table.Column<bool>(type: "boolean", nullable: false)
+                    ReadFlag = table.Column<bool>(type: "boolean", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1305,7 +1310,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     DefinitionId = table.Column<Guid>(type: "uuid", nullable: true),
                     CharacterId = table.Column<Guid>(type: "uuid", nullable: true),
-                    Value = table.Column<float>(type: "real", nullable: false)
+                    Value = table.Column<float>(type: "real", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1334,7 +1339,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     SenderAppearanceId = table.Column<Guid>(type: "uuid", nullable: true),
                     Message = table.Column<string>(type: "text", nullable: false),
                     Rotation = table.Column<byte>(type: "smallint", nullable: false),
-                    Animation = table.Column<byte>(type: "smallint", nullable: false)
+                    Animation = table.Column<byte>(type: "smallint", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1359,7 +1364,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 columns: table => new
                 {
                     CharacterId = table.Column<Guid>(type: "uuid", nullable: false),
-                    DropItemGroupId = table.Column<Guid>(type: "uuid", nullable: false)
+                    DropItemGroupId = table.Column<Guid>(type: "uuid", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1383,7 +1388,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     ActiveQuestId = table.Column<Guid>(type: "uuid", nullable: true),
                     CharacterId = table.Column<Guid>(type: "uuid", nullable: true),
                     Group = table.Column<short>(type: "smallint", nullable: false),
-                    ClientActionPerformed = table.Column<bool>(type: "boolean", nullable: false)
+                    ClientActionPerformed = table.Column<bool>(type: "boolean", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1409,7 +1414,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     MinimumMonsterLevel = table.Column<byte>(type: "smallint", nullable: true),
                     MaximumMonsterLevel = table.Column<byte>(type: "smallint", nullable: true),
                     ItemLevel = table.Column<byte>(type: "smallint", nullable: true),
-                    ItemType = table.Column<int>(type: "integer", nullable: false)
+                    ItemType = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1428,7 +1433,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 columns: table => new
                 {
                     GameMapDefinitionId = table.Column<Guid>(type: "uuid", nullable: false),
-                    DropItemGroupId = table.Column<Guid>(type: "uuid", nullable: false)
+                    DropItemGroupId = table.Column<Guid>(type: "uuid", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1455,7 +1460,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 columns: table => new
                 {
                     DropItemGroupId = table.Column<Guid>(type: "uuid", nullable: false),
-                    ItemDefinitionId = table.Column<Guid>(type: "uuid", nullable: false)
+                    ItemDefinitionId = table.Column<Guid>(type: "uuid", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1482,7 +1487,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     Level = table.Column<byte>(type: "smallint", nullable: false),
                     HasSkill = table.Column<bool>(type: "boolean", nullable: false),
                     SocketCount = table.Column<int>(type: "integer", nullable: false),
-                    StorePrice = table.Column<int>(type: "integer", nullable: true)
+                    StorePrice = table.Column<int>(type: "integer", nullable: true),
                 },
                 constraints: table =>
                 {
@@ -1504,7 +1509,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     ItemOptionId = table.Column<Guid>(type: "uuid", nullable: true),
                     ItemId = table.Column<Guid>(type: "uuid", nullable: true),
                     Level = table.Column<int>(type: "integer", nullable: false),
-                    Index = table.Column<int>(type: "integer", nullable: false)
+                    Index = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1532,7 +1537,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     DefinitionId = table.Column<Guid>(type: "uuid", nullable: true),
                     AppearanceDataId = table.Column<Guid>(type: "uuid", nullable: true),
                     ItemSlot = table.Column<byte>(type: "smallint", nullable: false),
-                    Level = table.Column<byte>(type: "smallint", nullable: false)
+                    Level = table.Column<byte>(type: "smallint", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1551,7 +1556,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 columns: table => new
                 {
                     ItemAppearanceId = table.Column<Guid>(type: "uuid", nullable: false),
-                    ItemOptionTypeId = table.Column<Guid>(type: "uuid", nullable: false)
+                    ItemOptionTypeId = table.Column<Guid>(type: "uuid", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1581,7 +1586,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     TargetAttributeId = table.Column<Guid>(type: "uuid", nullable: true),
                     BonusPerLevelTableId = table.Column<Guid>(type: "uuid", nullable: true),
                     ItemDefinitionId = table.Column<Guid>(type: "uuid", nullable: true),
-                    BaseValue = table.Column<float>(type: "real", nullable: false)
+                    BaseValue = table.Column<float>(type: "real", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1610,7 +1615,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     MonsterDefinitionId = table.Column<Guid>(type: "uuid", nullable: true),
                     Number = table.Column<byte>(type: "smallint", nullable: false),
                     Name = table.Column<string>(type: "text", nullable: false),
-                    ItemCraftingHandlerClassName = table.Column<string>(type: "text", nullable: false)
+                    ItemCraftingHandlerClassName = table.Column<string>(type: "text", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1629,7 +1634,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 columns: table => new
                 {
                     ItemCraftingRequiredItemId = table.Column<Guid>(type: "uuid", nullable: false),
-                    ItemDefinitionId = table.Column<Guid>(type: "uuid", nullable: false)
+                    ItemDefinitionId = table.Column<Guid>(type: "uuid", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1655,7 +1660,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     RandomMaximumLevel = table.Column<byte>(type: "smallint", nullable: false),
                     Durability = table.Column<byte>(type: "smallint", nullable: true),
                     Reference = table.Column<byte>(type: "smallint", nullable: false),
-                    AddLevel = table.Column<byte>(type: "smallint", nullable: false)
+                    AddLevel = table.Column<byte>(type: "smallint", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1691,7 +1696,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     Group = table.Column<byte>(type: "smallint", nullable: false),
                     Value = table.Column<int>(type: "integer", nullable: false),
                     ConsumeHandlerClass = table.Column<string>(type: "text", nullable: true),
-                    MaximumSockets = table.Column<int>(type: "integer", nullable: false)
+                    MaximumSockets = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1722,7 +1727,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 columns: table => new
                 {
                     ItemDefinitionId = table.Column<Guid>(type: "uuid", nullable: false),
-                    CharacterClassId = table.Column<Guid>(type: "uuid", nullable: false)
+                    CharacterClassId = table.Column<Guid>(type: "uuid", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1749,7 +1754,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 columns: table => new
                 {
                     ItemDefinitionId = table.Column<Guid>(type: "uuid", nullable: false),
-                    ItemOptionDefinitionId = table.Column<Guid>(type: "uuid", nullable: false)
+                    ItemOptionDefinitionId = table.Column<Guid>(type: "uuid", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1776,7 +1781,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 columns: table => new
                 {
                     ItemDefinitionId = table.Column<Guid>(type: "uuid", nullable: false),
-                    ItemSetGroupId = table.Column<Guid>(type: "uuid", nullable: false)
+                    ItemSetGroupId = table.Column<Guid>(type: "uuid", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1806,7 +1811,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     ItemSetGroupId = table.Column<Guid>(type: "uuid", nullable: true),
                     ItemDefinitionId = table.Column<Guid>(type: "uuid", nullable: true),
                     BonusOptionId = table.Column<Guid>(type: "uuid", nullable: true),
-                    AncientSetDiscriminator = table.Column<int>(type: "integer", nullable: false)
+                    AncientSetDiscriminator = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1840,7 +1845,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     SingleJewelId = table.Column<Guid>(type: "uuid", nullable: true),
                     MixedJewelId = table.Column<Guid>(type: "uuid", nullable: true),
                     GameConfigurationId = table.Column<Guid>(type: "uuid", nullable: true),
-                    Number = table.Column<byte>(type: "smallint", nullable: false)
+                    Number = table.Column<byte>(type: "smallint", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1889,7 +1894,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     MaximumCharacterLevel = table.Column<int>(type: "integer", nullable: false),
                     MinimumSpecialCharacterLevel = table.Column<int>(type: "integer", nullable: false),
                     MaximumSpecialCharacterLevel = table.Column<int>(type: "integer", nullable: false),
-                    TicketItemLevel = table.Column<int>(type: "integer", nullable: false)
+                    TicketItemLevel = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1920,7 +1925,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 columns: table => new
                 {
                     ItemId = table.Column<Guid>(type: "uuid", nullable: false),
-                    ItemOfItemSetId = table.Column<Guid>(type: "uuid", nullable: false)
+                    ItemOfItemSetId = table.Column<Guid>(type: "uuid", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1952,7 +1957,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     GameInstanceId = table.Column<Guid>(type: "uuid", nullable: false),
                     Timestamp = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
                     Score = table.Column<int>(type: "integer", nullable: false),
-                    Rank = table.Column<int>(type: "integer", nullable: false)
+                    Rank = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -1982,7 +1987,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     Description = table.Column<string>(type: "text", nullable: true),
                     Message = table.Column<string>(type: "text", nullable: true),
                     StartTime = table.Column<TimeSpan>(type: "interval", nullable: false),
-                    EndTime = table.Column<TimeSpan>(type: "interval", nullable: false)
+                    EndTime = table.Column<TimeSpan>(type: "interval", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -2006,7 +2011,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     ItemDefinitionId = table.Column<Guid>(type: "uuid", nullable: true),
                     SkillId = table.Column<Guid>(type: "uuid", nullable: true),
                     SkillId1 = table.Column<Guid>(type: "uuid", nullable: true),
-                    MinimumValue = table.Column<int>(type: "integer", nullable: false)
+                    MinimumValue = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -2050,7 +2055,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     MinimumLevel = table.Column<byte>(type: "smallint", nullable: false),
                     MaximumLevel = table.Column<byte>(type: "smallint", nullable: false),
                     RequiredCharacterLevel = table.Column<short>(type: "smallint", nullable: false),
-                    DropEffect = table.Column<int>(type: "integer", nullable: false)
+                    DropEffect = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -2069,7 +2074,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 columns: table => new
                 {
                     ItemDropItemGroupId = table.Column<Guid>(type: "uuid", nullable: false),
-                    ItemDefinitionId = table.Column<Guid>(type: "uuid", nullable: false)
+                    ItemDefinitionId = table.Column<Guid>(type: "uuid", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -2104,7 +2109,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     MinimumLevel = table.Column<byte>(type: "smallint", nullable: false),
                     ValueFormula = table.Column<string>(type: "text", nullable: false),
                     DisplayValueFormula = table.Column<string>(type: "text", nullable: false),
-                    Aggregation = table.Column<int>(type: "integer", nullable: false)
+                    Aggregation = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -2143,7 +2148,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     TargetRestriction = table.Column<int>(type: "integer", nullable: false),
                     MovesToTarget = table.Column<bool>(type: "boolean", nullable: false),
                     MovesTarget = table.Column<bool>(type: "boolean", nullable: false),
-                    AttackDamage = table.Column<int>(type: "integer", nullable: false)
+                    AttackDamage = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -2180,7 +2185,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 columns: table => new
                 {
                     MasterSkillDefinitionId = table.Column<Guid>(type: "uuid", nullable: false),
-                    SkillId = table.Column<Guid>(type: "uuid", nullable: false)
+                    SkillId = table.Column<Guid>(type: "uuid", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -2222,7 +2227,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     NumberOfMaximumItemDrops = table.Column<int>(type: "integer", nullable: false),
                     NpcWindow = table.Column<int>(type: "integer", nullable: false),
                     ObjectKind = table.Column<int>(type: "integer", nullable: false),
-                    IntelligenceTypeName = table.Column<string>(type: "text", nullable: true)
+                    IntelligenceTypeName = table.Column<string>(type: "text", nullable: true),
                 },
                 constraints: table =>
                 {
@@ -2253,7 +2258,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 columns: table => new
                 {
                     SkillId = table.Column<Guid>(type: "uuid", nullable: false),
-                    CharacterClassId = table.Column<Guid>(type: "uuid", nullable: false)
+                    CharacterClassId = table.Column<Guid>(type: "uuid", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -2282,7 +2287,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     SkillId = table.Column<Guid>(type: "uuid", nullable: true),
                     CharacterId = table.Column<Guid>(type: "uuid", nullable: true),
-                    Level = table.Column<int>(type: "integer", nullable: false)
+                    Level = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -2313,7 +2318,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     Rank = table.Column<int>(type: "integer", nullable: true),
                     RewardType = table.Column<int>(type: "integer", nullable: false),
                     RewardAmount = table.Column<int>(type: "integer", nullable: false),
-                    RequiredSuccess = table.Column<int>(type: "integer", nullable: false)
+                    RequiredSuccess = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -2346,7 +2351,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     AttributeDefinitionId = table.Column<Guid>(type: "uuid", nullable: true),
                     MonsterDefinitionId = table.Column<Guid>(type: "uuid", nullable: true),
-                    Value = table.Column<float>(type: "real", nullable: false)
+                    Value = table.Column<float>(type: "real", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -2371,7 +2376,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 columns: table => new
                 {
                     MonsterDefinitionId = table.Column<Guid>(type: "uuid", nullable: false),
-                    DropItemGroupId = table.Column<Guid>(type: "uuid", nullable: false)
+                    DropItemGroupId = table.Column<Guid>(type: "uuid", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -2408,7 +2413,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     Quantity = table.Column<short>(type: "smallint", nullable: false),
                     SpawnTrigger = table.Column<int>(type: "integer", nullable: false),
                     WaveNumber = table.Column<byte>(type: "smallint", nullable: false),
-                    MaximumHealthOverride = table.Column<int>(type: "integer", nullable: true)
+                    MaximumHealthOverride = table.Column<int>(type: "integer", nullable: true),
                 },
                 constraints: table =>
                 {
@@ -2445,7 +2450,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     RequiresClientAction = table.Column<bool>(type: "boolean", nullable: false),
                     RequiredStartMoney = table.Column<int>(type: "integer", nullable: false),
                     MinimumCharacterLevel = table.Column<int>(type: "integer", nullable: false),
-                    MaximumCharacterLevel = table.Column<int>(type: "integer", nullable: false)
+                    MaximumCharacterLevel = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -2485,7 +2490,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     Target = table.Column<int>(type: "integer", nullable: false),
                     MinimumTargetLevel = table.Column<short>(type: "smallint", nullable: true),
                     NumberOfKills = table.Column<short>(type: "smallint", nullable: false),
-                    MultiplyKillsByPlayers = table.Column<bool>(type: "boolean", nullable: false)
+                    MultiplyKillsByPlayers = table.Column<bool>(type: "boolean", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -2519,7 +2524,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     ItemId = table.Column<Guid>(type: "uuid", nullable: true),
                     DropItemGroupId = table.Column<Guid>(type: "uuid", nullable: true),
                     QuestDefinitionId = table.Column<Guid>(type: "uuid", nullable: true),
-                    MinimumNumber = table.Column<int>(type: "integer", nullable: false)
+                    MinimumNumber = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -2552,7 +2557,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     MonsterId = table.Column<Guid>(type: "uuid", nullable: true),
                     QuestDefinitionId = table.Column<Guid>(type: "uuid", nullable: true),
-                    MinimumNumber = table.Column<int>(type: "integer", nullable: false)
+                    MinimumNumber = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -2582,7 +2587,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     SkillRewardId = table.Column<Guid>(type: "uuid", nullable: true),
                     QuestDefinitionId = table.Column<Guid>(type: "uuid", nullable: true),
                     RewardType = table.Column<int>(type: "integer", nullable: false),
-                    Value = table.Column<int>(type: "integer", nullable: false)
+                    Value = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -2625,7 +2630,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     StartX = table.Column<byte>(type: "smallint", nullable: false),
                     StartY = table.Column<byte>(type: "smallint", nullable: false),
                     EndX = table.Column<byte>(type: "smallint", nullable: false),
-                    EndY = table.Column<byte>(type: "smallint", nullable: false)
+                    EndY = table.Column<byte>(type: "smallint", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -2646,7 +2651,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     RequirementId = table.Column<Guid>(type: "uuid", nullable: true),
                     CharacterQuestStateId = table.Column<Guid>(type: "uuid", nullable: true),
-                    KillCount = table.Column<int>(type: "integer", nullable: false)
+                    KillCount = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -3806,6 +3811,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 principalColumn: "Id");
         }
 
+        /// <inheritdoc/>
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropForeignKey(

--- a/src/Persistence/EntityFramework/Migrations/20221008183306_PetLevels.cs
+++ b/src/Persistence/EntityFramework/Migrations/20221008183306_PetLevels.cs
@@ -1,11 +1,16 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20221008183306_PetLevels.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     public partial class PetLevels : Migration
     {
+        /// <inheritdoc/>
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.AddColumn<string>(
@@ -24,6 +29,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 defaultValue: 0);
         }
 
+        /// <inheritdoc/>
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropColumn(

--- a/src/Persistence/EntityFramework/Migrations/20221018194652_Combo.cs
+++ b/src/Persistence/EntityFramework/Migrations/20221018194652_Combo.cs
@@ -1,12 +1,17 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20221018194652_Combo.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using System;
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     public partial class Combo : Migration
     {
+        /// <inheritdoc/>
         protected override void Up(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.AddColumn<Guid>(
@@ -23,7 +28,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 {
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     Name = table.Column<string>(type: "text", nullable: false),
-                    MaximumCompletionTime = table.Column<TimeSpan>(type: "interval", nullable: false)
+                    MaximumCompletionTime = table.Column<TimeSpan>(type: "interval", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -39,7 +44,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     SkillId = table.Column<Guid>(type: "uuid", nullable: true),
                     SkillComboDefinitionId = table.Column<Guid>(type: "uuid", nullable: true),
                     Order = table.Column<int>(type: "integer", nullable: false),
-                    IsFinalStep = table.Column<bool>(type: "boolean", nullable: false)
+                    IsFinalStep = table.Column<bool>(type: "boolean", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -86,6 +91,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 principalColumn: "Id");
         }
 
+        /// <inheritdoc/>
         protected override void Down(MigrationBuilder migrationBuilder)
         {
             migrationBuilder.DropForeignKey(

--- a/src/Persistence/EntityFramework/Migrations/20221121161552_DeleteCascade.cs
+++ b/src/Persistence/EntityFramework/Migrations/20221121161552_DeleteCascade.cs
@@ -1,10 +1,14 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20221121161552_DeleteCascade.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using System;
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class DeleteCascade : Migration
     {
@@ -505,7 +509,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     OptionTypeId = table.Column<Guid>(type: "uuid", nullable: true),
                     PowerUpDefinitionId = table.Column<Guid>(type: "uuid", nullable: true),
                     Number = table.Column<int>(type: "integer", nullable: false),
-                    SubOptionType = table.Column<int>(type: "integer", nullable: false)
+                    SubOptionType = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {

--- a/src/Persistence/EntityFramework/Migrations/20221121163220_AttributeRelationship_OperandAttribute.cs
+++ b/src/Persistence/EntityFramework/Migrations/20221121163220_AttributeRelationship_OperandAttribute.cs
@@ -1,10 +1,14 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20221121163220_AttributeRelationship_OperandAttribute.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using System;
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class AttributeRelationshipOperandAttribute : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20221128203249_RemoveConsumeHandler.cs
+++ b/src/Persistence/EntityFramework/Migrations/20221128203249_RemoveConsumeHandler.cs
@@ -1,9 +1,13 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20221128203249_RemoveConsumeHandler.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class RemoveConsumeHandler : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20221128204928_AddItemDropDuration.cs
+++ b/src/Persistence/EntityFramework/Migrations/20221128204928_AddItemDropDuration.cs
@@ -1,10 +1,14 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20221128204928_AddItemDropDuration.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using System;
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class AddItemDropDuration : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20221221182248_MuHelper.cs
+++ b/src/Persistence/EntityFramework/Migrations/20221221182248_MuHelper.cs
@@ -1,9 +1,13 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20221221182248_MuHelper.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class MuHelper : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20230303185735_ConfigurationUpdate.cs
+++ b/src/Persistence/EntityFramework/Migrations/20230303185735_ConfigurationUpdate.cs
@@ -1,10 +1,14 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20230303185735_ConfigurationUpdate.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using System;
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class ConfigurationUpdate : Migration
     {
@@ -21,7 +25,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     Name = table.Column<string>(type: "text", nullable: true),
                     Description = table.Column<string>(type: "text", nullable: true),
                     CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
-                    InstalledAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true)
+                    InstalledAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
                 },
                 constraints: table =>
                 {
@@ -35,7 +39,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 {
                     Id = table.Column<Guid>(type: "uuid", nullable: false),
                     InitializationKey = table.Column<string>(type: "text", nullable: true),
-                    CurrentInstalledVersion = table.Column<int>(type: "integer", nullable: false)
+                    CurrentInstalledVersion = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {

--- a/src/Persistence/EntityFramework/Migrations/20230306185635_MiniGameExt.cs
+++ b/src/Persistence/EntityFramework/Migrations/20230306185635_MiniGameExt.cs
@@ -1,10 +1,14 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20230306185635_MiniGameExt.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using System;
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class MiniGameExt : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20230324205415_AddSystemConfiguration.cs
+++ b/src/Persistence/EntityFramework/Migrations/20230324205415_AddSystemConfiguration.cs
@@ -1,10 +1,14 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20230324205415_AddSystemConfiguration.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using System;
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class AddSystemConfiguration : Migration
     {
@@ -26,7 +30,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     IpResolverParameter = table.Column<string>(type: "text", nullable: true),
                     AutoStart = table.Column<bool>(type: "boolean", nullable: false),
                     AutoUpdateSchema = table.Column<bool>(type: "boolean", nullable: false),
-                    ReadConsoleInput = table.Column<bool>(type: "boolean", nullable: false)
+                    ReadConsoleInput = table.Column<bool>(type: "boolean", nullable: false),
                 },
                 constraints: table =>
                 {

--- a/src/Persistence/EntityFramework/Migrations/20230504172021_StorageLimitPerCharacter.cs
+++ b/src/Persistence/EntityFramework/Migrations/20230504172021_StorageLimitPerCharacter.cs
@@ -1,9 +1,13 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20230504172021_StorageLimitPerCharacter.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class StorageLimitPerCharacter : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20230701010432_AddChatBanUntil.cs
+++ b/src/Persistence/EntityFramework/Migrations/20230701010432_AddChatBanUntil.cs
@@ -1,9 +1,13 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20230701010432_AddChatBanUntil.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class AddChatBanUntil : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20230724154747_AccountAndMapAttributes.cs
+++ b/src/Persistence/EntityFramework/Migrations/20230724154747_AccountAndMapAttributes.cs
@@ -1,10 +1,14 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20230724154747_AccountAndMapAttributes.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using System;
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class AccountAndMapAttributes : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20240602060055_FixItemOptions.cs
+++ b/src/Persistence/EntityFramework/Migrations/20240602060055_FixItemOptions.cs
@@ -1,9 +1,13 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20240602060055_FixItemOptions.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class FixItemOptions : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20240602085237_FixItemOptions2.cs
+++ b/src/Persistence/EntityFramework/Migrations/20240602085237_FixItemOptions2.cs
@@ -1,10 +1,14 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20240602085237_FixItemOptions2.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using System;
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class FixItemOptions2 : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20240707081614_DuelConfiguration.cs
+++ b/src/Persistence/EntityFramework/Migrations/20240707081614_DuelConfiguration.cs
@@ -1,10 +1,14 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20240707081614_DuelConfiguration.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using System;
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class DuelConfiguration : Migration
     {
@@ -28,7 +32,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     MaximumScore = table.Column<int>(type: "integer", nullable: false),
                     EntranceFee = table.Column<int>(type: "integer", nullable: false),
                     MinimumCharacterLevel = table.Column<int>(type: "integer", nullable: false),
-                    MaximumSpectatorsPerDuelRoom = table.Column<int>(type: "integer", nullable: false)
+                    MaximumSpectatorsPerDuelRoom = table.Column<int>(type: "integer", nullable: false),
                 },
                 constraints: table =>
                 {
@@ -51,7 +55,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     SecondPlayerGateId = table.Column<Guid>(type: "uuid", nullable: true),
                     SpectatorsGateId = table.Column<Guid>(type: "uuid", nullable: true),
                     DuelConfigurationId = table.Column<Guid>(type: "uuid", nullable: true),
-                    Index = table.Column<short>(type: "smallint", nullable: false)
+                    Index = table.Column<short>(type: "smallint", nullable: false),
                 },
                 constraints: table =>
                 {

--- a/src/Persistence/EntityFramework/Migrations/20240714154210_FixSetOptions.cs
+++ b/src/Persistence/EntityFramework/Migrations/20240714154210_FixSetOptions.cs
@@ -1,4 +1,8 @@
-﻿#nullable disable
+﻿// <copyright file="20240714154210_FixSetOptions.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+#nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {

--- a/src/Persistence/EntityFramework/Migrations/20240805183034_ExpFormulas.cs
+++ b/src/Persistence/EntityFramework/Migrations/20240805183034_ExpFormulas.cs
@@ -1,9 +1,13 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20240805183034_ExpFormulas.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class ExpFormulas : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20240805184944_FixGameMapMonsterSpawnRelation.cs
+++ b/src/Persistence/EntityFramework/Migrations/20240805184944_FixGameMapMonsterSpawnRelation.cs
@@ -1,10 +1,14 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20240805184944_FixGameMapMonsterSpawnRelation.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using System;
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class FixGameMapMonsterSpawnRelation : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20240816132011_AddAggregateTypeToItemBasePowerUpDef.cs
+++ b/src/Persistence/EntityFramework/Migrations/20240816132011_AddAggregateTypeToItemBasePowerUpDef.cs
@@ -1,9 +1,13 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20240816132011_AddAggregateTypeToItemBasePowerUpDef.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class AddAggregateTypeToItemBasePowerUpDef : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20240902181002_AddPvpOptionToGameServer.cs
+++ b/src/Persistence/EntityFramework/Migrations/20240902181002_AddPvpOptionToGameServer.cs
@@ -1,9 +1,13 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20240902181002_AddPvpOptionToGameServer.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class AddPvpOptionToGameServer : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20241003093659_AddGameConfigurationMaxItemOptLevelDrop.cs
+++ b/src/Persistence/EntityFramework/Migrations/20241003093659_AddGameConfigurationMaxItemOptLevelDrop.cs
@@ -1,9 +1,13 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20241003093659_AddGameConfigurationMaxItemOptLevelDrop.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class AddGameConfigurationMaxItemOptLevelDrop : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20241018200704_AddAttributeMaximum.cs
+++ b/src/Persistence/EntityFramework/Migrations/20241018200704_AddAttributeMaximum.cs
@@ -1,9 +1,13 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20241018200704_AddAttributeMaximum.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class AddAttributeMaximum : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20241021134401_AddIncreasableItemOptionWeight.cs
+++ b/src/Persistence/EntityFramework/Migrations/20241021134401_AddIncreasableItemOptionWeight.cs
@@ -1,9 +1,13 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20241021134401_AddIncreasableItemOptionWeight.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class AddIncreasableItemOptionWeight : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20241021175011_AddAreaSkillConfiguration.cs
+++ b/src/Persistence/EntityFramework/Migrations/20241021175011_AddAreaSkillConfiguration.cs
@@ -1,10 +1,14 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20241021175011_AddAreaSkillConfiguration.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using System;
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class AddAreaSkillConfiguration : Migration
     {
@@ -36,7 +40,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                     MinimumNumberOfHitsPerTarget = table.Column<int>(type: "integer", nullable: false),
                     MaximumNumberOfHitsPerTarget = table.Column<int>(type: "integer", nullable: false),
                     MaximumNumberOfHitsPerAttack = table.Column<int>(type: "integer", nullable: false),
-                    HitChancePerDistanceMultiplier = table.Column<float>(type: "real", nullable: false)
+                    HitChancePerDistanceMultiplier = table.Column<float>(type: "real", nullable: false),
                 },
                 constraints: table =>
                 {

--- a/src/Persistence/EntityFramework/Migrations/20241204090233_UpdateSimpleCraftingSettings.cs
+++ b/src/Persistence/EntityFramework/Migrations/20241204090233_UpdateSimpleCraftingSettings.cs
@@ -1,9 +1,13 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20241204090233_UpdateSimpleCraftingSettings.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class UpdateSimpleCraftingSettings : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20250114201231_AddAccountIsTemplate.cs
+++ b/src/Persistence/EntityFramework/Migrations/20250114201231_AddAccountIsTemplate.cs
@@ -1,9 +1,13 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20250114201231_AddAccountIsTemplate.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class AddAccountIsTemplate : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20250228170503_AddMasterSkillDefinitionExtendsDuration.cs
+++ b/src/Persistence/EntityFramework/Migrations/20250228170503_AddMasterSkillDefinitionExtendsDuration.cs
@@ -1,9 +1,13 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20250228170503_AddMasterSkillDefinitionExtendsDuration.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class AddMasterSkillDefinitionExtendsDuration : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20250302164032_AddStoreProperties.cs
+++ b/src/Persistence/EntityFramework/Migrations/20250302164032_AddStoreProperties.cs
@@ -1,9 +1,13 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20250302164032_AddStoreProperties.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class AddStoreProperties : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20250728194753_AddSkillAttributeRelationships.cs
+++ b/src/Persistence/EntityFramework/Migrations/20250728194753_AddSkillAttributeRelationships.cs
@@ -1,10 +1,14 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20250728194753_AddSkillAttributeRelationships.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using System;
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class AddSkillAttributeRelationships : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20251019192544_AddAccountLanguage.cs
+++ b/src/Persistence/EntityFramework/Migrations/20251019192544_AddAccountLanguage.cs
@@ -1,9 +1,13 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20251019192544_AddAccountLanguage.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class AddAccountLanguage : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20251116031101_AddClampMoneyOnPickup.cs
+++ b/src/Persistence/EntityFramework/Migrations/20251116031101_AddClampMoneyOnPickup.cs
@@ -1,9 +1,13 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20251116031101_AddClampMoneyOnPickup.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class AddClampMoneyOnPickup : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20251117222914_PreventExperienceOverflowToggle.cs
+++ b/src/Persistence/EntityFramework/Migrations/20251117222914_PreventExperienceOverflowToggle.cs
@@ -1,9 +1,13 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20251117222914_PreventExperienceOverflowToggle.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class PreventExperienceOverflowToggle : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20251211145710_AddMagicEffectChanceAndOthers.cs
+++ b/src/Persistence/EntityFramework/Migrations/20251211145710_AddMagicEffectChanceAndOthers.cs
@@ -1,10 +1,14 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20251211145710_AddMagicEffectChanceAndOthers.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using System;
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class AddMagicEffectChanceAndOthers : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20251217154940_AddSkillNumberOfHitsPerAttack.cs
+++ b/src/Persistence/EntityFramework/Migrations/20251217154940_AddSkillNumberOfHitsPerAttack.cs
@@ -1,9 +1,13 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20251217154940_AddSkillNumberOfHitsPerAttack.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class AddSkillNumberOfHitsPerAttack : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20260103173108_AddProjectileCountToAreaSkillSettings.cs
+++ b/src/Persistence/EntityFramework/Migrations/20260103173108_AddProjectileCountToAreaSkillSettings.cs
@@ -1,9 +1,13 @@
-using Microsoft.EntityFrameworkCore.Migrations;
+// <copyright file="20260103173108_AddProjectileCountToAreaSkillSettings.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class AddProjectileCountToAreaSkillSettings : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20260202204523_NonNullableLocalizedString.cs
+++ b/src/Persistence/EntityFramework/Migrations/20260202204523_NonNullableLocalizedString.cs
@@ -1,9 +1,13 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20260202204523_NonNullableLocalizedString.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class NonNullableLocalizedString : Migration
     {
@@ -16,7 +20,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 table: "MiniGameSpawnWave",
                 type: "text",
                 nullable: false,
-                defaultValue: "",
+                defaultValue: string.Empty,
                 oldClrType: typeof(string),
                 oldType: "text",
                 oldNullable: true);
@@ -27,7 +31,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 table: "MiniGameSpawnWave",
                 type: "text",
                 nullable: false,
-                defaultValue: "",
+                defaultValue: string.Empty,
                 oldClrType: typeof(string),
                 oldType: "text",
                 oldNullable: true);
@@ -38,7 +42,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 table: "MiniGameChangeEvent",
                 type: "text",
                 nullable: false,
-                defaultValue: "",
+                defaultValue: string.Empty,
                 oldClrType: typeof(string),
                 oldType: "text",
                 oldNullable: true);
@@ -49,7 +53,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 table: "MiniGameChangeEvent",
                 type: "text",
                 nullable: false,
-                defaultValue: "",
+                defaultValue: string.Empty,
                 oldClrType: typeof(string),
                 oldType: "text",
                 oldNullable: true);
@@ -60,7 +64,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 table: "ConfigurationUpdate",
                 type: "text",
                 nullable: false,
-                defaultValue: "",
+                defaultValue: string.Empty,
                 oldClrType: typeof(string),
                 oldType: "text",
                 oldNullable: true);
@@ -71,7 +75,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 table: "ConfigurationUpdate",
                 type: "text",
                 nullable: false,
-                defaultValue: "",
+                defaultValue: string.Empty,
                 oldClrType: typeof(string),
                 oldType: "text",
                 oldNullable: true);

--- a/src/Persistence/EntityFramework/Migrations/20260320211230_AddGlobalAttributes.cs
+++ b/src/Persistence/EntityFramework/Migrations/20260320211230_AddGlobalAttributes.cs
@@ -1,10 +1,14 @@
-﻿using System;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20260320211230_AddGlobalAttributes.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using System;
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class AddGlobalAttributes : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20260324211344_ExtendAreaSkillSettings.cs
+++ b/src/Persistence/EntityFramework/Migrations/20260324211344_ExtendAreaSkillSettings.cs
@@ -1,9 +1,13 @@
-﻿using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20260324211344_ExtendAreaSkillSettings.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class ExtendAreaSkillSettings : Migration
     {

--- a/src/Persistence/EntityFramework/Migrations/20260402113000_AddGlobalMasterExperienceRate.cs
+++ b/src/Persistence/EntityFramework/Migrations/20260402113000_AddGlobalMasterExperienceRate.cs
@@ -1,10 +1,14 @@
-﻿using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Migrations;
+﻿// <copyright file="20260402113000_AddGlobalMasterExperienceRate.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using Microsoft.EntityFrameworkCore.Infrastructure;
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     [DbContext(typeof(EntityDataContext))]
     [Migration("20260402113000_AddGlobalMasterExperienceRate")]

--- a/src/Persistence/EntityFramework/Migrations/20260404225637_AddExcellentItemDropLevelDelta.cs
+++ b/src/Persistence/EntityFramework/Migrations/20260404225637_AddExcellentItemDropLevelDelta.cs
@@ -1,10 +1,14 @@
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Migrations;
+// <copyright file="20260404225637_AddExcellentItemDropLevelDelta.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using Microsoft.EntityFrameworkCore.Infrastructure;
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     [DbContext(typeof(EntityDataContext))]
     [Migration("20260404225637_AddExcellentItemDropLevelDelta")]

--- a/src/Persistence/EntityFramework/Migrations/20260405170905_UpdateDaybreakWeaponDimensions.cs
+++ b/src/Persistence/EntityFramework/Migrations/20260405170905_UpdateDaybreakWeaponDimensions.cs
@@ -1,10 +1,14 @@
-using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Migrations;
+// <copyright file="20260405170905_UpdateDaybreakWeaponDimensions.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using Microsoft.EntityFrameworkCore.Infrastructure;
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     [DbContext(typeof(EntityDataContext))]
     [Migration("20260405170905_UpdateDaybreakWeaponDimensions")]

--- a/src/Persistence/EntityFramework/Migrations/20260425205521_MaximumDropLevel.cs
+++ b/src/Persistence/EntityFramework/Migrations/20260425205521_MaximumDropLevel.cs
@@ -1,9 +1,13 @@
-using Microsoft.EntityFrameworkCore.Migrations;
+// <copyright file="20260425205521_MaximumDropLevel.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
 
 #nullable disable
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
+    using Microsoft.EntityFrameworkCore.Migrations;
+
     /// <inheritdoc />
     public partial class MaximumDropLevel : Migration
     {

--- a/src/Persistence/EntityFramework/Model/AttributeDefinition.Custom.cs
+++ b/src/Persistence/EntityFramework/Model/AttributeDefinition.Custom.cs
@@ -27,7 +27,7 @@ internal partial class AttributeDefinition :
     {
         if (other is AttributeSystem.AttributeDefinition typedOther)
         {
-            AssignValuesOf(typedOther, gameConfiguration);
+            this.AssignValuesOf(typedOther, gameConfiguration);
         }
     }
 

--- a/src/Persistence/EntityFramework/PersistenceContextProvider.cs
+++ b/src/Persistence/EntityFramework/PersistenceContextProvider.cs
@@ -240,6 +240,7 @@ public class PersistenceContextProvider : IMigratableDatabaseContextProvider
         return new GuildServerContext(new GuildContext(), this.RepositoryProvider, this._loggerFactory.CreateLogger<GuildServerContext>());
     }
 
+    /// <inheritdoc/>
     public IContext CreateNewTypedContext(Type editType, bool useCache, DataModel.Configuration.GameConfiguration? gameConfiguration = null)
     {
         if (!editType.IsConfigurationType() && gameConfiguration is null)

--- a/src/Persistence/IMigratableDatabaseContextProvider.cs
+++ b/src/Persistence/IMigratableDatabaseContextProvider.cs
@@ -7,7 +7,7 @@ using System.Threading;
 
 /// <summary>
 /// Provider for persistence contexts which supports database creation and migration.
-/// TODO: find better name? ;-)
+/// TODO: find better name?.
 /// </summary>
 public interface IMigratableDatabaseContextProvider : IPersistenceContextProvider
 {

--- a/src/Persistence/IPlayerContext.cs
+++ b/src/Persistence/IPlayerContext.cs
@@ -4,9 +4,9 @@
 
 namespace MUnique.OpenMU.Persistence;
 
+using System.Threading;
 using MUnique.OpenMU.DataModel.Entities;
 using MUnique.OpenMU.Interfaces;
-using System.Threading;
 
 /// <summary>
 /// Persistence context which is used by in-game players.

--- a/src/Persistence/InMemory/InMemoryPersistenceContextProvider.cs
+++ b/src/Persistence/InMemory/InMemoryPersistenceContextProvider.cs
@@ -2,14 +2,13 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
-using Nito.Disposables;
-
 namespace MUnique.OpenMU.Persistence.InMemory;
 
 using System.Threading;
 using MUnique.OpenMU.DataModel.Configuration;
 using MUnique.OpenMU.Interfaces;
 using MUnique.OpenMU.PlugIns;
+using Nito.Disposables;
 
 /// <summary>
 /// A context provider which uses in-memory repositories to hold its data, e.g. for testing or demo purposes.

--- a/src/Persistence/InMemory/InMemoryRepositoryProvider.cs
+++ b/src/Persistence/InMemory/InMemoryRepositoryProvider.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="InMemoryRepositoryManager.cs" company="MUnique">
+﻿// <copyright file="InMemoryRepositoryProvider.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 

--- a/src/Persistence/InMemory/PlayerInMemoryContext.cs
+++ b/src/Persistence/InMemory/PlayerInMemoryContext.cs
@@ -2,10 +2,9 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
-using System.Threading;
-
 namespace MUnique.OpenMU.Persistence.InMemory;
 
+using System.Threading;
 using MUnique.OpenMU.Persistence.BasicModel;
 
 /// <summary>

--- a/src/Persistence/Initialization/BaseMapInitializer.cs
+++ b/src/Persistence/Initialization/BaseMapInitializer.cs
@@ -2,9 +2,6 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
-using MUnique.OpenMU.Network;
-using MUnique.OpenMU.Persistence.Initialization.Updates;
-
 namespace MUnique.OpenMU.Persistence.Initialization;
 
 using System.Diagnostics;
@@ -14,6 +11,8 @@ using MUnique.OpenMU.AttributeSystem;
 using MUnique.OpenMU.DataModel.Configuration;
 using MUnique.OpenMU.DataModel.Configuration.Items;
 using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.Network;
+using MUnique.OpenMU.Persistence.Initialization.Updates;
 
 /// <summary>
 /// Base class for a map initializer which provides some common basic functionality.

--- a/src/Persistence/Initialization/BaseMapInitializer.cs
+++ b/src/Persistence/Initialization/BaseMapInitializer.cs
@@ -97,9 +97,9 @@ internal abstract class BaseMapInitializer : IMapInitializer
                 return this.MapDefinition.Number;
             }
 
-            return NumberConversionExtensions.MakeWord(
+            return (short)NumberConversionExtensions.MakeWord(
                 (byte)this._mapDefinition!.Number,
-                (byte)this._mapDefinition.Discriminator).ToSigned();
+                (byte)this._mapDefinition.Discriminator);
         }
     }
 

--- a/src/Persistence/Initialization/CharacterClasses/CharacterClasses.cs
+++ b/src/Persistence/Initialization/CharacterClasses/CharacterClasses.cs
@@ -21,82 +21,82 @@ public enum CharacterClasses : long
     All = 0xFFFFFFFF,
 
     /// <summary>
-    /// The dark wizard
+    /// The dark wizard.
     /// </summary>
     DarkWizard = 0b0000_0001,
 
     /// <summary>
-    /// The soul master
+    /// The soul master.
     /// </summary>
     SoulMaster = 0b0000_0010,
 
     /// <summary>
-    /// The grand master
+    /// The grand master.
     /// </summary>
     GrandMaster = 0b0000_0100,
 
     /// <summary>
-    /// The dark knight
+    /// The dark knight.
     /// </summary>
     DarkKnight = 0b0001_0000,
 
     /// <summary>
-    /// The blade knight
+    /// The blade knight.
     /// </summary>
     BladeKnight = 0b0010_0000,
 
     /// <summary>
-    /// The blade master
+    /// The blade master.
     /// </summary>
     BladeMaster = 0b0100_0000,
 
     /// <summary>
-    /// The fairy elf
+    /// The fairy elf.
     /// </summary>
     FairyElf = 0b0001_000_0000,
 
     /// <summary>
-    /// The muse elf
+    /// The muse elf.
     /// </summary>
     MuseElf = 0b0010_0000_0000,
 
     /// <summary>
-    /// The high elf
+    /// The high elf.
     /// </summary>
     HighElf = 0b0100_0000_0000,
 
     /// <summary>
-    /// The magic gladiator
+    /// The magic gladiator.
     /// </summary>
     MagicGladiator = 0b0001_0000_0000_0000,
 
     /// <summary>
-    /// The duel master
+    /// The duel master.
     /// </summary>
     DuelMaster = 0b0010_0000_0000_0000,
 
     /// <summary>
-    /// The dark lord
+    /// The dark lord.
     /// </summary>
     DarkLord = 0b0001_0000_0000_0000_0000,
 
     /// <summary>
-    /// The lord emperor
+    /// The lord emperor.
     /// </summary>
     LordEmperor = 0b0010_0000_0000_0000_0000,
 
     /// <summary>
-    /// The summoner
+    /// The summoner.
     /// </summary>
     Summoner = 0b0001_0000_0000_0000_0000_0000,
 
     /// <summary>
-    /// The bloody summoner
+    /// The bloody summoner.
     /// </summary>
     BloodySummoner = 0b0010_0000_0000_0000_0000_0000,
 
     /// <summary>
-    /// The dimension master
+    /// The dimension master.
     /// </summary>
     DimensionMaster = 0b0100_0000_0000_0000_0000_0000,
 

--- a/src/Persistence/Initialization/GameConfigurationInitializerBase.cs
+++ b/src/Persistence/Initialization/GameConfigurationInitializerBase.cs
@@ -10,8 +10,8 @@ using MUnique.OpenMU.DataModel.Attributes;
 using MUnique.OpenMU.DataModel.Configuration;
 using MUnique.OpenMU.DataModel.Configuration.Items;
 using MUnique.OpenMU.GameLogic.Attributes;
-using MUnique.OpenMU.Persistence.Initialization.Version075.Items;
 using MUnique.OpenMU.Persistence.Initialization.CharacterClasses;
+using MUnique.OpenMU.Persistence.Initialization.Version075.Items;
 using MUnique.OpenMU.Persistence.Initialization.VersionSeasonSix.Maps;
 
 /// <summary>

--- a/src/Persistence/Initialization/GuidHelper.cs
+++ b/src/Persistence/Initialization/GuidHelper.cs
@@ -23,7 +23,7 @@ internal static class GuidHelper
     private static readonly Dictionary<Type, short> TypeIds = new();
 
     /// <summary>
-    /// Initializes the <see cref="GuidHelper" /> class.
+    /// Initializes static members of the <see cref="GuidHelper"/> class.
     /// </summary>
     static GuidHelper()
     {
@@ -114,7 +114,7 @@ internal static class GuidHelper
     /// <typeparam name="T">The type of object which should get the id.</typeparam>
     /// <param name="obj">The object.</param>
     /// <param name="guid">The unique identifier.</param>
-    /// <exception cref="System.InvalidOperationException">Object is not identifiable</exception>
+    /// <exception cref="System.InvalidOperationException">Object is not identifiable.</exception>
     public static void SetGuid<T>(this T obj, Guid guid)
     {
         if (obj is IIdentifiable identifiable)

--- a/src/Persistence/Initialization/Items/ArmorInitializerBase.cs
+++ b/src/Persistence/Initialization/Items/ArmorInitializerBase.cs
@@ -75,7 +75,7 @@ public abstract class ArmorInitializerBase : InitializerBase
             var def = this.Context.CreateNew<ItemOptionDefinition>();
             def.SetGuid(setLevel);
             def.Name = $"Complete Set Bonus (Level {setLevel})";
-            def.PossibleOptions.Add(this.BuildDefenseBonusOption(1 + (setLevel - 9) * 0.05f, setLevel));
+            def.PossibleOptions.Add(this.BuildDefenseBonusOption(1 + ((setLevel - 9) * 0.05f), setLevel));
             defenseBonus.Add(setLevel, def);
             this.GameConfiguration.ItemOptions.Add(def);
         }

--- a/src/Persistence/Initialization/Updates/AddItemDropGroupForJewelsUpdate075.cs
+++ b/src/Persistence/Initialization/Updates/AddItemDropGroupForJewelsUpdate075.cs
@@ -98,8 +98,8 @@ public class AddItemDropGroupForJewelsUpdate075 : UpdatePlugInBase
     /// <param name="context">The persistence context.</param>
     /// <param name="gameConfiguration">Game configuration context to update.</param>
     /// <param name="dropId">New drop id.</param>
-    /// <param name="mapNumber">Optionally the map number to asociate drop group item.</param>
-    /// <param name="name">Description of drop,</param>
+    /// <param name="mapNumber">Optionally the map number to associate drop group item.</param>
+    /// <param name="name">Description of drop.</param>
     /// <returns>Returns new drop item group.</returns>
     protected DropItemGroup CreateDropItemGroupForJewels(IContext context, GameConfiguration gameConfiguration, short dropId, short? mapNumber, string name)
     {

--- a/src/Persistence/Initialization/Updates/AddItemDropGroupForJewelsUpdate095d.cs
+++ b/src/Persistence/Initialization/Updates/AddItemDropGroupForJewelsUpdate095d.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="AddItemDropGroupForJewelsUpdate095D.cs" company="MUnique">
+﻿// <copyright file="AddItemDropGroupForJewelsUpdate095d.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 

--- a/src/Persistence/Initialization/Updates/FixAttackSpeedCalculationUpdate.cs
+++ b/src/Persistence/Initialization/Updates/FixAttackSpeedCalculationUpdate.cs
@@ -15,10 +15,10 @@ using MUnique.OpenMU.Network.Packets;
 using MUnique.OpenMU.Persistence.Initialization.Items;
 using MUnique.OpenMU.Persistence.Initialization.Skills;
 using MUnique.OpenMU.PlugIns;
-using static CharacterClasses.CharacterClassHelper;
+using static MUnique.OpenMU.Persistence.Initialization.CharacterClasses.CharacterClassHelper;
 
 /// <summary>
-/// This adds attributes and relations for attack speed. Adds effects for Ale and Potion of Soul
+/// This adds attributes and relations for attack speed. Adds effects for Ale and Potion of Soul.
 /// </summary>
 [PlugIn]
 [Display(Name = PlugInName, Description = PlugInDescription)]
@@ -131,11 +131,11 @@ public class FixAttackSpeedCalculationUpdate : UpdatePlugInBase
             return;
         }
 
-        AddStatIfNotExists(context, gameConfiguration, Stats.MagicSpeed);
-        AddStatIfNotExists(context, gameConfiguration, Stats.AttackSpeedByWeapon);
-        AddStatIfNotExists(context, gameConfiguration, Stats.AreTwoWeaponsEquipped);
-        AddStatIfNotExists(context, gameConfiguration, Stats.EquippedWeaponCount);
-        AddStatIfNotExists(context, gameConfiguration, Stats.WalkSpeed);
+        this.AddStatIfNotExists(context, gameConfiguration, Stats.MagicSpeed);
+        this.AddStatIfNotExists(context, gameConfiguration, Stats.AttackSpeedByWeapon);
+        this.AddStatIfNotExists(context, gameConfiguration, Stats.AreTwoWeaponsEquipped);
+        this.AddStatIfNotExists(context, gameConfiguration, Stats.EquippedWeaponCount);
+        this.AddStatIfNotExists(context, gameConfiguration, Stats.WalkSpeed);
 
         Stats.AttackSpeed.GetPersistent(gameConfiguration).MaximumValue = Stats.AttackSpeed.MaximumValue;
         Stats.MagicSpeed.GetPersistent(gameConfiguration).MaximumValue = Stats.MagicSpeed.MaximumValue;
@@ -219,7 +219,7 @@ public class FixAttackSpeedCalculationUpdate : UpdatePlugInBase
         new BlessPotionEffectInitializer(context, gameConfiguration).Initialize();
         new SoulPotionEffectInitializer(context, gameConfiguration).Initialize();
 
-        SetItemEffect(gameConfiguration, ItemConstants.Alcohol, MagicEffectNumber.Alcohol);
+        this.SetItemEffect(gameConfiguration, ItemConstants.Alcohol, MagicEffectNumber.Alcohol);
         var siegePotion = gameConfiguration.Items.First(item => item.Number == ItemConstants.SiegePotion.Number && item.Group == ItemConstants.SiegePotion.Group);
         siegePotion.Name = "Potion of Bless;Potion of Soul";
         siegePotion.Durability = 10;

--- a/src/Persistence/Initialization/Updates/FixWarriorMorningStarPlugIn.cs
+++ b/src/Persistence/Initialization/Updates/FixWarriorMorningStarPlugIn.cs
@@ -1,4 +1,8 @@
-﻿namespace MUnique.OpenMU.Persistence.Initialization.Updates;
+﻿// <copyright file="FixWarriorMorningStarPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Persistence.Initialization.Updates;
 
 using System.Runtime.InteropServices;
 using MUnique.OpenMU.DataModel.Configuration;

--- a/src/Persistence/Initialization/Version075/Items/Wings.cs
+++ b/src/Persistence/Initialization/Version075/Items/Wings.cs
@@ -59,7 +59,7 @@ public class Wings : WingsInitializerBase
 
         if (damageIncreaseInitial > 0)
         {
-            var powerUp = this.CreateItemBasePowerUpDefinition(Stats.AttackDamageIncrease, 1f + damageIncreaseInitial / 100f, AggregateType.Multiplicate);
+            var powerUp = this.CreateItemBasePowerUpDefinition(Stats.AttackDamageIncrease, 1f + (damageIncreaseInitial / 100f), AggregateType.Multiplicate);
             powerUp.BonusPerLevelTable = this._damageIncreaseByLevelTable;
             wing.BasePowerUpAttributes.Add(powerUp);
         }

--- a/src/Persistence/Initialization/Version095d/Items/BoxOfLuck.cs
+++ b/src/Persistence/Initialization/Version095d/Items/BoxOfLuck.cs
@@ -42,7 +42,7 @@ internal class BoxOfLuck : InitializerBase
     /// +8: Box of Kundun+1
     /// +9: Box of Kundun+2
     /// +10: Box of Kundun+3
-    /// +11: Box of Kundun+4
+    /// +11: Box of Kundun+4.
     /// </summary>
     /// <remarks>
     /// Regex for ExTeam Files:

--- a/src/Persistence/Initialization/Version095d/Items/Wings.cs
+++ b/src/Persistence/Initialization/Version095d/Items/Wings.cs
@@ -59,7 +59,7 @@ public class Wings : WingsInitializerBase
 
         if (damageIncreaseInitial > 0)
         {
-            var powerUp = this.CreateItemBasePowerUpDefinition(Stats.AttackDamageIncrease, 1f + damageIncreaseInitial / 100f, AggregateType.Multiplicate);
+            var powerUp = this.CreateItemBasePowerUpDefinition(Stats.AttackDamageIncrease, 1f + (damageIncreaseInitial / 100f), AggregateType.Multiplicate);
             powerUp.BonusPerLevelTable = this._damageIncreaseByLevelTable;
             wing.BasePowerUpAttributes.Add(powerUp);
         }

--- a/src/Persistence/Initialization/Version095d/Maps/DevilSquare3.cs
+++ b/src/Persistence/Initialization/Version095d/Maps/DevilSquare3.cs
@@ -2,13 +2,12 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
-using MUnique.OpenMU.AttributeSystem;
-using MUnique.OpenMU.GameLogic.Attributes;
-using MUnique.OpenMU.Persistence.Initialization.Skills;
-
 namespace MUnique.OpenMU.Persistence.Initialization.Version095d.Maps;
 
+using MUnique.OpenMU.AttributeSystem;
 using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.GameLogic.Attributes;
+using MUnique.OpenMU.Persistence.Initialization.Skills;
 using MUnique.OpenMU.Persistence.Initialization.Version095d.Events;
 
 /// <summary>

--- a/src/Persistence/Initialization/VersionSeasonSix/Items/AncientSets.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Items/AncientSets.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
-using MUnique.OpenMU.Network;
-
 namespace MUnique.OpenMU.Persistence.Initialization.VersionSeasonSix.Items;
 
 using MUnique.OpenMU.AttributeSystem;
@@ -11,6 +9,7 @@ using MUnique.OpenMU.DataModel.Attributes;
 using MUnique.OpenMU.DataModel.Configuration;
 using MUnique.OpenMU.DataModel.Configuration.Items;
 using MUnique.OpenMU.GameLogic.Attributes;
+using MUnique.OpenMU.Network;
 using MUnique.OpenMU.Persistence.Initialization.Items;
 
 /// <summary>

--- a/src/Persistence/Initialization/VersionSeasonSix/Items/Pets.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Items/Pets.cs
@@ -189,7 +189,7 @@ public class Pets : InitializerBase
         this.GameConfiguration.Items.Add(spirit);
 
         var horseDrop = this.Context.CreateNew<DropItemGroup>();
-        horseDrop.SetGuid(NumberConversionExtensions.MakeWord(13, 31).ToSigned(), 0, 1);
+        horseDrop.SetGuid((short)NumberConversionExtensions.MakeWord(13, 31), 0, 1);
         horseDrop.ItemLevel = 0;
         horseDrop.Chance = 0.001;
         horseDrop.Description = "Dark Horse Spirit";
@@ -199,7 +199,7 @@ public class Pets : InitializerBase
         BaseMapInitializer.RegisterDefaultDropItemGroup(horseDrop);
 
         var ravenDrop = this.Context.CreateNew<DropItemGroup>();
-        ravenDrop.SetGuid(NumberConversionExtensions.MakeWord(13, 31).ToSigned(), 1, 1);
+        ravenDrop.SetGuid((short)NumberConversionExtensions.MakeWord(13, 31), 1, 1);
         ravenDrop.ItemLevel = 1;
         ravenDrop.Chance = 0.001;
         ravenDrop.Description = "Dark Raven Spirit";

--- a/src/Persistence/Initialization/VersionSeasonSix/Items/Pets.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Items/Pets.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
-using MUnique.OpenMU.Network;
-
 namespace MUnique.OpenMU.Persistence.Initialization.VersionSeasonSix.Items;
 
 using MUnique.OpenMU.AttributeSystem;
@@ -12,6 +10,7 @@ using MUnique.OpenMU.DataModel.Configuration;
 using MUnique.OpenMU.DataModel.Configuration.Items;
 using MUnique.OpenMU.GameLogic;
 using MUnique.OpenMU.GameLogic.Attributes;
+using MUnique.OpenMU.Network;
 using MUnique.OpenMU.Persistence.Initialization.CharacterClasses;
 using MUnique.OpenMU.Persistence.Initialization.Skills;
 

--- a/src/Persistence/Initialization/VersionSeasonSix/TestAccounts/GameMaster.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/TestAccounts/GameMaster.cs
@@ -41,6 +41,7 @@ internal class GameMaster : Level400
         return account;
     }
 
+    /// <inheritdoc/>
     protected override Character CreateDarkLord()
     {
         var character = this.CreateDarkLord(CharacterClassNumber.LordEmperor);

--- a/src/Persistence/SourceGenerator/Program.cs
+++ b/src/Persistence/SourceGenerator/Program.cs
@@ -36,7 +36,7 @@ public static class Program
         {
             EfCoreModelGenerator.TargetAssemblyName => new EfCoreModelGenerator(),
             BasicModelGenerator.TargetAssemblyName => new BasicModelGenerator(),
-            _ => null
+            _ => null,
         };
 
         if (generator is null)

--- a/src/PlugIns/LocalizableString.cs
+++ b/src/PlugIns/LocalizableString.cs
@@ -23,6 +23,7 @@ internal sealed class LocalizableString
     private Type? _resourceType;
 
     /// <summary>
+    /// Initializes a new instance of the <see cref="LocalizableString"/> class.
     ///     Constructs a localizable string, specifying the property name associated
     ///     with this item.  The <paramref name="propertyName" /> value will be used
     ///     within any exceptions thrown as a result of localization failures.

--- a/src/Web/AdminPanel/API/ServerController.cs
+++ b/src/Web/AdminPanel/API/ServerController.cs
@@ -1,15 +1,19 @@
-﻿namespace MUnique.OpenMU.Web.API
+﻿// <copyright file="ServerController.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Web.API
 {
+    using System.Text.Json;
     using Microsoft.AspNetCore.Mvc;
     using MUnique.OpenMU.DataModel.Entities;
     using MUnique.OpenMU.GameLogic;
     using MUnique.OpenMU.GameServer;
     using MUnique.OpenMU.Interfaces;
     using MUnique.OpenMU.Persistence;
-    using System.Text.Json;
 
     /// <summary>
-    /// Server API controller
+    /// Server API controller.
     /// </summary>
     [Route("api/")]
     public class ServerController : Controller
@@ -17,28 +21,28 @@
         private IDictionary<int, IGameServer> _gameServers;
 
         /// <summary>
-        ///
+        /// Initializes a new instance of the <see cref="ServerController"/> class.
         /// </summary>
         /// <param name="gameServers"></param>
-        public ServerController(IDictionary<int, IGameServer> gameServers) => _gameServers = gameServers;
+        public ServerController(IDictionary<int, IGameServer> gameServers) => this._gameServers = gameServers;
 
         /// <summary>
-        ///
+        /// Sends a global message to the specified server.
         /// </summary>
         /// <param name="id"></param>
         /// <param name="msg"></param>
-        /// <returns></returns>
+        /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
         [Route("send/{id=0}")]
         public async Task<IActionResult> SendGlobalMessage(int id, [FromQuery(Name = "msg")] string msg)
         {
-            var server = (GameServer)_gameServers.Values.ElementAt(id);
+            var server = (GameServer)this._gameServers.Values.ElementAt(id);
             if (server is not null)
             {
                 await server.Context.SendGlobalNotificationAsync(msg).ConfigureAwait(false);
-                return Ok("Done");
+                return this.Ok("Done");
             }
 
-            return Ok("Server not ready");
+            return this.Ok("Server not ready");
         }
 
         /// <summary>
@@ -75,7 +79,7 @@
         {
             int sum = 0;
             var list = new List<string>();
-            _gameServers.Values.ForEach(async item =>
+            this._gameServers.Values.ForEach(async item =>
             {
                 var server = item as GameServer;
                 if (server is not null)
@@ -93,10 +97,10 @@
             {
                 state = "Online",
                 players = sum,
-                playersList = list
+                playersList = list,
             };
 
-            return Ok(JsonSerializer.Serialize(item));
+            return this.Ok(JsonSerializer.Serialize(item));
         }
     }
 }

--- a/src/Web/AdminPanel/Pages/CreateConnectServerConfig.razor.cs
+++ b/src/Web/AdminPanel/Pages/CreateConnectServerConfig.razor.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="CreateGameServerConfig.razor.cs" company="MUnique">
+﻿// <copyright file="CreateConnectServerConfig.razor.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
@@ -126,7 +126,7 @@ public partial class CreateConnectServerConfig : ComponentBase, IAsyncDisposable
         result.ServerId = this._viewModel.ServerId;
         result.Description = this._viewModel.Description;
         result.Client = this._viewModel.Client!;
-        result.ClientListenerPort = _viewModel.NetworkPort;
+        result.ClientListenerPort = this._viewModel.NetworkPort;
         return result;
     }
 

--- a/src/Web/AdminPanel/Pages/EditBase.cs
+++ b/src/Web/AdminPanel/Pages/EditBase.cs
@@ -307,7 +307,8 @@ public abstract class EditBase : ComponentBase, IAsyncDisposable
     {
         if (this._persistenceContext?.HasChanges is true)
         {
-            var isConfirmed = await this.JavaScript.InvokeAsync<bool>("window.confirm",
+            var isConfirmed = await this.JavaScript.InvokeAsync<bool>(
+                "window.confirm",
                     Resources.UnsavedChangesQuestion)
                 .ConfigureAwait(true);
 

--- a/src/Web/AdminPanel/Pages/EditConfig.cs
+++ b/src/Web/AdminPanel/Pages/EditConfig.cs
@@ -63,7 +63,7 @@ public sealed class EditConfig : EditBase
         StringBuilder? stringBuilder = null;
         if (this.Type is not null
             && (EditorPages.TryGetValue(this.Type, out var editors)
-                || this.Type.BaseType is { } baseType && EditorPages.TryGetValue(baseType, out editors)))
+                || (this.Type.BaseType is { } baseType && EditorPages.TryGetValue(baseType, out editors))))
         {
             foreach (var editor in editors)
             {

--- a/src/Web/ItemEditor/MuItem.razor.cs
+++ b/src/Web/ItemEditor/MuItem.razor.cs
@@ -52,7 +52,7 @@ public partial class MuItem
     private bool CanMoveLeft => this.Model.Column > 0;
     private bool CanMoveRight => this.Model.Column + this.Width < 8;
     private bool CanJumpDown => this.Model.Parent?.StorageType is StorageType.Inventory or StorageType.InventoryExtension;
-    private bool CanJumpUp => (this.Model.Parent?.StorageType is StorageType.InventoryExtension or StorageType.PersonalStore);
+    private bool CanJumpUp => this.Model.Parent?.StorageType is StorageType.InventoryExtension or StorageType.PersonalStore;
 
     private async Task OnKeyPressAsync(KeyboardEventArgs obj)
     {

--- a/src/Web/Shared/ComponentBuilders/DateTimeFieldBuilder.cs
+++ b/src/Web/Shared/ComponentBuilders/DateTimeFieldBuilder.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="DateFieldBuilder.cs" company="MUnique">
+﻿// <copyright file="DateTimeFieldBuilder.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 

--- a/src/Web/Shared/Components/Form/ValueTable.razor.cs
+++ b/src/Web/Shared/Components/Form/ValueTable.razor.cs
@@ -64,7 +64,7 @@ public partial class ValueTable<TValue>
         }
 
         this.WrappedList ??= new ValueListWrapper<TValue>(this.Value);
-        this.WrappedList!.Add(default(TValue));
+        this.WrappedList!.Add(new TValue());
         await this.InvokeAsync(this.StateHasChanged).ConfigureAwait(false);
     }
 

--- a/src/Web/Shared/Components/Form/ValueTable.razor.cs
+++ b/src/Web/Shared/Components/Form/ValueTable.razor.cs
@@ -64,7 +64,7 @@ public partial class ValueTable<TValue>
         }
 
         this.WrappedList ??= new ValueListWrapper<TValue>(this.Value);
-        this.WrappedList!.Add(new TValue());
+        this.WrappedList!.Add(default(TValue));
         await this.InvokeAsync(this.StateHasChanged).ConfigureAwait(false);
     }
 

--- a/src/Web/Shared/Components/ThemeSelector.razor.cs
+++ b/src/Web/Shared/Components/ThemeSelector.razor.cs
@@ -24,7 +24,7 @@ public partial class ThemeSelector : IAsyncDisposable
     private bool _hydrated;
 
     /// <summary>
-    /// Gets or sets the current dark-mode state as seen by the server-side renderer.
+    /// Gets or sets a value indicating whether the current dark-mode state as seen by the server-side renderer.
     /// </summary>
     /// <remarks>
     /// Only used until the first interactive render hydrates the value from the live DOM

--- a/src/Web/Shared/ExpressionExtensions.cs
+++ b/src/Web/Shared/ExpressionExtensions.cs
@@ -2,10 +2,9 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
-using System.ComponentModel.DataAnnotations;
-
 namespace MUnique.OpenMU.Web.Shared;
 
+using System.ComponentModel.DataAnnotations;
 using System.Linq.Expressions;
 using System.Reflection;
 using MUnique.OpenMU.DataModel.Composition;


### PR DESCRIPTION
## Summary

Fix low‑effort warnings to reduce build noise: ~740 diagnostics fixed across 142 files
(clean‑build count went from 1436 → 697).

## Changes

| Diagnostic | Description |
|---|---|
| CS1591 | Missing XML comment for public type/member |
| SA1101 | Prefix local calls with `this.` | across many files |
| SA1108 | Block statements must not contain embedded comments |
| SA1200 | `using` directives must be inside namespace |
| SA1201 | Elements must appear in correct order |
| SA1202 | `private` members must come before `public` |
| SA1312 | Variable names must begin with camelCase |
| SA1414 | Tuple element names should match |
| SA1600 | Elements must be documented |
| SA1601 | Partial elements must be documented |
| SA1602 | Enumeration items must be documented |
| SA1611 | `</param>` documentation required |
| SA1614 | Element parameter property documentation |
| SA1616 | Element return value documentation |
| SA1625 | Documentation must not be copied and pasted |
| SA1648 | `inheritdoc` must be used correctly |
