### PR TITLE
Add Castle Siege persistence and Season 6 initialization

### DIFF
--- a/src/Persistence/EntityFramework/EntityDataContext.cs
+++ b/src/Persistence/EntityFramework/EntityDataContext.cs
@@ -21,6 +21,16 @@ public class EntityDataContext : ExtendedTypeContext
     /// </summary>
     internal GameConfiguration? CurrentGameConfiguration { get; set; }
 
+    /// <summary>
+    /// Gets the persistent Castle Siege state.
+    /// </summary>
+    internal DbSet<CastleSiegeData> CastleSiegeData => this.Set<CastleSiegeData>();
+
+    /// <summary>
+    /// Gets the Castle Siege guild registrations.
+    /// </summary>
+    internal DbSet<CastleSiegeGuildRegistration> CastleSiegeGuildRegistrations => this.Set<CastleSiegeGuildRegistration>();
+
     /// <inheritdoc/>
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
@@ -58,6 +68,11 @@ public class EntityDataContext : ExtendedTypeContext
         modelBuilder.Entity<Account>().Apply();
         modelBuilder.Entity<Character>().Apply();
         modelBuilder.Entity<CharacterClass>().Apply();
+        modelBuilder.Entity<CastleSiegeConfiguration>().Apply();
+        modelBuilder.Entity<CastleSiegeData>().Apply();
+        modelBuilder.Entity<CastleSiegeGuildRegistration>().Apply();
+        modelBuilder.Entity<CastleSiegeNpcDefinition>().Apply();
+        modelBuilder.Entity<CastleSiegeNpcState>().Apply();
         modelBuilder.Entity<DropItemGroup>().Apply();
         modelBuilder.Entity<ExitGate>().Apply();
         modelBuilder.Entity<GameConfiguration>().Apply();

--- a/src/Persistence/EntityFramework/EntityFrameworkContextBase.cs
+++ b/src/Persistence/EntityFramework/EntityFrameworkContextBase.cs
@@ -302,6 +302,14 @@ internal class EntityFrameworkContextBase : IContext
     }
 
     /// <summary>
+    /// Determines whether changes of an entity type are published as configuration changes.
+    /// </summary>
+    /// <param name="entityType">The entity type.</param>
+    /// <returns><see langword="true"/> when the entity belongs to the configuration schema.</returns>
+    internal static bool PublishesConfigurationChanges(IReadOnlyEntityType entityType)
+        => entityType.GetSchema() == SchemaNames.Configuration;
+
+    /// <summary>
     /// Releases unmanaged and - optionally - managed resources.
     /// </summary>
     /// <param name="dispose"><c>true</c> to release both managed and unmanaged resources; <c>false</c> to release only unmanaged resources.</param>
@@ -392,7 +400,9 @@ internal class EntityFrameworkContextBase : IContext
             }
 
             var changedEntries = this.Context.ChangeTracker.Entries()
