### PR TITLE
fix: duplicate rows in deserialized aggregate collections

### DIFF
--- a/src/Persistence/Initialization/Updates/AddElfSoldierBuffPlugIn.cs
+++ b/src/Persistence/Initialization/Updates/AddElfSoldierBuffPlugIn.cs
@@ -94,7 +94,7 @@ public class AddElfSoldierBuffPlugIn : UpdatePlugInBase
             damagePowerUp.TargetAttribute = Stats.GreaterDamageBonus.GetPersistent(gameConfiguration);
             damagePowerUp.Boost = context.CreateNew<PowerUpDefinitionValue>();
             damagePowerUp.Boost.ConstantValue.Value = 45;
-            damagePowerUp.Boost.ConstantValue.AggregateType = AggregateType.AddFinal;
+            damagePowerUp.Boost.ConstantValue.AggregateType = AggregateType.AddRaw;
             var damagePerLevel = context.CreateNew<AttributeRelationship>();
             damagePerLevel.InputAttribute = Stats.Level.GetPersistent(gameConfiguration);
             damagePerLevel.InputOperand = 1f / 3;

--- a/src/Persistence/Initialization/Updates/AddElfSoldierBuffPlugIn.cs
+++ b/src/Persistence/Initialization/Updates/AddElfSoldierBuffPlugIn.cs
@@ -62,41 +62,46 @@ public class AddElfSoldierBuffPlugIn : UpdatePlugInBase
             return;
         }
 
-        var buffEffect = context.CreateNew<MagicEffectDefinition>();
-        gameConfiguration.MagicEffects.Add(buffEffect);
-        buffEffect.Number = (short)MagicEffectNumber.ElfSoldierBuff;
-        buffEffect.Name = "Elf Soldier Buff";
-        buffEffect.InformObservers = true;
-        buffEffect.StopByDeath = true;
+        var buffEffect = gameConfiguration.MagicEffects.FirstOrDefault(e => e.Number == (short)MagicEffectNumber.ElfSoldierBuff);
+        if (buffEffect is null)
+        {
+            buffEffect = context.CreateNew<MagicEffectDefinition>();
+            gameConfiguration.MagicEffects.Add(buffEffect);
+            buffEffect.Number = (short)MagicEffectNumber.ElfSoldierBuff;
+            buffEffect.Name = "Elf Soldier Buff";
+            buffEffect.InformObservers = true;
+            buffEffect.StopByDeath = true;
 
-        // Duration: 60 minutes
-        buffEffect.Duration = context.CreateNew<PowerUpDefinitionValue>();
-        buffEffect.Duration.ConstantValue.Value = 3600;
+            // Duration: 60 minutes
+            buffEffect.Duration = context.CreateNew<PowerUpDefinitionValue>();
+            buffEffect.Duration.ConstantValue.Value = 3600;
 
-        // Defense boost: 50 + (Level / 5)
-        var defensePowerUp = context.CreateNew<PowerUpDefinition>();
-        defensePowerUp.TargetAttribute = Stats.DefenseFinal.GetPersistent(gameConfiguration);
-        defensePowerUp.Boost = context.CreateNew<PowerUpDefinitionValue>();
-        defensePowerUp.Boost.ConstantValue.Value = 50;
-        defensePowerUp.Boost.ConstantValue.AggregateType = AggregateType.AddFinal;
-        var defensePerLevel = context.CreateNew<AttributeRelationship>();
-        defensePerLevel.InputAttribute = Stats.Level.GetPersistent(gameConfiguration);
-        defensePerLevel.InputOperand = 1f / 5;
-        defensePerLevel.InputOperator = InputOperator.Multiply;
-        defensePowerUp.Boost.RelatedValues.Add(defensePerLevel);
-        buffEffect.PowerUpDefinitions.Add(defensePowerUp);
+            // Defense boost: 50 + (Level / 5)
+            var defensePowerUp = context.CreateNew<PowerUpDefinition>();
+            defensePowerUp.TargetAttribute = Stats.DefenseFinal.GetPersistent(gameConfiguration);
+            defensePowerUp.Boost = context.CreateNew<PowerUpDefinitionValue>();
+            defensePowerUp.Boost.ConstantValue.Value = 50;
+            defensePowerUp.Boost.ConstantValue.AggregateType = AggregateType.AddFinal;
+            var defensePerLevel = context.CreateNew<AttributeRelationship>();
+            defensePerLevel.InputAttribute = Stats.Level.GetPersistent(gameConfiguration);
+            defensePerLevel.InputOperand = 1f / 5;
+            defensePerLevel.InputOperator = InputOperator.Multiply;
+            defensePowerUp.Boost.RelatedValues.Add(defensePerLevel);
+            buffEffect.PowerUpDefinitions.Add(defensePowerUp);
 
-        // Damage boost: 45 + (Level / 3)
-        var damagePowerUp = context.CreateNew<PowerUpDefinition>();
-        damagePowerUp.TargetAttribute = Stats.GreaterDamageBonus.GetPersistent(gameConfiguration);
-        damagePowerUp.Boost = context.CreateNew<PowerUpDefinitionValue>();
-        damagePowerUp.Boost.ConstantValue.Value = 45;
-        var damagePerLevel = context.CreateNew<AttributeRelationship>();
-        damagePerLevel.InputAttribute = Stats.Level.GetPersistent(gameConfiguration);
-        damagePerLevel.InputOperand = 1f / 3;
-        damagePerLevel.InputOperator = InputOperator.Multiply;
-        damagePowerUp.Boost.RelatedValues.Add(damagePerLevel);
-        buffEffect.PowerUpDefinitions.Add(damagePowerUp);
+            // Damage boost: 45 + (Level / 3)
+            var damagePowerUp = context.CreateNew<PowerUpDefinition>();
+            damagePowerUp.TargetAttribute = Stats.GreaterDamageBonus.GetPersistent(gameConfiguration);
+            damagePowerUp.Boost = context.CreateNew<PowerUpDefinitionValue>();
+            damagePowerUp.Boost.ConstantValue.Value = 45;
+            damagePowerUp.Boost.ConstantValue.AggregateType = AggregateType.AddFinal;
+            var damagePerLevel = context.CreateNew<AttributeRelationship>();
+            damagePerLevel.InputAttribute = Stats.Level.GetPersistent(gameConfiguration);
+            damagePerLevel.InputOperand = 1f / 3;
+            damagePerLevel.InputOperator = InputOperator.Multiply;
+            damagePowerUp.Boost.RelatedValues.Add(damagePerLevel);
+            buffEffect.PowerUpDefinitions.Add(damagePowerUp);
+        }
 
         var buff = context.CreateNew<Buff>();
         buff.MagicEffectDefinition = buffEffect;

