### PR TITLE
bugfix: standardize loading states and add save spinner to Create pages

### DIFF
--- a/src/Web/AdminPanel/Pages/CreateConnectServerConfig.razor
+++ b/src/Web/AdminPanel/Pages/CreateConnectServerConfig.razor
@@ -11,18 +11,8 @@
 
 @if (this._viewModel is null)
 {
-    <span class="spinner-border" role="status" aria-hidden="true"></span>
-    <span class="visually-hidden">@Resources.Loading</span>
     return;
 }
 
-@if (this._initState is { })
-{
-  <span class="spinner-border" role="status" aria-hidden="true"></span>
-  <span class="visually-hidden">@this._initState</span>
-  return;
-}
-
-
-<AutoForm Model="this._viewModel" OnValidSubmit="this.OnSaveButtonClickAsync"></AutoForm>
+<AutoForm Model="this._viewModel" OnValidSubmit="this.OnSaveButtonClickAsync" IsProcessing="this._isProcessing"></AutoForm>
 

--- a/src/Web/AdminPanel/Pages/CreateConnectServerConfig.razor.cs
+++ b/src/Web/AdminPanel/Pages/CreateConnectServerConfig.razor.cs
@@ -12,6 +12,7 @@ using MUnique.OpenMU.DataModel.Configuration;
 using MUnique.OpenMU.Interfaces;
 using MUnique.OpenMU.Persistence;
 using MUnique.OpenMU.Web.AdminPanel.Properties;
+using MUnique.OpenMU.Web.Shared.Services;
 
 /// <summary>
 /// Razor page which shows objects of the specified type in a grid.
@@ -22,7 +23,7 @@ public partial class CreateConnectServerConfig : ComponentBase, IAsyncDisposable
     private CancellationTokenSource? _disposeCts;
 
     private ConnectServerViewModel? _viewModel;
-    private string? _initState;
+    private bool _isProcessing;
 
     /// <summary>
     /// Gets or sets the context provider.
