### PR TITLE
Delete item rows when items leave the game

### DIFF
--- a/src/GameLogic/PlayerActions/Items/ItemStackAction.cs
+++ b/src/GameLogic/PlayerActions/Items/ItemStackAction.cs
@@ -52,6 +52,7 @@ public class ItemStackAction
             foreach (var jewel in jewels)
             {
                 await player.Inventory.RemoveItemAsync(jewel).ConfigureAwait(false);
+                await player.PersistenceContext.DeleteAsync(jewel).ConfigureAwait(false);
                 await player.InvokeViewPlugInAsync<IItemRemovedPlugIn>(p => p.RemoveItemAsync(jewel.ItemSlot)).ConfigureAwait(false);
             }
 
@@ -118,6 +119,7 @@ public class ItemStackAction
         }
 
         await player.Inventory.RemoveItemAsync(stacked).ConfigureAwait(false);
+        await player.PersistenceContext.DeleteAsync(stacked).ConfigureAwait(false);
         await player.InvokeViewPlugInAsync<IItemRemovedPlugIn>(p => p.RemoveItemAsync(slot)).ConfigureAwait(false);
         foreach (var freeSlot in freeSlots)
         {

--- a/src/GameLogic/PlayerActions/Items/SellItemToNpcAction.cs
+++ b/src/GameLogic/PlayerActions/Items/SellItemToNpcAction.cs
@@ -63,6 +63,7 @@ public class SellItemToNpcAction
         {
             player.Logger.LogDebug("Sold Item {0} for price: {1}", item, sellingPrice);
             await player.Inventory!.RemoveItemAsync(item).ConfigureAwait(false);
+            await player.PersistenceContext.DeleteAsync(item).ConfigureAwait(false);
             await player.InvokeViewPlugInAsync<IItemSoldToNpcPlugIn>(p => p.ItemSoldToNpcAsync(true)).ConfigureAwait(false);
 
             player.GameContext.PlugInManager.GetPlugInPoint<IItemSoldToMerchantPlugIn>()?.ItemSold(player, item, player.OpenedNpc!);


### PR DESCRIPTION
Two code paths remove an item from a storage without deleting it from the
database, so the row stays behind forever with a null `ItemStorageId`.

## The problem

`Storage.RemoveItemAsync` only detaches the item from the storage's collection:

```csharp
this.ItemStorage.Items.Remove(item);
```

Since the foreign key is optional, EF nulls `ItemStorageId` instead of deleting
the row. Most callers follow up with a delete — `DestroyInventoryItemAsync`
(consumed potions and jewels, mini-game tickets), `BaseItemCraftingHandler`
(crafting ingredients) and `DropItemAction` all do. Two do not:

- `SellItemToNpcAction.SellItemAsync` — every item sold to a merchant
- `ItemStackAction` — packing ten jewels into a stack leaves ten rows behind,
  unpacking leaves one

## Impact

Measured on a live server that had been running for a few months with nine
player accounts: **8,511 of 10,179 rows (84%) in `data."Item"` were orphans**.
After adding bots, which sell to merchants constantly, the count grew by
roughly **1,600 rows per day**.

The rows are not usable as history — `Item` has no timestamp and no owner
field, and `ItemStorageId` was the only link to who held it. Nothing in the
code ever reads items with a null storage.

This is not an urgent performance problem at that scale, but it is unbounded
growth of rows that serve no purpose.

## The fix

Delete the item right after removing it, matching the order already used by
`DestroyInventoryItemAsync` (remove → delete → notify the client):

```csharp
await player.Inventory!.RemoveItemAsync(item).ConfigureAwait(false);
await player.PersistenceContext.DeleteAsync(item).ConfigureAwait(false);
```

Three lines in two files. No change to the view plugin calls, so nothing the
client sees is affected.

## Notes for review

- `IItemSoldToMerchantPlugIn` is invoked after the removal and receives the
  item. It has no implementations in the repository, and the deletion is only
  staged in the persistence context, so the object stays usable for the call.
  If a plugin ever wants to keep the sold item — a buy-back feature, say —
  that plugin point would need rethinking regardless of this change.
- Paths that move an item between storages (`MoveItemAction`, player shop
  purchases in `BuyRequestAction`, returning items from temporary storage)
  are deliberately untouched: there the row must survive, only its owner
  changes.

## Testing

- `MUnique.OpenMU.Tests`: 570 passed, 18 failed.
- The same 18 tests fail on unmodified `master` at the same commit
  (`26fc908ba`), so they are pre-existing and unrelated to this change. They
  are the `Ancient`, `AncientWithoutBonus`, `Definition`, `Durability` and
  `Level` group around item definitions.
- Verified against a real server database: the orphaned rows are dominated by
  exactly what these two paths produce — jewels (Creation 323, Bless 261,
  Chaos 248, Life 204, Soul 175) and ordinary drops sold to merchants.