### PR TITLE
Fix zen from own experience

### DIFF
--- a/src/GameLogic/DroppedMoney.cs
+++ b/src/GameLogic/DroppedMoney.cs
@@ -148,7 +148,12 @@ public sealed class DroppedMoney : AsyncDisposable, ILocateable
             return true;
         }
 
-        var shares = this._shares.Count > 0
+        // Money has no owner - it can always be picked up, by strangers too. The recorded shares
+        // only apply when the party which picks it up is the one which earned it; then the money
+        // follows the experience. For anyone else there is no experience to follow, so it is split
+        // equally between the picking party, just like money without any shares (e.g. an item box).
+        var earnedByThisParty = this._shares.Any(share => party.IsEligibleForMoney(share.Player, player));
+        var shares = earnedByThisParty
             ? this._shares
             : MoneyDistribution.CreateEqualShares(this.Amount, party.PartyList.OfType<Player>().ToList());
 

--- a/src/GameLogic/DroppedMoney.cs
+++ b/src/GameLogic/DroppedMoney.cs
@@ -6,7 +6,6 @@ namespace MUnique.OpenMU.GameLogic;
 
 using System.Diagnostics;
 using System.Threading;
-using MUnique.OpenMU.GameLogic.Attributes;
 using MUnique.OpenMU.Pathfinding;
 using Nito.AsyncEx;
 
@@ -20,6 +19,8 @@ public sealed class DroppedMoney : AsyncDisposable, ILocateable
     /// </summary>
     private readonly AsyncLock _pickupLock;
 
+    private readonly IReadOnlyList<MoneyShare> _shares;
+
     private Timer? _removeTimer;
 
     private bool _availableToPick = true;
@@ -30,9 +31,14 @@ public sealed class DroppedMoney : AsyncDisposable, ILocateable
     /// <param name="amount">The amount.</param>
     /// <param name="position">The position where the item was dropped on the map.</param>
     /// <param name="map">The map.</param>
