### PR TITLE
bugfix: IndexOutOfRangeException in pathfinding due to byte overflow

### DIFF
--- a/src/Pathfinding/BaseGridNetwork.cs
+++ b/src/Pathfinding/BaseGridNetwork.cs
@@ -90,13 +90,18 @@ public abstract class BaseGridNetwork : INetwork
             newX = (byte)(node.X + DirectionOffsets[i, 0]);
             newY = (byte)(node.Y + DirectionOffsets[i, 1]);
 
+            if (!this.IsWithinBounds(newX, newY))
+            {
+                continue;
+            }
+
             if (!this._includeSafezone && (grid[newX, newY] & SafezoneBitFlag) > 0)
             {
                 continue;
             }
 
             var costToNode = grid[newX, newY] & CostBitMask;
-            if (!this.IsWithinBounds(newX, newY) || costToNode == UnreachableGridNodeValue)
+            if (costToNode == UnreachableGridNodeValue)
             {
                 continue;
             }

--- a/src/Pathfinding/BaseGridNetwork.cs
+++ b/src/Pathfinding/BaseGridNetwork.cs
@@ -110,6 +110,7 @@ public abstract class BaseGridNetwork : INetwork
 
             if (newNode.Status == NodeStatus.Open && newNode.CostUntilNow <= newG)
             {
+                // The current node has less cost than the previous? then skip this node
                 continue;
             }
 

--- a/src/Pathfinding/BaseGridNetwork.cs
+++ b/src/Pathfinding/BaseGridNetwork.cs
@@ -24,17 +24,8 @@ public abstract class BaseGridNetwork : INetwork
     /// </summary>
     private const byte CostBitMask = 0b0111_1111;
 
-    private static readonly sbyte[,] DirectionOffsets =
-    {
-        { 0, -1 },
-        { 1, 0 },
-        { 0, 1 },
-        { -1, 0 },
-        { 1, -1 },
-        { 1, 1 },
-        { -1, 1 },
-        { -1, -1 },
-    };
+    private static readonly sbyte[] DirectionOffsetsX = { 0, 1, 0, -1, 1, 1, -1, -1 };
+    private static readonly sbyte[] DirectionOffsetsY = { -1, 0, 1, 0, -1, 1, 1, -1 };
 
     private readonly int _numberOfDirections;
     private ushort _gridWidth;