-                .Where(entity => entity.State != EntityState.Unchanged).ToList();
+                .Where(entity => entity.State != EntityState.Unchanged
+                                 && PublishesConfigurationChanges(entity.Metadata))
+                .ToList();
             foreach (var entry in changedEntries)
             {
                 var (parent, parentCollectionNavigation) = this.GetParentInformation(entry);

--- a/src/Persistence/EntityFramework/Extensions/ModelBuilder/CastleSiegeExtensions.cs
+++ b/src/Persistence/EntityFramework/Extensions/ModelBuilder/CastleSiegeExtensions.cs
@@ -1,0 +1,85 @@
+// <copyright file="CastleSiegeExtensions.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Persistence.EntityFramework.Extensions.ModelBuilder;
+
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+using MUnique.OpenMU.Persistence.EntityFramework.Model;
+
+/// <summary>
+/// Extensions for Castle Siege-related <see cref="EntityTypeBuilder"/>s.
+/// </summary>
+internal static class CastleSiegeExtensions
+{
+    /// <summary>
+    /// Applies the settings for the <see cref="CastleSiegeConfiguration"/> entity.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    public static void Apply(this EntityTypeBuilder<CastleSiegeConfiguration> builder)
+    {
+        builder.Property(configuration => configuration.CrownHoldTimeSeconds).HasDefaultValue(30);
+        builder.Property(configuration => configuration.RegisterMinLevel).HasDefaultValue(200);
+        builder.Property(configuration => configuration.RegisterMinMembers).HasDefaultValue(20);
+        builder.Property(configuration => configuration.MaxAttackingGuilds).HasDefaultValue(3);
+
+        builder.HasOne(configuration => configuration.RawCastleSiegeMapDefinition)
+            .WithMany()
+            .OnDelete(DeleteBehavior.Restrict);
+        builder.HasOne(configuration => configuration.RawLandOfTrialsMapDefinition)
+            .WithMany()
+            .OnDelete(DeleteBehavior.Restrict);
+        builder.HasOne(configuration => configuration.RawRewardItemDefinition)
+            .WithMany()
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+
+    /// <summary>
+    /// Applies the settings for the <see cref="CastleSiegeNpcDefinition"/> entity.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    public static void Apply(this EntityTypeBuilder<CastleSiegeNpcDefinition> builder)
+    {
+        builder.HasOne(definition => definition.RawMonsterDefinition)
+            .WithMany()
+            .IsRequired()
+            .OnDelete(DeleteBehavior.Restrict);
+        builder.HasIndex(definition => new { definition.MonsterDefinitionId, definition.InstanceId });
+    }
+
+    /// <summary>
+    /// Applies the settings for the <see cref="CastleSiegeData"/> entity.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    public static void Apply(this EntityTypeBuilder<CastleSiegeData> builder)
+    {
+        builder.HasOne<Guild>()
+            .WithMany()
+            .HasForeignKey(data => data.OwnerGuildId)
+            .OnDelete(DeleteBehavior.SetNull);
+    }
+
+    /// <summary>
+    /// Applies the settings for the <see cref="CastleSiegeNpcState"/> entity.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    public static void Apply(this EntityTypeBuilder<CastleSiegeNpcState> builder)
+    {
+        builder.HasIndex(state => new { state.MonsterNumber, state.InstanceId }).IsUnique();
+    }
+
+    /// <summary>
+    /// Applies the settings for the <see cref="CastleSiegeGuildRegistration"/> entity.
+    /// </summary>
+    /// <param name="builder">The builder.</param>
+    public static void Apply(this EntityTypeBuilder<CastleSiegeGuildRegistration> builder)
+    {
+        builder.Property(registration => registration.GuildName).HasMaxLength(8).IsRequired();
+        builder.HasIndex(registration => registration.GuildId).IsUnique();
+        builder.HasOne<Guild>()
+            .WithMany()
+            .HasForeignKey(registration => registration.GuildId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/src/Persistence/EntityFramework/Migrations/20260801162427_ConfigureCastleSiegePersistence.Designer.cs
+++ b/src/Persistence/EntityFramework/Migrations/20260801162427_ConfigureCastleSiegePersistence.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MUnique.OpenMU.Persistence.EntityFramework;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
     [DbContext(typeof(EntityDataContext))]
-    partial class EntityDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260801162427_ConfigureCastleSiegePersistence")]
+    partial class ConfigureCastleSiegePersistence
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Persistence/EntityFramework/Migrations/20260801162427_ConfigureCastleSiegePersistence.cs
+++ b/src/Persistence/EntityFramework/Migrations/20260801162427_ConfigureCastleSiegePersistence.cs
@@ -46,7 +46,7 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 table: "CastleSiegeNpcDefinition",
                 type: "uuid",
                 nullable: false,
-                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                defaultValue: Guid.Empty,
                 oldClrType: typeof(Guid),
                 oldType: "uuid",
                 oldNullable: true);

--- a/src/Persistence/EntityFramework/Migrations/20260801162427_ConfigureCastleSiegePersistence.cs
+++ b/src/Persistence/EntityFramework/Migrations/20260801162427_ConfigureCastleSiegePersistence.cs
@@ -1,0 +1,333 @@
+// <copyright file="20260801162427_ConfigureCastleSiegePersistence.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+#nullable disable
+
+namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
+{
+    using System;
+    using Microsoft.EntityFrameworkCore.Migrations;
+
+    /// <inheritdoc />
+    public partial class ConfigureCastleSiegePersistence : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CastleSiegeConfiguration_GameMapDefinition_CastleSiegeMapDe~",
+                schema: "config",
+                table: "CastleSiegeConfiguration");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_CastleSiegeConfiguration_GameMapDefinition_LandOfTrialsMapD~",
+                schema: "config",
+                table: "CastleSiegeConfiguration");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_CastleSiegeConfiguration_ItemDefinition_RewardItemDefinitio~",
+                schema: "config",
+                table: "CastleSiegeConfiguration");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_CastleSiegeNpcDefinition_MonsterDefinition_MonsterDefinitio~",
+                schema: "config",
+                table: "CastleSiegeNpcDefinition");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CastleSiegeNpcDefinition_MonsterDefinitionId",
+                schema: "config",
+                table: "CastleSiegeNpcDefinition");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "MonsterDefinitionId",
+                schema: "config",
+                table: "CastleSiegeNpcDefinition",
+                type: "uuid",
+                nullable: false,
+                defaultValue: new Guid("00000000-0000-0000-0000-000000000000"),
+                oldClrType: typeof(Guid),
+                oldType: "uuid",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "RegisterMinMembers",
+                schema: "config",
+                table: "CastleSiegeConfiguration",
+                type: "integer",
+                nullable: false,
+                defaultValue: 20,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "RegisterMinLevel",
+                schema: "config",
+                table: "CastleSiegeConfiguration",
+                type: "integer",
+                nullable: false,
+                defaultValue: 200,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "MaxAttackingGuilds",
+                schema: "config",
+                table: "CastleSiegeConfiguration",
+                type: "integer",
+                nullable: false,
+                defaultValue: 3,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "CrownHoldTimeSeconds",
+                schema: "config",
+                table: "CastleSiegeConfiguration",
+                type: "integer",
+                nullable: false,
+                defaultValue: 30,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.CreateTable(
+                name: "CastleSiegeGuildRegistration",
+                schema: "data",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    GuildId = table.Column<Guid>(type: "uuid", nullable: false),
+                    GuildName = table.Column<string>(type: "character varying(8)", maxLength: 8, nullable: false),
+                    Marks = table.Column<int>(type: "integer", nullable: false),
+                    RegistrationOrder = table.Column<int>(type: "integer", nullable: false),
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_CastleSiegeGuildRegistration", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_CastleSiegeGuildRegistration_Guild_GuildId",
+                        column: x => x.GuildId,
+                        principalSchema: "guild",
+                        principalTable: "Guild",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CastleSiegeNpcState_MonsterNumber_InstanceId",
+                schema: "data",
+                table: "CastleSiegeNpcState",
+                columns: new[] { "MonsterNumber", "InstanceId" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CastleSiegeNpcDefinition_MonsterDefinitionId_InstanceId",
+                schema: "config",
+                table: "CastleSiegeNpcDefinition",
+                columns: new[] { "MonsterDefinitionId", "InstanceId" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CastleSiegeData_OwnerGuildId",
+                schema: "data",
+                table: "CastleSiegeData",
+                column: "OwnerGuildId");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CastleSiegeGuildRegistration_GuildId",
+                schema: "data",
+                table: "CastleSiegeGuildRegistration",
+                column: "GuildId",
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CastleSiegeConfiguration_GameMapDefinition_CastleSiegeMapDe~",
+                schema: "config",
+                table: "CastleSiegeConfiguration",
+                column: "CastleSiegeMapDefinitionId",
+                principalSchema: "config",
+                principalTable: "GameMapDefinition",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CastleSiegeConfiguration_GameMapDefinition_LandOfTrialsMapD~",
+                schema: "config",
+                table: "CastleSiegeConfiguration",
+                column: "LandOfTrialsMapDefinitionId",
+                principalSchema: "config",
+                principalTable: "GameMapDefinition",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CastleSiegeConfiguration_ItemDefinition_RewardItemDefinitio~",
+                schema: "config",
+                table: "CastleSiegeConfiguration",
+                column: "RewardItemDefinitionId",
+                principalSchema: "config",
+                principalTable: "ItemDefinition",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CastleSiegeData_Guild_OwnerGuildId",
+                schema: "data",
+                table: "CastleSiegeData",
+                column: "OwnerGuildId",
+                principalSchema: "guild",
+                principalTable: "Guild",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CastleSiegeNpcDefinition_MonsterDefinition_MonsterDefinitio~",
+                schema: "config",
+                table: "CastleSiegeNpcDefinition",
+                column: "MonsterDefinitionId",
+                principalSchema: "config",
+                principalTable: "MonsterDefinition",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CastleSiegeConfiguration_GameMapDefinition_CastleSiegeMapDe~",
+                schema: "config",
+                table: "CastleSiegeConfiguration");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_CastleSiegeConfiguration_GameMapDefinition_LandOfTrialsMapD~",
+                schema: "config",
+                table: "CastleSiegeConfiguration");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_CastleSiegeConfiguration_ItemDefinition_RewardItemDefinitio~",
+                schema: "config",
+                table: "CastleSiegeConfiguration");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_CastleSiegeData_Guild_OwnerGuildId",
+                schema: "data",
+                table: "CastleSiegeData");
+
+            migrationBuilder.DropForeignKey(
+                name: "FK_CastleSiegeNpcDefinition_MonsterDefinition_MonsterDefinitio~",
+                schema: "config",
+                table: "CastleSiegeNpcDefinition");
+
+            migrationBuilder.DropTable(
+                name: "CastleSiegeGuildRegistration",
+                schema: "data");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CastleSiegeNpcState_MonsterNumber_InstanceId",
+                schema: "data",
+                table: "CastleSiegeNpcState");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CastleSiegeNpcDefinition_MonsterDefinitionId_InstanceId",
+                schema: "config",
+                table: "CastleSiegeNpcDefinition");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CastleSiegeData_OwnerGuildId",
+                schema: "data",
+                table: "CastleSiegeData");
+
+            migrationBuilder.AlterColumn<Guid>(
+                name: "MonsterDefinitionId",
+                schema: "config",
+                table: "CastleSiegeNpcDefinition",
+                type: "uuid",
+                nullable: true,
+                oldClrType: typeof(Guid),
+                oldType: "uuid");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "RegisterMinMembers",
+                schema: "config",
+                table: "CastleSiegeConfiguration",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldDefaultValue: 20);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "RegisterMinLevel",
+                schema: "config",
+                table: "CastleSiegeConfiguration",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldDefaultValue: 200);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "MaxAttackingGuilds",
+                schema: "config",
+                table: "CastleSiegeConfiguration",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldDefaultValue: 3);
+
+            migrationBuilder.AlterColumn<int>(
+                name: "CrownHoldTimeSeconds",
+                schema: "config",
+                table: "CastleSiegeConfiguration",
+                type: "integer",
+                nullable: false,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldDefaultValue: 30);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CastleSiegeNpcDefinition_MonsterDefinitionId",
+                schema: "config",
+                table: "CastleSiegeNpcDefinition",
+                column: "MonsterDefinitionId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CastleSiegeConfiguration_GameMapDefinition_CastleSiegeMapDe~",
+                schema: "config",
+                table: "CastleSiegeConfiguration",
+                column: "CastleSiegeMapDefinitionId",
+                principalSchema: "config",
+                principalTable: "GameMapDefinition",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CastleSiegeConfiguration_GameMapDefinition_LandOfTrialsMapD~",
+                schema: "config",
+                table: "CastleSiegeConfiguration",
+                column: "LandOfTrialsMapDefinitionId",
+                principalSchema: "config",
+                principalTable: "GameMapDefinition",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CastleSiegeConfiguration_ItemDefinition_RewardItemDefinitio~",
+                schema: "config",
+                table: "CastleSiegeConfiguration",
+                column: "RewardItemDefinitionId",
+                principalSchema: "config",
+                principalTable: "ItemDefinition",
+                principalColumn: "Id");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CastleSiegeNpcDefinition_MonsterDefinition_MonsterDefinitio~",
+                schema: "config",
+                table: "CastleSiegeNpcDefinition",
+                column: "MonsterDefinitionId",
+                principalSchema: "config",
+                principalTable: "MonsterDefinition",
+                principalColumn: "Id");
+        }
+    }
+}