-    public DroppedMoney(uint amount, Point position, GameMap map)
+    /// <param name="shares">
+    /// The part of the money which is reserved for each player, matching the experience they gained from the kill.
+    /// When it's empty - for example for money from an item box - the money is split equally instead.
+    /// </param>
+    public DroppedMoney(uint amount, Point position, GameMap map, IReadOnlyList<MoneyShare>? shares = null)
     {
         this.Amount = amount;
+        this._shares = shares ?? [];
         this._pickupLock = new();
         this.Position = position;
         this.CurrentMap = map;
@@ -131,54 +137,28 @@ public sealed class DroppedMoney : AsyncDisposable, ILocateable
     /// <returns><c>True</c>, if at least one player received money; Otherwise, <c>false</c>.</returns>
     private bool TryGiveMoneyTo(Player player)
     {
-        if (player.Party is { } party)
+        if (player.Party is not { } party)
         {
-            var partyMembers = party.PartyList
-                .OfType<Player>()
-                .Where(p => p.CurrentMap == player.CurrentMap && !p.IsAtSafezone() && p.Attributes is { })
-                .ToList();
-
-            if (partyMembers.Count == 0)
+            if (!MoneyDistribution.TryPay(player, this.Amount))
             {
-                player.Logger.LogDebug("No party member could receive the money, Player {0}, Money {1}", player, this);
+                player.Logger.LogDebug("Money could not be added to the inventory, Player {0}, Money {1}", player, this);
                 return false;
             }
 
-            var share = (int)(this.Amount / partyMembers.Count);
-            var received = false;
-            foreach (var member in partyMembers)
-            {
-                received |= member.TryAddMoney((int)(share * member.Attributes![Stats.MoneyAmountRate]));
-            }
-
-            if (!received)
-            {
-                player.Logger.LogDebug("No party member could take the money, Player {0}, Money {1}", player, this);
-            }
-
-            return received;
+            return true;
         }
 
-        var amountToAdd = (int)this.Amount;
-        if (player.GameContext?.Configuration?.ClampMoneyOnPickup ?? false)
+        var shares = this._shares.Count > 0
+            ? this._shares
+            : MoneyDistribution.CreateEqualShares(this.Amount, party.PartyList.OfType<Player>().ToList());
+
+        var received = MoneyDistribution.TryPayShares(shares, member => party.IsEligibleForMoney(member, player));
+        if (!received)
         {
-            var maxMoney = player.GameContext?.Configuration?.MaximumInventoryMoney ?? int.MaxValue;
-            amountToAdd = (int)Math.Min(this.Amount, (uint)Math.Max(0, maxMoney - player.Money));
-
-            if (amountToAdd <= 0)
-            {
-                player.Logger.LogDebug("Player is at maximum money limit, Player {0}, Money {1}", player, this);
-                return false;
-            }
+            player.Logger.LogDebug("No party member could take the money, Player {0}, Money {1}", player, this);
         }
 
-        if (!player.TryAddMoney(amountToAdd))
-        {
-            player.Logger.LogDebug("Money could not be added to the inventory, Player {0}, Money {1}", player, this);
-            return false;
-        }
-
-        return true;
+        return received;
     }
 
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD100:Avoid async void methods", Justification = "Catching all Exceptions.")]

--- a/src/GameLogic/ExperienceShare.cs
+++ b/src/GameLogic/ExperienceShare.cs
@@ -1,0 +1,12 @@
+// <copyright file="ExperienceShare.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic;
+
+/// <summary>
+/// The experience which a single player gained from a kill.
+/// </summary>
+/// <param name="Player">The player which gained the experience.</param>
+/// <param name="Experience">The gained experience, with all experience rates already applied.</param>
+public readonly record struct ExperienceShare(Player Player, int Experience);

--- a/src/GameLogic/MoneyDistribution.cs
+++ b/src/GameLogic/MoneyDistribution.cs
@@ -1,0 +1,223 @@
+// <copyright file="MoneyDistribution.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic;
+
+using MUnique.OpenMU.GameLogic.Attributes;
+
+/// <summary>
+/// Splits a money drop between players and hands it over to them.
+/// </summary>
+/// <remarks>
+/// This is the single place where <see cref="Stats.MoneyAmountRate"/> and
+/// <see cref="DataModel.Configuration.GameConfiguration.ClampMoneyOnPickup"/> are applied, so that
+/// every path - dropped on the ground, added directly, solo or in a party - treats them the same way.
+/// </remarks>
+internal static class MoneyDistribution
+{
+    /// <summary>
+    /// Splits the money proportionally to the experience each player gained from the kill.
+    /// </summary>
+    /// <param name="amount">The total amount of money to split.</param>
+    /// <param name="experienceShares">The experience gained per player.</param>
+    /// <returns>The part of the money which is reserved for each player.</returns>
+    public static IReadOnlyList<MoneyShare> CreateShares(uint amount, IReadOnlyList<ExperienceShare> experienceShares)
+    {
+        if (experienceShares.Count == 0)
+        {
+            return [];
+        }
+
+        if (experienceShares.Count == 1)
+        {
+            return [new MoneyShare(experienceShares[0].Player, amount)];
+        }
+
+        var weights = new long[experienceShares.Count];
+        for (int i = 0; i < experienceShares.Count; i++)
+        {
+            weights[i] = experienceShares[i].Experience;
+        }
+
+        var parts = SplitByWeight(amount, weights);
+        var shares = new MoneyShare[experienceShares.Count];
+        for (int i = 0; i < experienceShares.Count; i++)
+        {
+            shares[i] = new MoneyShare(experienceShares[i].Player, parts[i]);
+        }
+
+        return shares;
+    }
+
+    /// <summary>
+    /// Splits the money equally, which is used when no per player experience is known - for example
+    /// for the fixed money amount of an item box.
+    /// </summary>
+    /// <param name="amount">The total amount of money to split.</param>
+    /// <param name="players">The players to split it between.</param>
+    /// <returns>The part of the money which is reserved for each player.</returns>
+    public static IReadOnlyList<MoneyShare> CreateEqualShares(uint amount, IReadOnlyList<Player> players)
+    {
+        if (players.Count == 0)
+        {
+            return [];
+        }
+
+        var parts = SplitByWeight(amount, new long[players.Count]);
+        var shares = new MoneyShare[players.Count];
+        for (int i = 0; i < players.Count; i++)
+        {
+            shares[i] = new MoneyShare(players[i], parts[i]);
+        }
+
+        return shares;
+    }
+
+    /// <summary>
+    /// Hands the shares over to the players which are still eligible. The shares of players which
+    /// are not eligible anymore are re-distributed between the remaining ones.
+    /// </summary>
+    /// <param name="shares">The shares.</param>
+    /// <param name="isEligible">Determines whether a player may still receive their share.</param>
+    /// <returns><c>True</c>, if at least one player received money; Otherwise, <c>false</c>.</returns>
+    public static bool TryPayShares(IReadOnlyList<MoneyShare> shares, Func<Player, bool> isEligible)
+    {
+        var eligible = new List<MoneyShare>(shares.Count);
+        uint forfeited = 0;
+        foreach (var share in shares)
+        {
+            if (isEligible(share.Player))
+            {
+                eligible.Add(share);
+            }
+            else
+            {
+                forfeited += share.Amount;
+            }
+        }
+
+        if (eligible.Count == 0)
+        {
+            return false;
+        }
+
+        var extra = new uint[eligible.Count];
+        if (forfeited > 0)
+        {
+            var weights = new long[eligible.Count];
+            for (int i = 0; i < eligible.Count; i++)
+            {
+                weights[i] = eligible[i].Amount;
+            }
+
+            extra = SplitByWeight(forfeited, weights);
+        }
+
+        var received = false;
+        for (int i = 0; i < eligible.Count; i++)
+        {
+            received |= TryPay(eligible[i].Player, eligible[i].Amount + extra[i]);
+        }
+
+        return received;
+    }
+
+    /// <summary>
+    /// Adds the money to the inventory of the player, applying their <see cref="Stats.MoneyAmountRate"/>
+    /// and the configured pick up clamp.
+    /// </summary>
+    /// <param name="player">The player which should receive the money.</param>
+    /// <param name="amount">The amount, before the money rate of the player is applied.</param>
+    /// <returns><c>True</c>, if the player received money; Otherwise, <c>false</c>.</returns>
+    public static bool TryPay(Player player, uint amount)
+    {
+        if (amount == 0)
+        {
+            return false;
+        }
+
+        // The rate is applied in double precision: a float multiplication would round money amounts
+        // above the ~16.7M the float mantissa can represent exactly, before the cast to long.
+        var scaled = (long)(amount * (double)(player.Attributes?[Stats.MoneyAmountRate] ?? 1.0f));
+        if (scaled <= 0)
+        {
+            return false;
+        }
+
+        var amountToAdd = (int)Math.Min(scaled, int.MaxValue);
+        if (player.GameContext?.Configuration?.ClampMoneyOnPickup ?? false)
+        {
+            var maximumMoney = player.GameContext?.Configuration?.MaximumInventoryMoney ?? int.MaxValue;
+            amountToAdd = (int)Math.Min(amountToAdd, Math.Max(0, maximumMoney - player.Money));
+            if (amountToAdd <= 0)
+            {
+                return false;
+            }
+        }
+
+        return player.TryAddMoney(amountToAdd);
+    }
+
+    /// <summary>
+    /// Splits an amount proportionally to the given weights. When all weights are zero, it's split equally.
+    /// </summary>
+    private static uint[] SplitByWeight(uint amount, IReadOnlyList<long> weights)
+    {
+        var result = new uint[weights.Count];
+        if (weights.Count == 0 || amount == 0)
+        {
+            return result;
+        }
+
+        long totalWeight = 0;
+        foreach (var weight in weights)
+        {
+            totalWeight += Math.Max(0, weight);
+        }
+
+        var remainders = new long[weights.Count];
+        uint distributed = 0;
+        for (int i = 0; i < weights.Count; i++)
+        {
+            if (totalWeight > 0)
+            {
+                var numerator = (long)amount * Math.Max(0, weights[i]);
+                result[i] = (uint)(numerator / totalWeight);
+                remainders[i] = numerator % totalWeight;
+            }
+            else
+            {
+                result[i] = amount / (uint)weights.Count;
+                remainders[i] = 1;
+            }
+
+            distributed += result[i];
+        }
+
+        // The integer division loses up to one unit per share. Handing all of it to the same
+        // share would systematically favour one player over many kills, so the units go to the
+        // shares which were cut the most, one each (largest remainder method).
+        for (var rest = amount - distributed; rest > 0; rest--)
+        {
+            var pick = -1;
+            for (int i = 0; i < remainders.Length; i++)
+            {
+                if (remainders[i] > 0 && (pick < 0 || remainders[i] > remainders[pick]))
+                {
+                    pick = i;
+                }
+            }
+
+            if (pick < 0)
+            {
+                break;
+            }
+
+            result[pick]++;
+            remainders[pick] = 0;
+        }
+
+        return result;
+    }
+}

--- a/src/GameLogic/MoneyShare.cs
+++ b/src/GameLogic/MoneyShare.cs
@@ -1,0 +1,12 @@
+// <copyright file="MoneyShare.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic;
+
+/// <summary>
+/// The part of a money drop which is reserved for a single player.
+/// </summary>
+/// <param name="Player">The player for which the part is reserved.</param>
+/// <param name="Amount">The amount of money, before the <see cref="Attributes.Stats.MoneyAmountRate"/> of the player is applied.</param>
+public readonly record struct MoneyShare(Player Player, uint Amount);

--- a/src/GameLogic/NPC/AttackableNpcBase.cs
+++ b/src/GameLogic/NPC/AttackableNpcBase.cs
@@ -307,7 +307,9 @@ public abstract class AttackableNpcBase : NonPlayerCharacter, IAttackable
         var player = this.GetHitNotificationTarget(attacker);
         if (player is { })
         {
-            int exp = await (player.Party?.DistributeExperienceAfterKillAsync(this, player) ?? player.AddExpAfterKillAsync(this)).ConfigureAwait(false);
+            var experienceShares = player.Party is { } party
+                ? await party.DistributeExperienceAfterKillAsync(this, player).ConfigureAwait(false)
+                : [new ExperienceShare(player, await player.AddExpAfterKillAsync(this).ConfigureAwait(false))];
             if (attacker == player)
             {
                 await player.AfterKilledMonsterAsync().ConfigureAwait(false);
@@ -325,7 +327,7 @@ public abstract class AttackableNpcBase : NonPlayerCharacter, IAttackable
                     selectedCharacter.StateRemainingSeconds -= (int)this.Attributes[Stats.Level];
                 }
 
-                _ = this.DropItemDelayedAsync(player, exp); // don't wait for completion.
+                _ = this.DropItemDelayedAsync(player, experienceShares); // don't wait for completion.
             }
         }
     }