@@ -79,28 +70,30 @@ public abstract class BaseGridNetwork : INetwork
     {
         var grid = this._grid ?? throw new InvalidOperationException("Call Prepare before");
 
-        // ReSharper disable once TooWideLocalVariableScope performance improvement
-        byte newX;
-
-        // ReSharper disable once TooWideLocalVariableScope performance improvement
-        byte newY;
-
         for (int i = 0; i < this._numberOfDirections; i++)
         {
-            newX = (byte)(node.X + DirectionOffsets[i, 0]);
-            newY = (byte)(node.Y + DirectionOffsets[i, 1]);
+            var calculatedX = node.X + DirectionOffsetsX[i];
+            var calculatedY = node.Y + DirectionOffsetsY[i];
+            if ((uint)calculatedX > byte.MaxValue || (uint)calculatedY > byte.MaxValue)
+            {
+                continue;
+            }
+
+            var newX = (byte)calculatedX;
+            var newY = (byte)calculatedY;
 
             if (!this.IsWithinBounds(newX, newY))
             {
                 continue;
             }
 
-            if (!this._includeSafezone && (grid[newX, newY] & SafezoneBitFlag) > 0)
+            var gridValue = grid[newX, newY];
+            if (!this._includeSafezone && (gridValue & SafezoneBitFlag) > 0)
             {
                 continue;
             }
 
-            var costToNode = grid[newX, newY] & CostBitMask;
+            var costToNode = gridValue & CostBitMask;
             if (costToNode == UnreachableGridNodeValue)
             {
                 continue;
@@ -113,11 +106,10 @@ public abstract class BaseGridNetwork : INetwork
                 continue;
             }
 
-            var newG = node.CostUntilNow + this._grid[newNode.X, newNode.Y];
+            var newG = node.CostUntilNow + costToNode;
 
             if (newNode.Status == NodeStatus.Open && newNode.CostUntilNow <= newG)
             {
-                // The current node has less cost than the previous? then skip this node
                 continue;
             }
 

--- a/src/Pathfinding/ScopedGridNetwork.cs
+++ b/src/Pathfinding/ScopedGridNetwork.cs
@@ -82,10 +82,7 @@ public sealed class ScopedGridNetwork : BaseGridNetwork
         var maxX = offsetX + this._actualSegmentSideLength;
         var maxY = offsetY + this._actualSegmentSideLength;
 
-        // Note: x and y must be wider than byte. offsetX/offsetY can be clamped so that
-        // maxX/maxY equal 256 (grid width/height, since coordinates are bytes 0-255), and a
-        // byte loop counter would overflow back to 0 instead of terminating, eventually
-        // producing an out-of-range index below.
+        // Must use int; a byte loop counter wraps at 256 and would not terminate.
         for (int x = offsetX; x < maxX; ++x)
         {
             for (int y = offsetY; y < maxY; ++y)

--- a/src/Pathfinding/ScopedGridNetwork.cs
+++ b/src/Pathfinding/ScopedGridNetwork.cs
@@ -82,16 +82,25 @@ public sealed class ScopedGridNetwork : BaseGridNetwork
         var maxX = offsetX + this._actualSegmentSideLength;
         var maxY = offsetY + this._actualSegmentSideLength;
 
-        for (byte x = offsetX; x < maxX; ++x)
+        // Note: x and y must be wider than byte. offsetX/offsetY can be clamped so that
+        // maxX/maxY equal 256 (grid width/height, since coordinates are bytes 0-255), and a
+        // byte loop counter would overflow back to 0 instead of terminating, eventually
+        // producing an out-of-range index below.
+        for (int x = offsetX; x < maxX; ++x)
         {
-            for (byte y = offsetY; y < maxY; ++y)
+            for (int y = offsetY; y < maxY; ++y)
             {
                 var i = this.GetIndexOfPoint(x, y);
+                if (i < 0 || i >= this._gridNodes.Length)
+                {
+                    continue;
+                }
+
                 var node = this._gridNodes[i];
                 if (node is not null)
                 {
                     node.Status = NodeStatus.Undefined;
-                    node.Position = new(x, y);
+                    node.Position = new((byte)x, (byte)y);
                 }
             }
         }
@@ -100,9 +109,9 @@ public sealed class ScopedGridNetwork : BaseGridNetwork
 
         byte GetOffset(byte avgValue, int gridSize)
         {
-            var offset = (byte)Math.Max(avgValue - (this._actualSegmentSideLength / 2), 0);
-            offset = (byte)Math.Min(offset, gridSize - this._actualSegmentSideLength);
-            return offset;
+            var offset = Math.Max(avgValue - (this._actualSegmentSideLength / 2), 0);
+            offset = Math.Min(offset, Math.Max(gridSize - this._actualSegmentSideLength, 0));
+            return (byte)offset;
         }
     }
 


### PR DESCRIPTION
Two `IndexOutOfRangeException` bugs caused by `byte` arithmetic overflow when
monsters walk near map edges, plus additional performance improvements on the
hot neighbor-expansion path.

### Bug fixes

**Bug 1: Byte loop counter overflow in `ScopedGridNetwork.Prepare`** — `maxX`
is `int` (byte+byte promotes to int) but the loop used `byte x`. At offset 240
with segment length 16, `maxX = 256`. When `x` wraps from 255→0 the loop
continues, `GetIndexOfPoint(0, y)` returns -1, crashing on `_gridNodes[-1]`.

**Bug 2: Byte overflow in `BaseGridNetwork.GetPossibleNextNodes` direction
offsets** — `(byte)(node.X + (-1))` wraps to 255. The code accessed
`grid[255, y]` before the bounds check could reject it.

**Additional fix in `GetOffset`** — `(byte)(gridSize - segmentLength)` wraps
negative values to large positives (e.g. `(byte)(-6) = 250`), pushing the
segment outside grid bounds.

### Performance improvements (same hot path)

- **Unsigned range check** — `(uint)x > 255` replaces two signed comparisons
  with one branch per axis.
- **Single grid read** — `grid[newX, newY]` read once, reused for safezone
  check and cost mask, eliminating redundant `byte[,]` bounds checks.
- **Flat direction arrays** — two `sbyte[]` instead of `sbyte[,]`, removing 2D
  stride multiply and improving JIT bounds-check elimination.
- **Fixed latent cost bug** — `newG` now uses the masked `costToNode` instead
  of raw `this._grid[...]`, so safezone flags (bit 7) no longer corrupt path
  cost.