@@ -53,6 +54,12 @@ public partial class CreateConnectServerConfig : ComponentBase, IAsyncDisposable
     /// </summary>
     [Inject]
     public NavigationManager NavigationManager { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the loading overlay service.
+    /// </summary>
+    [Inject]
+    public LoadingOverlayService LoadingService { get; set; } = null!;
 
     /// <inheritdoc />
     public async ValueTask DisposeAsync()
@@ -86,6 +93,7 @@ public partial class CreateConnectServerConfig : ComponentBase, IAsyncDisposable
 
     private async Task LoadDataAsync(CancellationToken cancellationToken)
     {
+        using var loading = this.LoadingService.ShowLoadingIndicator();
         cancellationToken.ThrowIfCancellationRequested();
 
         var gameConfiguration = await this.DataSource.GetOwnerAsync(default, cancellationToken).ConfigureAwait(true);
@@ -134,8 +142,8 @@ public partial class CreateConnectServerConfig : ComponentBase, IAsyncDisposable
     {
         try
         {
+            this._isProcessing = true;
             var gameConfiguration = await this.DataSource.GetOwnerAsync().ConfigureAwait(false);
-
             using var saveContext = this.ContextProvider.CreateNewTypedContext(typeof(DataModel.Configuration.ConnectServerDefinition), true, gameConfiguration);
 
             var existingServerDefinitions = (await saveContext.GetAsync<ConnectServerDefinition>().ConfigureAwait(false)).ToList();
@@ -151,19 +159,12 @@ public partial class CreateConnectServerConfig : ComponentBase, IAsyncDisposable
                 return;
             }
 
-            this._initState = Resources.CreatingConfigurationInfo;
-            await this.InvokeAsync(this.StateHasChanged);
             var connectServerDefinition = await this.CreateDefinitionByViewModelAsync(saveContext).ConfigureAwait(false);
-            this._initState = Resources.SavingConfigurationInfo;
-            await this.InvokeAsync(this.StateHasChanged);
             var success = await saveContext.SaveChangesAsync().ConfigureAwait(true);
 
-            // if success, init new game server instance
             if (success)
             {
                 this.ToastService.ShowSuccess(Resources.ConnectionServerConfigurationSaved);
-                this._initState = Resources.InitializingConnectServerInfo;
-                await this.InvokeAsync(this.StateHasChanged);
                 await this.ServerInstanceManager.InitializeConnectServerAsync(connectServerDefinition.ConfigurationId);
                 this.NavigationManager.NavigateTo("servers");
                 return;
@@ -175,8 +176,10 @@ public partial class CreateConnectServerConfig : ComponentBase, IAsyncDisposable
         {
             this.ToastService.ShowError(string.Format(Resources.UnexpectedErrorOccurred, ex.Message));
         }
-
-        this._initState = null;
+        finally
+        {
+            this._isProcessing = false;
+        }
     }
 
     /// <summary>

--- a/src/Web/AdminPanel/Pages/CreateConnectServerConfig.razor.cs
+++ b/src/Web/AdminPanel/Pages/CreateConnectServerConfig.razor.cs
@@ -143,10 +143,10 @@ public partial class CreateConnectServerConfig : ComponentBase, IAsyncDisposable
         try
         {
             this._isProcessing = true;
-            var gameConfiguration = await this.DataSource.GetOwnerAsync().ConfigureAwait(false);
+            var gameConfiguration = await this.DataSource.GetOwnerAsync().ConfigureAwait(true);
             using var saveContext = this.ContextProvider.CreateNewTypedContext(typeof(DataModel.Configuration.ConnectServerDefinition), true, gameConfiguration);
 
-            var existingServerDefinitions = (await saveContext.GetAsync<ConnectServerDefinition>().ConfigureAwait(false)).ToList();
+            var existingServerDefinitions = (await saveContext.GetAsync<ConnectServerDefinition>().ConfigureAwait(true)).ToList();
             if (existingServerDefinitions.Any(def => def.ServerId == this._viewModel?.ServerId))
             {
                 this.ToastService.ShowError(string.Format(Resources.ServerWithIdAlreadyExists, this._viewModel?.ServerId));
@@ -159,13 +159,13 @@ public partial class CreateConnectServerConfig : ComponentBase, IAsyncDisposable
                 return;
             }
 
-            var connectServerDefinition = await this.CreateDefinitionByViewModelAsync(saveContext).ConfigureAwait(false);
+            var connectServerDefinition = await this.CreateDefinitionByViewModelAsync(saveContext).ConfigureAwait(true);
             var success = await saveContext.SaveChangesAsync().ConfigureAwait(true);
 
             if (success)
             {
                 this.ToastService.ShowSuccess(Resources.ConnectionServerConfigurationSaved);
-                await this.ServerInstanceManager.InitializeConnectServerAsync(connectServerDefinition.ConfigurationId);
+                await this.ServerInstanceManager.InitializeConnectServerAsync(connectServerDefinition.ConfigurationId).ConfigureAwait(true);
                 this.NavigationManager.NavigateTo("servers");
                 return;
             }

--- a/src/Web/AdminPanel/Pages/CreateGameServerConfig.razor
+++ b/src/Web/AdminPanel/Pages/CreateGameServerConfig.razor
@@ -11,18 +11,8 @@
 
 @if (this._viewModel is null)
 {
-    <span class="spinner-border" role="status" aria-hidden="true"></span>
-    <span class="visually-hidden">@Resources.Loading</span>
     return;
 }
 
-@if (this._initState is { })
-{
-  <span class="spinner-border" role="status" aria-hidden="true"></span>
-  <span class="visually-hidden">@this._initState</span>
-  return;
-}
-
-
-<AutoForm Model="this._viewModel" OnValidSubmit="this.OnSaveButtonClickAsync"></AutoForm>
+<AutoForm Model="this._viewModel" OnValidSubmit="this.OnSaveButtonClickAsync" IsProcessing="this._isProcessing"></AutoForm>
 

--- a/src/Web/AdminPanel/Pages/CreateGameServerConfig.razor.cs
+++ b/src/Web/AdminPanel/Pages/CreateGameServerConfig.razor.cs
@@ -159,10 +159,10 @@ public partial class CreateGameServerConfig : ComponentBase, IAsyncDisposable
         try
         {
             this._isProcessing = true;
-            var gameConfiguration = await this.DataSource.GetOwnerAsync().ConfigureAwait(false);
+            var gameConfiguration = await this.DataSource.GetOwnerAsync().ConfigureAwait(true);
             using var saveContext = this.ContextProvider.CreateNewTypedContext(typeof(DataModel.Configuration.GameServerDefinition), true, gameConfiguration);
 
-            var existingServerDefinitions = (await saveContext.GetAsync<GameServerDefinition>().ConfigureAwait(false)).ToList();
+            var existingServerDefinitions = (await saveContext.GetAsync<GameServerDefinition>().ConfigureAwait(true)).ToList();
             if (existingServerDefinitions.Any(def => def.ServerID == this._viewModel?.ServerId))
             {
                 this.ToastService.ShowError(string.Format(Resources.ServerWithIdAlreadyExists, this._viewModel?.ServerId));
@@ -175,13 +175,13 @@ public partial class CreateGameServerConfig : ComponentBase, IAsyncDisposable
                 return;
             }
 
-            var gameServerDefinition = await this.CreateDefinitionByViewModelAsync(saveContext).ConfigureAwait(false);
+            var gameServerDefinition = await this.CreateDefinitionByViewModelAsync(saveContext).ConfigureAwait(true);
             var success = await saveContext.SaveChangesAsync().ConfigureAwait(true);
 
             if (success)
             {
                 this.ToastService.ShowSuccess(Resources.GameServerConfigurationSavedInfo);
-                await this.ServerInstanceManager.InitializeGameServerAsync(gameServerDefinition.ServerID);
+                await this.ServerInstanceManager.InitializeGameServerAsync(gameServerDefinition.ServerID).ConfigureAwait(true);
                 this.NavigationManager.NavigateTo("servers");
                 return;
             }

--- a/src/Web/AdminPanel/Pages/CreateGameServerConfig.razor.cs
+++ b/src/Web/AdminPanel/Pages/CreateGameServerConfig.razor.cs
@@ -13,6 +13,7 @@ using MUnique.OpenMU.Interfaces;
 using MUnique.OpenMU.Persistence;
 using MUnique.OpenMU.Web.AdminPanel.Properties;
 using MUnique.OpenMU.Web.Shared.Components.Modal;
+using MUnique.OpenMU.Web.Shared.Services;
 
 /// <summary>
 /// Razor page that shows objects of the specified type in a grid.
@@ -23,7 +24,7 @@ public partial class CreateGameServerConfig : ComponentBase, IAsyncDisposable
     private CancellationTokenSource? _disposeCts;
 
     private GameServerViewModel? _viewModel;
-    private string? _initState;
+    private bool _isProcessing;
 
     /// <summary>
     /// Gets or sets the context provider.
@@ -61,6 +62,12 @@ public partial class CreateGameServerConfig : ComponentBase, IAsyncDisposable
     [Inject]
     public NavigationManager NavigationManager { get; set; } = null!;
 
+    /// <summary>
+    /// Gets or sets the loading overlay service.
+    /// </summary>
+    [Inject]
+    public LoadingOverlayService LoadingService { get; set; } = null!;
+
     /// <inheritdoc />
     public async ValueTask DisposeAsync()
     {
@@ -93,6 +100,7 @@ public partial class CreateGameServerConfig : ComponentBase, IAsyncDisposable
 
     private async Task LoadDataAsync(CancellationToken cancellationToken)
     {
+        using var loading = this.LoadingService.ShowLoadingIndicator();
         cancellationToken.ThrowIfCancellationRequested();
 
         var gameConfiguration = await this.DataSource.GetOwnerAsync(default, cancellationToken).ConfigureAwait(true);
@@ -150,8 +158,8 @@ public partial class CreateGameServerConfig : ComponentBase, IAsyncDisposable
     {
         try
         {
+            this._isProcessing = true;
             var gameConfiguration = await this.DataSource.GetOwnerAsync().ConfigureAwait(false);
-
             using var saveContext = this.ContextProvider.CreateNewTypedContext(typeof(DataModel.Configuration.GameServerDefinition), true, gameConfiguration);
 
             var existingServerDefinitions = (await saveContext.GetAsync<GameServerDefinition>().ConfigureAwait(false)).ToList();
@@ -167,19 +175,12 @@ public partial class CreateGameServerConfig : ComponentBase, IAsyncDisposable
                 return;
             }
 
-            this._initState = Resources.CreatingConfigurationInfo;
-            await this.InvokeAsync(this.StateHasChanged);
             var gameServerDefinition = await this.CreateDefinitionByViewModelAsync(saveContext).ConfigureAwait(false);
-            this._initState = Resources.SavingConfigurationInfo;
-            await this.InvokeAsync(this.StateHasChanged);
             var success = await saveContext.SaveChangesAsync().ConfigureAwait(true);
 
-            // if success, init new game server instance
             if (success)
             {
                 this.ToastService.ShowSuccess(Resources.GameServerConfigurationSavedInfo);
-                this._initState = Resources.InitializingGameServerInfo;
-                await this.InvokeAsync(this.StateHasChanged);
                 await this.ServerInstanceManager.InitializeGameServerAsync(gameServerDefinition.ServerID);
                 this.NavigationManager.NavigateTo("servers");
                 return;
@@ -191,8 +192,10 @@ public partial class CreateGameServerConfig : ComponentBase, IAsyncDisposable
         {
             this.ToastService.ShowError(string.Format(Resources.UnexpectedErrorOccurred, ex.Message));
         }
-
-        this._initState = null;
+        finally
+        {
+            this._isProcessing = false;
+        }
     }
 
     /// <summary>

--- a/src/Web/AdminPanel/Pages/EditConfigGrid.razor
+++ b/src/Web/AdminPanel/Pages/EditConfigGrid.razor
@@ -15,8 +15,6 @@
 
 @if (this.ViewModels is null)
 {
-    <span class="spinner-border" role="status" aria-hidden="true"></span>
-    <span class="visually-hidden">@Resources.Loading</span>
     return;
 }
 

--- a/src/Web/AdminPanel/Pages/EditConfigGrid.razor.cs
+++ b/src/Web/AdminPanel/Pages/EditConfigGrid.razor.cs
@@ -81,6 +81,12 @@ public partial class EditConfigGrid : ComponentBase, IAsyncDisposable
     public ILogger<EditConfigGrid> Logger { get; set; } = null!;
 
     /// <summary>
+    /// Gets or sets the loading overlay service.
+    /// </summary>
+    [Inject]
+    public LoadingOverlayService LoadingService { get; set; } = null!;
+
+    /// <summary>
     /// Gets or sets the type.
     /// </summary>
     private Type? Type { get; set; }
@@ -145,6 +151,7 @@ public partial class EditConfigGrid : ComponentBase, IAsyncDisposable
 
     private async Task LoadDataAsync(CancellationToken cancellationToken)
     {
+        using var loading = this.LoadingService.ShowLoadingIndicator();
         cancellationToken.ThrowIfCancellationRequested();
         if (this.Type is null)
         {

--- a/src/Web/AdminPanel/Pages/Merchants.razor
+++ b/src/Web/AdminPanel/Pages/Merchants.razor
@@ -13,8 +13,6 @@
 
 @if (this.ViewModels is null)
 {
-    <span class="spinner-border" role="status" aria-hidden="true"></span>
-    <span class="visually-hidden">@Resources.Loading</span>
     return;
 }
 

--- a/src/Web/AdminPanel/Pages/Merchants.razor.cs
+++ b/src/Web/AdminPanel/Pages/Merchants.razor.cs
@@ -16,6 +16,7 @@ using MUnique.OpenMU.DataModel.Configuration;
 using MUnique.OpenMU.DataModel.Entities;
 using MUnique.OpenMU.Persistence;
 using MUnique.OpenMU.Web.AdminPanel.Properties;
+using MUnique.OpenMU.Web.Shared.Services;
 
 /// <summary>
 /// Razor page which shows objects of the specified type in a grid.
@@ -67,6 +68,12 @@ public partial class Merchants : ComponentBase, IAsyncDisposable
     /// </summary>
     [Inject]
     public ILogger<Merchants> Logger { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the loading overlay service.
+    /// </summary>
+    [Inject]
+    public LoadingOverlayService LoadingService { get; set; } = null!;
 
     private IQueryable<MerchantStorageViewModel>? ViewModels => this._viewModels?.AsQueryable();
 
@@ -134,6 +141,7 @@ public partial class Merchants : ComponentBase, IAsyncDisposable
 
     private async Task LoadDataAsync(CancellationToken cancellationToken)
     {
+        using var loading = this.LoadingService.ShowLoadingIndicator();
         try
         {
             cancellationToken.ThrowIfCancellationRequested();
@@ -192,8 +200,15 @@ public partial class Merchants : ComponentBase, IAsyncDisposable
     {
         if (this._persistenceContext?.HasChanges is true)
         {
+            var previousMerchantId = this._selectedMerchant?.Id;
             await this.DataSource.DiscardChangesAsync().ConfigureAwait(true);
+            this._viewModels = null;
+            this.StateHasChanged();
             await this.LoadDataAsync(this._disposeCts?.Token ?? default).ConfigureAwait(true);
+            if (previousMerchantId is { } id && this._viewModels is not null)
+            {
+                this._selectedMerchant = this._viewModels.FirstOrDefault(vm => vm.Id == id);
+            }
         }
     }
 

--- a/src/Web/AdminPanel/Pages/Merchants.razor.cs
+++ b/src/Web/AdminPanel/Pages/Merchants.razor.cs
@@ -202,8 +202,6 @@ public partial class Merchants : ComponentBase, IAsyncDisposable
         {
             var previousMerchantId = this._selectedMerchant?.Id;
             await this.DataSource.DiscardChangesAsync().ConfigureAwait(true);
-            this._viewModels = null;
-            this.StateHasChanged();
             await this.LoadDataAsync(this._disposeCts?.Token ?? default).ConfigureAwait(true);
             if (previousMerchantId is { } id && this._viewModels is not null)
             {

--- a/src/Web/Shared/Components/Form/AutoForm.razor
+++ b/src/Web/Shared/Components/Form/AutoForm.razor
@@ -19,7 +19,13 @@
         <AutoFields HideCollections="@this.HideCollections" SearchTerm="@this._currentSearchTerm" />
         <ValidationSummary />
         <div class="form-actions">
-            <button type="submit" class="btn btn-primary">Save</button>
+            <button type="submit" class="btn btn-primary" disabled="@this.IsProcessing">
+                @if (this.IsProcessing)
+                {
+                    <span class="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true"></span>
+                }
+                @Resources.Save
+            </button>
             @if (this.OnRefresh != null)
             {
                 <button type="button" class="btn btn-secondary" @onclick="this.OnRefresh.Value" >@Resources.Refresh</button>

--- a/src/Web/Shared/Components/Form/AutoForm.razor.cs
+++ b/src/Web/Shared/Components/Form/AutoForm.razor.cs
@@ -36,6 +36,14 @@ public partial class AutoForm<T>
     public EventCallback OnValidSubmit { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the form is in a processing state,
+    /// e.g. while saving data. When <see langword="true" />, the save button is
+    /// disabled and shows a spinner.
+    /// </summary>
+    [Parameter]
+    public bool IsProcessing { get; set; }
+
+    /// <summary>
     /// Gets or sets the callback invoked when the cancel button is clicked.
     /// When <see langword="null"/>, the cancel button is not rendered.
     /// </summary>

--- a/src/Web/Shared/Components/ItemEdit/ItemEdit.razor
+++ b/src/Web/Shared/Components/ItemEdit/ItemEdit.razor
@@ -201,7 +201,7 @@
     <div class="form-actions">
         @if (this.OnValidSubmit.HasDelegate)
         {
-            <button type="submit" class="btn btn-primary">Save</button>
+            <button type="submit" class="btn btn-primary">@Resources.Save</button>
         }
 
         @if (this.OnCancel.HasDelegate)


### PR DESCRIPTION
### Problem 1 — Inconsistent loading states
`Merchants`, `EditConfigGrid`, `CreateGameServerConfig`, and `CreateConnectServerConfig` used inline `spinner-border` elements while data loaded, while other pages used the `LoadingOverlayService` modal overlay. The inline spinners also didn't cover the full page.

**Fix:** Replaced inline spinners with `LoadingOverlayService.ShowLoadingIndicator()` modal overlay in all four pages.

### Problem 2 — `_initState` progress messages never visible
The Create pages had a `string? _initState` that displayed step messages ("Creating configuration...", "Saving...") via `InvokeAsync(StateHasChanged)`. Due to Blazor Server's render batching, intermediate states never reached the client — only the final `null` rendered, so the div never appeared. The progress messages and their `InvokeAsync` wrappers were dead code.

**Fix:** Replaced `_initState` with `bool _isProcessing`. Set to `true` at the top of `OnSaveButtonClickAsync`, reset in a `finally` block (so it always clears). Flows into `AutoForm`'s `IsProcessing` parameter, which disables the Save button and shows a `spinner-border-sm`. Gives immediate visual feedback without relying on intermediate string updates.

### Problem 3 — EF tracking conflict on Merchants discard
`OnCancelButtonClickAsync` called `DiscardChangesAsync` then `LoadDataAsync`, but the old `_selectedMerchant` was still tracked by EF, causing a tracking conflict.

**Fix:** Fix: Capture the merchant's Id before discard. After reload, re-select the merchant by matching the ID against the fresh _viewModels.