### PR TITLE
fix: correct QuestProgressExtended packet type from C1 to C2

### DIFF
--- a/docs/Packets/C2-F6-0C-QuestProgressExtended_by-server.md
+++ b/docs/Packets/C2-F6-0C-QuestProgressExtended_by-server.md
@@ -1,4 +1,4 @@
-# C1 F6 0C - QuestProgressExtended (by server)
+# C2 F6 0C - QuestProgressExtended (by server)
 
 ## Is sent when
 
@@ -12,10 +12,10 @@ The client shows the quest progress accordingly.
 
 | Index | Length | Data Type | Value | Description |
 |-------|--------|-----------|-------|-------------|
-| 0 | 1 |   Byte   | 0xC1  | [Packet type](PacketTypes.md) |
-| 1 | 1 |    Byte   |   272   | Packet header - length of the packet |
-| 2 | 1 |    Byte   | 0xF6  | Packet header - packet type identifier |
-| 3 | 1 |    Byte   | 0x0C  | Packet header - sub packet type identifier |
+| 0 | 1 |   Byte   | 0xC2  | [Packet type](PacketTypes.md) |
+| 1 | 2 |    Short   |   272   | Packet header - length of the packet |
+| 3 | 1 |    Byte   | 0xF6  | Packet header - packet type identifier |
+| 4 | 1 |    Byte   | 0x0C  | Packet header - sub packet type identifier |
 | 5 | 1 | Byte |  | ConditionCount |
 | 6 | 1 | Byte |  | RewardCount |
 | 7 | 1 | Byte |  | RandomRewardCount |

--- a/docs/Packets/ServerToClient.md
+++ b/docs/Packets/ServerToClient.md
@@ -234,7 +234,7 @@
   * [C1 F6 0A - AvailableQuests (by server)](C1-F6-0A-AvailableQuests_by-server.md)
   * [C1 F6 0B - QuestStepInfo (by server)](C1-F6-0B-QuestStepInfo_by-server.md)
   * [C1 F6 0C - QuestProgress (by server)](C1-F6-0C-QuestProgress_by-server.md)
-  * [C1 F6 0C - QuestProgressExtended (by server)](C1-F6-0C-QuestProgressExtended_by-server.md)
+  * [C2 F6 0C - QuestProgressExtended (by server)](C2-F6-0C-QuestProgressExtended_by-server.md)
   * [C1 F6 0D - QuestCompletionResponse (by server)](C1-F6-0D-QuestCompletionResponse_by-server.md)
   * [C1 F6 0F - QuestCancelled (by server)](C1-F6-0F-QuestCancelled_by-server.md)
   * [C1 F6 1A - QuestStateList (by server)](C1-F6-1A-QuestStateList_by-server.md)


### PR DESCRIPTION
The `QuestProgressExtended` packet (opcode `F6 0C`) is currently documented as a `C1` packet, but its declared length is **272 bytes**.
A `C1` header uses a **1-byte length field**, which can only represent values up to 255. A 272-byte packet cannot fit in a `C1` header — the correct type is **`C2`**, which uses a **2-byte length field**.
## Changes
- Renamed `C1-F6-0C-QuestProgressExtended_by-server.md` → `C2-F6-0C-QuestProgressExtended_by-server.md`
- Fixed packet type byte: `0xC1` → `0xC2`
- Fixed length field: `1 byte (Byte)` → `2 bytes (Short)`
- Corrected field byte offsets to reflect the 4-byte `C2` header (vs 3-byte `C1`)
- Updated the link in `ServerToClient.md`