@@ -385,46 +387,44 @@ public abstract class AttackableNpcBase : NonPlayerCharacter, IAttackable
         }
     }
 
-    private async ValueTask HandleMoneyDropAsync(uint amount, Player killer)
+    private async ValueTask HandleMoneyDropAsync(uint amount, Player killer, IReadOnlyList<ExperienceShare> experienceShares)
     {
+        // Each player gets the part of the money which matches the experience they gained from the kill,
+        // so that money follows the same distribution as the experience it is derived from.
+        var shares = MoneyDistribution.CreateShares(amount, experienceShares);
+
         // We don't drop money in Devil Square, etc.
         var shouldDropMoney = killer.GameContext.Configuration.ShouldDropMoney && killer.CurrentMiniGame is null;
         if (!shouldDropMoney)
         {
-            var party = killer.Party;
-            if (party is null)
+            if (killer.Party is { } party)
             {
-                killer.TryAddMoney((int)amount);
+                await party.DistributeMoneyAfterKillAsync(this, killer, shares).ConfigureAwait(false);
             }
             else
             {
-                await party.DistributeMoneyAfterKillAsync(this, killer, amount).ConfigureAwait(false);
+                _ = MoneyDistribution.TryPay(killer, amount);
             }
 
             return;
         }
 
-        var droppedMoney = new DroppedMoney((uint)(amount * (killer.Attributes?[Stats.MoneyAmountRate] ?? 1.0f)), this.Position, this.CurrentMap);
+        var droppedMoney = new DroppedMoney(amount, this.Position, this.CurrentMap, shares);
         await this.CurrentMap.AddAsync(droppedMoney).ConfigureAwait(false);
     }
 
-    private async ValueTask DropItemAsync(int exp, Player killer)
+    private async ValueTask DropItemAsync(IReadOnlyList<ExperienceShare> experienceShares, Player killer)
     {
-        // When the killer is in a party, DistributeExperienceAfterKillAsync returns a
-        // total party experience that does NOT include game rate (ExperienceRate) or
-        // personal experience rate multipliers. Since the money drop amount is
-        // derived from this experience value, party money drops were dramatically
-        // lower than solo drops. We recalculate the experience for money purposes
-        // using the solo formula so money is consistent regardless of party state.
-        if (killer.Party is not null)
+        var exp = 0;
+        foreach (var share in experienceShares)
         {
-            exp = killer.CalculateExpAfterKill(this);
+            exp += share.Experience;
         }
 
         var (generatedItems, droppedMoney) = await this._dropGenerator.GenerateItemDropsAsync(this.Definition, exp, killer).ConfigureAwait(false);
         if (droppedMoney > 0)
         {
-            await this.HandleMoneyDropAsync(droppedMoney.Value, killer).ConfigureAwait(false);
+            await this.HandleMoneyDropAsync(droppedMoney.Value, killer, experienceShares).ConfigureAwait(false);
         }
 
         var firstItem = !droppedMoney.HasValue;
@@ -447,12 +447,12 @@ public abstract class AttackableNpcBase : NonPlayerCharacter, IAttackable
         }
     }
 
-    private async ValueTask DropItemDelayedAsync(Player player, int gainedExp)
+    private async ValueTask DropItemDelayedAsync(Player player, IReadOnlyList<ExperienceShare> experienceShares)
     {
         try
         {
             await Task.Delay(1000).ConfigureAwait(false);
-            await this.DropItemAsync(gainedExp, player).ConfigureAwait(false);
+            await this.DropItemAsync(experienceShares, player).ConfigureAwait(false);
         }
         catch (Exception ex)
         {

--- a/src/GameLogic/Party.cs
+++ b/src/GameLogic/Party.cs
@@ -388,19 +388,20 @@ public sealed class Party : AsyncDisposable
             return exp;
         }
 
+        var normalExperience = (int)(perLevel
+                                     * attributes[Stats.Level]
+                                     * player.GameContext.ExperienceRate
+                                     * (attributes[Stats.ExperienceRate] + attributes[Stats.BonusExperienceRate]));
+
         if (!isAtMaxLevel)
         {
-            var exp = (int)(perLevel
-                            * attributes[Stats.Level]
-                            * player.GameContext.ExperienceRate
-                            * (attributes[Stats.ExperienceRate] + attributes[Stats.BonusExperienceRate]));
-
-            await player.AddExperienceAsync(exp, killed).ConfigureAwait(false);
-            return exp;
+            await player.AddExperienceAsync(normalExperience, killed).ConfigureAwait(false);
         }
 
-        // Player is at max level but has not completed master quest. No experience awarded.
-        return 0;
+        // At the maximum level without the master quest no experience is awarded, but the amount is
+        // still returned: the money drop is derived from it, and a solo kill returns it as well
+        // (see Player.AddExpAfterKillAsync), so such a member must not end up without any money.
+        return normalExperience;
     }
 
     private async ValueTask ExitPartyAsync(IPartyMember member, byte index)

--- a/src/GameLogic/Party.cs
+++ b/src/GameLogic/Party.cs
@@ -201,8 +201,8 @@ public sealed class Party : AsyncDisposable
     /// </summary>
     /// <param name="killedObject">The object that was killed.</param>
     /// <param name="killer">The killer who is a party member.</param>
-    /// <returns>The total experience distributed.</returns>
-    public async ValueTask<int> DistributeExperienceAfterKillAsync(IAttackable killedObject, IObservable killer)
+    /// <returns>The experience which each party member gained, with all experience rates applied.</returns>
+    public async ValueTask<IReadOnlyList<ExperienceShare>> DistributeExperienceAfterKillAsync(IAttackable killedObject, IObservable killer)
     {
         using var l = await this._distributionLock.LockAsync();
         try
@@ -220,34 +220,29 @@ public sealed class Party : AsyncDisposable
     /// </summary>
     /// <param name="killed">The object that was killed.</param>
     /// <param name="killer">The killer who is a party member.</param>
-    /// <param name="amount">The amount of money to distribute.</param>
-    public async ValueTask DistributeMoneyAfterKillAsync(IAttackable killed, IPartyMember killer, uint amount)
+    /// <param name="shares">The part of the money which is reserved for each party member.</param>
+    public ValueTask DistributeMoneyAfterKillAsync(IAttackable killed, IPartyMember killer, IReadOnlyList<MoneyShare> shares)
     {
-        using var l = await this._distributionLock.LockAsync();
-        try
-        {
-            this._logger.LogDebug("Distributing money after killing {name}", killed.GetName());
-            this._distributionList.AddRange(
-                this._partyMembers.OfType<Player>()
-                    .Where(p => p.CurrentMap == killer.CurrentMap
-                                && !p.IsAtSafezone()
-                                && p.Attributes is { }));
+        // No lock is taken here: unlike the experience distribution this no longer touches the shared
+        // _distributionList, and paying out the pre-computed shares is consistent with the lock-free
+        // pick up path in DroppedMoney.
+        this._logger.LogDebug("Distributing money after killing {name}", killed.GetName());
+        _ = MoneyDistribution.TryPayShares(shares, player => this.IsEligibleForMoney(player, killer));
+        return ValueTask.CompletedTask;
+    }
 
-            if (this._distributionList.Count == 0)
-            {
-                return;
-            }
-
-            var moneyPart = amount / this._distributionList.Count;
-            foreach (var player in this._distributionList)
-            {
-                player.TryAddMoney((int)(moneyPart * player.Attributes![Stats.MoneyAmountRate]));
-            }
-        }
-        finally
-        {
-            this._distributionList.Clear();
-        }
+    /// <summary>
+    /// Determines whether the player may receive a part of a money drop of the party.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="killer">The killer who is a party member.</param>
+    /// <returns><c>True</c>, if the player may receive money; Otherwise, <c>false</c>.</returns>
+    internal bool IsEligibleForMoney(Player player, IPartyMember killer)
+    {
+        return this._partyMembers.Contains(player)
+               && player.CurrentMap == killer.CurrentMap
+               && !player.IsAtSafezone()
+               && player.Attributes is { };
     }
 
     /// <summary>
@@ -340,7 +335,7 @@ public sealed class Party : AsyncDisposable
         base.Dispose(disposing);
     }
 