--- a/src/Persistence/Initialization/VersionSeasonSix/NpcInitialization.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/NpcInitialization.cs
@@ -151,7 +151,7 @@ internal partial class NpcInitialization : Version095d.NpcInitialization
             damagePowerUp.TargetAttribute = Stats.GreaterDamageBonus.GetPersistent(this.GameConfiguration);
             damagePowerUp.Boost = this.Context.CreateNew<PowerUpDefinitionValue>();
             damagePowerUp.Boost.ConstantValue.Value = 45;
-            damagePowerUp.Boost.ConstantValue.AggregateType = AggregateType.AddFinal;
+            damagePowerUp.Boost.ConstantValue.AggregateType = AggregateType.AddRaw;
             var damagePerLevel = this.Context.CreateNew<AttributeRelationship>();
             damagePerLevel.InputAttribute = Stats.Level.GetPersistent(this.GameConfiguration);
             damagePerLevel.InputOperand = 1f / 3;

--- a/src/Persistence/Initialization/VersionSeasonSix/NpcInitialization.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/NpcInitialization.cs
@@ -151,6 +151,7 @@ internal partial class NpcInitialization : Version095d.NpcInitialization
             damagePowerUp.TargetAttribute = Stats.GreaterDamageBonus.GetPersistent(this.GameConfiguration);
             damagePowerUp.Boost = this.Context.CreateNew<PowerUpDefinitionValue>();
             damagePowerUp.Boost.ConstantValue.Value = 45;
+            damagePowerUp.Boost.ConstantValue.AggregateType = AggregateType.AddFinal;
             var damagePerLevel = this.Context.CreateNew<AttributeRelationship>();
             damagePerLevel.InputAttribute = Stats.Level.GetPersistent(this.GameConfiguration);
             damagePerLevel.InputOperand = 1f / 3;