--- a/src/Persistence/EntityFramework/Migrations/20260801162427_ConfigureCastleSiegePersistence.cs
+++ b/src/Persistence/EntityFramework/Migrations/20260801162427_ConfigureCastleSiegePersistence.cs
@@ -40,13 +40,23 @@ namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
                 schema: "config",
                 table: "CastleSiegeNpcDefinition");
 
+            migrationBuilder.Sql(
+                """
+                DO $$
+                BEGIN
+                    IF EXISTS (SELECT 1 FROM config."CastleSiegeNpcDefinition" WHERE "MonsterDefinitionId" IS NULL) THEN
+                        RAISE EXCEPTION 'CastleSiegeNpcDefinition contains rows without a MonsterDefinitionId. Repair or remove these rows before applying this migration.';
+                    END IF;
+                END
+                $$;
+                """);
+
             migrationBuilder.AlterColumn<Guid>(
                 name: "MonsterDefinitionId",
                 schema: "config",
                 table: "CastleSiegeNpcDefinition",
                 type: "uuid",
                 nullable: false,
-                defaultValue: Guid.Empty,
                 oldClrType: typeof(Guid),
                 oldType: "uuid",
                 oldNullable: true);

--- a/src/Persistence/Initialization/Updates/AddCastleSiegeDataUpdatePlugIn.cs
+++ b/src/Persistence/Initialization/Updates/AddCastleSiegeDataUpdatePlugIn.cs
@@ -1,0 +1,59 @@
+// <copyright file="AddCastleSiegeDataUpdatePlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Persistence.Initialization.Updates;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.DataModel.Entities;
+using MUnique.OpenMU.Persistence.Initialization.VersionSeasonSix.Events;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Adds the Castle Siege configuration and persistent state to an existing Season 6 database.
+/// </summary>
+[PlugIn]
+[Display(Name = PlugInName, Description = PlugInDescription)]
+[Guid("CD201E33-37C9-4C85-95CC-16042B28E974")]
+public class AddCastleSiegeDataUpdatePlugIn : UpdatePlugInBase
+{
+    /// <summary>
+    /// The plug-in name.
+    /// </summary>
+    internal const string PlugInName = "Add Castle Siege data";
+
+    /// <summary>
+    /// The plug-in description.
+    /// </summary>
+    internal const string PlugInDescription = "This update adds the Castle Siege configuration and persistent state.";
+
+    /// <inheritdoc />
+    public override string Name => PlugInName;
+
+    /// <inheritdoc />
+    public override string Description => PlugInDescription;
+
+    /// <inheritdoc />
+    public override UpdateVersion Version => UpdateVersion.AddCastleSiegeData;
+
+    /// <inheritdoc />
+    public override string DataInitializationKey => VersionSeasonSix.DataInitialization.Id;
+
+    /// <inheritdoc />
+    public override bool IsMandatory => true;
+
+    /// <inheritdoc />
+    public override DateTime CreatedAt => new(2026, 07, 28, 20, 0, 0, DateTimeKind.Utc);
+
+    /// <inheritdoc />
+    protected override async ValueTask ApplyAsync(IContext context, GameConfiguration gameConfiguration)
+    {
+        var initializer = new CastleSiegeInitializer(context, gameConfiguration);
+        var configuration = initializer.InitializeConfiguration();
+        if (!(await context.GetAsync<CastleSiegeData>().ConfigureAwait(false)).Any())
+        {
+            initializer.InitializeData(configuration);
+        }
+    }
+}

--- a/src/Persistence/Initialization/Updates/UpdateVersion.cs
+++ b/src/Persistence/Initialization/Updates/UpdateVersion.cs
@@ -504,4 +504,9 @@ public enum UpdateVersion
     /// The version of the <see cref="AddRenaItemUpdatePlugIn"/>.
     /// </summary>
     AddRenaItem = 99,
+
+    /// <summary>
+    /// The version of the <see cref="AddCastleSiegeDataUpdatePlugIn"/>.
+    /// </summary>
+    AddCastleSiegeData = 100,
 }

--- a/src/Persistence/Initialization/VersionSeasonSix/Events/CastleSiegeInitializer.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Events/CastleSiegeInitializer.cs
@@ -95,7 +95,12 @@ internal sealed class CastleSiegeInitializer : InitializerBase
             npcState.DefenseLevel = 0;
             npcState.RegenLevel = 0;
             npcState.LifeLevel = 0;
-            npcState.CurrentHp = npcState.MonsterNumber == GateMonsterNumber ? gateHitPoints : statueHitPoints;
+            npcState.CurrentHp = npcState.MonsterNumber switch
+            {
+                GateMonsterNumber => gateHitPoints,
+                StatueMonsterNumber => statueHitPoints,
+                _ => throw new InvalidOperationException($"The persisted Castle Siege NPC monster number {npcState.MonsterNumber} is unsupported."),
+            };
             data.NpcStates.Add(npcState);
         }
 
@@ -184,7 +189,6 @@ internal sealed class CastleSiegeInitializer : InitializerBase
 
         configuration.DefenseMachineZones.Add(this.CreateZone(61, 88, 93, 108));
         configuration.DefenseMachineZones.Add(this.CreateZone(92, 89, 127, 111));
-        configuration.DefenseMachineZones.Add(this.CreateZone(84, 52, 102, 66));
         configuration.DefenseMachineZones.Add(this.CreateZone(84, 52, 102, 66));
     }
 