-    private static (int Total, float PerLevel) CalculatePartyExperience(List<Player> recipients, IAttackable killed)
+    private static float CalculatePartyExperiencePerLevel(List<Player> recipients, IAttackable killed)
     {
         var memberCount = recipients.Count;
         var totalLevel = recipients.Sum(p => (int)p.Attributes![Stats.TotalLevel]);
@@ -355,9 +350,8 @@ public sealed class Party : AsyncDisposable
         var randomMinMultiplier = attributes[Stats.RandomExperienceMinMultiplier];
         var randomMaxMultiplier = attributes[Stats.RandomExperienceMaxMultiplier];
         var totalExperience = CalculateTotalExperience(totalBaseExperience, randomMinMultiplier, randomMaxMultiplier);
-        var perLevel = (float)totalExperience / totalLevel;
 
-        return (totalExperience, perLevel);
+        return (float)totalExperience / totalLevel;
     }
 
     private static int CalculateTotalExperience(double totalBaseExperience, float randomMinMultiplier, float randomMaxMultiplier)
@@ -377,7 +371,7 @@ public sealed class Party : AsyncDisposable
         return (int)totalBaseExperience;
     }
 
-    private static async ValueTask AwardExperienceAsync(Player player, float perLevel, IAttackable killed)
+    private static async ValueTask<int> AwardExperienceAsync(Player player, float perLevel, IAttackable killed)
     {
         var attributes = player.Attributes!;
         var isAtMaxLevel = (short)attributes[Stats.Level] == player.GameContext.Configuration.MaximumLevel;
@@ -391,8 +385,10 @@ public sealed class Party : AsyncDisposable
                             * (attributes[Stats.MasterExperienceRate] + attributes[Stats.BonusExperienceRate]));
 
             await player.AddMasterExperienceAsync(exp, killed).ConfigureAwait(false);
+            return exp;
         }
-        else if (!isAtMaxLevel)
+
+        if (!isAtMaxLevel)
         {
             var exp = (int)(perLevel
                             * attributes[Stats.Level]
@@ -400,11 +396,11 @@ public sealed class Party : AsyncDisposable
                             * (attributes[Stats.ExperienceRate] + attributes[Stats.BonusExperienceRate]));
 
             await player.AddExperienceAsync(exp, killed).ConfigureAwait(false);
+            return exp;
         }
-        else
-        {
-            // Player is at max level but has not completed master quest. No experience awarded.
-        }
+
+        // Player is at max level but has not completed master quest. No experience awarded.
+        return 0;
     }
 
     private async ValueTask ExitPartyAsync(IPartyMember member, byte index)
@@ -466,11 +462,11 @@ public sealed class Party : AsyncDisposable
         }
     }
 
-    private async ValueTask<int> InternalDistributeExperienceAfterKillAsync(IAttackable killedObject, IObservable killer)
+    private async ValueTask<IReadOnlyList<ExperienceShare>> InternalDistributeExperienceAfterKillAsync(IAttackable killedObject, IObservable killer)
     {
         if (killedObject.IsSummonedMonster)
         {
-            return 0;
+            return [];
         }
 
         using (await killer.ObserverLock.ReaderLockAsync().ConfigureAwait(false))
@@ -483,17 +479,20 @@ public sealed class Party : AsyncDisposable
 
         if (this._distributionList.Count == 0)
         {
-            return 0;
+            return [];
         }
 
-        var (total, perLevel) = CalculatePartyExperience(this._distributionList, killedObject);
+        var perLevel = CalculatePartyExperiencePerLevel(this._distributionList, killedObject);
 
+        // The shares are copied into their own list, because _distributionList is reused and cleared by the caller.
+        var shares = new List<ExperienceShare>(this._distributionList.Count);
         foreach (var player in this._distributionList)
         {
-            await AwardExperienceAsync(player, perLevel, killedObject).ConfigureAwait(false);
+            var experience = await AwardExperienceAsync(player, perLevel, killedObject).ConfigureAwait(false);
+            shares.Add(new ExperienceShare(player, experience));
         }
 
-        return total;
+        return shares;
     }
 
     private async ValueTask UpdateNearbyCountAsync()

--- a/tests/MUnique.OpenMU.GameLogic.Benchmarks/PartyBenchmarks.cs
+++ b/tests/MUnique.OpenMU.GameLogic.Benchmarks/PartyBenchmarks.cs
@@ -71,7 +71,8 @@ public class PartyBenchmarks
     [Benchmark]
     public async ValueTask DistributeMoneyAfterKillAsync()
     {
-        await _party.DistributeMoneyAfterKillAsync(_killedObject, _killer, 10000);
+        var shares = _players.Select(p => new MoneyShare(p, 10000 / (uint)_players.Count)).ToList();
+        await _party.DistributeMoneyAfterKillAsync(_killedObject, _killer, shares);
     }
 
     /// <summary>

--- a/tests/MUnique.OpenMU.Tests/DroppedMoneyTest.cs
+++ b/tests/MUnique.OpenMU.Tests/DroppedMoneyTest.cs
@@ -4,6 +4,7 @@
 
 namespace MUnique.OpenMU.Tests;
 
+using Microsoft.Extensions.Logging.Abstractions;
 using MUnique.OpenMU.GameLogic;
 using MUnique.OpenMU.Pathfinding;
 using NUnit.Framework;
@@ -61,5 +62,77 @@ public class DroppedMoneyTest
 
         Assert.That(await money.TryPickUpByAsync(otherPlayer).ConfigureAwait(false), Is.False);
         Assert.That(otherPlayer.Money, Is.EqualTo(0));
