### PR TITLE
bugfix: fix invisible item in player storage

### DIFF
--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -28,7 +28,6 @@ using MUnique.OpenMU.GameLogic.Views.Guild;
 using MUnique.OpenMU.GameLogic.Views.Inventory;
 using MUnique.OpenMU.GameLogic.Views.MuHelper;
 using MUnique.OpenMU.GameLogic.Views.Pet;
-using MUnique.OpenMU.GameLogic.Views.PlayerShop;
 using MUnique.OpenMU.GameLogic.Views.Quest;
 using MUnique.OpenMU.GameLogic.Views.World;
 using MUnique.OpenMU.Interfaces;
@@ -2596,18 +2595,8 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         }
 
         // Restore previously opened Store.
-        if (selectedCharacter.IsStoreOpened
-            && !string.IsNullOrWhiteSpace(selectedCharacter.StoreName)
-            && this.IsPlayerStoreOpeningAfterEnterSupported)
-        {
-            await this.InvokeViewPlugInAsync<IShowShopItemListPlugIn>(p => p.ShowShopItemListAsync(this, true)).ConfigureAwait(false);
-            var action = new PlayerActions.PlayerStore.OpenStoreAction();
-            await action.OpenStoreAsync(this, selectedCharacter.StoreName).ConfigureAwait(false);
-        }
-        else
-        {
-            selectedCharacter.IsStoreOpened = false;
-        }
+        var openStoreAction = new PlayerActions.PlayerStore.OpenStoreAction();
+        await openStoreAction.RestoreAfterEnterWorldAsync(this, this.IsPlayerStoreOpeningAfterEnterSupported).ConfigureAwait(false);
     }
 
     private void LogInvalidVaultItems()

--- a/src/GameLogic/PlayerActions/PlayerStore/OpenStoreAction.cs
+++ b/src/GameLogic/PlayerActions/PlayerStore/OpenStoreAction.cs
@@ -70,6 +70,7 @@ public class OpenStoreAction
             && !string.IsNullOrWhiteSpace(character.StoreName)
             && isStoreOpeningAfterEnterSupported)
         {
+            character.IsStoreOpened = false;
             await this.OpenStoreAsync(player, character.StoreName).ConfigureAwait(false);
         }
         else

--- a/src/GameLogic/PlayerActions/PlayerStore/OpenStoreAction.cs
+++ b/src/GameLogic/PlayerActions/PlayerStore/OpenStoreAction.cs
@@ -44,4 +44,37 @@ public class OpenStoreAction
         player.Logger.LogDebug("OpenStore: Player: [{0}], StoreName: [{1}]", character.Name, character.StoreName);
         await player.ForEachWorldObserverAsync<IPlayerShopOpenedPlugIn>(p => p.PlayerShopOpenedAsync(player), true).ConfigureAwait(false);
     }
+
+    /// <summary>
+    /// Restores the store's open state after the player entered the game.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="isStoreOpeningAfterEnterSupported">
+    /// Whether re-opening the store to other players after entering the game is supported by the player's client.
+    /// </param>
+    /// <remarks>
+    /// If the store was left open before logging out, its name is set, and the client supports it,
+    /// the store is properly re-opened and announced to nearby players (and the owner) via
+    /// <see cref="OpenStoreAsync"/>. Otherwise, the store is (re-)marked as closed for everyone,
+    /// including the owner - it must never appear open only to the owner while staying closed to
+    /// everyone else.
+    /// </remarks>
+    public async ValueTask RestoreAfterEnterWorldAsync(Player player, bool isStoreOpeningAfterEnterSupported)
+    {
+        if (player.SelectedCharacter is not { } character)
+        {
+            return;
+        }
+
+        if (character.IsStoreOpened
+            && !string.IsNullOrWhiteSpace(character.StoreName)
+            && isStoreOpeningAfterEnterSupported)
+        {
+            await this.OpenStoreAsync(player, character.StoreName).ConfigureAwait(false);
+        }
+        else
+        {
+            character.IsStoreOpened = false;
+        }
+    }
 }

--- a/src/GameServer/RemoteView/Inventory/UpdateInventoryListPlugIn.cs
+++ b/src/GameServer/RemoteView/Inventory/UpdateInventoryListPlugIn.cs
@@ -38,7 +38,9 @@ public class UpdateInventoryListPlugIn : IUpdateInventoryListPlugIn
         }
 
         // C4 00 00 00 F3 10 ...
-        var items = (this._player.Inventory?.Items ?? this._player.SelectedCharacter?.Inventory?.Items ?? Enumerable.Empty<Item>())
+        var items = (this._player.Inventory?.Items is { } inventoryItems
+                ? inventoryItems.Concat(this._player.ShopStorage?.Items ?? Enumerable.Empty<Item>())
+                : this._player.SelectedCharacter?.Inventory?.Items ?? Enumerable.Empty<Item>())
             .OrderBy(item => item.ItemSlot)
             .ToList();
         int Write()


### PR DESCRIPTION
### Summary
Fixed a bug where items placed in a player's personal store would become invisible after logging out and back in, while still occupying their slot (blocking new items from being placed there). Also fixed an inconsistency where, on login, the store's "open" state could appear open to the owner while still being closed to everyone else (with an empty shop name).

#### Root cause

Items in store slots are backed by the same underlying item storage as the regular inventory, but were never included in the login inventory sync (UpdateInventoryListPlugIn), which only covered equip/inventory/extension slots.
The store's item list was only ever sent to the client via IShowShopItemListPlugIn, which per protocol is meant to open the "browse a shop" dialog — not to passively sync the owner's own items. Sending it to the owner regardless of the store's open state caused a shop dialog to pop up client-side with an empty name (since StoreName is only set once a store has actually been opened), while other players correctly saw nothing.