--- a/src/Persistence/Initialization/VersionSeasonSix/Events/CastleSiegeInitializer.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Events/CastleSiegeInitializer.cs
@@ -1,0 +1,246 @@
+// <copyright file="CastleSiegeInitializer.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Persistence.Initialization.VersionSeasonSix.Events;
+
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.DataModel.Entities;
+using MUnique.OpenMU.Persistence.Initialization.VersionSeasonSix.Maps;
+
+/// <summary>
+/// Initializes the Castle Siege configuration and persistent state.
+/// </summary>
+internal sealed class CastleSiegeInitializer : InitializerBase
+{
+    private const short GateMonsterNumber = 277;
+    private const short StatueMonsterNumber = 283;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeInitializer"/> class.
+    /// </summary>
+    /// <param name="context">The context.</param>
+    /// <param name="gameConfiguration">The game configuration.</param>
+    public CastleSiegeInitializer(IContext context, GameConfiguration gameConfiguration)
+        : base(context, gameConfiguration)
+    {
+    }
+
+    /// <inheritdoc />
+    public override void Initialize()
+    {
+        var configuration = this.InitializeConfiguration();
+        this.InitializeData(configuration);
+    }
+
+    /// <summary>
+    /// Initializes the Castle Siege configuration, if it does not exist yet.
+    /// </summary>
+    /// <returns>The Castle Siege configuration.</returns>
+    internal CastleSiegeConfiguration InitializeConfiguration()
+    {
+        if (this.GameConfiguration.CastleSiegeConfiguration is { } existingConfiguration)
+        {
+            return existingConfiguration;
+        }
+
+        var configuration = this.Context.CreateNew<CastleSiegeConfiguration>();
+        configuration.Enabled = true;
+        configuration.CrownHoldTimeSeconds = 30;
+        configuration.RegisterMinLevel = 200;
+        configuration.RegisterMinMembers = 20;
+        configuration.ParticipantRewardMinSeconds = 60;
+        configuration.MaxAttackingGuilds = 3;
+        configuration.GuildScoreCastleSiege = 0;
+        configuration.GuildScoreCastleSiegeMembers = 0;
+        configuration.GateBuyPrice = 9_500_000;
+        configuration.StatueBuyPrice = 4_500_000;
+        configuration.CastleSiegeMapDefinition = this.GameConfiguration.Maps.Single(map => map.Number == ValleyOfLoren.Number);
+        configuration.LandOfTrialsMapDefinition = this.GameConfiguration.Maps.Single(map => map.Number == LandOfTrials.Number);
+
+        this.InitializeStateSchedule(configuration);
+        this.InitializeNpcDefinitions(configuration);
+        this.InitializeUpgradeDefinitions(configuration);
+        this.InitializeMachineZones(configuration);
+        configuration.DefenseRespawnArea = this.CreateZone(74, 144, 115, 154);
+        configuration.AttackRespawnArea = this.CreateZone(35, 11, 144, 48);
+
+        this.GameConfiguration.CastleSiegeConfiguration = configuration;
+        return configuration;
+    }
+
+    /// <summary>
+    /// Initializes the persistent Castle Siege state.
+    /// </summary>
+    /// <param name="configuration">The Castle Siege configuration.</param>
+    /// <returns>The persistent Castle Siege state.</returns>
+    internal CastleSiegeData InitializeData(CastleSiegeConfiguration configuration)
+    {
+        var data = this.Context.CreateNew<CastleSiegeData>();
+        data.OwnerGuildId = null;
+        data.IsOccupied = false;
+        data.TaxChaos = 0;
+        data.TaxStore = 0;
+        data.TaxHunt = 0;
+        data.IsHuntZoneEnabled = false;
+        data.TributeMoney = 0;
+
+        var gateHitPoints = configuration.GateLifeUpgrades.Single(upgrade => upgrade.Level == 0).Value;
+        var statueHitPoints = configuration.StatueLifeUpgrades.Single(upgrade => upgrade.Level == 0).Value;
+        foreach (var npcDefinition in configuration.NpcDefinitions.Where(definition => definition.IsPersistedToDatabase))
+        {
+            var npcState = this.Context.CreateNew<CastleSiegeNpcState>();
+            npcState.MonsterNumber = npcDefinition.MonsterDefinition!.Number;
+            npcState.InstanceId = npcDefinition.InstanceId;
+            npcState.DefenseLevel = 0;
+            npcState.RegenLevel = 0;
+            npcState.LifeLevel = 0;
+            npcState.CurrentHp = npcState.MonsterNumber == GateMonsterNumber ? gateHitPoints : statueHitPoints;
+            data.NpcStates.Add(npcState);
+        }
+
+        return data;
+    }
+
+    private void InitializeStateSchedule(CastleSiegeConfiguration configuration)
+    {
+        configuration.StateSchedule.Add(this.CreateScheduleEntry(CastleSiegeState.Idle1, DayOfWeek.Sunday, 0, 0));
+        configuration.StateSchedule.Add(this.CreateScheduleEntry(CastleSiegeState.RegisterGuild, DayOfWeek.Monday, 0, 0));
+        configuration.StateSchedule.Add(this.CreateScheduleEntry(CastleSiegeState.Idle2, DayOfWeek.Tuesday, 0, 0));
+        configuration.StateSchedule.Add(this.CreateScheduleEntry(CastleSiegeState.RegisterMark, DayOfWeek.Wednesday, 0, 0));
+        configuration.StateSchedule.Add(this.CreateScheduleEntry(CastleSiegeState.Idle3, DayOfWeek.Thursday, 0, 0));
+        configuration.StateSchedule.Add(this.CreateScheduleEntry(CastleSiegeState.Notify, DayOfWeek.Friday, 0, 0));
+        configuration.StateSchedule.Add(this.CreateScheduleEntry(CastleSiegeState.Ready, DayOfWeek.Saturday, 18, 0));
+        configuration.StateSchedule.Add(this.CreateScheduleEntry(CastleSiegeState.Start, DayOfWeek.Saturday, 20, 0));
+        configuration.StateSchedule.Add(this.CreateScheduleEntry(CastleSiegeState.End, DayOfWeek.Saturday, 22, 0));
+        configuration.StateSchedule.Add(this.CreateScheduleEntry(CastleSiegeState.EndCycle, DayOfWeek.Saturday, 22, 5));
+    }
+
+    private void InitializeNpcDefinitions(CastleSiegeConfiguration configuration)
+    {
+        this.AddNpc(configuration, 216, 1, false, CastleSiegeJoinSide.Attack1, 176, 212, Direction.SouthWest);
+        this.AddNpc(configuration, 217, 1, false, CastleSiegeJoinSide.Attack1, 167, 194, Direction.NorthWest);
+        this.AddNpc(configuration, 218, 1, false, CastleSiegeJoinSide.Attack1, 184, 195, Direction.NorthWest);
+
+        this.AddNpc(configuration, 219, 1, false, CastleSiegeJoinSide.Defense, 93, 208, Direction.SouthWest);
+        this.AddNpc(configuration, 219, 2, false, CastleSiegeJoinSide.Defense, 81, 165, Direction.SouthWest);
+        this.AddNpc(configuration, 219, 3, false, CastleSiegeJoinSide.Defense, 107, 165, Direction.SouthWest);
+        this.AddNpc(configuration, 219, 4, false, CastleSiegeJoinSide.Defense, 67, 118, Direction.SouthWest);
+        this.AddNpc(configuration, 219, 5, false, CastleSiegeJoinSide.Defense, 93, 118, Direction.SouthWest);
+        this.AddNpc(configuration, 219, 6, false, CastleSiegeJoinSide.Defense, 119, 118, Direction.SouthWest);
+
+        this.AddNpc(configuration, 221, 1, false, CastleSiegeJoinSide.Attack1, 63, 19, Direction.NorthEast);
+        this.AddNpc(configuration, 221, 2, false, CastleSiegeJoinSide.Attack1, 119, 19, Direction.NorthEast);
+        this.AddNpc(configuration, 222, 1, false, CastleSiegeJoinSide.Defense, 80, 188, Direction.SouthWest);
+        this.AddNpc(configuration, 222, 2, false, CastleSiegeJoinSide.Defense, 105, 188, Direction.SouthWest);
+
+        this.AddNpc(configuration, GateMonsterNumber, 1, true, CastleSiegeJoinSide.Defense, 93, 204, Direction.SouthWest);
+        this.AddNpc(configuration, GateMonsterNumber, 2, true, CastleSiegeJoinSide.Defense, 81, 161, Direction.SouthWest);
+        this.AddNpc(configuration, GateMonsterNumber, 3, true, CastleSiegeJoinSide.Defense, 107, 161, Direction.SouthWest);
+        this.AddNpc(configuration, GateMonsterNumber, 4, true, CastleSiegeJoinSide.Defense, 67, 114, Direction.SouthWest);
+        this.AddNpc(configuration, GateMonsterNumber, 5, true, CastleSiegeJoinSide.Defense, 93, 114, Direction.SouthWest);
+        this.AddNpc(configuration, GateMonsterNumber, 6, true, CastleSiegeJoinSide.Defense, 119, 114, Direction.SouthWest);
+
+        this.AddNpc(configuration, StatueMonsterNumber, 1, true, CastleSiegeJoinSide.Defense, 94, 227, Direction.SouthWest);
+        this.AddNpc(configuration, StatueMonsterNumber, 2, true, CastleSiegeJoinSide.Defense, 94, 182, Direction.SouthWest);
+        this.AddNpc(configuration, StatueMonsterNumber, 3, true, CastleSiegeJoinSide.Defense, 82, 130, Direction.SouthWest);
+        this.AddNpc(configuration, StatueMonsterNumber, 4, true, CastleSiegeJoinSide.Defense, 107, 130, Direction.SouthWest);
+    }
+
+    private void InitializeUpgradeDefinitions(CastleSiegeConfiguration configuration)
+    {
+        this.AddUpgrade(configuration.GateDefenseUpgrades, 0, 0, 0, 100);
+        this.AddUpgrade(configuration.GateDefenseUpgrades, 1, 2, 3_000_000, 180);
+        this.AddUpgrade(configuration.GateDefenseUpgrades, 2, 3, 3_000_000, 300);
+        this.AddUpgrade(configuration.GateDefenseUpgrades, 3, 4, 3_000_000, 520);
+
+        this.AddUpgrade(configuration.StatueDefenseUpgrades, 0, 0, 0, 80);
+        this.AddUpgrade(configuration.StatueDefenseUpgrades, 1, 3, 3_000_000, 180);
+        this.AddUpgrade(configuration.StatueDefenseUpgrades, 2, 5, 3_000_000, 340);
+        this.AddUpgrade(configuration.StatueDefenseUpgrades, 3, 7, 3_000_000, 550);
+
+        this.AddUpgrade(configuration.GateLifeUpgrades, 0, 0, 0, 1_900_000);
+        this.AddUpgrade(configuration.GateLifeUpgrades, 1, 2, 1_000_000, 2_500_000);
+        this.AddUpgrade(configuration.GateLifeUpgrades, 2, 3, 1_000_000, 3_500_000);
+        this.AddUpgrade(configuration.GateLifeUpgrades, 3, 4, 1_000_000, 5_200_000);
+
+        this.AddUpgrade(configuration.StatueLifeUpgrades, 0, 0, 0, 1_500_000);
+        this.AddUpgrade(configuration.StatueLifeUpgrades, 1, 3, 1_000_000, 2_200_000);
+        this.AddUpgrade(configuration.StatueLifeUpgrades, 2, 5, 1_000_000, 3_400_000);
+        this.AddUpgrade(configuration.StatueLifeUpgrades, 3, 7, 1_000_000, 5_000_000);
+
+        this.AddUpgrade(configuration.StatueRegenUpgrades, 0, 0, 0, 0);
+        this.AddUpgrade(configuration.StatueRegenUpgrades, 1, 3, 5_000_000, 1);
+        this.AddUpgrade(configuration.StatueRegenUpgrades, 2, 5, 5_000_000, 2);
+        this.AddUpgrade(configuration.StatueRegenUpgrades, 3, 7, 5_000_000, 3);
+    }
+
+    private void InitializeMachineZones(CastleSiegeConfiguration configuration)
+    {
+        configuration.AttackMachineZones.Add(this.CreateZone(62, 103, 72, 112));
+        configuration.AttackMachineZones.Add(this.CreateZone(88, 104, 124, 111));
+        configuration.AttackMachineZones.Add(this.CreateZone(116, 105, 124, 112));
+        configuration.AttackMachineZones.Add(this.CreateZone(73, 86, 105, 103));
+
+        configuration.DefenseMachineZones.Add(this.CreateZone(61, 88, 93, 108));
+        configuration.DefenseMachineZones.Add(this.CreateZone(92, 89, 127, 111));
+        configuration.DefenseMachineZones.Add(this.CreateZone(84, 52, 102, 66));
+        configuration.DefenseMachineZones.Add(this.CreateZone(84, 52, 102, 66));
+    }
+
+    private CastleSiegeStateScheduleEntry CreateScheduleEntry(CastleSiegeState state, DayOfWeek dayOfWeek, byte hour, byte minute)
+    {
+        var entry = this.Context.CreateNew<CastleSiegeStateScheduleEntry>();
+        entry.State = state;
+        entry.DayOfWeek = dayOfWeek;
+        entry.Hour = hour;
+        entry.Minute = minute;
+        return entry;
+    }
+
+    private void AddNpc(
+        CastleSiegeConfiguration configuration,
+        short monsterNumber,
+        byte instanceId,
+        bool isPersisted,
+        CastleSiegeJoinSide defaultSide,
+        byte spawnX,
+        byte spawnY,
+        Direction direction)
+    {
+        var definition = this.Context.CreateNew<CastleSiegeNpcDefinition>();
+        definition.MonsterDefinition = this.GameConfiguration.Monsters.Single(monster => monster.Number == monsterNumber);
+        definition.InstanceId = instanceId;
+        definition.IsPersistedToDatabase = isPersisted;
+        definition.DefaultSide = defaultSide;
+        definition.SpawnX = spawnX;
+        definition.SpawnY = spawnY;
+        definition.Direction = direction;
+        configuration.NpcDefinitions.Add(definition);
+    }
+
+    private void AddUpgrade(
+        ICollection<CastleSiegeUpgradeDefinition> target,
+        byte level,
+        int jewelCount,
+        int zen,
+        int value)
+    {
+        var upgrade = this.Context.CreateNew<CastleSiegeUpgradeDefinition>();
+        upgrade.Level = level;
+        upgrade.RequiredJewelOfGuardianCount = jewelCount;
+        upgrade.RequiredZen = zen;
+        upgrade.Value = value;
+        target.Add(upgrade);
+    }
+
+    private CastleSiegeZoneDefinition CreateZone(byte x1, byte y1, byte x2, byte y2)
+    {
+        var zone = this.Context.CreateNew<CastleSiegeZoneDefinition>();
+        zone.X1 = x1;
+        zone.Y1 = y1;
+        zone.X2 = x2;
+        zone.Y2 = y2;
+        return zone;
+    }
+}