+    }
+
+    /// <summary>
+    /// Tests that money earned by one party can still be picked up by a stranger's party - money has no
+    /// owner - and is then split equally between the picking party, because there is no experience of theirs
+    /// to follow. The earner, who is not in the picking party, receives nothing.
+    /// </summary>
+    [Test]
+    public async Task StrangerPartySplitsPickedUpMoneyEquallyAsync()
+    {
+        var earner = await PlayerTestHelper.CreatePlayerAsync().ConfigureAwait(false);
+        var gameContext = earner.GameContext;
+        gameContext.Configuration.MaximumInventoryMoney = int.MaxValue;
+
+        var strangerParty = CreateParty();
+        var stranger1 = await AddPartyMemberAsync(gameContext, strangerParty).ConfigureAwait(false);
+        var stranger2 = await AddPartyMemberAsync(gameContext, strangerParty).ConfigureAwait(false);
+
+        // The money was earned by 'earner', who is in neither of the picking party's members.
+        var shares = new[] { new MoneyShare(earner, DroppedAmount) };
+        var money = new DroppedMoney(DroppedAmount, new Point(100, 100), stranger1.CurrentMap!, shares);
+
+        Assert.That(await money.TryPickUpByAsync(stranger1).ConfigureAwait(false), Is.True);
+        Assert.That(earner.Money, Is.EqualTo(0));
+        Assert.That(stranger1.Money + stranger2.Money, Is.EqualTo((int)DroppedAmount));
+        Assert.That(stranger1.Money, Is.EqualTo((int)DroppedAmount / 2));
+        Assert.That(stranger2.Money, Is.EqualTo((int)DroppedAmount / 2));
+    }
+
+    /// <summary>
+    /// Tests that when the earning party picks its own money up, it follows the recorded shares
+    /// (proportional to the experience each member gained) instead of being split equally.
+    /// </summary>
+    [Test]
+    public async Task EarningPartyReceivesMoneyByExperienceShareAsync()
+    {
+        var big = await PlayerTestHelper.CreatePlayerAsync().ConfigureAwait(false);
+        var gameContext = big.GameContext;
+        gameContext.Configuration.MaximumInventoryMoney = int.MaxValue;
+
+        var party = CreateParty();
+        await party.AddAsync(big).ConfigureAwait(false);
+        var small = await AddPartyMemberAsync(gameContext, party).ConfigureAwait(false);
+
+        var shares = new[]
+        {
+            new MoneyShare(big, 800),
+            new MoneyShare(small, 200),
+        };
+        var money = new DroppedMoney(DroppedAmount, new Point(100, 100), big.CurrentMap!, shares);
+
+        Assert.That(await money.TryPickUpByAsync(big).ConfigureAwait(false), Is.True);
+        Assert.That(big.Money, Is.EqualTo(800));
+        Assert.That(small.Money, Is.EqualTo(200));
+    }
+
+    private static Party CreateParty()
+    {
+        // The party manager of the lightweight test context has a maximum size of zero, which would
+        // reject every member. A stand-alone party with a real size is enough for the money distribution.
+        var partyManager = new PartyManager(5, new NullLogger<Party>());
+        return new Party(partyManager, 5, new NullLogger<Party>());
+    }
+
+    private static async ValueTask<Player> AddPartyMemberAsync(IGameContext gameContext, Party party)
+    {
+        // The test helper already enters the player into the world, so it shares the live map of the
+        // context with the other members created from the same context - which is what the money
+        // distribution's eligibility check compares.
+        var player = await PlayerTestHelper.CreatePlayerAsync(gameContext).ConfigureAwait(false);
+        await party.AddAsync(player).ConfigureAwait(false);
+        return player;
     }
 }

--- a/tests/MUnique.OpenMU.Tests/ExperienceRateSplitTest.cs
+++ b/tests/MUnique.OpenMU.Tests/ExperienceRateSplitTest.cs
@@ -114,6 +114,39 @@ public class ExperienceRateSplitTest
     }
 
     /// <summary>
+    /// Verifies that a party member at the maximum level without the master quest still gets a
+    /// money basis. It gains no experience, but the money drop is derived from that value, and a
+    /// solo kill returns it too - so returning zero would leave it without any zen in a party.
+    /// </summary>
+    [Test]
+    public async ValueTask MaxLevelMemberWithoutMasterQuestStillHasMoneyBasisAsync()
+    {
+        var context = this.CreateGameServerContext(
+            normalExperienceRate: 1.0f,
+            globalMasterExperienceRate: 1.0f,
+            maximumLevel: 3,
+            maximumMasterLevel: 200);
+
+        var maxedPlayer = await this.CreatePlayerAsync(context, level: 3, totalLevel: 3, isMasterClass: false).ConfigureAwait(false);
+        var levelingPlayer = await this.CreatePlayerAsync(context, level: 2, totalLevel: 2, isMasterClass: false).ConfigureAwait(false);
+
+        var party = new Party(new PartyManager(5, new NullLogger<Party>()), 5, new NullLogger<Party>());
+        await party.AddAsync(maxedPlayer).ConfigureAwait(false);
+        await party.AddAsync(levelingPlayer).ConfigureAwait(false);
+        await maxedPlayer.AddObserverAsync(levelingPlayer).ConfigureAwait(false);
+
+        var killedObject = CreateKilledObject(level: 5);
+        var shares = await party.DistributeExperienceAfterKillAsync(killedObject.Object, maxedPlayer).ConfigureAwait(false);
+
+        var maxedShare = shares.First(s => s.Player == maxedPlayer);
+        Assert.That(maxedShare.Experience, Is.GreaterThan(0));
+
+        // It still must not actually gain any experience.
+        Assert.That(maxedPlayer.SelectedCharacter!.Experience, Is.EqualTo(0));
+        Assert.That(maxedPlayer.SelectedCharacter.MasterExperience, Is.EqualTo(0));
+    }
+
+    /// <summary>
     /// Verifies that concurrent normal experience gains cannot exceed the maximum level.
     /// </summary>
     [Test]

