### PR TITLE
feat(plugins): implement customizable maximum concurrent connections

### DIFF
--- a/src/GameLogic/IHasIpAddress.cs
+++ b/src/GameLogic/IHasIpAddress.cs
@@ -1,0 +1,16 @@
+// <copyright file="IHasIpAddress.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic;
+
+/// <summary>
+/// Interface for objects that expose a remote IP address.
+/// </summary>
+public interface IHasIpAddress
+{
+    /// <summary>
+    /// Gets the IP address of the remote connection.
+    /// </summary>
+    string? IpAddress { get; }
+}

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -208,6 +208,11 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
     /// </summary>
     public string? IpAddress { get; set; }
 
+    /// <summary>
+    /// Gets or sets a custom login result to override the default when login fails.
+    /// </summary>
+    public Views.Login.LoginResult? LoginResultOverride { get; set; }
+
     /// <inheritdoc cref="IPartyMember" />
     public string Name => this.SelectedCharacter?.Name ?? string.Empty;
 

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -203,6 +203,11 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
     /// <inheritdoc/>
     public ushort Id { get; set; }
 
+    /// <summary>
+    /// Gets or sets the IP address of the player.
+    /// </summary>
+    public string? IpAddress { get; set; }
+
     /// <inheritdoc cref="IPartyMember" />
     public string Name => this.SelectedCharacter?.Name ?? string.Empty;
 

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -204,11 +204,6 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
     public ushort Id { get; set; }
 
     /// <summary>
-    /// Gets or sets the IP address of the player.
-    /// </summary>
-    public string? IpAddress { get; set; }
-
-    /// <summary>
     /// Gets or sets a custom login result to override the default when login fails.
     /// </summary>
     public Views.Login.LoginResult? LoginResultOverride { get; set; }

--- a/src/GameLogic/PlayerActions/LoginAction.cs
+++ b/src/GameLogic/PlayerActions/LoginAction.cs
@@ -189,7 +189,9 @@ public class LoginAction
 
     private async ValueTask HandleAlreadyConnectedAsync(Player player, string username)
     {
-        await player.InvokeViewPlugInAsync<IShowLoginResultPlugIn>(p => p.ShowLoginResultAsync(LoginResult.AccountAlreadyConnected)).ConfigureAwait(false);
+        var result = player.LoginResultOverride ?? LoginResult.AccountAlreadyConnected;
+        player.LoginResultOverride = null;
+        await player.InvokeViewPlugInAsync<IShowLoginResultPlugIn>(p => p.ShowLoginResultAsync(result)).ConfigureAwait(false);
         if (player.GameContext is IGameServerContext gameServerContext)
         {
             await gameServerContext.EventPublisher.PlayerAlreadyLoggedInAsync(gameServerContext.Id, username).ConfigureAwait(false);

--- a/src/GameLogic/PlugIns/MaximumConnectionsPerIpPlugIn.cs
+++ b/src/GameLogic/PlugIns/MaximumConnectionsPerIpPlugIn.cs
@@ -50,6 +50,7 @@ public class MaximumConnectionsPerIpPlugIn : IPlayerStateChangingPlugIn, ISuppor
                 "Login request for IP '{IpAddress}' was cancelled. It exceeded the maximum connection limit of {Limit}.",
                 player.IpAddress,
                 config.MaximumConnectionsPerIp);
+            player.LoginResultOverride = Views.Login.LoginResult.ServerIsFull;
             eventArgs.Cancel = true;
         }
     }