--- a/src/Persistence/Initialization/VersionSeasonSix/GameConfigurationInitializer.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/GameConfigurationInitializer.cs
@@ -89,6 +89,7 @@ public class GameConfigurationInitializer : GameConfigurationInitializerBase
         new DevilSquareInitializer(this.Context, this.GameConfiguration).Initialize();
         new BloodCastleInitializer(this.Context, this.GameConfiguration).Initialize();
         new ChaosCastleInitializer(this.Context, this.GameConfiguration).Initialize();
+        new CastleSiegeInitializer(this.Context, this.GameConfiguration).Initialize();
     }
 
     /// <summary>

--- a/tests/MUnique.OpenMU.Persistence.Initialization.Tests/ConfigurationChangePublishingTests.cs
+++ b/tests/MUnique.OpenMU.Persistence.Initialization.Tests/ConfigurationChangePublishingTests.cs
@@ -16,19 +16,19 @@ internal class ConfigurationChangePublishingTests
     /// <summary>
     /// Verifies that only configuration entities are published to the configuration change listener.
     /// </summary>
-    [Test]
-    public void OnlyConfigurationEntitiesArePublished()
+    /// <param name="entityType">The entity type.</param>
+    /// <param name="shouldPublish">Whether changes of this entity type should be published.</param>
+    [TestCase(typeof(CastleSiegeConfiguration), true)]
+    [TestCase(typeof(CastleSiegeNpcState), false)]
+    [TestCase(typeof(Account), false)]
+    [TestCase(typeof(Guild), false)]
+    [TestCase(typeof(Friend), false)]
+    public void OnlyConfigurationEntitiesArePublished(Type entityType, bool shouldPublish)
     {
         using var context = new EntityDataContext();
-        var configurationType = context.Model.FindEntityType(typeof(CastleSiegeConfiguration));
-        var dataType = context.Model.FindEntityType(typeof(CastleSiegeNpcState));
+        var modelType = context.Model.FindEntityType(entityType);
 
-        Assert.Multiple(() =>
-        {
-            Assert.That(configurationType, Is.Not.Null);
-            Assert.That(dataType, Is.Not.Null);
-            Assert.That(EntityFrameworkContextBase.PublishesConfigurationChanges(configurationType!), Is.True);
-            Assert.That(EntityFrameworkContextBase.PublishesConfigurationChanges(dataType!), Is.False);
-        });
+        Assert.That(modelType, Is.Not.Null);
+        Assert.That(EntityFrameworkContextBase.PublishesConfigurationChanges(modelType!), Is.EqualTo(shouldPublish));
     }
 }

