### PR TITLE
Cascade delete mini game ranking entries

### DIFF
--- a/src/Persistence/EntityFramework/EntityDataContext.cs
+++ b/src/Persistence/EntityFramework/EntityDataContext.cs
@@ -44,7 +44,7 @@ public class EntityDataContext : ExtendedTypeContext
         modelBuilder.Entity<Model.AttributeDefinition>();
         modelBuilder.Entity<ConnectServerDefinition>();
         modelBuilder.Entity<ChatServerDefinition>();
-        modelBuilder.Entity<MiniGameRankingEntry>();
+        modelBuilder.Entity<MiniGameRankingEntry>().Apply();
         modelBuilder.Entity<GameServerDefinition>(entity =>
         {
             entity.Property(e => e.PvpEnabled).HasDefaultValue(true);

--- a/src/Persistence/EntityFramework/Extensions/ModelBuilder/MiniGameExtensions.cs
+++ b/src/Persistence/EntityFramework/Extensions/ModelBuilder/MiniGameExtensions.cs
@@ -4,6 +4,7 @@
 
 namespace MUnique.OpenMU.Persistence.EntityFramework.Extensions.ModelBuilder;
 
+using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using MUnique.OpenMU.Persistence.EntityFramework.Model;
 
@@ -40,5 +41,22 @@ internal static class MiniGameExtensions
     {
         builder.Property(p => p.Name).HasConversion(LocalizedStringConverter.Instance);
         builder.Property(p => p.Description).HasConversion(LocalizedStringConverter.Instance);
+    }
+
+    /// <summary>
+    /// Applies the settings for the <see cref="MiniGameRankingEntry"/> entity.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    /// <remarks>
+    /// A ranking entry is a member of neither the character's nor the mini game definition's
+    /// aggregate. The model generator only emits a cascading delete for navigations marked with
+    /// <see cref="MUnique.OpenMU.DataModel.Composition.MemberOfAggregateAttribute"/>, so these two
+    /// references are left without a delete behavior; Entity Framework then defaults to no action
+    /// for them, and the database refuses to delete a character which has played a mini game.
+    /// </remarks>
+    public static void Apply(this EntityTypeBuilder<MiniGameRankingEntry> builder)
+    {
+        builder.HasOne(entry => entry.RawCharacter).WithMany().OnDelete(DeleteBehavior.Cascade);
+        builder.HasOne(entry => entry.RawMiniGame).WithMany().OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/src/Persistence/EntityFramework/Migrations/20260723073950_CascadeDeleteMiniGameRankingEntries.Designer.cs
+++ b/src/Persistence/EntityFramework/Migrations/20260723073950_CascadeDeleteMiniGameRankingEntries.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MUnique.OpenMU.Persistence.EntityFramework;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
     [DbContext(typeof(EntityDataContext))]
-    partial class EntityDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260723073950_CascadeDeleteMiniGameRankingEntries")]
+    partial class CascadeDeleteMiniGameRankingEntries
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Persistence/EntityFramework/Migrations/20260723073950_CascadeDeleteMiniGameRankingEntries.cs
+++ b/src/Persistence/EntityFramework/Migrations/20260723073950_CascadeDeleteMiniGameRankingEntries.cs
@@ -1,0 +1,80 @@
+// <copyright file="20260723073950_CascadeDeleteMiniGameRankingEntries.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+#nullable disable
+
+namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
+{
+    using Microsoft.EntityFrameworkCore.Migrations;
+
+    /// <inheritdoc />
+    public partial class CascadeDeleteMiniGameRankingEntries : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_MiniGameRankingEntry_Character_CharacterId",
+                schema: "data",
+                table: "MiniGameRankingEntry");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_MiniGameRankingEntry_MiniGameDefinition_MiniGameId",
+                schema: "data",
+                table: "MiniGameRankingEntry");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MiniGameRankingEntry_Character_CharacterId",
+                schema: "data",
+                table: "MiniGameRankingEntry",
+                column: "CharacterId",
+                principalSchema: "data",
+                principalTable: "Character",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MiniGameRankingEntry_MiniGameDefinition_MiniGameId",
+                schema: "data",
+                table: "MiniGameRankingEntry",
+                column: "MiniGameId",
+                principalSchema: "config",
+                principalTable: "MiniGameDefinition",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_MiniGameRankingEntry_Character_CharacterId",
+                schema: "data",
+                table: "MiniGameRankingEntry");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_MiniGameRankingEntry_MiniGameDefinition_MiniGameId",
+                schema: "data",
+                table: "MiniGameRankingEntry");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MiniGameRankingEntry_Character_CharacterId",
+                schema: "data",
+                table: "MiniGameRankingEntry",
+                column: "CharacterId",
+                principalSchema: "data",
+                principalTable: "Character",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_MiniGameRankingEntry_MiniGameDefinition_MiniGameId",
+                schema: "data",
+                table: "MiniGameRankingEntry",
+                column: "MiniGameId",
+                principalSchema: "config",
+                principalTable: "MiniGameDefinition",
+                principalColumn: "Id");
+        }
+    }
+}