--- a/tests/MUnique.OpenMU.Tests/MoneyDistributionTest.cs
+++ b/tests/MUnique.OpenMU.Tests/MoneyDistributionTest.cs
@@ -1,0 +1,266 @@
+// <copyright file="MoneyDistributionTest.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Tests;
+
+using Microsoft.Extensions.Logging.Abstractions;
+using MUnique.OpenMU.AttributeSystem;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.Attributes;
+using MUnique.OpenMU.Pathfinding;
+using NUnit.Framework;
+
+/// <summary>
+/// Tests for the distribution of a money drop between the players which earned it.
+/// </summary>
+[TestFixture]
+public class MoneyDistributionTest
+{
+    private static readonly Point DropPosition = new(100, 100);
+
+    /// <summary>
+    /// Tests that the money is split proportionally to the experience each player gained,
+    /// because the money amount is derived from that experience.
+    /// </summary>
+    [Test]
+    public async Task SharesFollowExperienceProportionsAsync()
+    {
+        var (first, second) = await CreateTwoPlayersAsync().ConfigureAwait(false);
+
+        var shares = MoneyDistribution.CreateShares(1000, [new ExperienceShare(first, 800), new ExperienceShare(second, 200)]);
+
+        Assert.That(shares.Count, Is.EqualTo(2));
+        Assert.That(shares[0].Amount, Is.EqualTo(800u));
+        Assert.That(shares[1].Amount, Is.EqualTo(200u));
+    }
+
+    /// <summary>
+    /// Tests that the remainder of the integer division is not lost, so the shares always add up
+    /// to the dropped amount.
+    /// </summary>
+    [Test]
+    public async Task SharesAddUpToTheDroppedAmountAsync()
+    {
+        var (first, second) = await CreateTwoPlayersAsync().ConfigureAwait(false);
+        var third = await PlayerTestHelper.CreatePlayerAsync(first.GameContext).ConfigureAwait(false);
+
+        var shares = MoneyDistribution.CreateShares(10, [new ExperienceShare(first, 1), new ExperienceShare(second, 1), new ExperienceShare(third, 1)]);
+
+        Assert.That(shares.Sum(s => (long)s.Amount), Is.EqualTo(10));
+    }
+
+    /// <summary>
+    /// Tests that the units lost to the integer division are spread over the shares which were cut
+    /// the most, instead of always landing on the same player - which would favour them over many kills.
+    /// </summary>
+    [Test]
+    public async Task RemainderIsSpreadInsteadOfAlwaysGoingToTheSamePlayerAsync()
+    {
+        var (first, second) = await CreateTwoPlayersAsync().ConfigureAwait(false);
+        var third = await PlayerTestHelper.CreatePlayerAsync(first.GameContext).ConfigureAwait(false);
+
+        // 52 split between three equal contributors: 17 each leaves a remainder of 1.
+        var shares = MoneyDistribution.CreateShares(52, [new ExperienceShare(first, 9), new ExperienceShare(second, 9), new ExperienceShare(third, 9)]);
+
+        Assert.That(shares.Sum(s => (long)s.Amount), Is.EqualTo(52));
+        Assert.That(shares.Max(s => s.Amount) - shares.Min(s => s.Amount), Is.LessThanOrEqualTo(1u));
+    }
+
+    /// <summary>
+    /// Tests that a player who gained no experience from the kill gets no money from it.
+    /// </summary>
+    [Test]
+    public async Task PlayerWithoutExperienceGetsNoShareAsync()
+    {
+        var (first, second) = await CreateTwoPlayersAsync().ConfigureAwait(false);
+
+        var shares = MoneyDistribution.CreateShares(8, [new ExperienceShare(first, 0), new ExperienceShare(second, 1)]);
+
+        Assert.That(shares[0].Amount, Is.EqualTo(0u));
+        Assert.That(shares[1].Amount, Is.EqualTo(8u));
+    }
+
+    /// <summary>
+    /// Tests that a player without a party gets the money multiplied by their money rate.
+    /// </summary>
+    [Test]
+    public async Task SoloPickUpAppliesMoneyRateAsync()
+    {
+        var player = await PlayerTestHelper.CreatePlayerAsync().ConfigureAwait(false);
+        player.GameContext.Configuration.MaximumInventoryMoney = int.MaxValue;
+        player.Money = 0;
+        SetMoneyRate(player, 2.0f);
+
+        var money = new DroppedMoney(100, DropPosition, player.CurrentMap!);
+
+        Assert.That(await money.TryPickUpByAsync(player).ConfigureAwait(false), Is.True);
+        Assert.That(player.Money, Is.EqualTo(200));
+    }
+
+    /// <summary>
+    /// Tests that the pick up clamp is calculated on the amount *after* the money rate was applied.
+    /// Clamping the raw amount would let the player exceed the maximum inventory money.
+    /// </summary>
+    [Test]
+    public async Task SoloPickUpClampsAfterApplyingMoneyRateAsync()
+    {
+        var player = await PlayerTestHelper.CreatePlayerAsync().ConfigureAwait(false);
+        player.GameContext.Configuration.MaximumInventoryMoney = 150;
+        player.GameContext.Configuration.ClampMoneyOnPickup = true;
+        player.Money = 0;
+        SetMoneyRate(player, 2.0f);
+
+        var money = new DroppedMoney(100, DropPosition, player.CurrentMap!);
+
+        Assert.That(await money.TryPickUpByAsync(player).ConfigureAwait(false), Is.True);
+        Assert.That(player.Money, Is.EqualTo(150));
+    }
+
+    /// <summary>
+    /// Tests that every party member receives exactly the share which was reserved for them.
+    /// </summary>
+    [Test]
+    public async Task PartyPickUpPaysReservedSharesAsync()
+    {
+        var (first, second) = await CreateTwoPlayersAsync().ConfigureAwait(false);
+        await CreatePartyAsync(first, second).ConfigureAwait(false);
+
+        var money = new DroppedMoney(1000, DropPosition, first.CurrentMap!, [new MoneyShare(first, 800), new MoneyShare(second, 200)]);
+
+        Assert.That(await money.TryPickUpByAsync(first).ConfigureAwait(false), Is.True);
+        Assert.That(first.Money, Is.EqualTo(800));
+        Assert.That(second.Money, Is.EqualTo(200));
+    }
+
+    /// <summary>
+    /// Tests that the money rate of a party member is applied exactly once, on their own share.
+    /// It used to be applied twice: once for the killer when the drop was created, and once for
+    /// the receiver when it was picked up.
+    /// </summary>
+    [Test]
+    public async Task PartyPickUpAppliesEachMembersOwnRateOnceAsync()
+    {
+        var (first, second) = await CreateTwoPlayersAsync().ConfigureAwait(false);
+        await CreatePartyAsync(first, second).ConfigureAwait(false);
+        SetMoneyRate(first, 2.0f);
+
+        var money = new DroppedMoney(200, DropPosition, first.CurrentMap!, [new MoneyShare(first, 100), new MoneyShare(second, 100)]);
+
+        Assert.That(await money.TryPickUpByAsync(first).ConfigureAwait(false), Is.True);
+        Assert.That(first.Money, Is.EqualTo(200));
+        Assert.That(second.Money, Is.EqualTo(100));
+    }
+
+    /// <summary>
+    /// Tests that the share of a player who is not eligible anymore - because they left the party,
+    /// logged out or went to another map - is given to the remaining members instead of being lost.
+    /// </summary>
+    [Test]
+    public async Task PartyPickUpRedistributesShareOfIneligiblePlayerAsync()
+    {
+        var (first, second) = await CreateTwoPlayersAsync().ConfigureAwait(false);
+        await CreatePartyAsync(first).ConfigureAwait(false);
+
+        // 'second' never joined the party, so it can't receive its share.
+        var money = new DroppedMoney(200, DropPosition, first.CurrentMap!, [new MoneyShare(first, 100), new MoneyShare(second, 100)]);
+
+        Assert.That(await money.TryPickUpByAsync(first).ConfigureAwait(false), Is.True);
+        Assert.That(first.Money, Is.EqualTo(200));
+        Assert.That(second.Money, Is.EqualTo(0));
+    }
+
+    /// <summary>
+    /// Tests that the pick up clamp is honoured for each party member separately. A member at the
+    /// money limit used to silently lose their share, because the clamp was only applied for solo pick ups.
+    /// </summary>
+    [Test]
+    public async Task PartyPickUpHonoursClampPerMemberAsync()
+    {
+        var (first, second) = await CreateTwoPlayersAsync().ConfigureAwait(false);
+        await CreatePartyAsync(first, second).ConfigureAwait(false);
+        first.GameContext.Configuration.MaximumInventoryMoney = 150;
+        first.GameContext.Configuration.ClampMoneyOnPickup = true;
+        first.Money = 100;
+        second.Money = 0;
+
+        var money = new DroppedMoney(200, DropPosition, first.CurrentMap!, [new MoneyShare(first, 100), new MoneyShare(second, 100)]);
+
+        Assert.That(await money.TryPickUpByAsync(first).ConfigureAwait(false), Is.True);
+        Assert.That(first.Money, Is.EqualTo(150));
+        Assert.That(second.Money, Is.EqualTo(100));
+    }
+
+    /// <summary>
+    /// Tests that money without reserved shares - for example the fixed amount of an item box -
+    /// is still split equally between the party members.
+    /// </summary>
+    [Test]
+    public async Task MoneyWithoutSharesIsSplitEquallyAsync()
+    {
+        var (first, second) = await CreateTwoPlayersAsync().ConfigureAwait(false);
+        await CreatePartyAsync(first, second).ConfigureAwait(false);
+
+        var money = new DroppedMoney(200, DropPosition, first.CurrentMap!);
+
+        Assert.That(await money.TryPickUpByAsync(first).ConfigureAwait(false), Is.True);
+        Assert.That(first.Money, Is.EqualTo(100));
+        Assert.That(second.Money, Is.EqualTo(100));
+    }
+
+    /// <summary>
+    /// Tests that the drop is not consumed when no party member could take anything, so it stays
+    /// available instead of being lost.
+    /// </summary>
+    [Test]
+    public async Task PartyPickUpKeepsMoneyAvailableWhenNobodyCanTakeItAsync()
+    {
+        var (first, second) = await CreateTwoPlayersAsync().ConfigureAwait(false);
+        await CreatePartyAsync(first, second).ConfigureAwait(false);
+        first.GameContext.Configuration.MaximumInventoryMoney = 100;
+        first.Money = 100;
+        second.Money = 100;
+
+        var money = new DroppedMoney(200, DropPosition, first.CurrentMap!, [new MoneyShare(first, 100), new MoneyShare(second, 100)]);
+
+        Assert.That(await money.TryPickUpByAsync(first).ConfigureAwait(false), Is.False);
+        Assert.That(first.Money, Is.EqualTo(100));
+        Assert.That(second.Money, Is.EqualTo(100));
+    }
+
+    private static void SetMoneyRate(Player player, float rate)
+    {
+        player.Attributes!.AddElement(new SimpleElement(rate, AggregateType.Multiplicate), Stats.MoneyAmountRate);
+        Assert.That(
+            player.Attributes[Stats.MoneyAmountRate],
+            Is.EqualTo(rate).Within(0.001f),
+            "test setup: the money rate was not applied as expected");
+    }
+
+    private static async ValueTask<Party> CreatePartyAsync(params Player[] members)
+    {
+        var party = new Party(new PartyManager(5, new NullLogger<Party>()), 5, new NullLogger<Party>());
+        foreach (var member in members)
+        {
+            await party.AddAsync(member).ConfigureAwait(false);
+        }
+
+        return party;
+    }
+
+    private static async ValueTask<(Player First, Player Second)> CreateTwoPlayersAsync()
+    {
+        var first = await PlayerTestHelper.CreatePlayerAsync().ConfigureAwait(false);
+        first.GameContext.Configuration.MaximumInventoryMoney = int.MaxValue;
+        first.Money = 0;
+
+        var second = await PlayerTestHelper.CreatePlayerAsync(first.GameContext).ConfigureAwait(false);
+        second.Money = 0;
+
+        Assert.That(first.CurrentMap, Is.Not.Null, "test setup: the players need a map");
+        Assert.That(second.CurrentMap, Is.SameAs(first.CurrentMap), "test setup: the players need to be on the same map");
+        Assert.That(first.IsAtSafezone(), Is.False, "test setup: the players must not be at a safezone");
+
+        return (first, second);
+    }
+}