--- a/tests/MUnique.OpenMU.Persistence.Initialization.Tests/ConfigurationChangePublishingTests.cs
+++ b/tests/MUnique.OpenMU.Persistence.Initialization.Tests/ConfigurationChangePublishingTests.cs
@@ -1,0 +1,34 @@
+// <copyright file="ConfigurationChangePublishingTests.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Persistence.Initialization.Tests;
+
+using MUnique.OpenMU.Persistence.EntityFramework;
+using MUnique.OpenMU.Persistence.EntityFramework.Model;
+
+/// <summary>
+/// Tests filtering of Entity Framework configuration change notifications.
+/// </summary>
+[TestFixture]
+internal class ConfigurationChangePublishingTests
+{
+    /// <summary>
+    /// Verifies that only configuration entities are published to the configuration change listener.
+    /// </summary>
+    [Test]
+    public void OnlyConfigurationEntitiesArePublished()
+    {
+        using var context = new EntityDataContext();
+        var configurationType = context.Model.FindEntityType(typeof(CastleSiegeConfiguration));
+        var dataType = context.Model.FindEntityType(typeof(CastleSiegeNpcState));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(configurationType, Is.Not.Null);
+            Assert.That(dataType, Is.Not.Null);
+            Assert.That(EntityFrameworkContextBase.PublishesConfigurationChanges(configurationType!), Is.True);
+            Assert.That(EntityFrameworkContextBase.PublishesConfigurationChanges(dataType!), Is.False);
+        });
+    }
+}

--- a/tests/MUnique.OpenMU.Persistence.Initialization.Tests/JsonQueryBuilderTests.cs
+++ b/tests/MUnique.OpenMU.Persistence.Initialization.Tests/JsonQueryBuilderTests.cs
@@ -24,7 +24,10 @@ internal class JsonQueryBuilderTests
     [OneTimeSetUp]
     public void Setup()
     {
-        ConnectionConfigurator.Initialize(new ConfigFileDatabaseConnectionStringProvider());
+        if (!ConnectionConfigurator.IsInitialized)
+        {
+            ConnectionConfigurator.Initialize(new ConfigFileDatabaseConnectionStringProvider());
+        }
     }
 
     /// <summary>

--- a/tests/MUnique.OpenMU.Persistence.Initialization.Tests/TestInitializationWithEfCore.cs
+++ b/tests/MUnique.OpenMU.Persistence.Initialization.Tests/TestInitializationWithEfCore.cs
@@ -274,7 +274,7 @@ internal class TestInitializationWithEfCore
         this.AssertUpgrades(configuration.StatueRegenUpgrades, [(0, 0, 0, 0), (1, 3, 5_000_000, 1), (2, 5, 5_000_000, 2), (3, 7, 5_000_000, 3)]);
 
         this.AssertZones(configuration.AttackMachineZones, [(62, 103, 72, 112), (88, 104, 124, 111), (116, 105, 124, 112), (73, 86, 105, 103)]);
-        this.AssertZones(configuration.DefenseMachineZones, [(61, 88, 93, 108), (92, 89, 127, 111), (84, 52, 102, 66), (84, 52, 102, 66)]);
+        this.AssertZones(configuration.DefenseMachineZones, [(61, 88, 93, 108), (92, 89, 127, 111), (84, 52, 102, 66)]);
         this.AssertZone(configuration.DefenseRespawnArea!, (74, 144, 115, 154));
         this.AssertZone(configuration.AttackRespawnArea!, (35, 11, 144, 48));
 

--- a/tests/MUnique.OpenMU.Persistence.Initialization.Tests/TestInitializationWithEfCore.cs
+++ b/tests/MUnique.OpenMU.Persistence.Initialization.Tests/TestInitializationWithEfCore.cs
@@ -1,4 +1,4 @@
-﻿// <copyright file="TestInitializationWithEfCore.cs" company="MUnique">
+// <copyright file="TestInitializationWithEfCore.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
@@ -7,6 +7,7 @@ namespace MUnique.OpenMU.Persistence.Initialization.Tests;
 using Microsoft.Extensions.Logging.Abstractions;
 using MUnique.OpenMU.DataModel;
 using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.DataModel.Entities;
 using MUnique.OpenMU.GameLogic;
 using MUnique.OpenMU.Persistence.EntityFramework;
 using MUnique.OpenMU.Persistence.Initialization.Updates;