### PR DESCRIPTION
Fixes #796.

## What this changes

- A character which has ever placed in a mini game ranking (Blood Castle, Devil
  Square, Chaos Castle, …) can be deleted again — both by the player and by an
  administrator in the admin panel.
- A mini game definition can be deleted again in the configuration editor. It
  hit the very same restriction, so it is fixed in the same pass.
- Existing databases are migrated: the two foreign keys of
  `MiniGameRankingEntry` are recreated with `ON DELETE CASCADE`.
- No behaviour changes for anything else — this only defines what happens to a
  ranking entry when the row it points at goes away.

## The defect

Deleting such a character failed with

```
Npgsql.PostgresException 23503: update or delete on table "Character"
violates foreign key constraint "FK_MiniGameRankingEntry_Character_CharacterId"
on table "MiniGameRankingEntry"
```

`MiniGameRankingEntry` is a member of neither the character's nor the mini game
definition's aggregate. The model generator emits a cascading delete only for
navigations marked with `MemberOfAggregateAttribute`
(`Persistence/SourceGenerator/EfCoreModelGenerator.cs`), and the entity was
registered in `EntityDataContext` without any further configuration:

```csharp
modelBuilder.Entity<MiniGameRankingEntry>();
```

So Entity Framework fell back to `NO ACTION` for both optional relationships,
which PostgreSQL implements as a restricting foreign key.

This looks like an oversight rather than a decision: the blanket
`20221121161552_DeleteCascade` migration gave every other character-owned
relationship a cascade — `CharacterQuestState`, `SkillEntry`, `StatAttribute`,
`LetterHeader` — and skipped this one. It was the only one of the seven foreign
keys pointing at `Character` that blocked deletion.

## The fix

Configure both references explicitly:

```csharp
public static void Apply(this EntityTypeBuilder<MiniGameRankingEntry> builder)
{
    builder.HasOne(entry => entry.RawCharacter).WithMany().OnDelete(DeleteBehavior.Cascade);
    builder.HasOne(entry => entry.RawMiniGame).WithMany().OnDelete(DeleteBehavior.Cascade);
}
```

…plus the matching migration, since a model change alone would only fix newly
created databases.

Ranking entries are scoped per game instance (`GameInstanceId`), so dropping
them together with the character is consistent with how the rest of the
character's data behaves. Option B from the issue — `SET NULL` plus a
denormalized name snapshot — would only be worth it if persistent leaderboards
were intended; the current `NO ACTION` implements neither.

### On soft deletion

You mentioned in the issue that for the normal use case you are thinking about
soft deletion (an `IsDeleted` flag) of character and account data. That is a
larger and separate discussion, and this change neither implements nor blocks
it — but it also does not depend on it, for three reasons:

1. **Hard deletion has to keep working either way.** Even with soft deletion in
   place, rows eventually get removed for real: administrative cleanup, data
   retention / erasure requests, purging generated test or bot populations. All
   of those run into this exact foreign key. Leaving it as `NO ACTION` just
   moves the failure to a rarer, less convenient moment.
2. **It does not help the databases that are broken today.** A soft-delete flag
   is a model plus a migration plus query filters — and it would have to be
   mirrored in the InMemory provider, plus partial unique indexes so that the
   name of a deleted character can be reused. That is a cross-cutting change;
   this one is two lines and a migration, and it unblocks affected servers now.
3. **The accident case is already covered on both deletion paths.** Deleting a
   character as a player is not a stray click: `DeleteCharacterAction` verifies
   the account's security code, or the account password when no security code is
   set, and refuses outright while the character is in a guild. In the admin
   panel it takes two deliberate steps — removing the character from the account
   and then saving. So the value soft deletion adds here is not protection from
   mis-clicks; it is the ability to restore on request and to keep an audit
   trail, which is a feature decision rather than a fix for this defect.

Happy to be wrong on the priority — but the cascade seems worth having whether
or not soft deletion lands later.

### Note on the second cascade

The cascade on `MiniGameDefinition` goes one step beyond the reported symptom,
so it should be a conscious decision rather than a side effect: it means that
deleting a mini game definition in the admin panel now also drops that game's
ranking history, where it previously failed with the same FK error. Happy to
split it out if you would rather keep this PR to the character path alone.

## Verification

- `dotnet build` of `MUnique.OpenMU.Persistence.EntityFramework`: succeeds, no
  new warnings (the StyleCop warnings under `Migrations/` are pre-existing, from
  `AddIsQuestItemFlag` and `AddBuff`).
- The model snapshot keeps `HasForeignKey("CharacterId")` / `("MiniGameId")` and
  only gains `OnDelete(DeleteBehavior.Cascade)` — no shadow foreign key was
  introduced by configuring a previously convention-discovered relationship.
- All seven relationships pointing at `Character` now cascade.
- `Down()` restores the previous `NO ACTION` foreign keys.

## Commits

- `Cascade delete mini game ranking entries` — model configuration, migration
  `20260723073950_CascadeDeleteMiniGameRankingEntries`, snapshot update.