### PR TITLE
Don't check offline players for speedhacking

### DIFF
--- a/src/GameLogic/PlugIns/SpeedHackDetectPlugIn.cs
+++ b/src/GameLogic/PlugIns/SpeedHackDetectPlugIn.cs
@@ -36,7 +36,7 @@ public class SpeedHackDetectPlugIn : IFeaturePlugIn, ISupportCustomConfiguration
     /// <inheritdoc/>
     public async ValueTask WalkCheatCheckAsync(Player player, Memory<WalkingStep> steps, SpeedHackCheckEventArgs eventArgs)
     {
-        if (steps.IsEmpty)
+        if (steps.IsEmpty || IsServerControlled(player))
         {
             return;
         }
@@ -139,7 +139,7 @@ public class SpeedHackDetectPlugIn : IFeaturePlugIn, ISupportCustomConfiguration
     /// <inheritdoc/>
     public async ValueTask AttackCheatCheckAsync(Player player, SpeedHackCheckEventArgs eventArgs)
     {
-        if (player.Attributes is not { } attributes)
+        if (player.Attributes is not { } attributes || IsServerControlled(player))
         {
             return;
         }
@@ -228,6 +228,19 @@ public class SpeedHackDetectPlugIn : IFeaturePlugIn, ISupportCustomConfiguration
             state.LastAlertTime = time;
         }
     }
+
+    /// <summary>
+    /// Determines whether the player's actions originate on the server instead of a game client.
+    /// These checks validate what a client claims about its own timing, so there is nothing to
+    /// validate for an offline player: the server itself paces its walks and attacks. Its MU Helper
+    /// tick performs the same work cycle as the original client helper (recover, then attack), which
+    /// draws two attack tokens from one 500 ms tick and eventually empties the bucket - so leaving
+    /// these players in would only ever produce false positives, and with the default configuration
+    /// those are answered with a persisted account ban.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <returns><c>true</c> if the player is controlled by the server; otherwise, <c>false</c>.</returns>
+    private static bool IsServerControlled(Player player) => player is Offline.OfflinePlayer;
 
     private SpeedHackState GetState(Player player)
     {

--- a/tests/MUnique.OpenMU.Tests/SpeedHackAntiCheatTests.cs
+++ b/tests/MUnique.OpenMU.Tests/SpeedHackAntiCheatTests.cs
@@ -16,6 +16,7 @@ using MUnique.OpenMU.DataModel.Configuration.Items;
 using MUnique.OpenMU.DataModel.Entities;
 using MUnique.OpenMU.GameLogic;
 using MUnique.OpenMU.GameLogic.Attributes;
+using MUnique.OpenMU.GameLogic.Offline;
 using MUnique.OpenMU.GameLogic.Views;
 using MUnique.OpenMU.GameLogic.Views.World;
 using MUnique.OpenMU.Pathfinding;
@@ -387,6 +388,70 @@ public class SpeedHackAntiCheatTests
         // The account should still be normal (no autoban) and not disconnected
         Assert.That(player.Account?.State, Is.EqualTo(AccountState.Normal));
         Assert.That(player.GameContext.FeaturePlugIns.GetPlugIn<SpeedHackDetectPlugIn>()!.GetWarningCount(player), Is.GreaterThan(5));
+    }
+
+    /// <summary>
+    /// Tests that an offline player - whose walks are issued by the server itself - is not checked at all.
+    /// </summary>
+    [Test]
+    public async Task TestOfflinePlayerIsNotCheckedOnWalkAsync()
+    {
+        var player = await CreatePlayerWithSpeedAttributesAsync().ConfigureAwait(false);
+        var offlinePlayer = await CreateOfflinePlayerAsync(player).ConfigureAwait(false);
+        var plugin = player.GameContext.FeaturePlugIns.GetPlugIn<SpeedHackDetectPlugIn>()!;
+
+        // The same walk pattern which bans a regular player in TestWalkSpeedHackDetectionBansAccountAsync.
+        for (int i = 0; i < 12; i++)
+        {
+            var nextFrom = new Point((byte)(StartPoint.X + (i * 2)), StartPoint.Y);
+            var nextTo = new Point((byte)(StartPoint.X + (i * 2) + 2), StartPoint.Y);
+
+            offlinePlayer.Position = nextFrom;
+            plugin.SetLastAlertTime(offlinePlayer, DateTime.MinValue);
+
+            WalkingStep[] steps = [new() { From = nextFrom, To = nextTo, Direction = Direction.East }];
+
+            await offlinePlayer.WalkToAsync(nextTo, steps).ConfigureAwait(false);
+        }
+
+        Assert.That(plugin.GetWarningCount(offlinePlayer), Is.EqualTo(0));
+        Assert.That(offlinePlayer.Account?.State, Is.EqualTo(AccountState.Normal));
+    }
+
+    /// <summary>
+    /// Tests that an offline player is not checked on attacks. Its MU Helper tick performs the same work
+    /// cycle as the original client helper (recover, then attack), which draws more than one token from a
+    /// single tick and would eventually empty the bucket.
+    /// </summary>
+    [Test]
+    public async Task TestOfflinePlayerIsNotCheckedOnAttackAsync()
+    {
+        var player = await CreatePlayerWithSpeedAttributesAsync().ConfigureAwait(false);
+        var offlinePlayer = await CreateOfflinePlayerAsync(player).ConfigureAwait(false);
+        offlinePlayer.Attributes![Stats.AttackSpeed] = 20;
+
+        var speedCheck = player.GameContext.PlugInManager.GetPlugInPoint<ISpeedHackCheatCheckPlugIn>()!;
+
+        // The same burst which is detected for a regular player in TestAttackSpeedHackDetectionAsync.
+        for (int i = 0; i < 20; i++)
+        {
+            var args = new SpeedHackCheckEventArgs();
+            await speedCheck.AttackCheatCheckAsync(offlinePlayer, args).ConfigureAwait(false);
+            Assert.That(args.IsCheatDetected, Is.False);
+        }
+
+        Assert.That(player.GameContext.FeaturePlugIns.GetPlugIn<SpeedHackDetectPlugIn>()!.GetWarningCount(offlinePlayer), Is.EqualTo(0));
+        Assert.That(offlinePlayer.Account?.State, Is.EqualTo(AccountState.Normal));
+    }
+
+    private static async ValueTask<OfflinePlayer> CreateOfflinePlayerAsync(Player regularPlayer)
+    {
+        var offlinePlayer = new OfflinePlayer(regularPlayer.GameContext) { Account = regularPlayer.Account };
+        await offlinePlayer.PlayerState.TryAdvanceToAsync(PlayerState.LoginScreen).ConfigureAwait(false);
+        await offlinePlayer.PlayerState.TryAdvanceToAsync(PlayerState.Authenticated).ConfigureAwait(false);
+        await offlinePlayer.PlayerState.TryAdvanceToAsync(PlayerState.CharacterSelection).ConfigureAwait(false);
+        await offlinePlayer.SetSelectedCharacterAsync(regularPlayer.SelectedCharacter!).ConfigureAwait(false);
+        return offlinePlayer;
     }
 
     private static async ValueTask<Player> CreatePlayerWithSpeedAttributesAsync(List<Item>? inventoryItems = null)