@@ -53,6 +54,7 @@ internal class TestInitializationWithEfCore
         var dataInitialization = new VersionSeasonSix.DataInitialization(contextProvider, new NullLoggerFactory());
         await dataInitialization.CreateInitialDataAsync(1, true).ConfigureAwait(false);
         await this.AssertIcarusFeatherAndCrestDropGroupsAsync(contextProvider).ConfigureAwait(false);
+        await this.AssertCastleSiegeUpdatePlugInAsync(contextProvider).ConfigureAwait(false);
         await this.TestIfItemsFitIntoInventoriesAsync(contextProvider).ConfigureAwait(false);
     }
 
@@ -125,6 +127,8 @@ internal class TestInitializationWithEfCore
         var gameConfiguraton = (await context.GetAsync<DataModel.Configuration.GameConfiguration>().ConfigureAwait(false)).FirstOrDefault();
         Assert.That(gameConfiguraton, Is.Not.Null);
 
+        await this.AssertCastleSiegeDataAsync(contextProvider).ConfigureAwait(false);
+
         // Testing loading of an account
         using var accountContext = contextProvider.CreateNewPlayerContext(gameConfiguraton!);
         var account1 = await accountContext.GetAccountByLoginNameAsync("test1", "test1").ConfigureAwait(false);
@@ -181,5 +185,165 @@ internal class TestInitializationWithEfCore
         Assert.That(crestGroup.PossibleItems, Has.Count.EqualTo(1));
         Assert.That(crestGroup.PossibleItems.Single().Group, Is.EqualTo((byte)13));
         Assert.That(crestGroup.PossibleItems.Single().Number, Is.EqualTo((short)14));
