### PR TITLE
Search accounts in the database instead of loading all of them

### DIFF
--- a/src/Persistence/EntityFramework/PlayerContext.cs
+++ b/src/Persistence/EntityFramework/PlayerContext.cs
@@ -101,6 +101,26 @@ internal class PlayerContext : CachingEntityFrameworkContext, IPlayerContext
     }
 
     /// <inheritdoc />
+    public async ValueTask<IEnumerable<DataModel.Entities.Account>> SearchAccountsAsync(string searchTerm, int skip, int count, CancellationToken cancellationToken = default)
+    {
+        using (this.RepositoryProvider.ContextStack.UseContext(this))
+        {
+            // Invariant: this one runs in .NET, so it must not depend on the server's locale - in a
+            // Turkish one, "I".ToLower() is a dotless "ı" and the term would match nothing. The
+            // ToLower() calls inside the query below are a different matter: they are translated to
+            // the database's own lower(), which is why they cannot take a culture.
+            var term = searchTerm.ToLowerInvariant();
+            return await this.Context.Set<Account>().AsNoTracking()
+                .Where(a => a.LoginName.ToLower().Contains(term)
+                            || a.RawCharacters.Any(c => c.Name.ToLower().Contains(term)))
+                .OrderBy(a => a.LoginName)
+                .Skip(skip)
+                .Take(count)
+                .ToListAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+
+    /// <inheritdoc />
     public async ValueTask<DataModel.Entities.Account?> GetAccountByCharacterNameAsync(string characterName, CancellationToken cancellationToken = default)
     {
         using (this.RepositoryProvider.ContextStack.UseContext(this))

--- a/src/Persistence/IPlayerContext.cs
+++ b/src/Persistence/IPlayerContext.cs
@@ -79,6 +79,19 @@ public interface IPlayerContext : IContext
     ValueTask<IEnumerable<Account>> GetAccountsOrderedByLoginNameAsync(int skip, int count, CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Gets the accounts which contain the search term in their login name or in one of
+    /// their character names, ordered by login name.
+    /// </summary>
+    /// <param name="searchTerm">The search term.</param>
+    /// <param name="skip">The skip count.</param>
+    /// <param name="count">The count.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>
+    /// The account objects, without dependent data.
+    /// </returns>
+    ValueTask<IEnumerable<Account>> SearchAccountsAsync(string searchTerm, int skip, int count, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Gets the account by character name.
     /// </summary>
     /// <param name="characterName">The character name.</param>

--- a/src/Persistence/InMemory/PlayerInMemoryContext.cs
+++ b/src/Persistence/InMemory/PlayerInMemoryContext.cs
@@ -58,6 +58,18 @@ public class PlayerInMemoryContext : InMemoryContext, IPlayerContext
     }
 
     /// <inheritdoc/>
+    public async ValueTask<IEnumerable<MUnique.OpenMU.DataModel.Entities.Account>> SearchAccountsAsync(string searchTerm, int skip, int count, CancellationToken cancellationToken = default)
+    {
+        var allAccounts = await this.Provider.GetRepository<Account>().GetAllAsync(cancellationToken).ConfigureAwait(false);
+        return allAccounts
+            .Where(a => a.LoginName.Contains(searchTerm, StringComparison.InvariantCultureIgnoreCase)
+                        || a.Characters.Any(c => c.Name.Contains(searchTerm, StringComparison.InvariantCultureIgnoreCase)))
+            .OrderBy(a => a.LoginName)
+            .Skip(skip)
+            .Take(count);
+    }
+
+    /// <inheritdoc/>
     public async ValueTask<bool> CanSaveLetterAsync(Interfaces.LetterHeader letterHeader, CancellationToken cancellationToken = default)
     {
         return true;

--- a/src/Web/Shared/Services/AccountService.cs
+++ b/src/Web/Shared/Services/AccountService.cs
@@ -80,18 +80,14 @@ public class AccountService : IDataService<Account>, ISupportDataChangedNotifica
                 return (await playerContext.GetAccountsOrderedByLoginNameAsync(offset, count).ConfigureAwait(false)).ToList();
             }
 
-            var allAccounts = await playerContext.GetAsync<Account>().ConfigureAwait(false);
-            var results = allAccounts.Where(account =>
-                (account.LoginName != null && account.LoginName.Contains(filter, StringComparison.InvariantCultureIgnoreCase))
-                || account.Characters.Any(c => c.Name != null && c.Name.Contains(filter, StringComparison.InvariantCultureIgnoreCase))
-            ).ToList();
-
-            if (offset >= results.Count)
+            var results = (await playerContext.SearchAccountsAsync(filter, offset, count).ConfigureAwait(false)).ToList();
+            if (results.Count == 0 && offset > 0)
             {
-                return results.Take(count).ToList();
+                // The filter narrowed the result set down to less entries than the current page offset - show the first page instead.
+                results = (await playerContext.SearchAccountsAsync(filter, 0, count).ConfigureAwait(false)).ToList();
             }
 
-            return results.Skip(offset).Take(count).ToList();
+            return results;
         }
         catch
         {


### PR DESCRIPTION
## The bug

Using the search box on the account list makes the admin panel show an **empty inventory and
vault for every account** it opens afterwards - including accounts which displayed correctly a
moment earlier. It stays that way until the server is restarted.

The data is fine; the panel just stops loading it.

## Cause

`AccountService.GetAsync` filtered in memory:

```csharp
var allAccounts = await playerContext.GetAsync<Account>().ConfigureAwait(false);
var results = allAccounts.Where(account => ...).ToList();
```

`GetAsync<Account>()` ends up in `GenericRepositoryBase.GetAllAsync`, which runs
`Set<Account>().ToListAsync()` - **tracked** - and then `LoadDependentDataAsync` over the
result. The unfiltered account list uses `AsNoTracking()`; the search did not.

`IDataSource<Account>` is registered as a singleton (`WebApplicationExtensions.cs:77`) and keeps
one context for its whole lifetime, so those tracked instances stay there. From then on
`AccountRepository.GetByIdAsync` takes its early exit:

```csharp
var accountEntry = context.Context.ChangeTracker.Entries<Account>().FirstOrDefault(a => a.Entity.Id == id);
var account = accountEntry?.Entity;
if (account is null || accountEntry?.References.Any(reference => !reference.IsLoaded) is true)
{
    // ... load the whole graph through the AccountJsonObjectLoader
}

return account;
```

The account is found in the change tracker and its reference navigations count as loaded, so the
`AccountJsonObjectLoader` never runs - and the instances left behind by the mass load carry no
items.

It looks like it depends on the number of accounts, because the list shows twenty entries per
page: as long as everything fits on the first page, nobody touches the search box.

## The fix

A new `IPlayerContext.SearchAccountsAsync` runs the filter in the database, without tracking, and
returns only the requested page. `AccountService` uses it instead of `GetAsync<Account>()`.

## Measured on a database with 109 accounts / 515 characters / 5968 items

Same interaction - type a name into the search box, open the account, open a character:

| | before | after |
|---|---|---|
| queries | ~16000 | 33 |
| N+1 queries for item data | 5968 | 0 |
| account graph loaded through `AccountJsonObjectLoader` | 0 | 1 |

The N+1 storm came from `LoadDependentDataAsync` walking every account of the database - one
query per storage, per item, per character, per letter, per quest state - on **every** search
(debounced, so roughly every 300 ms of typing).

## Notes

- `EF.Functions` is not used for the filter; `.ToLower().Contains(...)` translates to
  `lower(x) LIKE '%term%'`. A `%` or `_` typed into the search box therefore acts as a wildcard.
  That seemed acceptable for a search box, but it is easy to escape if preferred.
- `PlayerInMemoryContext` got the equivalent implementation.
- `AccountService.BanAsync` / `UnbanAsync` need a tracked account, but nothing calls them at the
  moment, and they were never reachable from the search results anyway - the unfiltered list has
  always been `AsNoTracking`.
- Something I noticed while tracking this down, but did not touch here: the mass load also logged
  one `No repository found which supports loading by foreign key for type Item` per item storage.
  `GenericRepositoryBase.LoadCollectionAsync` asks the repository provider for `Item` and gets
  `ConfigurationTypeRepository<Item>` - registered for the merchant stores - which does not
  implement `ILoadByProperty`, so the collection is left empty and marked as `Failed`. The
  `?? _nonCachingRepositoryProvider` fallback in `CacheAwareRepositoryProvider.GetRepository`
  cannot help, because the caching provider does return a repository, just not a usable one.
  With this change nothing reaches that path anymore, so it is a latent trap rather than a bug
  anyone can hit today - happy to open a separate issue if you want it addressed.