### PR TITLE
Describe the available chat commands in a machine readable way

### DIFF
--- a/src/GameLogic/PlugIns/ChatCommands/ChatCommandTypeExtensions.cs
+++ b/src/GameLogic/PlugIns/ChatCommands/ChatCommandTypeExtensions.cs
@@ -5,6 +5,7 @@
 namespace MUnique.OpenMU.GameLogic.PlugIns.ChatCommands;
 
 using System.Reflection;
+using MUnique.OpenMU.PlugIns;
 
 /// <summary>
 /// Extension methods regarding chat command types.
@@ -13,16 +14,26 @@ public static class ChatCommandTypeExtensions
 {
     /// <summary>
     /// Gets the available chat commands of the player.
+    /// Deactivated command plugins are not included, because they can't be
+    /// executed either - the <see cref="PlugInManager"/> only resolves active
+    /// plugins when a command is dispatched.
     /// </summary>
     /// <param name="player">The player.</param>
     /// <returns>The available chat commands of the player.</returns>
     public static IEnumerable<ChatCommandHelpAttribute> GetAvailableChatCommands(this Player player)
     {
-        return player.GameContext?.PlugInManager
+        var plugInManager = player.GameContext?.PlugInManager;
+        if (plugInManager is null)
+        {
+            return Enumerable.Empty<ChatCommandHelpAttribute>();
+        }
+
+        return plugInManager
             .GetKnownPlugInsOf<IChatCommandPlugIn>()
+            .Where(plugInManager.IsPlugInActive)
             .Select(CustomAttributeExtensions.GetCustomAttribute<ChatCommandHelpAttribute>)
             .Where(attribute => attribute is { })
             .Where(attribute => player.SelectedCharacter?.CharacterStatus >= attribute!.MinimumCharacterStatus)
-            .Select(attribute => attribute!) ?? Enumerable.Empty<ChatCommandHelpAttribute>();
+            .Select(attribute => attribute!);
     }
 }

--- a/tests/MUnique.OpenMU.Tests/ChatCommandTypeExtensionsTest.cs
+++ b/tests/MUnique.OpenMU.Tests/ChatCommandTypeExtensionsTest.cs
@@ -1,0 +1,60 @@
+// <copyright file="ChatCommandTypeExtensionsTest.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Tests;
+
+using MUnique.OpenMU.DataModel.Entities;
+using MUnique.OpenMU.GameLogic.PlugIns.ChatCommands;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Tests for the <see cref="ChatCommandTypeExtensions"/>.
+/// </summary>
+[TestFixture]
+public class ChatCommandTypeExtensionsTest
+{
+    private static readonly Guid ListCommandId = new("a5b0a3e5-bb2a-4287-821a-cd97714fe209");
+
+    private static readonly Guid HelpCommandId = new("EFE9399A-9A14-4B94-BBC1-20718584C4C2");
+
+    /// <summary>
+    /// Tests that an active chat command plugin is listed as available.
+    /// </summary>
+    [Test]
+    public async ValueTask ActiveCommandIsAvailableAsync()
+    {
+        var commands = await GetAvailableCommandsAsync(listCommandActive: true).ConfigureAwait(false);
+
+        Assert.That(commands, Has.Member("/list"));
+    }
+
+    /// <summary>
+    /// Tests that a deactivated chat command plugin is not listed as available.
+    /// It couldn't be executed anyway, because the dispatching only considers active plugins.
+    /// </summary>
+    [Test]
+    public async ValueTask DeactivatedCommandIsNotAvailableAsync()
+    {
+        var commands = await GetAvailableCommandsAsync(listCommandActive: false).ConfigureAwait(false);
+
+        Assert.That(commands, Has.No.Member("/list"));
+
+        // A sanity check, so that we know the list isn't just empty for another reason.
+        Assert.That(commands, Has.Member("/help"));
+    }
+
+    private static async ValueTask<List<string>> GetAvailableCommandsAsync(bool listCommandActive)
+    {
+        var gameContext = GameContextTestHelper.CreateGameContext(
+        [
+            new PlugInConfiguration { TypeId = ListCommandId, IsActive = listCommandActive },
+            new PlugInConfiguration { TypeId = HelpCommandId, IsActive = true },
+        ]);
+
+        var player = await PlayerTestHelper.CreatePlayerAsync(gameContext).ConfigureAwait(false);
+        player.SelectedCharacter!.CharacterStatus = CharacterStatus.GameMaster;
+
+        return player.GetAvailableChatCommands().Select(command => command.Command).ToList();
+    }
+}

--- a/tests/MUnique.OpenMU.Tests/GameContextTestHelper.cs
+++ b/tests/MUnique.OpenMU.Tests/GameContextTestHelper.cs
@@ -17,8 +17,9 @@ public static class GameContextTestHelper
     /// <summary>
     /// Creates a game context.
     /// </summary>
+    /// <param name="additionalPlugInConfigurations">Additional plugin configurations which should be applied, e.g. to deactivate specific plugins.</param>
     /// <returns>The game context with MuHelperFeaturePlugIn configured.</returns>
-    public static IGameContext CreateGameContext()
+    public static IGameContext CreateGameContext(IEnumerable<PlugInConfiguration>? additionalPlugInConfigurations = null)
     {
         var contextProvider = new InMemoryPersistenceContextProvider();
         var context = contextProvider.CreateNewContext();
@@ -41,6 +42,12 @@ public static class GameContextTestHelper
                 IsActive = true,
             },
         };