### PR DESCRIPTION
The speedhack checks validate what a game *client* claims about its own timing.
An offline player has no client - the server itself paces its walks and attacks,
so there is nothing to validate there and every hit is a false positive. With the
default configuration a false positive is answered with `AccountState.Banned`,
saved to the database.

## They do get hit

On a test server running 500 offline bots, **15 of 100 accounts were banned
within half an hour**, at roughly one account a minute and accelerating:

```
14:36:22 [Error] Player "Jorarmir" exceeded speedhack warning limit. Banning account "bot0070" and disconnecting.
14:37:00 [Error] Player "Fenarlin" exceeded speedhack warning limit. Banning account "bot0018" and disconnecting.
```

Of the 101 warnings in that window, exactly **one** came from the walk check -
the only one which logs a line of its own. The other hundred came from
`AttackCheatCheckAsync`, whose bucket holds five tokens and refills at most one
per `max(60, 450 - AttackSpeed * 1.2)` ms, i.e. one per 450 ms.

A MU Helper tick attacks once per 500 ms, which normally stays ahead of that
refill. It stops staying ahead when the ticks lose their cadence: `PeriodicTimer`
starts the next tick immediately after one that ran long, so two attacks can land
a few dozen milliseconds apart while the bucket only refills for the time that
actually elapsed. Once it is empty, every following tick is a violation until the
fourth warning bans the account.

That makes it load dependent, and the evidence says so too: the warnings fall in
a window in which the host was also timing out database connections, and a later
two-hour run of the same fleet on an idle host produced none.

One configuration draws two tokens from a single tick on its own: with
`UseDrainLife` enabled, `PerformDrainLifeRecoveryAsync` attacks before
`PerformAttackAsync` in the same cycle.

This is not specific to bots. The same class and the same tick drive a regular
player's `/offlevel` session, and nothing in the checks or in the tick
distinguishes the two - the only `IsBot` gate on this path is a randomized
250-900 ms delay before engaging a new target, which makes a bot *slower* than a
human's offline session, not faster.

## The change

Both check methods return early for `OfflinePlayer`. The four call sites
(`Player.WalkToAsync`, `HitAction`, `TargetedSkillDefaultPlugin`,
`AreaSkillAttackAction`) are untouched, so a fifth one added later inherits the
exemption automatically.

No new configuration option: a switch would only offer to re-enable a check that
cannot produce a true positive for these players, and the cost of a false one is
a persisted ban.

Retuning `MaxAttackTokens` or `WalkSpeedToleranceMs` was the alternative. It
would weaken the check against the clients it was written for and still leave the
cause in place, so it is not what this does.

## Testing

`MUnique.OpenMU.Tests`: 590 passed, 0 failed.

Two regression tests were added to the existing fixture, both built from the
patterns that already detect a *regular* player there:

- `TestOfflinePlayerIsNotCheckedOnWalkAsync` - the twelve-walk burst which bans a
  regular player in `TestWalkSpeedHackDetectionBansAccountAsync`;
- `TestOfflinePlayerIsNotCheckedOnAttackAsync` - the rapid attack series detected
  in `TestAttackSpeedHackDetectionAsync`.

Both were verified to fail without the change (2 failed, 0 passed) and pass with
it, so they cannot go vacuously green.

## Workaround for anyone hitting this before the fix ships

`SpeedHackDetectConfiguration` is editable in the admin panel: turning `AutoBan`
off keeps the warnings in the log while stopping the bans.