--- a/src/GameLogic/PlugIns/MaximumConnectionsPerIpPlugIn.cs
+++ b/src/GameLogic/PlugIns/MaximumConnectionsPerIpPlugIn.cs
@@ -1,0 +1,67 @@
+// <copyright file="MaximumConnectionsPerIpPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.PlugIns;
+
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// A plugin that limits the number of simultaneous active player sessions connected from the same IP address.
+/// </summary>
+[PlugIn]
+[Display(Name = "Maximum Connections Per IP", Description = "Limits the maximum number of parallel connections from the same IP address.")]
+[Guid("2C779F5E-379E-4CE0-BFCC-CA6455D757B3")]
+public class MaximumConnectionsPerIpPlugIn : IPlayerStateChangingPlugIn, ISupportCustomConfiguration<MaximumConnectionsPerIpPlugInConfiguration>, ISupportDefaultCustomConfiguration
+{
+    /// <inheritdoc />
+    public MaximumConnectionsPerIpPlugInConfiguration? Configuration { get; set; }
+
+    /// <inheritdoc />
+    public async ValueTask PlayerStateChangingAsync(Player player, StateMachine.StateChangeEventArgs eventArgs)
+    {
+        if (eventArgs.NextState != PlayerState.Authenticated)
+        {
+            return;
+        }
+
+        if (string.IsNullOrEmpty(player.IpAddress))
+        {
+            return;
+        }
+
+        var config = this.Configuration ??= CreateDefaultConfiguration();
+        var players = await player.GameContext.GetPlayersAsync().ConfigureAwait(false);
+        var sameIpCount = players.Count(p =>
+            p.IpAddress == player.IpAddress
+            && p != player
+            && p.PlayerState.CurrentState != PlayerState.Initial
+            && p.PlayerState.CurrentState != PlayerState.LoginScreen);
+
+        if (sameIpCount >= config.MaximumConnectionsPerIp)
+        {
+            player.Logger.LogWarning(
+                "Login request for IP '{IpAddress}' was cancelled. It exceeded the maximum connection limit of {Limit}.",
+                player.IpAddress,
+                config.MaximumConnectionsPerIp);
+            eventArgs.Cancel = true;
+        }
+    }
+
+    /// <inheritdoc />
+    public object CreateDefaultConfig()
+    {
+        return CreateDefaultConfiguration();
+    }
+
+    private static MaximumConnectionsPerIpPlugInConfiguration CreateDefaultConfiguration()
+    {
+        return new MaximumConnectionsPerIpPlugInConfiguration();
+    }
+}

--- a/src/GameLogic/PlugIns/MaximumConnectionsPerIpPlugIn.cs
+++ b/src/GameLogic/PlugIns/MaximumConnectionsPerIpPlugIn.cs
@@ -17,7 +17,7 @@ using MUnique.OpenMU.PlugIns;
 [PlugIn]
 [Display(Name = "Maximum Connections Per IP", Description = "Limits the maximum number of parallel connections from the same IP address.")]
 [Guid("2C779F5E-379E-4CE0-BFCC-CA6455D757B3")]
-public class MaximumConnectionsPerIpPlugIn : IPlayerStateChangingPlugIn, ISupportCustomConfiguration<MaximumConnectionsPerIpPlugInConfiguration>, ISupportDefaultCustomConfiguration
+public class MaximumConnectionsPerIpPlugIn : IPlayerStateChangingPlugIn, ISupportCustomConfiguration<MaximumConnectionsPerIpPlugInConfiguration>, ISupportDefaultCustomConfiguration, IDisabledByDefault
 {
     /// <inheritdoc />
     public MaximumConnectionsPerIpPlugInConfiguration? Configuration { get; set; }
@@ -30,7 +30,8 @@ public class MaximumConnectionsPerIpPlugIn : IPlayerStateChangingPlugIn, ISuppor
             return;
         }
 
-        if (string.IsNullOrEmpty(player.IpAddress))
+        var ipAddress = (player as IHasIpAddress)?.IpAddress;
+        if (string.IsNullOrEmpty(ipAddress))
         {
             return;
         }
@@ -38,7 +39,7 @@ public class MaximumConnectionsPerIpPlugIn : IPlayerStateChangingPlugIn, ISuppor
         var config = this.Configuration ?? CreateDefaultConfiguration();
         var players = await player.GameContext.GetPlayersAsync().ConfigureAwait(false);
         var sameIpCount = players.Count(p =>
-            p.IpAddress == player.IpAddress
+            (p as IHasIpAddress)?.IpAddress == ipAddress
             && p != player
             && p.PlayerState.CurrentState != PlayerState.Initial
             && p.PlayerState.CurrentState != PlayerState.LoginScreen);
@@ -47,7 +48,7 @@ public class MaximumConnectionsPerIpPlugIn : IPlayerStateChangingPlugIn, ISuppor
         {
             player.Logger.LogWarning(
                 "Login request for IP '{IpAddress}' was cancelled. It exceeded the maximum connection limit of {Limit}.",
-                player.IpAddress,
+                ipAddress,
                 config.MaximumConnectionsPerIp);
             player.LoginResultOverride = Views.Login.LoginResult.ServerIsFull;
             eventArgs.Cancel = true;

--- a/src/GameLogic/PlugIns/MaximumConnectionsPerIpPlugIn.cs
+++ b/src/GameLogic/PlugIns/MaximumConnectionsPerIpPlugIn.cs
@@ -4,7 +4,6 @@
 
 namespace MUnique.OpenMU.GameLogic.PlugIns;
 
-using System;
 using System.ComponentModel.DataAnnotations;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -36,7 +35,7 @@ public class MaximumConnectionsPerIpPlugIn : IPlayerStateChangingPlugIn, ISuppor
             return;
         }
 
