### PR TITLE
Release a money drop again when nobody could take it

### DIFF
--- a/src/GameLogic/DroppedMoney.cs
+++ b/src/GameLogic/DroppedMoney.cs
@@ -80,51 +80,16 @@ public sealed class DroppedMoney : AsyncDisposable, ILocateable
             this._availableToPick = false;
         }
 
-        if (player.Party is { } party)
+        if (!this.TryGiveMoneyTo(player))
         {
-            var partyMembers = party.PartyList
-                .OfType<Player>()
-                .Where(p => p.CurrentMap == player.CurrentMap && !p.IsAtSafezone() && p.Attributes is { })
-                .ToList();
-
-            if (partyMembers.Count > 0)
+            // Nobody got the money, so the drop is released again. Keeping it claimed would leave it
+            // lying on the map, unpickable for everyone until it expires - and then lost.
+            using (await this._pickupLock.LockAsync())
             {
-                var share = (int)(this.Amount / partyMembers.Count);
-                foreach (var member in partyMembers)
-                {
-                    member.TryAddMoney((int)(share * member.Attributes![Stats.MoneyAmountRate]));
-                }
+                this._availableToPick = true;
             }
-        }
-        else
-        {
-            var clampMoneyOnPickup = player.GameContext?.Configuration?.ClampMoneyOnPickup ?? false;
-            if (clampMoneyOnPickup)
-            {
-                var maxMoney = player.GameContext?.Configuration?.MaximumInventoryMoney ?? int.MaxValue;
-                var currentMoney = player.Money;
-                var amountToAdd = (int)Math.Min(this.Amount, (uint)Math.Max(0, maxMoney - currentMoney));
 
-                if (amountToAdd <= 0)
-                {
-                    player.Logger.LogDebug("Player is at maximum money limit, Player {0}, Money {1}", player, this);
-                    return false;
-                }
-
-                if (!player.TryAddMoney(amountToAdd))
-                {
-                    player.Logger.LogDebug("Money could not be added to the inventory, Player {0}, Money {1}", player, this);
-                    return false;
-                }
-            }
-            else
-            {
-                if (!player.TryAddMoney((int)this.Amount))
-                {
-                    player.Logger.LogDebug("Money could not be added to the inventory, Player {0}, Money {1}", player, this);
-                    return false;
-                }
-            }
+            return false;
         }
 
         await this.DisposeAsync().ConfigureAwait(false);
@@ -156,6 +121,64 @@ public sealed class DroppedMoney : AsyncDisposable, ILocateable
         }
 
         await base.DisposeAsyncCore().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Tries to hand the money over to the player, or to its party. Returns <c>false</c> if it could not be
