### PR TITLE
Seed default potion hotkeys for new characters

### DIFF
--- a/src/GameLogic/PlayerActions/Character/CreateCharacterAction.cs
+++ b/src/GameLogic/PlayerActions/Character/CreateCharacterAction.cs
@@ -43,6 +43,32 @@ public class CreateCharacterAction
         await player.InvokeViewPlugInAsync<IShowCharacterCreationFailedPlugIn>(p => p.ShowCharacterCreationFailedAsync()).ConfigureAwait(false);
     }
 
+    /// <summary>
+    /// Creates the default key configuration for a newly created character.
+    /// </summary>
+    /// <returns>The default key configuration.</returns>
+    /// <remarks>
+    /// The key configuration is an opaque blob which is interpreted by the game client. Within it,
+    /// the potion quick-slots Q, W, E and R are stored as offsets into the potion item group, at
+    /// byte indices 21 (Q), 22 (W), 23 (E) and 25 (R). We bind Q to the healing potion and W to the
+    /// mana potion; E and R stay unbound. An all-zero configuration would otherwise make the client
+    /// bind offset 0 (the apple, which it treats as a healing item) to all four slots, so each one
+    /// would act as a health potion.
+    /// </remarks>
+    private static byte[] CreateDefaultKeyConfiguration()
+    {
+        const byte healingPotion = 1;
+        const byte manaPotion = 4;
+        const byte unbound = 0xFF;
+
+        var keyConfiguration = new byte[30];
+        keyConfiguration[21] = healingPotion; // Q
+        keyConfiguration[22] = manaPotion; // W
+        keyConfiguration[23] = unbound; // E
+        keyConfiguration[25] = unbound; // R
+        return keyConfiguration;
+    }
+
     private async ValueTask<DataModel.Entities.Character?> CreateCharacterAsync(Player player, string name, CharacterClass characterClass)
     {
         var account = player.Account;
@@ -76,7 +102,7 @@ public class CreateCharacterAction
         character.Name = name;
         character.CharacterSlot = freeSlot.Value;
         character.CreateDate = DateTime.UtcNow;
-        character.KeyConfiguration = new byte[30];
+        character.KeyConfiguration = CreateDefaultKeyConfiguration();
         var attributes = character.CharacterClass.StatAttributes.Select(a => player.PersistenceContext.CreateNew<StatAttribute>(a.Attribute, a.BaseValue)).ToList();
         attributes.ForEach(character.Attributes.Add);
         character.CurrentMap = characterClass.HomeMap;


### PR DESCRIPTION
# Seed default potion hotkeys for new characters

## Problem

A freshly created character has all four potion quick-slots (Q, W, E, R) behaving as **health potions**. Every slot consumes/displays the HP potion; the mana slot never works as a mana slot.

## Root cause

`CreateCharacterAction` initializes a new character with an all-zero key configuration:

```csharp
character.KeyConfiguration = new byte[30];
```

`KeyConfiguration` is an opaque blob that is interpreted by the game client (the server stores and echoes it verbatim via `ApplyKeyConfigurationPlugIn`). Within that blob the client reads the four potion quick-slots as offsets into the potion item group:

- byte `21` → Q, byte `22` → W, byte `23` → E, byte `25` → R

A value of `0` resolves to potion-group offset `0`, which is the **apple**. The client treats the apple as a healing item (it falls in the `apple … large healing potion` range), so with an all-zero configuration **all four slots bind to a health potion**. The intended default (Q = healing potion, W = mana potion) is never set.

## Fix

Seed a sensible default key configuration on character creation instead of an all-zero array:

- Q → small healing potion (offset `1`)
- W → small mana potion (offset `4`)
- E and R → unbound (`0xFF`)

This is a **data-only** change — no packet, serialization, or client change. The client already renders a slot only when a matching item is present in the inventory, so the slots still appear empty until the player actually picks up a potion; they simply now light up under the correct key (HP under Q, mana under W) instead of HP under all four.

```csharp
character.KeyConfiguration = CreateDefaultKeyConfiguration();

// ...

private static byte[] CreateDefaultKeyConfiguration()
{
    const byte healingPotion = 1;
    const byte manaPotion = 4;
    const byte unbound = 0xFF;

    var keyConfiguration = new byte[30];
    keyConfiguration[21] = healingPotion; // Q
    keyConfiguration[22] = manaPotion; // W
    keyConfiguration[23] = unbound; // E
    keyConfiguration[25] = unbound; // R
    return keyConfiguration;
}
```

## Scope

- Affects **newly created characters** only. Existing characters keep their stored configuration; they were already able to rebind manually.

## Testing

- Builds cleanly (`dotnet publish -c Release -p:ci=true`), no new analyzer warnings on the changed file.
- New character: Q binds the healing potion, W binds the mana potion, E/R stay unbound; slots remain empty until the matching potion is in the inventory.

## Notes

- The byte offsets (21/22/23/25) and values follow the layout the client uses when it sends the configuration back (`KeyQWE[0..2]` and `KeyR`, each as an offset from the potion item group); they are documented in the method's `<remarks>`.
- A migration for existing all-zero characters could be added separately as a configuration update if desired, but is intentionally out of scope here.