--- a/src/Persistence/Json/ReferenceResolvingConverter.cs
+++ b/src/Persistence/Json/ReferenceResolvingConverter.cs
@@ -47,11 +47,12 @@ public class ReferenceResolvingConverter<T> : JsonConverter<T>
                 else if (x.CollectionInterface != null && x.Property.Name.StartsWith("Raw"))
                 {
                     propertyType = x.CollectionInterface.GetGenericArguments()[0];
+                    var collectionExpr = Expression.Property(tParam, x.Property);
+                    var itemExpr = Expression.Convert(objParam, propertyType);
+                    var containsCall = Expression.Call(collectionExpr, x.CollectionInterface.GetMethod("Contains")!, itemExpr);
+                    var addCall = Expression.Call(collectionExpr, x.CollectionInterface.GetMethod("Add")!, itemExpr);
                     adder = Expression.Lambda<Action<T, object>>(
-                            Expression.Call(
-                                Expression.Property(tParam, x.Property),
-                                x.CollectionInterface.GetMethod("Add")!,
-                                Expression.Convert(objParam, propertyType)),
+                            Expression.IfThen(Expression.Not(containsCall), addCall),
                             tParam,
                             objParam)
                         .Compile();
@@ -66,11 +67,13 @@ public class ReferenceResolvingConverter<T> : JsonConverter<T>
 
                     propertyType = propertyType.GetProperties().First(p => p.PropertyType.BaseType == baseType).PropertyType;
                     jsonPropertyName = basePropertyName;
+
+                    var collectionExpr = Expression.Property(tParam, baseCollectionProperty);
+                    var itemExpr = Expression.Convert(objParam, propertyType);
+                    var containsCall = Expression.Call(collectionExpr, baseCollectionProperty.PropertyType.GetMethod("Contains")!, itemExpr);
+                    var addCall = Expression.Call(collectionExpr, baseCollectionProperty.PropertyType.GetMethod("Add")!, itemExpr);
                     adder = Expression.Lambda<Action<T, object>>(
-                            Expression.Call(
-                                Expression.Property(tParam, baseCollectionProperty),
-                                baseCollectionProperty.PropertyType.GetMethod("Add")!,
-                                Expression.Convert(objParam, propertyType)),
+                            Expression.IfThen(Expression.Not(containsCall), addCall),
                             tParam,
                             objParam)
                         .Compile();

--- a/src/Persistence/Json/ReferenceResolvingConverter.cs
+++ b/src/Persistence/Json/ReferenceResolvingConverter.cs
@@ -47,10 +47,12 @@ public class ReferenceResolvingConverter<T> : JsonConverter<T>
                 else if (x.CollectionInterface != null && x.Property.Name.StartsWith("Raw"))
                 {
                     propertyType = x.CollectionInterface.GetGenericArguments()[0];
-                    var collectionExpr = Expression.Property(tParam, x.Property);
+
+                    var collectionExpr = Expression.Convert(Expression.Property(tParam, x.Property), x.CollectionInterface);
                     var itemExpr = Expression.Convert(objParam, propertyType);
                     var containsCall = Expression.Call(collectionExpr, x.CollectionInterface.GetMethod("Contains")!, itemExpr);
                     var addCall = Expression.Call(collectionExpr, x.CollectionInterface.GetMethod("Add")!, itemExpr);
+
                     adder = Expression.Lambda<Action<T, object>>(
                             Expression.IfThen(Expression.Not(containsCall), addCall),
                             tParam,
@@ -68,10 +70,12 @@ public class ReferenceResolvingConverter<T> : JsonConverter<T>
                     propertyType = propertyType.GetProperties().First(p => p.PropertyType.BaseType == baseType).PropertyType;
                     jsonPropertyName = basePropertyName;
 
-                    var collectionExpr = Expression.Property(tParam, baseCollectionProperty);
+                    var baseCollectionInterface = DetermineCollectionInterface(baseCollectionProperty)!;
+                    var collectionExpr = Expression.Convert(Expression.Property(tParam, baseCollectionProperty), baseCollectionInterface);
                     var itemExpr = Expression.Convert(objParam, propertyType);
-                    var containsCall = Expression.Call(collectionExpr, baseCollectionProperty.PropertyType.GetMethod("Contains")!, itemExpr);
-                    var addCall = Expression.Call(collectionExpr, baseCollectionProperty.PropertyType.GetMethod("Add")!, itemExpr);
+                    var containsCall = Expression.Call(collectionExpr, baseCollectionInterface.GetMethod("Contains")!, itemExpr);
+                    var addCall = Expression.Call(collectionExpr, baseCollectionInterface.GetMethod("Add")!, itemExpr);
+
                     adder = Expression.Lambda<Action<T, object>>(
                             Expression.IfThen(Expression.Not(containsCall), addCall),
                             tParam,


### PR DESCRIPTION
### Fix: Duplicate rows in deserialized aggregate collections

The custom `ReferenceResolvingConverter<T>`'s generated adder delegates unconditionally called `collection.Add(item)`. When the JSON deserializer encounters the same `$id` a second time (e.g., a `PowerUpDefinitionValue` embedded under `RawDuration` and later referenced by `$ref` from `RawBoost`), the item was added again to the backing `List<T>`, producing a duplicate in memory despite the database having only one row.

Fixed by adding a `Contains` guard before `Add`, matching the pattern already used in `GenericRepositoryBase.LoadCollectionAsync`.

### Elf Soldier buff updates

`NpcInitialization.cs` and `AddElfSoldierBuffPlugIn.cs` updated to add the missing `AggregateType.AddFinal` for the damage boost. `AddElfSoldierBuffPlugIn.cs` also hardened to find-or-create the `MagicEffectDefinition` instead of always creating new ones.