### PR TITLE
Support externally-provisioned databases (opt-in, no drop/create)

### DIFF
--- a/src/Persistence/EntityFramework/PersistenceContextProvider.cs
+++ b/src/Persistence/EntityFramework/PersistenceContextProvider.cs
@@ -152,21 +152,30 @@ public class PersistenceContextProvider : IMigratableDatabaseContextProvider
     /// <summary>
     /// Recreates the database by deleting and creating it again.
     /// </summary>
+    /// <param name="dropExistingDatabase">
+    /// If <see langword="true"/> (the default), the database is dropped and created again from scratch.
+    /// If <see langword="false"/>, the existing database is kept and only its schema is built via
+    /// migrations — required when the database is provisioned externally and the connecting role is
+    /// not permitted to create or drop databases.
+    /// </param>
     /// <returns>The disposable that should be disposed of when the data creation process is finished.</returns>
-    public async Task<IDisposable> ReCreateDatabaseAsync()
+    public async Task<IDisposable> ReCreateDatabaseAsync(bool dropExistingDatabase = true)
     {
         var changePublisher = this._changeListener;
         this._changeListener = null;
         try
         {
-            try
+            if (dropExistingDatabase)
             {
-                await using var installationContext = new EntityDataContext();
-                await installationContext.Database.EnsureDeletedAsync().ConfigureAwait(false);
-            }
-            catch (NpgsqlException)
-            {
-                // That's expected for a fresh database
+                try
+                {
+                    await using var installationContext = new EntityDataContext();
+                    await installationContext.Database.EnsureDeletedAsync().ConfigureAwait(false);
+                }
+                catch (NpgsqlException)
+                {
+                    // That's expected for a fresh database
+                }
             }
 
             await this.ApplyAllPendingUpdatesAsync().ConfigureAwait(false);

--- a/src/Persistence/IMigratableDatabaseContextProvider.cs
+++ b/src/Persistence/IMigratableDatabaseContextProvider.cs
@@ -63,8 +63,15 @@ public interface IMigratableDatabaseContextProvider : IPersistenceContextProvide
     /// <summary>
     /// Recreates the database by deleting and creating it again.
     /// </summary>
+    /// <param name="dropExistingDatabase">
+    /// If <see langword="true"/> (the default), the database is dropped and created again from scratch.
+    /// If <see langword="false"/>, the existing database is kept and only its schema is built via
+    /// migrations. Set this to <see langword="false"/> when the database is provisioned externally
+    /// (e.g. by a Kubernetes operator, infrastructure-as-code, or a managed cloud database) and the
+    /// connecting role is not permitted to create or drop databases.
+    /// </param>
     /// <returns>The disposable which should be disposed when the data creation process is finished.</returns>
-    Task<IDisposable> ReCreateDatabaseAsync();
+    Task<IDisposable> ReCreateDatabaseAsync(bool dropExistingDatabase = true);
 
     /// <summary>
     /// Resets the cache of this instance.

--- a/src/Persistence/InMemory/InMemoryPersistenceContextProvider.cs
+++ b/src/Persistence/InMemory/InMemoryPersistenceContextProvider.cs
@@ -127,7 +127,7 @@ public class InMemoryPersistenceContextProvider : IMigratableDatabaseContextProv
     }
 
     /// <inheritdoc />
-    public Task<IDisposable> ReCreateDatabaseAsync()
+    public Task<IDisposable> ReCreateDatabaseAsync(bool dropExistingDatabase = true)
     {
         this._repositoryProvider = new();
         return Task.FromResult<IDisposable>(new Disposable(() => { }));

--- a/src/Startup/Program.cs
+++ b/src/Startup/Program.cs
@@ -51,6 +51,7 @@ internal sealed class Program : IDisposable
     private readonly IDictionary<int, IGameServer> _gameServers = new Dictionary<int, IGameServer>();
     private readonly IList<IManageableServer> _servers = new List<IManageableServer>();
     private readonly Serilog.ILogger _logger;
+    private readonly IConfiguration _configuration;
 
     private IHost? _serverHost;
 
@@ -65,8 +66,10 @@ internal sealed class Program : IDisposable
             .SetBasePath(Directory.GetCurrentDirectory())
             .AddJsonFile("appsettings.json", false, true)
             .AddJsonFile($"appsettings.{Environment.GetEnvironmentVariable("ASPNETCORE_ENVIRONMENT") ?? "Production"}.json", true, true)
+            .AddEnvironmentVariables()
             .Build();
 
+        this._configuration = configuration;
         this._logger = new LoggerConfiguration()
             .ReadFrom.Configuration(configuration)
             .CreateLogger();
@@ -475,8 +478,19 @@ internal sealed class Program : IDisposable
         var contextProvider = new PersistenceContextProvider(loggerFactory, changeListener);
         if (reinit || !await contextProvider.DatabaseExistsAsync().ConfigureAwait(false))
         {
-            this._logger.Information("The database is getting (re-)initialized...");
-            using var update = await contextProvider.ReCreateDatabaseAsync().ConfigureAwait(false);
+            // The database can be provisioned externally (e.g. by a Kubernetes operator,
+            // infrastructure-as-code, or a managed cloud database), where the connecting role is
+            // typically not permitted to create or drop databases. Enabling
+            // Database:AssumeExternallyProvisioned keeps the existing database and only builds its
+            // schema via migrations, instead of dropping and recreating it. The default (false)
+            // preserves the original drop-and-recreate behaviour; an explicit -reinit always recreates.
+            var assumeExternallyProvisioned = !reinit
+                && this._configuration.GetValue<bool>("Database:AssumeExternallyProvisioned");
+
+            this._logger.Information(assumeExternallyProvisioned
+                ? "Building the schema on the externally-provisioned database (no drop/create)..."
+                : "The database is getting (re-)initialized...");
+            using var update = await contextProvider.ReCreateDatabaseAsync(dropExistingDatabase: !assumeExternallyProvisioned).ConfigureAwait(false);
             await this.InitializeDataAsync(version, loggerFactory, contextProvider).ConfigureAwait(false);
             this._logger.Information("...initialization finished.");
         }

--- a/src/Startup/Readme.md
+++ b/src/Startup/Readme.md
@@ -14,6 +14,30 @@ only actions of certain players, for example.
 In the future, it might be possible to change logging settings over the admin
 panel, too.
 
+## Externally-provisioned database
+
+By default, when no database exists yet, the server drops and (re-)creates it
+before building the schema. This requires the connecting database role to be
+allowed to create and drop databases (upstream the connection strings use the
+`postgres` superuser, optionally overridden via `DB_ADMIN_USER`/`DB_ADMIN_PW`).
+
+In managed environments — a Kubernetes operator, infrastructure-as-code, or a
+managed cloud database — the database is often provisioned ahead of time and the
+connecting role is intentionally *not* permitted to create or drop databases
+(least privilege; it only owns its own database). In that case, set:
+
+```json
+"Database": {
+  "AssumeExternallyProvisioned": true
+}
+```
+
+or, equivalently, the environment variable
+`Database__AssumeExternallyProvisioned=true`. The server then keeps the existing
+(empty) database and only builds its schema via migrations, instead of dropping
+and recreating it. The default (`false`) preserves the original behaviour. An
+explicit `-reinit` always drops and recreates, regardless of this setting.
+
 ## Parameters
 
 **Please note, that the most of these parameters (except ```-demo``` and ```-adminpanel```)
@@ -62,6 +86,7 @@ They may be helpful when running the server in a container or under linux.
 | DB_HOST | Host name/address of the postgres database |
 | DB_ADMIN_USER | User name of the admin user of the postgres database |
 | DB_ADMIN_PW   | Password of the admin user of the postgres database |
+| Database__AssumeExternallyProvisioned | When `true`, keep an already-provisioned (empty) database and only build its schema via migrations, instead of dropping and recreating it. Useful when the connecting role may not create/drop databases. Default: `false`. See *Externally-provisioned database* above. |
 
 ## Settings priority
 

--- a/src/Startup/appsettings.json
+++ b/src/Startup/appsettings.json
@@ -1,6 +1,9 @@
 {
   "DetailedErrors": true,
   "AllowedHosts": "*",
+  "Database": {
+    "AssumeExternallyProvisioned": false
+  },
   "Serilog": {
     "Using": [ "Serilog.Sinks.Console", "Serilog.Sinks.File" ],
     "MinimumLevel": {


### PR DESCRIPTION
### Summary

Adds an opt-in setting that lets the server run against a database it is **not** allowed to create or drop. When enabled and the database has no schema yet, the server keeps the existing (empty) database and builds its schema via migrations, instead of dropping and recreating it.

- Setting: `Database:AssumeExternallyProvisioned` in `appsettings.json`, or the `Database__AssumeExternallyProvisioned` environment variable.
- Default `false` → **unchanged** drop-and-recreate behaviour.
- `-reinit` → always drops and recreates, regardless of the setting.

### Motivation

Today the initial `ReCreateDatabaseAsync()` runs `EnsureDeletedAsync()` + migrate, which requires the connecting role to be able to `CREATE`/`DROP` databases. This works when connecting as `postgres` (or a `DB_ADMIN_USER` with equivalent rights).

It does **not** work in increasingly common managed setups — a Kubernetes operator (e.g. CloudNativePG), infrastructure-as-code, or a managed cloud database — where the database is provisioned ahead of time and the application role is intentionally least-privilege: it owns only its own database and cannot create or drop databases.

In that environment the current behaviour is a crash loop: `EnsureDeleted` drops the database (the role owns it), the following `CREATE DATABASE` fails (no `CREATEDB`), and startup dies with `3D000: database "..." does not exist`.

### Behaviour

`DatabaseExistsAsync()` reports "does the database exist" as "have any migrations been applied", so an empty-but-present database is treated as absent and sent down the recreate path. With `AssumeExternallyProvisioned=true`, that path skips the drop/create and only applies migrations to the existing database — cleanly separating database ownership (the operator/infra) from schema ownership (the server).

### Changes

- `ReCreateDatabaseAsync` gains a backward-compatible `dropExistingDatabase = true` parameter; when `false` it skips `EnsureDeletedAsync`.
- `Program` reads the setting (adds `AddEnvironmentVariables()` to the config builder) and passes `dropExistingDatabase: !assumeExternallyProvisioned`.
- Documented in `src/Startup/Readme.md`; registered in `appsettings.json`.

Verified with `dotnet build` of `Startup` and `Persistence.EntityFramework`.