+    /// given to anyone, e.g. because the receiver is already at the maximum inventory money.
+    /// </summary>
+    /// <param name="player">The player which picks the money up.</param>
+    /// <returns><c>True</c>, if at least one player received money; Otherwise, <c>false</c>.</returns>
+    private bool TryGiveMoneyTo(Player player)
+    {
+        if (player.Party is { } party)
+        {
+            var partyMembers = party.PartyList
+                .OfType<Player>()
+                .Where(p => p.CurrentMap == player.CurrentMap && !p.IsAtSafezone() && p.Attributes is { })
+                .ToList();
+
+            if (partyMembers.Count == 0)
+            {
+                player.Logger.LogDebug("No party member could receive the money, Player {0}, Money {1}", player, this);
+                return false;
+            }
+
+            var share = (int)(this.Amount / partyMembers.Count);
+            var received = false;
+            foreach (var member in partyMembers)
+            {
+                received |= member.TryAddMoney((int)(share * member.Attributes![Stats.MoneyAmountRate]));
+            }
+
+            if (!received)
+            {
+                player.Logger.LogDebug("No party member could take the money, Player {0}, Money {1}", player, this);
+            }
+
+            return received;
+        }
+
+        var amountToAdd = (int)this.Amount;
+        if (player.GameContext?.Configuration?.ClampMoneyOnPickup ?? false)
+        {
+            var maxMoney = player.GameContext?.Configuration?.MaximumInventoryMoney ?? int.MaxValue;
+            amountToAdd = (int)Math.Min(this.Amount, (uint)Math.Max(0, maxMoney - player.Money));
+
+            if (amountToAdd <= 0)
+            {
+                player.Logger.LogDebug("Player is at maximum money limit, Player {0}, Money {1}", player, this);
+                return false;
+            }
+        }
+
+        if (!player.TryAddMoney(amountToAdd))
+        {
+            player.Logger.LogDebug("Money could not be added to the inventory, Player {0}, Money {1}", player, this);
+            return false;
+        }
+
+        return true;
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD100:Avoid async void methods", Justification = "Catching all Exceptions.")]

--- a/tests/MUnique.OpenMU.Tests/DroppedMoneyTest.cs
+++ b/tests/MUnique.OpenMU.Tests/DroppedMoneyTest.cs
@@ -1,0 +1,65 @@
+// <copyright file="DroppedMoneyTest.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Tests;
+
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.Pathfinding;
+using NUnit.Framework;
+
+/// <summary>
+/// Tests for the <see cref="DroppedMoney"/>.
+/// </summary>
+[TestFixture]
+public class DroppedMoneyTest
+{
+    private const uint DroppedAmount = 1000;
+
+    /// <summary>
+    /// Tests that a failed pick up doesn't consume the drop, so it's still available for the next player.
+    /// A player at the maximum inventory money can't take it, and used to claim it nevertheless - which left
+    /// it lying on the map, unpickable for everyone until it expired.
+    /// </summary>
+    [Test]
+    public async Task FailedPickUpKeepsMoneyAvailableAsync()
+    {
+        var player = await PlayerTestHelper.CreatePlayerAsync().ConfigureAwait(false);
+        player.GameContext.Configuration.MaximumInventoryMoney = int.MaxValue;
+        var maximumMoney = player.GameContext.Configuration.MaximumInventoryMoney;
+        player.Money = maximumMoney;
+
+        var money = new DroppedMoney(DroppedAmount, new Point(100, 100), player.CurrentMap!);
+
+        Assert.That(await money.TryPickUpByAsync(player).ConfigureAwait(false), Is.False);
+        Assert.That(player.Money, Is.EqualTo(maximumMoney));
+
+        var otherPlayer = await PlayerTestHelper.CreatePlayerAsync(player.GameContext).ConfigureAwait(false);
+        otherPlayer.Money = 0;
+
+        Assert.That(await money.TryPickUpByAsync(otherPlayer).ConfigureAwait(false), Is.True);
+        Assert.That(otherPlayer.Money, Is.EqualTo((int)DroppedAmount));
+    }
+
+    /// <summary>
+    /// Tests that a successful pick up still consumes the drop, so it can't be picked up twice.
+    /// </summary>
+    [Test]
+    public async Task SuccessfulPickUpConsumesMoneyAsync()
+    {
+        var player = await PlayerTestHelper.CreatePlayerAsync().ConfigureAwait(false);
+        player.GameContext.Configuration.MaximumInventoryMoney = int.MaxValue;
+        player.Money = 0;
+
+        var money = new DroppedMoney(DroppedAmount, new Point(100, 100), player.CurrentMap!);
+
+        Assert.That(await money.TryPickUpByAsync(player).ConfigureAwait(false), Is.True);
+        Assert.That(player.Money, Is.EqualTo((int)DroppedAmount));
+
+        var otherPlayer = await PlayerTestHelper.CreatePlayerAsync(player.GameContext).ConfigureAwait(false);
+        otherPlayer.Money = 0;
+
+        Assert.That(await money.TryPickUpByAsync(otherPlayer).ConfigureAwait(false), Is.False);
+        Assert.That(otherPlayer.Money, Is.EqualTo(0));
+    }
+}


### PR DESCRIPTION
### Release a money drop again when nobody could take it

`DroppedMoney.TryPickUpByAsync` claims the drop first and hands the money over
afterwards:

```csharp
using (await this._pickupLock.LockAsync())
{
    if (!this._availableToPick) { ...; return false; }
    this._availableToPick = false;   // claimed here
}
...
if (!player.TryAddMoney((int)this.Amount))
{
    ...
    return false;                    // and never released
}
```

Every failure path leaves the flag down and the object undisposed. The pile
stays on the map, but from that moment on every attempt - by anyone - is
answered with *"Picked up by another player in the mean time"*. It stays that way
until `ItemDropDuration` expires, and is then lost.

A player at `MaximumInventoryMoney` triggers it just by walking over a pile.
`TryAddMoney` refuses, and the pile is dead for everyone standing there. On a
test server, one pile produced 458 pick-up retries from a single player before it
expired.

`DroppedItem` already does this the other way round: it sets `_availableToPick`
only after `AddItemAsync` has actually put the item into the inventory, and
detaches it again when that fails. Only money claims first and asks later.

## The change

The handover moves into `TryGiveMoneyTo`, and the claim is released when it
returns `false`. The exclusivity itself is unchanged - the drop is still claimed
under the lock before anything is attempted, so two players cannot both receive
it.

Two cases which previously consumed the drop without anyone receiving anything
now count as failures as well:

- a party in which no member is eligible (none on the same map outside a safe
  zone), and
- a party in which no member could take a share, e.g. because they are all at the
  money limit.

Both used to fall through to `DisposeAsync`, which deleted the drop and the
money with it.

## Testing

`MUnique.OpenMU.Tests`: 590 passed, 0 failed.

New `DroppedMoneyTest`:

- `FailedPickUpKeepsMoneyAvailableAsync` - a player at the maximum money fails to
  pick a pile up, and the next player still can;
- `SuccessfulPickUpConsumesMoneyAsync` - a successful pick up still consumes it,
  so it cannot be taken twice.

Verified against the unfixed code: the first test fails there, the second passes
in both, which is what tells them apart.
