### PR TITLE
bugfix: replace duplicate GUID

### DIFF
--- a/src/GameLogic/PlayerActions/Skills/PollutionSkillPlugIn.cs
+++ b/src/GameLogic/PlayerActions/Skills/PollutionSkillPlugIn.cs
@@ -16,7 +16,7 @@ using MUnique.OpenMU.PlugIns;
 /// </summary>
 [PlugIn]
 [Display(Name = nameof(PlugInResources.PollutionSkillPlugIn_Name), Description = nameof(PlugInResources.PollutionSkillPlugIn_Description), ResourceType = typeof(PlugInResources))]
-[Guid("9F4B2C1D-E7A6-4B3C-8D9E-0FAB12C3D4E5")]
+[Guid("97BE0BFD-C55C-4E68-9B2D-12156825481A")]
 public class PollutionSkillPlugIn : IAreaSkillPlugIn
 {
     /// <inheritdoc />


### PR DESCRIPTION
## Fix duplicate plugin GUID causing `ArgumentException` in PlugInController

### Problem

The `PlugInController.GetAsync` method crashed with:

System.ArgumentException: An item with the same key has already been added. Key: 9f4b2c1d-e7a6-4b3c-8d9e-0fab12c3d4e5

when building a `Dictionary<Guid, Type>` from discovered plugin types via `.ToDictionary(t => t.GUID, t => t)`.

### Root Cause

Two plugin classes shared the same `[Guid]` attribute value `9F4B2C1D-E7A6-4B3C-8D9E-0FAB12C3D4E5`:

| Plugin | File |
|--------|------|
| `TwistingSlashMasterySkillPlugIn` | `src/GameLogic/PlayerActions/Skills/TwistingSlashMasterySkillPlugIn.cs` |
| `PollutionSkillPlugIn` | `src/GameLogic/PlayerActions/Skills/PollutionSkillPlugIn.cs` |

- `TwistingSlashMasterySkillPlugIn` had the GUID from the initial commit `cf29196329`.
- Commit `0aa8a21758` ("Fixed GUIDs, added try-catch") changed `PollutionSkillPlugIn`'s GUID from `A2B3C4D5-E6F7-4812-3456-7890ABCDEF12` to `9F4B2C1D-...`, creating the collision.

### Changes

**Assigned a unique GUID** to `PollutionSkillPlugIn` — `97BE0BFD-C55C-4E68-9B2D-12156825481A`.


### Cleanup

If you have an existing database with cached `PlugInConfiguration` rows using the old duplicate GUID, run:

```sql
DELETE FROM config."PlugInConfiguration"
 WHERE "TypeId" = '9F4B2C1D-E7A6-4B3C-8D9E-0FAB12C3D4E5';
The system will auto-create fresh configurations for both plugins on next startup.