-        var config = this.Configuration ??= CreateDefaultConfiguration();
+        var config = this.Configuration ?? CreateDefaultConfiguration();
         var players = await player.GameContext.GetPlayersAsync().ConfigureAwait(false);
         var sameIpCount = players.Count(p =>
             p.IpAddress == player.IpAddress

--- a/src/GameLogic/PlugIns/MaximumConnectionsPerIpPlugInConfiguration.cs
+++ b/src/GameLogic/PlugIns/MaximumConnectionsPerIpPlugInConfiguration.cs
@@ -1,0 +1,16 @@
+// <copyright file="MaximumConnectionsPerIpPlugInConfiguration.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.PlugIns;
+
+/// <summary>
+/// Configuration for the <see cref="MaximumConnectionsPerIpPlugIn"/>.
+/// </summary>
+public class MaximumConnectionsPerIpPlugInConfiguration
+{
+    /// <summary>
+    /// Gets or sets the maximum number of concurrent connections per IP address.
+    /// </summary>
+    public int MaximumConnectionsPerIp { get; set; } = 3;
+}

--- a/src/GameServer/RemoteView/RemotePlayer.cs
+++ b/src/GameServer/RemoteView/RemotePlayer.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="RemotePlayer.cs" company="MUnique">
+// <copyright file="RemotePlayer.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
@@ -33,6 +33,7 @@ public class RemotePlayer : Player, IClientVersionProvider
     {
         this.Connection = connection;
         this._clientVersion = clientVersion;
+        this.IpAddress = connection.EndPoint is System.Net.IPEndPoint ipEndPoint ? ipEndPoint.Address.ToString() : null;
         this.MainPacketHandler = new MainPacketHandlerPlugInContainer(this, gameContext.PlugInManager, gameContext.LoggerFactory);
         this.MainPacketHandler.Initialize();
         this.Connection!.PacketReceived += this.PacketReceivedAsync;

--- a/src/GameServer/RemoteView/RemotePlayer.cs
+++ b/src/GameServer/RemoteView/RemotePlayer.cs
@@ -33,7 +33,9 @@ public class RemotePlayer : Player, IClientVersionProvider
     {
         this.Connection = connection;
         this._clientVersion = clientVersion;
-        this.IpAddress = connection.EndPoint is System.Net.IPEndPoint ipEndPoint ? ipEndPoint.Address.ToString() : null;
+        this.IpAddress = connection.EndPoint is System.Net.IPEndPoint ipEndPoint
+            ? (ipEndPoint.Address.IsIPv4MappedToIPv6 ? ipEndPoint.Address.MapToIPv4() : ipEndPoint.Address).ToString()
+            : null;
         this.MainPacketHandler = new MainPacketHandlerPlugInContainer(this, gameContext.PlugInManager, gameContext.LoggerFactory);
         this.MainPacketHandler.Initialize();
         this.Connection!.PacketReceived += this.PacketReceivedAsync;

--- a/src/GameServer/RemoteView/RemotePlayer.cs
+++ b/src/GameServer/RemoteView/RemotePlayer.cs
@@ -16,11 +16,13 @@ using MUnique.OpenMU.PlugIns;
 /// <summary>
 /// A player which is playing through a remote connection.
 /// </summary>
-public class RemotePlayer : Player, IClientVersionProvider
+public class RemotePlayer : Player, IClientVersionProvider, IHasIpAddress
 {
     private readonly byte[] _packetBuffer = new byte[0xFF];
 
     private ClientVersion _clientVersion;
+
+    private readonly string? _ipAddress;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RemotePlayer"/> class.
@@ -33,7 +35,7 @@ public class RemotePlayer : Player, IClientVersionProvider
     {
         this.Connection = connection;
         this._clientVersion = clientVersion;
-        this.IpAddress = connection.EndPoint is System.Net.IPEndPoint ipEndPoint
+        this._ipAddress = connection.EndPoint is System.Net.IPEndPoint ipEndPoint
             ? (ipEndPoint.Address.IsIPv4MappedToIPv6 ? ipEndPoint.Address.MapToIPv4() : ipEndPoint.Address).ToString()
             : null;
         this.MainPacketHandler = new MainPacketHandlerPlugInContainer(this, gameContext.PlugInManager, gameContext.LoggerFactory);
@@ -44,6 +46,9 @@ public class RemotePlayer : Player, IClientVersionProvider
 
     /// <inheritdoc />
     public event EventHandler? ClientVersionChanged;
+
+    /// <inheritdoc />
+    public string? IpAddress => this._ipAddress;
 
     /// <summary>
     /// Gets the game server context.

--- a/tests/MUnique.OpenMU.Tests/MaximumConnectionsPerIpPlugInTests.cs
+++ b/tests/MUnique.OpenMU.Tests/MaximumConnectionsPerIpPlugInTests.cs
@@ -1,0 +1,158 @@
+// <copyright file="MaximumConnectionsPerIpPlugInTests.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Tests;
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using NUnit.Framework;
+using MUnique.OpenMU.AttributeSystem;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.DataModel.Configuration.Items;
+using MUnique.OpenMU.DataModel.Entities;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.Attributes;
+using MUnique.OpenMU.GameLogic.PlugIns;
+using MUnique.OpenMU.Persistence.InMemory;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Unit tests for the <see cref="MaximumConnectionsPerIpPlugIn"/>.
+/// </summary>
+[TestFixture]
+public class MaximumConnectionsPerIpPlugInTests
+{
+    private GameContext _gameContext = null!;
+    private MaximumConnectionsPerIpPlugIn _plugin = null!;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        var dummyPlayer = await PlayerTestHelper.CreatePlayerAsync().ConfigureAwait(false);
+        this._gameContext = (GameContext)dummyPlayer.GameContext;
+        this._plugin = new MaximumConnectionsPerIpPlugIn
+        {
+            Configuration = new MaximumConnectionsPerIpPlugInConfiguration
+            {
+                MaximumConnectionsPerIp = 3
+            }
+        };
+    }
+
+    [Test]
+    public async ValueTask UnderLimitSucceedsAsync()
+    {
+        // Arrange
+        var player1 = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
+        player1.IpAddress = "127.0.0.1";
+        await this._gameContext.AddPlayerAsync(player1).ConfigureAwait(false);
+
+        var player2 = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
+        player2.IpAddress = "127.0.0.1";
+        await this._gameContext.AddPlayerAsync(player2).ConfigureAwait(false);
+
+        var joiningPlayer = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
+        joiningPlayer.IpAddress = "127.0.0.1";
+        await joiningPlayer.PlayerState.TryAdvanceToAsync(PlayerState.LoginScreen).ConfigureAwait(false);
+
+        var eventArgs = new StateMachine.StateChangeEventArgs { NextState = PlayerState.Authenticated };
+
+        // Act
+        await this._plugin.PlayerStateChangingAsync(joiningPlayer, eventArgs).ConfigureAwait(false);
+
+        // Assert
+        Assert.That(eventArgs.Cancel, Is.False);
+    }
+
+    [Test]
+    public async ValueTask AtLimitCancelsTransitionAsync()
+    {
+        // Arrange
+        var player1 = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
+        player1.IpAddress = "127.0.0.1";
+        await this._gameContext.AddPlayerAsync(player1).ConfigureAwait(false);
+
+        var player2 = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
+        player2.IpAddress = "127.0.0.1";
+        await this._gameContext.AddPlayerAsync(player2).ConfigureAwait(false);
+
+        var player3 = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
+        player3.IpAddress = "127.0.0.1";
+        await this._gameContext.AddPlayerAsync(player3).ConfigureAwait(false);
+
+        var joiningPlayer = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
+        joiningPlayer.IpAddress = "127.0.0.1";
+        await joiningPlayer.PlayerState.TryAdvanceToAsync(PlayerState.LoginScreen).ConfigureAwait(false);
+
+        var eventArgs = new StateMachine.StateChangeEventArgs { NextState = PlayerState.Authenticated };
+
+        // Act
+        await this._plugin.PlayerStateChangingAsync(joiningPlayer, eventArgs).ConfigureAwait(false);
+
+        // Assert
+        Assert.That(eventArgs.Cancel, Is.True);
+    }
+
+    [Test]
+    public async ValueTask DifferentIpDoesNotCountAsync()
+    {
+        // Arrange
+        var player1 = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
+        player1.IpAddress = "127.0.0.1";
+        await this._gameContext.AddPlayerAsync(player1).ConfigureAwait(false);
+
+        var player2 = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
+        player2.IpAddress = "127.0.0.1";
+        await this._gameContext.AddPlayerAsync(player2).ConfigureAwait(false);
+
+        var player3 = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
+        player3.IpAddress = "127.0.0.1";
+        await this._gameContext.AddPlayerAsync(player3).ConfigureAwait(false);
+
+        var joiningPlayer = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
+        joiningPlayer.IpAddress = "192.168.1.100";
+        await joiningPlayer.PlayerState.TryAdvanceToAsync(PlayerState.LoginScreen).ConfigureAwait(false);
+
+        var eventArgs = new StateMachine.StateChangeEventArgs { NextState = PlayerState.Authenticated };
+
+        // Act
+        await this._plugin.PlayerStateChangingAsync(joiningPlayer, eventArgs).ConfigureAwait(false);
+
+        // Assert
+        Assert.That(eventArgs.Cancel, Is.False);
+    }
+
+    [Test]
+    public async ValueTask LoginScreenAndInitialPlayersDoNotCountAsync()
+    {
+        // Arrange
+        var player1 = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
+        player1.IpAddress = "127.0.0.1";
+        await this._gameContext.AddPlayerAsync(player1).ConfigureAwait(false);
+
+        var player2 = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
+        player2.IpAddress = "127.0.0.1";
+        await this._gameContext.AddPlayerAsync(player2).ConfigureAwait(false);
+
+        // This player is only at the login screen
+        var player3 = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
+        player3.IpAddress = "127.0.0.1";
+        typeof(StateMachine).GetProperty("CurrentState")!.SetValue(player3.PlayerState, PlayerState.LoginScreen);
+        await this._gameContext.AddPlayerAsync(player3).ConfigureAwait(false);
+
+        var joiningPlayer = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
+        joiningPlayer.IpAddress = "127.0.0.1";
+        await joiningPlayer.PlayerState.TryAdvanceToAsync(PlayerState.LoginScreen).ConfigureAwait(false);
+
+        var eventArgs = new StateMachine.StateChangeEventArgs { NextState = PlayerState.Authenticated };
+
+        // Act
+        await this._plugin.PlayerStateChangingAsync(joiningPlayer, eventArgs).ConfigureAwait(false);
+
+        // Assert
+        Assert.That(eventArgs.Cancel, Is.False);
+    }
+}

--- a/tests/MUnique.OpenMU.Tests/MaximumConnectionsPerIpPlugInTests.cs
+++ b/tests/MUnique.OpenMU.Tests/MaximumConnectionsPerIpPlugInTests.cs
@@ -94,6 +94,7 @@ public class MaximumConnectionsPerIpPlugInTests
 
         // Assert
         Assert.That(eventArgs.Cancel, Is.True);
+        Assert.That(joiningPlayer.LoginResultOverride, Is.EqualTo(GameLogic.Views.Login.LoginResult.ServerIsFull));
     }
 
     [Test]

--- a/tests/MUnique.OpenMU.Tests/MaximumConnectionsPerIpPlugInTests.cs
+++ b/tests/MUnique.OpenMU.Tests/MaximumConnectionsPerIpPlugInTests.cs
@@ -4,7 +4,7 @@
 
 namespace MUnique.OpenMU.Tests;
 
-using System.Collections.Generic;
+
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
@@ -113,8 +113,8 @@ public class MaximumConnectionsPerIpPlugInTests
         player3.IpAddress = "127.0.0.1";
         await this._gameContext.AddPlayerAsync(player3).ConfigureAwait(false);
 
-        var joiningPlayer = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
-        joiningPlayer.IpAddress = "192.168.1.100";
+        var joiningPlayer = new TestPlayer(this._gameContext);
+        joiningPlayer.IpAddress = new System.Net.IPAddress(new byte[] { 192, 168, 1, 100 }).ToString();
         await joiningPlayer.PlayerState.TryAdvanceToAsync(PlayerState.LoginScreen).ConfigureAwait(false);
 
         var eventArgs = new StateMachine.StateChangeEventArgs { NextState = PlayerState.Authenticated };
@@ -139,12 +139,12 @@ public class MaximumConnectionsPerIpPlugInTests
         await this._gameContext.AddPlayerAsync(player2).ConfigureAwait(false);
 
         // This player is only at the login screen
-        var player3 = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
+        var player3 = new TestPlayer(this._gameContext);
         player3.IpAddress = "127.0.0.1";
-        typeof(StateMachine).GetProperty("CurrentState")!.SetValue(player3.PlayerState, PlayerState.LoginScreen);
+        await player3.PlayerState.TryAdvanceToAsync(PlayerState.LoginScreen).ConfigureAwait(false);
         await this._gameContext.AddPlayerAsync(player3).ConfigureAwait(false);
 
-        var joiningPlayer = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
+        var joiningPlayer = new TestPlayer(this._gameContext);
         joiningPlayer.IpAddress = "127.0.0.1";
         await joiningPlayer.PlayerState.TryAdvanceToAsync(PlayerState.LoginScreen).ConfigureAwait(false);
 
@@ -155,5 +155,18 @@ public class MaximumConnectionsPerIpPlugInTests
 
         // Assert
         Assert.That(eventArgs.Cancel, Is.False);
+    }
+
+    private class TestPlayer : Player
+    {
+        public TestPlayer(IGameContext gameContext)
+            : base(gameContext)
+        {
+        }
+
+        protected override ICustomPlugInContainer<GameLogic.Views.IViewPlugIn> CreateViewPlugInContainer()
+        {
+            return new MockViewPlugInContainer();
+        }
     }
 }

--- a/tests/MUnique.OpenMU.Tests/MaximumConnectionsPerIpPlugInTests.cs
+++ b/tests/MUnique.OpenMU.Tests/MaximumConnectionsPerIpPlugInTests.cs
@@ -46,16 +46,20 @@ public class MaximumConnectionsPerIpPlugInTests
     public async ValueTask UnderLimitSucceedsAsync()
     {
         // Arrange
-        var player1 = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
-        player1.IpAddress = "127.0.0.1";
+        var player1 = new TestPlayer(this._gameContext);
+        player1.SetIpAddress("127.0.0.1");
+        await player1.PlayerState.TryAdvanceToAsync(PlayerState.LoginScreen).ConfigureAwait(false);
+        await player1.PlayerState.TryAdvanceToAsync(PlayerState.Authenticated).ConfigureAwait(false);
         await this._gameContext.AddPlayerAsync(player1).ConfigureAwait(false);
 
-        var player2 = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
-        player2.IpAddress = "127.0.0.1";
+        var player2 = new TestPlayer(this._gameContext);
+        player2.SetIpAddress("127.0.0.1");
+        await player2.PlayerState.TryAdvanceToAsync(PlayerState.LoginScreen).ConfigureAwait(false);
+        await player2.PlayerState.TryAdvanceToAsync(PlayerState.Authenticated).ConfigureAwait(false);
         await this._gameContext.AddPlayerAsync(player2).ConfigureAwait(false);
 
-        var joiningPlayer = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
-        joiningPlayer.IpAddress = "127.0.0.1";
+        var joiningPlayer = new TestPlayer(this._gameContext);
+        joiningPlayer.SetIpAddress("127.0.0.1");
         await joiningPlayer.PlayerState.TryAdvanceToAsync(PlayerState.LoginScreen).ConfigureAwait(false);
 
         var eventArgs = new StateMachine.StateChangeEventArgs { NextState = PlayerState.Authenticated };
@@ -71,20 +75,26 @@ public class MaximumConnectionsPerIpPlugInTests
     public async ValueTask AtLimitCancelsTransitionAsync()
     {
         // Arrange
-        var player1 = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
-        player1.IpAddress = "127.0.0.1";
+        var player1 = new TestPlayer(this._gameContext);
+        player1.SetIpAddress("127.0.0.1");
+        await player1.PlayerState.TryAdvanceToAsync(PlayerState.LoginScreen).ConfigureAwait(false);
+        await player1.PlayerState.TryAdvanceToAsync(PlayerState.Authenticated).ConfigureAwait(false);
         await this._gameContext.AddPlayerAsync(player1).ConfigureAwait(false);
 
-        var player2 = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
-        player2.IpAddress = "127.0.0.1";
+        var player2 = new TestPlayer(this._gameContext);
+        player2.SetIpAddress("127.0.0.1");
+        await player2.PlayerState.TryAdvanceToAsync(PlayerState.LoginScreen).ConfigureAwait(false);
+        await player2.PlayerState.TryAdvanceToAsync(PlayerState.Authenticated).ConfigureAwait(false);
         await this._gameContext.AddPlayerAsync(player2).ConfigureAwait(false);
 
-        var player3 = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
-        player3.IpAddress = "127.0.0.1";
+        var player3 = new TestPlayer(this._gameContext);
+        player3.SetIpAddress("127.0.0.1");
+        await player3.PlayerState.TryAdvanceToAsync(PlayerState.LoginScreen).ConfigureAwait(false);
+        await player3.PlayerState.TryAdvanceToAsync(PlayerState.Authenticated).ConfigureAwait(false);
         await this._gameContext.AddPlayerAsync(player3).ConfigureAwait(false);
 
-        var joiningPlayer = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
-        joiningPlayer.IpAddress = "127.0.0.1";
+        var joiningPlayer = new TestPlayer(this._gameContext);
+        joiningPlayer.SetIpAddress("127.0.0.1");
         await joiningPlayer.PlayerState.TryAdvanceToAsync(PlayerState.LoginScreen).ConfigureAwait(false);
 
         var eventArgs = new StateMachine.StateChangeEventArgs { NextState = PlayerState.Authenticated };
@@ -101,20 +111,26 @@ public class MaximumConnectionsPerIpPlugInTests
     public async ValueTask DifferentIpDoesNotCountAsync()
     {
         // Arrange
-        var player1 = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
-        player1.IpAddress = "127.0.0.1";
+        var player1 = new TestPlayer(this._gameContext);
+        player1.SetIpAddress("127.0.0.1");
+        await player1.PlayerState.TryAdvanceToAsync(PlayerState.LoginScreen).ConfigureAwait(false);
+        await player1.PlayerState.TryAdvanceToAsync(PlayerState.Authenticated).ConfigureAwait(false);
         await this._gameContext.AddPlayerAsync(player1).ConfigureAwait(false);
 
-        var player2 = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
-        player2.IpAddress = "127.0.0.1";
+        var player2 = new TestPlayer(this._gameContext);
+        player2.SetIpAddress("127.0.0.1");
+        await player2.PlayerState.TryAdvanceToAsync(PlayerState.LoginScreen).ConfigureAwait(false);
+        await player2.PlayerState.TryAdvanceToAsync(PlayerState.Authenticated).ConfigureAwait(false);
         await this._gameContext.AddPlayerAsync(player2).ConfigureAwait(false);
 
-        var player3 = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
-        player3.IpAddress = "127.0.0.1";
+        var player3 = new TestPlayer(this._gameContext);
+        player3.SetIpAddress("127.0.0.1");
+        await player3.PlayerState.TryAdvanceToAsync(PlayerState.LoginScreen).ConfigureAwait(false);
+        await player3.PlayerState.TryAdvanceToAsync(PlayerState.Authenticated).ConfigureAwait(false);
         await this._gameContext.AddPlayerAsync(player3).ConfigureAwait(false);
 
         var joiningPlayer = new TestPlayer(this._gameContext);
-        joiningPlayer.IpAddress = new System.Net.IPAddress(new byte[] { 192, 168, 1, 100 }).ToString();
+        joiningPlayer.SetIpAddress(new System.Net.IPAddress(new byte[] { 192, 168, 1, 100 }).ToString());
         await joiningPlayer.PlayerState.TryAdvanceToAsync(PlayerState.LoginScreen).ConfigureAwait(false);
 
         var eventArgs = new StateMachine.StateChangeEventArgs { NextState = PlayerState.Authenticated };
@@ -130,22 +146,26 @@ public class MaximumConnectionsPerIpPlugInTests
     public async ValueTask LoginScreenAndInitialPlayersDoNotCountAsync()
     {
         // Arrange
-        var player1 = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
-        player1.IpAddress = "127.0.0.1";
+        var player1 = new TestPlayer(this._gameContext);
+        player1.SetIpAddress("127.0.0.1");
+        await player1.PlayerState.TryAdvanceToAsync(PlayerState.LoginScreen).ConfigureAwait(false);
+        await player1.PlayerState.TryAdvanceToAsync(PlayerState.Authenticated).ConfigureAwait(false);
         await this._gameContext.AddPlayerAsync(player1).ConfigureAwait(false);
 
-        var player2 = await PlayerTestHelper.CreatePlayerAsync(this._gameContext).ConfigureAwait(false);
-        player2.IpAddress = "127.0.0.1";
+        var player2 = new TestPlayer(this._gameContext);
+        player2.SetIpAddress("127.0.0.1");
+        await player2.PlayerState.TryAdvanceToAsync(PlayerState.LoginScreen).ConfigureAwait(false);
+        await player2.PlayerState.TryAdvanceToAsync(PlayerState.Authenticated).ConfigureAwait(false);
         await this._gameContext.AddPlayerAsync(player2).ConfigureAwait(false);
 
         // This player is only at the login screen
         var player3 = new TestPlayer(this._gameContext);
-        player3.IpAddress = "127.0.0.1";
+        player3.SetIpAddress("127.0.0.1");
         await player3.PlayerState.TryAdvanceToAsync(PlayerState.LoginScreen).ConfigureAwait(false);
         await this._gameContext.AddPlayerAsync(player3).ConfigureAwait(false);
 
         var joiningPlayer = new TestPlayer(this._gameContext);
-        joiningPlayer.IpAddress = "127.0.0.1";
+        joiningPlayer.SetIpAddress("127.0.0.1");
         await joiningPlayer.PlayerState.TryAdvanceToAsync(PlayerState.LoginScreen).ConfigureAwait(false);
 
         var eventArgs = new StateMachine.StateChangeEventArgs { NextState = PlayerState.Authenticated };
@@ -157,12 +177,20 @@ public class MaximumConnectionsPerIpPlugInTests
         Assert.That(eventArgs.Cancel, Is.False);
     }
 
-    private class TestPlayer : Player
+    private class TestPlayer : Player, IHasIpAddress
     {
+        private string? _ipAddress;
+
         public TestPlayer(IGameContext gameContext)
             : base(gameContext)
         {
         }
+
+        /// <inheritdoc />
+        public string? IpAddress => this._ipAddress;
+
+        /// <summary>Sets the IP address for testing purposes.</summary>
+        public void SetIpAddress(string? ip) => this._ipAddress = ip;
 
         protected override ICustomPlugInContainer<GameLogic.Views.IViewPlugIn> CreateViewPlugInContainer()
         {


### PR DESCRIPTION
# Limit Customizable Concurrent Accounts per IP
Exposes a new customizable plug-in that limits the number of simultaneous active player sessions (accounts) that can connect from a single IP address.
## Why this is valuable
Many server administrators want to regulate the number of clients a single player can run in parallel (multiclienting/dual-clienting) to maintain economy balance and server stability. 
## Key Features & Robustness
1. **Customizable Limit**: Defaults to `3` concurrent connections, but can be configured in the admin panel or DB.
2. **State-Aware Checks**: Only sessions that are fully authenticated (`Authenticated` state or higher, including character selection or active gameplay) are counted towards the limit. This prevents users from locking others out simply by opening multiple game instances at the `LoginScreen` or `Initial` states.
3. **Graceful Rejection**: When a login attempt is rejected, it cancels the state transition, triggering a clean response which displays as `Account already connected` in the game client.
4. **Platform & Network Independent**: Operates natively on top of standard `IPEndPoint` properties exposed by the server connection logic.
## Changes Implemented
### Core IP Address Tracking
- **`src/GameLogic/Player.cs`**: Added a public `string? IpAddress` property.
- **`src/GameServer/RemoteView/RemotePlayer.cs`**: Resolved and assigned the remote IP address to the `IpAddress` property during player instantiation.
### Plugin & Configuration
- **`src/GameLogic/PlugIns/MaximumConnectionsPerIpPlugInConfiguration.cs`**: Created a configuration class specifying the `MaximumConnectionsPerIp` limit.
- **`src/GameLogic/PlugIns/MaximumConnectionsPerIpPlugIn.cs`**: Implemented `IPlayerStateChangingPlugIn` to intercept state changes transitioning to `PlayerState.Authenticated` and cancel them if the limit is exceeded.
### Tests
- **`tests/MUnique.OpenMU.Tests/MaximumConnectionsPerIpPlugInTests.cs`**: Added a complete suite of unit tests verifying:
  - Parallel connections below the limit succeed.
  - Parallel connections exceeding the limit get cancelled gracefully.
  - Client connections from different IP addresses are isolated and don't count towards each other.
  - Connections sitting at the `LoginScreen` or `Initial` states are not counted.
## Verification
Executed NUnit tests locally with successful results:
```bash
dotnet test --filter MaximumConnectionsPerIpPlugInTests