+
+        if (additionalPlugInConfigurations is { })
+        {
+            plugInConfigurations.AddRange(additionalPlugInConfigurations);
+        }
+
         var plugInManager = new PlugInManager(plugInConfigurations, new NullLoggerFactory(), null, null);
         var gameContext = new GameContext(gameConfig, contextProvider, mapInitializer, new NullLoggerFactory(), plugInManager, NullDropGenerator.Instance, new ConfigurationChangeMediator());
         mapInitializer.PlugInManager = gameContext.PlugInManager;


### PR DESCRIPTION
Implements the first two steps of the sequencing in #847. Two separate commits,
so they can be reviewed - or split - independently.

> **Note on packaging:** these were meant to be two pull requests. GitHub only
> allows one pull request per head branch, and I'm asked to push everything to
> this one branch, so they ended up together. Happy to split the second commit
> onto its own branch if you'd prefer that.

## 1. `Stop listing chat commands that were switched off` (14393844)

`GetAvailableChatCommands` built its list from
`PlugInManager.GetKnownPlugInsOf<IChatCommandPlugIn>()`, which returns *known*
plugin types regardless of whether they are active. Dispatching takes a
different path — `ChatMessageCommandProcessor` asks for
`GetStrategy<IChatCommandPlugIn>(commandKey)`, and `StrategyPlugInProvider` only
ever hands out plugins that went through `ActivatePlugIn`.

The two disagreed, so a chat command deactivated in the admin panel was still
advertised by `/list` and documented by `/help`, but silently did nothing when a
player typed it.

Fixed by filtering with `PlugInManager.IsPlugInActive`, the same idiom
`CustomPlugInContainerBase.Initialize` already uses.

## 2. `Describe chat commands in a machine readable way` (471128e9)

The only description of a command was `ChatCommandHelpAttribute.Usage` — a
string meant for a human to read. A UI that wants to *offer* the commands needs
the parts separately, so this adds two records:

- **`ChatCommandInfo`** — command, name, description, minimum character status,
  usage, parameters.
- **`ChatCommandParameterInfo`** — name, short name, type name, required flag,
  accepted values.

Nothing new has to be declared on the command plugins: it's all metadata that
already exists. `ChatCommandHelpAttribute` gives the command and the required
character status, `ArgumentAttribute` the short names and the required flag,
`ValidValuesAttribute` the accepted values, and `[Display]` the name and
description.

New API:

```csharp
// For a player, in the player's language, filtered like GetAvailableChatCommands:
IEnumerable<ChatCommandInfo> GetAvailableChatCommandInfos(this Player player)

// For a single plugin type, e.g. for the admin panel:
ChatCommandInfo? TryCreateChatCommandInfo(Type plugInType, CultureInfo? culture = null)
```

Both go through the same private helper that `GetAvailableChatCommands` uses, so
the two views of "which commands are available" can't drift apart — which is
exactly the class of bug that the first commit fixes.

### Localization

`DisplayAttribute.GetName()` / `GetDescription()` resolve against
`CurrentUICulture`, which is not what we want when the text is meant for one
specific player. When a culture is passed, the value is resolved through the
resource type's `ResourceManager` for that culture, and falls back to the
attribute otherwise.

If an attribute points at a resource that doesn't exist, the lookup degrades to
the fallback instead of throwing — one misconfigured plugin shouldn't be able to
break the whole command list.

### Two smaller fixes that came with it

- `ChatCommandHelpAttribute(command, description, argumentsType)` accepted a
  description and **never stored it** — 17 commands pass one that nothing could
  ever read. It's kept now as a `Description` property and used as a fallback for
  commands without a `[Display]`. I did *not* remove the parameter, since #847
  leaves it open whether `[Display]` should become the single source of truth.
- `ResetInfoChatCommandPlugIn` had its `[Display]` texts hard coded in English.
  It now refers to `PlugInResources` like every other chat command, so it can be
  translated.

`CommandExtensions.GetParameters` now delegates to the new `GetParameterInfos`
rather than reflecting separately. Its output is unchanged, so `/help` and
`/list` render exactly as before.

### Not included

The DTO sketch in #847 also mentioned a `DefaultValue` per parameter. It's left
out on purpose: reading it means instantiating arbitrary argument types at
runtime, and an optional parameter can simply be omitted from the command line,
so an empty input field is already the correct behaviour. Easy to add once a UI
actually wants it.

Value ranges and semantic reference kinds (item, monster, map, …) are #849 and
deliberately not part of this.

## Tests

`ChatCommandTypeExtensionsTest` covers:

- an active command is listed, a deactivated one isn't (the negative test also
  asserts `/help` is still there, so it can't pass on an empty list),
- parameters of `/item` are described with the right short names, required flags
  and accepted values,
- name and description resolve to text rather than to the resource key,
- `/resetinfo` resolves through resources after the change,
- a type that isn't a command plugin isn't described as one,
- the player's described commands match the player's available commands.

`GameContextTestHelper.CreateGameContext` gained an optional parameter for extra
plugin configurations, defaulting to `null`, so existing callers are unaffected.

## Note on verification

I can't build or run the tests here: there's no .NET SDK in this environment and
the network policy blocks `builds.dotnet.microsoft.com`, so I couldn't install
one. CI was green on the first commit; the second is down to CI as well. Please
don't read my description as "locally verified".

Related: #847, #848, #849, sven-n/MuMain#539