### PR TITLE
Fix modals making app crash

### DIFF
--- a/src/Web/Shared/Components/Modal/ModalContainer.razor
+++ b/src/Web/Shared/Components/Modal/ModalContainer.razor
@@ -82,7 +82,15 @@
 
         if (this.ModalService.Current is { } current)
         {
-            result["Modal"] = current.Instance;
+            // Only supply the Modal instance to content components that actually declare
+            // a matching parameter (e.g. ModalQuestion). Passing it to a component that
+            // doesn't - like the plain ModalMessage - makes Blazor throw "does not have a
+            // property matching the name 'Modal'". This keeps simple modals boilerplate-free.
+            var modalProperty = current.ComponentType.GetProperty("Modal");
+            if (modalProperty is not null && modalProperty.PropertyType.IsAssignableFrom(typeof(ModalInstance)))
+            {
+                result["Modal"] = current.Instance;
+            }
         }
         return result;
     }

--- a/src/Web/Shared/Components/Modal/ModalMessage.razor
+++ b/src/Web/Shared/Components/Modal/ModalMessage.razor
@@ -3,6 +3,15 @@
 @code {
 
     /// <summary>
+    /// Gets or sets the modal instance. The <see cref="ModalContainer"/> passes this to
+    /// every modal content component, so it must be declared here even though a plain
+    /// message doesn't use it - otherwise Blazor throws "does not have a property
+    /// matching the name 'Modal'".
+    /// </summary>
+    [Parameter]
+    public ModalInstance Modal { get; set; } = null!;
+
+    /// <summary>
     /// Gets or sets the text.
     /// </summary>
     [Parameter]

--- a/src/Web/Shared/Components/Modal/ModalMessage.razor
+++ b/src/Web/Shared/Components/Modal/ModalMessage.razor
@@ -3,15 +3,6 @@
 @code {
 
     /// <summary>
-    /// Gets or sets the modal instance. The <see cref="ModalContainer"/> passes this to
-    /// every modal content component, so it must be declared here even though a plain
-    /// message doesn't use it - otherwise Blazor throws "does not have a property
-    /// matching the name 'Modal'".
-    /// </summary>
-    [Parameter]
-    public ModalInstance Modal { get; set; } = null!;
-
-    /// <summary>
     /// Gets or sets the text.
     /// </summary>
     [Parameter]


### PR DESCRIPTION
### Description

In many places where a Modal should be shown in the AdminPanel (example: Uploading a file into the terrain data of a map) the app crashes with:

`Error: System.InvalidOperationException: Object of type 'MUnique.OpenMU.Web.Shared.Components.Modal.ModalMessage' does not have a property matching the name 'Modal'.`

This PR fixes that.