### PR TITLE
Log the disabled auto-repair once per session

### DIFF
--- a/src/GameLogic/Offline/RepairHandler.cs
+++ b/src/GameLogic/Offline/RepairHandler.cs
@@ -22,6 +22,8 @@ internal sealed class RepairHandler
     private readonly IMuHelperSettings? _config;
     private readonly ItemRepairAction _repairAction = new();
 
+    private bool _loggedDisabled;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="RepairHandler"/> class.
     /// </summary>
@@ -41,7 +43,13 @@ internal sealed class RepairHandler
     {
         if (this._config is not { RepairItem: true })
         {
-            this._player.Logger.LogDebug("Auto-repair is disabled by MU Helper configuration for character {CharacterName}.", this._player.Name);
+            // Once per session: this states a configuration, not an event, and the tick runs twice a second.
+            if (!this._loggedDisabled)
+            {
+                this._loggedDisabled = true;
+                this._player.Logger.LogDebug("Auto-repair is disabled by MU Helper configuration for character {CharacterName}.", this._player.Name);
+            }
+
             return;
         }
 


### PR DESCRIPTION
## Log the disabled auto-repair once per session

`RepairHandler.PerformRepairsAsync` reports the MU Helper configuration on every
tick:

```csharp
if (this._config is not { RepairItem: true })
{
    this._player.Logger.LogDebug("Auto-repair is disabled by MU Helper configuration for character {CharacterName}.", this._player.Name);
    return;
}
```

The tick runs twice a second per offline player. The message states a setting,
not an event - it is identical every time, and nothing happened between two of
them.

At `Debug` level it drowns everything else. While looking into an unrelated
matter on a server with 500 offline players, this single line accounted for about
70% of the log, which makes debugging anything else around the offline players
needlessly painful.

## The change

It is still emitted, once, the first time the handler finds auto-repair switched
off - which is the moment it carries its information. The MU Helper settings
cannot change during an offline session (the client is gone), so a per-session
flag is enough.

Nothing else changes: no behaviour, no other log statement. The neighbouring
`WalkToAsync` lines are left alone on purpose - those report an actual event and
are merely numerous because there are many players walking.

## Testing

`MUnique.OpenMU.Tests`: 588 passed, 0 failed. No test was added: asserting on
logging frequency would pin down a detail that is not worth freezing.