+    }
+
+    private async Task AssertCastleSiegeDataAsync(IPersistenceContextProvider contextProvider)
+    {
+        using var configurationContext = contextProvider.CreateNewConfigurationContext();
+        var gameConfiguration = (await configurationContext.GetAsync<GameConfiguration>().ConfigureAwait(false)).Single();
+        var configuration = gameConfiguration.CastleSiegeConfiguration;
+        Assert.That(configuration, Is.Not.Null);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(configuration!.Enabled, Is.True);
+            Assert.That(configuration.CrownHoldTimeSeconds, Is.EqualTo(30));
+            Assert.That(configuration.RegisterMinLevel, Is.EqualTo(200));
+            Assert.That(configuration.RegisterMinMembers, Is.EqualTo(20));
+            Assert.That(configuration.ParticipantRewardMinSeconds, Is.EqualTo(60));
+            Assert.That(configuration.MaxAttackingGuilds, Is.EqualTo(3));
+            Assert.That(configuration.GateBuyPrice, Is.EqualTo(9_500_000));
+            Assert.That(configuration.StatueBuyPrice, Is.EqualTo(4_500_000));
+            Assert.That(configuration.CastleSiegeMapDefinition?.Number, Is.EqualTo(30));
+            Assert.That(configuration.LandOfTrialsMapDefinition?.Number, Is.EqualTo(31));
+            Assert.That(configuration.DefenseRespawnArea, Is.Not.Null);
+            Assert.That(configuration.AttackRespawnArea, Is.Not.Null);
+        });
+
+        var expectedSchedule = new (CastleSiegeState State, DayOfWeek Day, byte Hour, byte Minute)[]
+        {
+            (CastleSiegeState.Idle1, DayOfWeek.Sunday, 0, 0),
+            (CastleSiegeState.RegisterGuild, DayOfWeek.Monday, 0, 0),
+            (CastleSiegeState.Idle2, DayOfWeek.Tuesday, 0, 0),
+            (CastleSiegeState.RegisterMark, DayOfWeek.Wednesday, 0, 0),
+            (CastleSiegeState.Idle3, DayOfWeek.Thursday, 0, 0),
+            (CastleSiegeState.Notify, DayOfWeek.Friday, 0, 0),
+            (CastleSiegeState.Ready, DayOfWeek.Saturday, 18, 0),
+            (CastleSiegeState.Start, DayOfWeek.Saturday, 20, 0),
+            (CastleSiegeState.End, DayOfWeek.Saturday, 22, 0),
+            (CastleSiegeState.EndCycle, DayOfWeek.Saturday, 22, 5),
+        };
+        var actualSchedule = configuration!.StateSchedule
+            .Select(entry => (entry.State, entry.DayOfWeek, entry.Hour, entry.Minute));
+        Assert.That(actualSchedule, Is.EquivalentTo(expectedSchedule));
+
+        var expectedNpcs = new (short Number, byte Instance, bool Persisted, CastleSiegeJoinSide Side, byte X, byte Y, Direction Direction)[]
+        {
+            (216, 1, false, CastleSiegeJoinSide.Attack1, 176, 212, Direction.SouthWest),
+            (217, 1, false, CastleSiegeJoinSide.Attack1, 167, 194, Direction.NorthWest),
+            (218, 1, false, CastleSiegeJoinSide.Attack1, 184, 195, Direction.NorthWest),
+            (219, 1, false, CastleSiegeJoinSide.Defense, 93, 208, Direction.SouthWest),
+            (219, 2, false, CastleSiegeJoinSide.Defense, 81, 165, Direction.SouthWest),
+            (219, 3, false, CastleSiegeJoinSide.Defense, 107, 165, Direction.SouthWest),
+            (219, 4, false, CastleSiegeJoinSide.Defense, 67, 118, Direction.SouthWest),
+            (219, 5, false, CastleSiegeJoinSide.Defense, 93, 118, Direction.SouthWest),
+            (219, 6, false, CastleSiegeJoinSide.Defense, 119, 118, Direction.SouthWest),
+            (221, 1, false, CastleSiegeJoinSide.Attack1, 63, 19, Direction.NorthEast),
+            (221, 2, false, CastleSiegeJoinSide.Attack1, 119, 19, Direction.NorthEast),
+            (222, 1, false, CastleSiegeJoinSide.Defense, 80, 188, Direction.SouthWest),
+            (222, 2, false, CastleSiegeJoinSide.Defense, 105, 188, Direction.SouthWest),
+            (277, 1, true, CastleSiegeJoinSide.Defense, 93, 204, Direction.SouthWest),
+            (277, 2, true, CastleSiegeJoinSide.Defense, 81, 161, Direction.SouthWest),
+            (277, 3, true, CastleSiegeJoinSide.Defense, 107, 161, Direction.SouthWest),
+            (277, 4, true, CastleSiegeJoinSide.Defense, 67, 114, Direction.SouthWest),
+            (277, 5, true, CastleSiegeJoinSide.Defense, 93, 114, Direction.SouthWest),
+            (277, 6, true, CastleSiegeJoinSide.Defense, 119, 114, Direction.SouthWest),
+            (283, 1, true, CastleSiegeJoinSide.Defense, 94, 227, Direction.SouthWest),
+            (283, 2, true, CastleSiegeJoinSide.Defense, 94, 182, Direction.SouthWest),
+            (283, 3, true, CastleSiegeJoinSide.Defense, 82, 130, Direction.SouthWest),
+            (283, 4, true, CastleSiegeJoinSide.Defense, 107, 130, Direction.SouthWest),
+        };
+        var actualNpcs = configuration.NpcDefinitions.Select(
+            definition =>
+                (definition.MonsterDefinition!.Number,
+                 definition.InstanceId,
+                 definition.IsPersistedToDatabase,
+                 definition.DefaultSide,
+                 definition.SpawnX,
+                 definition.SpawnY,
+                 definition.Direction));
+        Assert.That(actualNpcs, Is.EquivalentTo(expectedNpcs));
+        Assert.That(
+            gameConfiguration.Monsters.Select(monster => monster.Number),
+            Is.SupersetOf(new short[] { 216, 217, 218, 219, 220, 221, 222, 223, 224, 277, 283 }));
+
+        this.AssertUpgrades(configuration.GateDefenseUpgrades, [(0, 0, 0, 100), (1, 2, 3_000_000, 180), (2, 3, 3_000_000, 300), (3, 4, 3_000_000, 520)]);
+        this.AssertUpgrades(configuration.StatueDefenseUpgrades, [(0, 0, 0, 80), (1, 3, 3_000_000, 180), (2, 5, 3_000_000, 340), (3, 7, 3_000_000, 550)]);
+        this.AssertUpgrades(configuration.GateLifeUpgrades, [(0, 0, 0, 1_900_000), (1, 2, 1_000_000, 2_500_000), (2, 3, 1_000_000, 3_500_000), (3, 4, 1_000_000, 5_200_000)]);
+        this.AssertUpgrades(configuration.StatueLifeUpgrades, [(0, 0, 0, 1_500_000), (1, 3, 1_000_000, 2_200_000), (2, 5, 1_000_000, 3_400_000), (3, 7, 1_000_000, 5_000_000)]);
+        this.AssertUpgrades(configuration.StatueRegenUpgrades, [(0, 0, 0, 0), (1, 3, 5_000_000, 1), (2, 5, 5_000_000, 2), (3, 7, 5_000_000, 3)]);
+
+        this.AssertZones(configuration.AttackMachineZones, [(62, 103, 72, 112), (88, 104, 124, 111), (116, 105, 124, 112), (73, 86, 105, 103)]);
+        this.AssertZones(configuration.DefenseMachineZones, [(61, 88, 93, 108), (92, 89, 127, 111), (84, 52, 102, 66), (84, 52, 102, 66)]);
+        this.AssertZone(configuration.DefenseRespawnArea!, (74, 144, 115, 154));
+        this.AssertZone(configuration.AttackRespawnArea!, (35, 11, 144, 48));
+
+        using (var dataContext = contextProvider.CreateNewContext(gameConfiguration))
+        {
+            var data = (await dataContext.GetAsync<CastleSiegeData>().ConfigureAwait(false)).Single();
+            Assert.Multiple(() =>
+            {
+                Assert.That(data.OwnerGuildId, Is.Null);
+                Assert.That(data.IsOccupied, Is.False);
+                Assert.That(data.TaxChaos, Is.Zero);
+                Assert.That(data.TaxStore, Is.Zero);
+                Assert.That(data.TaxHunt, Is.Zero);
+                Assert.That(data.IsHuntZoneEnabled, Is.False);
+                Assert.That(data.TributeMoney, Is.Zero);
+                Assert.That(data.NpcStates, Has.Count.EqualTo(10));
+                Assert.That(data.NpcStates.Count(state => state.MonsterNumber == 277 && state.CurrentHp == 1_900_000), Is.EqualTo(6));
+                Assert.That(data.NpcStates.Count(state => state.MonsterNumber == 283 && state.CurrentHp == 1_500_000), Is.EqualTo(4));
+            });
+
+            Assert.That(await dataContext.GetAsync<CastleSiegeGuildRegistration>().ConfigureAwait(false), Is.Empty);
+
+            data.TaxStore = 1;
+            data.NpcStates.First().CurrentHp--;
+            Assert.That(await dataContext.SaveChangesAsync().ConfigureAwait(false), Is.True);
+        }
+
+        using var reloadedContext = contextProvider.CreateNewContext(gameConfiguration);
+        var reloadedData = (await reloadedContext.GetAsync<CastleSiegeData>().ConfigureAwait(false)).Single();
+        Assert.That(reloadedData.TaxStore, Is.EqualTo(1));
+        Assert.That(reloadedData.NpcStates, Has.One.Matches<CastleSiegeNpcState>(state => state.CurrentHp is 1_899_999 or 1_499_999));
+    }
+
+    private async Task AssertCastleSiegeUpdatePlugInAsync(InMemoryPersistenceContextProvider contextProvider)
+    {
+        using var context = contextProvider.CreateNewContext();
+        var gameConfiguration = (await context.GetAsync<GameConfiguration>().ConfigureAwait(false)).Single();
+        var existingConfiguration = gameConfiguration.CastleSiegeConfiguration!;
+        var existingData = (await context.GetAsync<CastleSiegeData>().ConfigureAwait(false)).Single();
+        gameConfiguration.CastleSiegeConfiguration = null;
+        Assert.That(await context.DeleteAsync(existingConfiguration).ConfigureAwait(false), Is.True);
+        Assert.That(await context.DeleteAsync(existingData).ConfigureAwait(false), Is.True);
+
+        var update = new AddCastleSiegeDataUpdatePlugIn();
+        await update.ApplyUpdateAsync(context, gameConfiguration).ConfigureAwait(false);
+        await update.ApplyUpdateAsync(context, gameConfiguration).ConfigureAwait(false);
+
+        Assert.That(gameConfiguration.CastleSiegeConfiguration, Is.Not.Null);
+        Assert.That(await context.GetAsync<CastleSiegeData>().ConfigureAwait(false), Has.Exactly(1).Items);
+    }
+
+    private void AssertUpgrades(
+        IEnumerable<CastleSiegeUpgradeDefinition> actual,
+        IEnumerable<(byte Level, int JewelCount, int Zen, int Value)> expected)
+    {
+        Assert.That(
+            actual.Select(upgrade => (upgrade.Level, upgrade.RequiredJewelOfGuardianCount, upgrade.RequiredZen, upgrade.Value)),
+            Is.EquivalentTo(expected));
+    }
+
+    private void AssertZones(
+        IEnumerable<CastleSiegeZoneDefinition> actual,
+        IEnumerable<(byte X1, byte Y1, byte X2, byte Y2)> expected)
+    {
+        Assert.That(actual.Select(zone => (zone.X1, zone.Y1, zone.X2, zone.Y2)), Is.EquivalentTo(expected));
+    }
+
+    private void AssertZone(CastleSiegeZoneDefinition actual, (byte X1, byte Y1, byte X2, byte Y2) expected)
+    {
+        Assert.That((actual.X1, actual.Y1, actual.X2, actual.Y2), Is.EqualTo(expected));
     }
 }


### PR DESCRIPTION
## Summary

- configure the EF Core mappings for Castle Siege configuration and persistent entities
- add the follow-up migration required after the data model merged in #721
- initialize the Season 6 schedule, NPC definitions, upgrade tables, machine zones, respawn areas, and persistent state
- add an idempotent update plug-in for existing Season 6 databases
- prevent persistent Castle Siege state changes from being published as configuration changes
- add initialization, update, model-mapping, and round-trip regression coverage

## Testing

- `ConfigurationChangePublishingTests`
- `TestInitializationWithEfCore.TestSeason6DataAsync`

Both focused tests pass.

Closes #732
Part of #735