### PR DESCRIPTION
## Zen from own experience

| Commit | Subject |
|---|---|
| `53f25aca0` | Derive each player's zen from the experience they actually gained |
| `7cdb34b7c` | Keep a money basis for party members at max level without master quest |
| `468ada58c` | Let strangers pick up party money and split it equally |

No new configuration property, no EF migration, no schema change. Only `GameLogic`
and tests are touched.

## Background

The money amount of a monster drop is computed in one place,
`src/GameLogic/DefaultDropGenerator.cs:517`:

```csharp
droppedMoney = (uint)(gainedExperience + BaseMoneyDrop);   // BaseMoneyDrop = 7
```

So the zen of a kill is the experience gained from it, plus a flat 7. The drop item
group (`SpecialItemType.Money`, 50 % chance) only decides *whether* this runs, never
*how much*. This formula is unchanged by this branch.

## What was wrong

### 1. Two different quantities landed in the same variable

`src/GameLogic/NPC/AttackableNpcBase.cs:310`:

```csharp
int exp = await (player.Party?.DistributeExperienceAfterKillAsync(this, player)
                 ?? player.AddExpAfterKillAsync(this));
```

- solo — `AddExpAfterKillAsync` returns the value from `CalculateExpAfterKill`
  (`Player.cs:1209` → `:1230`), **including** the game rate and the personal
  experience rates (`Player.cs:1257-1259`)
- party — `DistributeExperienceAfterKillAsync` returned the total from
  `CalculatePartyExperience` (`Party.cs:489` → `:496`), **excluding** the game rate
  and the personal rates; those were applied later, per member, in
  `AwardExperienceAsync`

On a server with `ExperienceRate = 500` the party number was therefore roughly 500x
too small, and since the money is derived from it, party zen was correspondingly tiny.

### 2. The workaround for it pinned the party pool to a solo-sized amount

`AttackableNpcBase.cs:411-422` (introduced by PR 778) discarded the party
value and recalculated the killer's solo experience for money purposes. That cured the
symptom, but the party money pool no longer grew with the party size, while the
experience pool does (`Party.cs:350-352`: `base x memberCount x 1.05^(n-1)`).

For a party of three level 400 characters on the same monster:

| | experience | zen |
|---|---|---|
| party pool | `3.31x` solo | `1x` solo |
| per member | `~1.10x` solo | `~0.33x` solo |

### 3. Zen was split evenly, experience by level

Zen: `DroppedMoney.cs:147` and `Party.cs:241` divided by the member count.
Experience: `Party.cs:346`, `:358`, `:389`/`:399` weight it by each member's level.

A level 400 and a level 10 character in the same party received identical zen while
their experience differed by a factor of ~40.

### 4. `MoneyAmountRate` applied zero, one or two times

The multiplication in `AttackableNpcBase.cs:407` predates PR 778 (added in
`d2536e9eb`). PR 778 added a second one in the new party branch
(`DroppedMoney.cs:151`), so the bag - already scaled by the killer's rate - was scaled
again by the receiver's.

| Path | Where | Times applied |
|---|---|---|
| `ShouldDropMoney=false`, solo | `AttackableNpcBase.cs:397` | **0** |
| `ShouldDropMoney=false`, party | `Party.cs:244` | 1 |
| `ShouldDropMoney=true`, solo | `AttackableNpcBase.cs:407` | 1 |
| `ShouldDropMoney=true`, party | `AttackableNpcBase.cs:407` **and** `DroppedMoney.cs:151` | **2** |

Invisible at the default `MoneyAmountRate = 1.0`; at 3.0 a party was paid 9x.

### 5. `ClampMoneyOnPickup` was ignored in a party

