### PR TITLE
Fix download button for web AdminPanel

### DIFF
--- a/src/Web/Shared/Services/ByteArrayDownloadController.cs
+++ b/src/Web/Shared/Services/ByteArrayDownloadController.cs
@@ -61,13 +61,11 @@ public class ByteArrayDownloadController : Controller
         }
 
         var array = (byte[]?)property.GetValue(obj);
-        this.Response.ContentType = "application/octet-stream";
         if (array is null || array.Length == 0)
         {
             return this.NoContent();
         }
 
-        await this.Response.Body.WriteAsync(array, 0, array.Length).ConfigureAwait(false);
-        return this.Ok();
+        return this.File(array, "application/octet-stream", $"{type.Name}_{id}_{propertyName}.bin");
     }
 }


### PR DESCRIPTION
### Description

In AdminPanel, if you go to Game configuration -> Game maps, you select any map to edit, and press the "Download" button in the Terrain Data, it triggers a download but if you actually download it shows an error, cannot download.

This PR fixes it and it lets you download.

Why `.bin` ? because the download controller is not only for Terrain Data (`.att`) but its generic.