The clamp lived only in the solo branch (`DroppedMoney.cs:163-173`). The party branch
called `TryAddMoney` directly, so a member at `MaximumInventoryMoney` silently lost their
share while the drop was consumed by the others.

## What was changed

**Each player's zen is derived from the experience that player actually gained.**

`AwardExperienceAsync` (`Party.cs:380`) already computed the per member experience with
all rates applied - it just discarded it. It now returns that value,
`InternalDistributeExperienceAfterKillAsync` returns the per member breakdown, and the
money is split proportionally to it. The workaround from point 2 is gone; the pool follows
the experience, and each member's zen matches their own level, their own rates and their own
master/normal branch.

New types, all internal to the game logic:

| File | Purpose |
|---|---|
| `src/GameLogic/ExperienceShare.cs` | the experience a single player gained from a kill |
| `src/GameLogic/MoneyShare.cs` | the part of a money drop reserved for a single player |
| `src/GameLogic/MoneyDistribution.cs` | all share arithmetic, and the **single** place where `MoneyAmountRate` and the pickup clamp are applied |

Consequences:

- `MoneyAmountRate` is applied exactly once, always for the receiver, on their own share
- the clamp runs on the shared payout path, after the rate, so it clamps the amount
  actually credited
- the units lost to the integer division go to the shares which were cut the most, one
  each (largest remainder method), so no member is systematically favoured
- shares of players who are no longer eligible are redistributed among the rest instead
  of being lost
- money without a per player breakdown - the fixed amount of an item box
  (`ItemBoxDroppedPlugIn.cs:42`) - is still split equally

### Follow-up commit `7cdb34b7c`

Making the money follow the *awarded* experience introduced a regression: a character at
the maximum level which has not completed the master quest gains neither normal nor
master experience, and `AwardExperienceAsync` returned 0 for it - so it received no zen
at all in a party, while the same character still earns zen solo (`AddExpAfterKillAsync`
returns the calculated amount regardless of whether it could be applied).

The normal experience is now always calculated and returned, and only awarded when the
character can still gain it.

### Follow-up commit `468ada58c` - money still has no owner

Recording the shares on the drop introduced a second, subtler regression. Unlike a
dropped item, money has never had an owner: it can be picked up by anyone standing on it
(`PickupItemAction.CanPickup` only checks that the picker is alive and within three tiles -
there is no ownership timer). The first version paid strictly the recorded shares, so a
stranger who picked the money up got nothing, and the drop was left lying on the ground -
which, for a party of strangers, silently destroyed money that on `master` they would
have taken.

The recorded shares now only apply when the party which picks the money up is the one
which earned it. For anyone else there is no experience of theirs to follow, so the money
is split equally between the picking party, exactly as `master` did and as money without
any shares (e.g. from an item box) already is:

```csharp
var earnedByThisParty = this._shares.Any(share => party.IsEligibleForMoney(share.Player, player));
var shares = earnedByThisParty
    ? this._shares
    : MoneyDistribution.CreateEqualShares(this.Amount, party.PartyList.OfType<Player>().ToList());
```

So the earner's party gets the money proportional to the experience it gained, a solo
picker takes it all, and a stranger's party splits it equally - none of which can strand
the money. Covered by `DroppedMoneyTest.StrangerPartySplitsPickedUpMoneyEquallyAsync`
and `EarningPartyReceivesMoneyByExperienceShareAsync`.

## What was deliberately not changed

- **`zen = experience + 7`** stays. Raising `ExperienceRate` still raises zen exactly as
  before.
- **The master experience rate still applies to zen.** Once a character reaches the
  maximum level as a master class, the formula switches from `ExperienceRate` to
  `MasterExperienceRate` (`Player.cs:1253-1254`). With `500` and `200` configured, the
  same monster pays 40 % of what it paid before the character maxed out. This is
  pre-existing behaviour and was left as is by decision.
- **No new configuration field.** The knob for scaling the zen amount remains the
  existing `Stats.MoneyAmountRate` global base attribute (`Stats.cs:153`, default 1.0,
  set up in `GameConfigurationInitializerBase.cs:275`). It is reachable in the admin
  panel under *Game Configuration -> Full configuration -> Global Base Attribute Values
  -> Money Drop Amount Rate* - not under *General*, which is rendered with
  `hide-collections` and therefore omits it. The value is read when a character's
  attribute system is built, i.e. at login.
- **Item drops** are unrelated to experience and were not touched.
- **The fixed money amount of an item box** (e.g. a Box of Kundun) is unchanged in how it
  is divided - still split equally between the picking party, since a box has no per player
  experience to follow. It does now go through the single `MoneyAmountRate` application in
  `MoneyDistribution.TryPay`, which means a **solo** pick up is scaled by the rate too;
  `master` scaled item-box money only on the party path, so this makes the rate consistent
  rather than depending on party state. At the default rate of `1.0` this is invisible.

## Verification

### Unit tests

`dotnet test src/MUnique.OpenMU.sln -p:ci=true` - **1252 tests, 0 failures**, no new
StyleCop warnings. New coverage in
`tests/MUnique.OpenMU.Tests/MoneyDistributionTest.cs` (14 tests), one added case in
`ExperienceRateSplitTest.cs`, and two in `DroppedMoneyTest.cs`, covering: shares
proportional to experience, shares adding up to the dropped amount, a player with no
experience getting no share, fair remainder distribution, `MoneyAmountRate` applied
exactly once solo and in a party, the clamp honoured per member, redistribution of
ineligible shares, item-box money still split equally, the max-level-without-master-quest
money basis, a stranger's party splitting picked-up money equally, and the earning party
receiving it by experience share.

Everything is built and tested inside a container
(`mcr.microsoft.com/dotnet/sdk:10.0-alpine`, `-p:ci=true` to skip the code generation
pre-build steps).

### Live test with bots

An isolated stack (own volume, network and ports, separate from the `openmu-db` dev
volume) was run with 40 bot accounts x 5 characters = 200 bot characters, on an image
built from this branch plus two temporary log lines - **the instrumentation is not part
of either commit**.

| Test | Rates | Kill amount before the multiplier | credited / raw |
|---|---|---|---|
| A | money 1, exp 1 | ~350 | **1.0000** (5695 / 5695 payouts) |
| B | money 3, exp 1 | ~350, unchanged | **3.0000** (4547 / 4547 payouts) |
| C | money 1, exp 5 | ~6100, scales with experience | **1.0000** (4221 / 4221 payouts) |

Test B is the decisive one: the old code would have paid a party 9x. In every window
100 % of kills satisfied `amount == sum(experience) + 7` and the shares summed exactly
to the dropped amount.

Independent check over 964 party kills with unequal member experience: mean deviation
from the proportional-to-experience model **0.651 zen**, from the equal-split model
**8.706 zen**. A member with `exp=0` received `share=0`, where an equal split would have
paid it half.

The live run is also what surfaced the remainder bias fixed above: `total=52`,
`exp=[9,9,9,9,9]` produced `share=[12,10,10,10,10]` before the largest-remainder change.

### Measurement note

Tracking a bot's zen balance in the database does **not** measure income - bots spend
almost everything at merchants (one was observed dropping to 7 zen after a single
trip). The figures above come from per-payout log lines, not from balance deltas.