### PR TITLE
Add Castle Siege state machine

### DIFF
--- a/src/GameLogic/CastleSiege/CastleSiegeContext.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeContext.cs
@@ -1,0 +1,317 @@
+// <copyright file="CastleSiegeContext.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege;
+
+using System.Collections.Concurrent;
+using System.Threading;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.DataModel.Entities;
+
+/// <summary>
+/// Holds the runtime state of Castle Siege for one game context.
+/// </summary>
+public class CastleSiegeContext : IEventStateProvider
+{
+    private readonly IGameContext _gameContext;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeContext"/> class.
+    /// </summary>
+    /// <param name="gameContext">The game context.</param>
+    /// <param name="configuration">The Castle Siege configuration.</param>
+    public CastleSiegeContext(IGameContext gameContext, CastleSiegeConfiguration configuration)
+    {
+        this._gameContext = gameContext;
+        this.Configuration = configuration;
+        this.Schedule = new CastleSiegeSchedule(configuration.StateSchedule);
+    }
+
+    /// <summary>
+    /// Gets the current state.
+    /// </summary>
+    public CastleSiegeState CurrentState { get; internal set; }
+
+    /// <summary>
+    /// Gets the UTC time at which the current state started.
+    /// </summary>
+    public DateTime StateStartTimeUtc { get; internal set; }
+
+    /// <summary>
+    /// Gets the UTC time at which the current state ends.
+    /// </summary>
+    public DateTime StateEndTimeUtc { get; internal set; }
+
+    /// <summary>
+    /// Gets the Castle Siege configuration.
+    /// </summary>
+    public CastleSiegeConfiguration Configuration { get; }
+
+    /// <summary>
+    /// Gets the persistent Castle Siege state.
+    /// </summary>
+    public CastleSiegeData SiegeData { get; private set; } = null!;
+
+    /// <summary>
+    /// Gets the guild registrations keyed by their persistent guild identifier.
+    /// </summary>
+    public ConcurrentDictionary<Guid, CastleSiegeGuildRegistration> RegisteredGuilds { get; } = new();
+
+    /// <summary>
+    /// Gets the selected guilds keyed by their runtime guild identifier.
+    /// </summary>
+    public Dictionary<uint, CastleSiegeGuildParticipant> FinalGuildList { get; } = new();
+
+    /// <summary>
+    /// Gets the participating characters keyed by their persistent character identifier.
+    /// </summary>
+    public ConcurrentDictionary<Guid, CastleSiegeParticipant> ParticipantTracking { get; } = new();
+
+    /// <summary>
+    /// Gets or sets the runtime identifier of the guild which most recently captured the Crown.
+    /// </summary>
+    public uint? MiddleOwnerGuildId { get; set; }
+
+    /// <summary>
+    /// Gets the active Castle Siege NPCs.
+    /// </summary>
+    public List<CastleSiegeNpcRuntime> ActiveNpcs { get; } = new();
+
+    /// <summary>
+    /// Gets or sets the player which currently operates the Crown.
+    /// </summary>
+    public Player? CrownUser { get; set; }
+
+    /// <summary>
+    /// Gets the players which currently operate the Crown switches.
+    /// </summary>
+    public Player?[] SwitchUsers { get; } = new Player?[2];
+
+    /// <summary>
+    /// Gets or sets the accumulated Crown operation time.
+    /// </summary>
+    public TimeSpan CrownAccumulatedTime { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the Crown can currently be operated.
+    /// </summary>
+    public bool IsCrownAvailable { get; set; }
+
+    /// <inheritdoc />
+    public bool IsEventRunning => this.CurrentState == CastleSiegeState.Start;
+
+    /// <summary>
+    /// Gets a value indicating whether the context has been initialized.
+    /// </summary>
+    internal bool IsInitialized { get; private set; }
+
+    /// <summary>
+    /// Gets the game context.
+    /// </summary>
+    internal IGameContext GameContext => this._gameContext;
+
+    /// <summary>
+    /// Gets the configured weekly schedule.
+    /// </summary>
+    internal CastleSiegeSchedule Schedule { get; }
+
+    /// <summary>
+    /// Gets the lock which prevents overlapping timer executions for this context.
+    /// </summary>
+    internal SemaphoreSlim ExecutionLock { get; } = new(1, 1);
+
+    /// <summary>
+    /// Gets or sets the next regular notification time.
+    /// </summary>
+    internal DateTime NextNotificationUtc { get; set; } = DateTime.MaxValue;
+
+    /// <summary>
+    /// Gets or sets the next NPC persistence time.
+    /// </summary>
+    internal DateTime NextNpcSaveUtc { get; set; } = DateTime.MaxValue;
+
+    /// <summary>
+    /// Gets the Ready-state countdown values which have already been sent.
+    /// </summary>
+    internal HashSet<int> SentReadyCountdownMinutes { get; } = new();
+
+    /// <summary>
+    /// Gets or sets the last force-state request processed by this context.
+    /// </summary>
+    internal int LastForceRequestVersion { get; set; }
+
+    /// <inheritdoc />
+    public bool IsSpawnWaveActive(byte waveNumber) => false;
+
+    /// <summary>
+    /// Gets the remaining time of the current state.
+    /// </summary>
+    /// <returns>The remaining time, or <see cref="TimeSpan.Zero"/> if the state already ended.</returns>
+    public TimeSpan GetRemainingTime() => this.GetRemainingTime(DateTime.UtcNow);
+
+    /// <summary>
+    /// Gets the side of a player in the current Castle Siege.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <returns>The assigned side, or <see cref="CastleSiegeJoinSide.None"/>.</returns>
+    public CastleSiegeJoinSide GetPlayerJoinSide(Player player)
+    {
+        return player.GuildStatus is { } guildStatus
+               && this.FinalGuildList.TryGetValue(guildStatus.GuildId, out var guild)
+            ? guild.Side
+            : CastleSiegeJoinSide.None;
+    }
+
+    /// <summary>
+    /// Loads the persistent Castle Siege state and registrations.
+    /// </summary>
+    public async ValueTask LoadAsync()
+    {
+        using (var context = this._gameContext.PersistenceContextProvider.CreateNewTypedContext(typeof(CastleSiegeData), false, this._gameContext.Configuration))
+        {
+            this.SiegeData = (await context.GetAsync<CastleSiegeData>().ConfigureAwait(false)).FirstOrDefault()
+                ?? context.CreateNew<CastleSiegeData>();
+            await context.SaveChangesAsync().ConfigureAwait(false);
+        }
+
+        using (var context = this._gameContext.PersistenceContextProvider.CreateNewTypedContext(typeof(CastleSiegeGuildRegistration), false, this._gameContext.Configuration))
+        {
+            var registrations = await context.GetAsync<CastleSiegeGuildRegistration>().ConfigureAwait(false);
+            this.RegisteredGuilds.Clear();
+            foreach (var registration in registrations)
+            {
+                this.RegisteredGuilds[registration.GuildId] = registration;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Saves the persistent Castle Siege owner and economy state.
+    /// </summary>
+    public async ValueTask SaveOwnerAsync()
+    {
+        if (this.SiegeData is null)
+        {
+            return;
+        }
+
+        using var context = this._gameContext.PersistenceContextProvider.CreateNewTypedContext(typeof(CastleSiegeData), false, this._gameContext.Configuration);
+        var persistentData = await context.GetByIdAsync<CastleSiegeData>(this.SiegeData.Id).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("The persistent Castle Siege state no longer exists.");
+
+        CopyScalarState(this.SiegeData, persistentData);
+        await context.SaveChangesAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Replaces the persistent NPC states with the current runtime snapshot.
+    /// </summary>
+    public async ValueTask SaveNpcStatesAsync()
+    {
+        if (this.SiegeData is null)
+        {
+            return;
+        }
+
+        var activeNpcStates = this.ActiveNpcs
+            .Where(npc => npc.IsAlive && npc.Definition.IsPersistedToDatabase && npc.PersistedState is not null)
+            .Select(npc => npc.PersistedState!)
+            .ToList();
+        var statesToSave = this.ActiveNpcs.Count > 0 ? activeNpcStates : this.SiegeData.NpcStates.ToList();
+
+        using var context = this._gameContext.PersistenceContextProvider.CreateNewTypedContext(typeof(CastleSiegeData), false, this._gameContext.Configuration);
+        var persistentData = await context.GetByIdAsync<CastleSiegeData>(this.SiegeData.Id).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("The persistent Castle Siege state no longer exists.");
+
+        foreach (var oldState in persistentData.NpcStates.ToList())
+        {
+            await context.DeleteAsync(oldState).ConfigureAwait(false);
+        }
+
+        persistentData.NpcStates.Clear();
+        foreach (var source in statesToSave)
+        {
+            var target = context.CreateNew<CastleSiegeNpcState>();
+            CopyNpcState(source, target);
+            persistentData.NpcStates.Add(target);
+        }
+
+        await context.SaveChangesAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Deletes all guild registrations of the completed cycle.
+    /// </summary>
+    public async ValueTask ClearRegistrationsAsync()
+    {
+        using var context = this._gameContext.PersistenceContextProvider.CreateNewTypedContext(typeof(CastleSiegeGuildRegistration), false, this._gameContext.Configuration);
+        foreach (var registration in (await context.GetAsync<CastleSiegeGuildRegistration>().ConfigureAwait(false)).ToList())
+        {
+            await context.DeleteAsync(registration).ConfigureAwait(false);
+        }
+
+        await context.SaveChangesAsync().ConfigureAwait(false);
+        this.RegisteredGuilds.Clear();
+    }
+
+    /// <summary>
+    /// Initializes the context at the state which contains <paramref name="utcNow"/>.
+    /// </summary>
+    /// <param name="utcNow">The current UTC time.</param>
+    /// <returns>The initialized state period.</returns>
+    internal async ValueTask<CastleSiegeStatePeriod> InitializeAsync(DateTime utcNow)
+    {
+        await this.LoadAsync().ConfigureAwait(false);
+        var period = this.Schedule.GetCurrentEventPeriod(utcNow);
+        this.SetPeriod(period);
+        this.NextNpcSaveUtc = utcNow.AddMinutes(2);
+        this.IsInitialized = true;
+        return period;
+    }
+
+    /// <summary>
+    /// Sets the current state period.
+    /// </summary>
+    /// <param name="period">The state period.</param>
+    internal void SetPeriod(CastleSiegeStatePeriod period)
+    {
+        this.CurrentState = period.State;
+        this.StateStartTimeUtc = period.StartUtc;
+        this.StateEndTimeUtc = period.EndUtc;
+        this.NextNotificationUtc = DateTime.MaxValue;
+        this.SentReadyCountdownMinutes.Clear();
+    }
+
+    /// <summary>
+    /// Gets the remaining time at the specified UTC time.
+    /// </summary>
+    /// <param name="utcNow">The current UTC time.</param>
+    /// <returns>The remaining time.</returns>
+    internal TimeSpan GetRemainingTime(DateTime utcNow)
+    {
+        var remaining = this.StateEndTimeUtc - utcNow;
+        return remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero;
+    }
+
+    private static void CopyScalarState(CastleSiegeData source, CastleSiegeData target)
+    {
+        target.OwnerGuildId = source.OwnerGuildId;
+        target.IsOccupied = source.IsOccupied;
+        target.TaxChaos = source.TaxChaos;
+        target.TaxStore = source.TaxStore;
+        target.TaxHunt = source.TaxHunt;
+        target.IsHuntZoneEnabled = source.IsHuntZoneEnabled;
+        target.TributeMoney = source.TributeMoney;
+    }
+
+    private static void CopyNpcState(CastleSiegeNpcState source, CastleSiegeNpcState target)
+    {
+        target.MonsterNumber = source.MonsterNumber;
+        target.InstanceId = source.InstanceId;
+        target.DefenseLevel = source.DefenseLevel;
+        target.RegenLevel = source.RegenLevel;
+        target.LifeLevel = source.LifeLevel;
+        target.CurrentHp = source.CurrentHp;
+    }
+}

--- a/src/GameLogic/CastleSiege/CastleSiegeContext.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeContext.cs
@@ -166,22 +166,9 @@ public class CastleSiegeContext : IEventStateProvider
     /// </summary>
     public async ValueTask LoadAsync()
     {
-        using (var context = this._gameContext.PersistenceContextProvider.CreateNewTypedContext(typeof(CastleSiegeData), false, this._gameContext.Configuration))
-        {
-            this.SiegeData = (await context.GetAsync<CastleSiegeData>().ConfigureAwait(false)).FirstOrDefault()
-                ?? context.CreateNew<CastleSiegeData>();
-            await context.SaveChangesAsync().ConfigureAwait(false);
-        }
-
-        using (var context = this._gameContext.PersistenceContextProvider.CreateNewTypedContext(typeof(CastleSiegeGuildRegistration), false, this._gameContext.Configuration))
-        {
-            var registrations = await context.GetAsync<CastleSiegeGuildRegistration>().ConfigureAwait(false);
-            this.RegisteredGuilds.Clear();
-            foreach (var registration in registrations)
-            {
-                this.RegisteredGuilds[registration.GuildId] = registration;
-            }
-        }
+        this.SiegeData = await this.LoadDataAsync().ConfigureAwait(false)
+            ?? throw new InvalidOperationException("The persistent Castle Siege state does not exist.");
+        await this.LoadRegistrationsAsync().ConfigureAwait(false);
     }
 
     /// <summary>
@@ -203,7 +190,7 @@ public class CastleSiegeContext : IEventStateProvider
     }
 
     /// <summary>
-    /// Replaces the persistent NPC states with the current runtime snapshot.
+    /// Updates the persistent NPC states from a complete runtime snapshot.
     /// </summary>
     public async ValueTask SaveNpcStatesAsync()
     {
@@ -212,23 +199,37 @@ public class CastleSiegeContext : IEventStateProvider
             return;
         }
 
-        var activeNpcStates = this.ActiveNpcs
-            .Where(npc => npc.IsAlive && npc.Definition.IsPersistedToDatabase && npc.PersistedState is not null)
-            .Select(npc => npc.PersistedState!)
+        var persistedNpcs = this.ActiveNpcs
+            .Where(npc => npc.Definition.IsPersistedToDatabase)
             .ToList();
-        var statesToSave = this.ActiveNpcs.Count > 0 ? activeNpcStates : this.SiegeData.NpcStates.ToList();
+        if (persistedNpcs.Count == 0 || persistedNpcs.Any(npc => npc.PersistedState is null))
+        {
+            return;
+        }
+
+        var statesToSave = persistedNpcs
+            .Where(npc => npc.IsAlive)
+            .Select(npc => npc.PersistedState!)
+            .ToDictionary(GetNpcKey);
 
         using var context = this._gameContext.PersistenceContextProvider.CreateNewTypedContext(typeof(CastleSiegeData), false, this._gameContext.Configuration);
         var persistentData = await context.GetByIdAsync<CastleSiegeData>(this.SiegeData.Id).ConfigureAwait(false)
             ?? throw new InvalidOperationException("The persistent Castle Siege state no longer exists.");
 
-        foreach (var oldState in persistentData.NpcStates.ToList())
+        foreach (var target in persistentData.NpcStates.ToList())
         {
-            await context.DeleteAsync(oldState).ConfigureAwait(false);
+            if (statesToSave.Remove(GetNpcKey(target), out var source))
+            {
+                CopyNpcState(source, target);
+            }
+            else
+            {
+                await context.DeleteAsync(target).ConfigureAwait(false);
+                persistentData.NpcStates.Remove(target);
+            }
         }
 
-        persistentData.NpcStates.Clear();
-        foreach (var source in statesToSave)
+        foreach (var source in statesToSave.Values)
         {
             var target = context.CreateNew<CastleSiegeNpcState>();
             CopyNpcState(source, target);
@@ -260,7 +261,9 @@ public class CastleSiegeContext : IEventStateProvider
     /// <returns>The initialized state period.</returns>
     internal async ValueTask<CastleSiegeStatePeriod> InitializeAsync(DateTime utcNow)
     {
-        await this.LoadAsync().ConfigureAwait(false);
+        this.SiegeData = await this.LoadDataAsync().ConfigureAwait(false)
+            ?? await this.CreateDataAsync().ConfigureAwait(false);
+        await this.LoadRegistrationsAsync().ConfigureAwait(false);
         var period = this.Schedule.GetCurrentEventPeriod(utcNow);
         this.SetPeriod(period);
         this.NextNpcSaveUtc = utcNow.AddMinutes(2);
@@ -311,5 +314,35 @@ public class CastleSiegeContext : IEventStateProvider
         target.RegenLevel = source.RegenLevel;
         target.LifeLevel = source.LifeLevel;
         target.CurrentHp = source.CurrentHp;
+    }
+
+    private static (short MonsterNumber, byte InstanceId) GetNpcKey(CastleSiegeNpcState state)
+    {
+        return (state.MonsterNumber, state.InstanceId);
+    }
+
+    private async ValueTask<CastleSiegeData?> LoadDataAsync()
+    {
+        using var context = this._gameContext.PersistenceContextProvider.CreateNewTypedContext(typeof(CastleSiegeData), false, this._gameContext.Configuration);
+        return (await context.GetAsync<CastleSiegeData>().ConfigureAwait(false)).FirstOrDefault();
+    }
+
+    private async ValueTask<CastleSiegeData> CreateDataAsync()
+    {
+        using var context = this._gameContext.PersistenceContextProvider.CreateNewTypedContext(typeof(CastleSiegeData), false, this._gameContext.Configuration);
+        var data = context.CreateNew<CastleSiegeData>();
+        await context.SaveChangesAsync().ConfigureAwait(false);
+        return data;
+    }
+
+    private async ValueTask LoadRegistrationsAsync()
+    {
+        using var context = this._gameContext.PersistenceContextProvider.CreateNewTypedContext(typeof(CastleSiegeGuildRegistration), false, this._gameContext.Configuration);
+        var registrations = await context.GetAsync<CastleSiegeGuildRegistration>().ConfigureAwait(false);
+        this.RegisteredGuilds.Clear();
+        foreach (var registration in registrations)
+        {
+            this.RegisteredGuilds[registration.GuildId] = registration;
+        }
     }
 }

--- a/src/GameLogic/CastleSiege/CastleSiegeContext.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeContext.cs
@@ -4,7 +4,6 @@
 
 namespace MUnique.OpenMU.GameLogic.CastleSiege;
 
-using System.Collections.Concurrent;
 using System.Threading;
 using MUnique.OpenMU.DataModel.Configuration;
 using MUnique.OpenMU.DataModel.Entities;
@@ -56,7 +55,7 @@ public class CastleSiegeContext : IEventStateProvider
     /// <summary>
     /// Gets the guild registrations keyed by their persistent guild identifier.
     /// </summary>
-    public ConcurrentDictionary<Guid, CastleSiegeGuildRegistration> RegisteredGuilds { get; } = new();
+    public System.Collections.Concurrent.ConcurrentDictionary<Guid, CastleSiegeGuildRegistration> RegisteredGuilds { get; } = new();
 
     /// <summary>
     /// Gets the selected guilds keyed by their runtime guild identifier.
@@ -66,7 +65,7 @@ public class CastleSiegeContext : IEventStateProvider
     /// <summary>
     /// Gets the participating characters keyed by their persistent character identifier.
     /// </summary>
-    public ConcurrentDictionary<Guid, CastleSiegeParticipant> ParticipantTracking { get; } = new();
+    public System.Collections.Concurrent.ConcurrentDictionary<Guid, CastleSiegeParticipant> ParticipantTracking { get; } = new();
 
     /// <summary>
     /// Gets or sets the runtime identifier of the guild which most recently captured the Crown.
@@ -100,6 +99,11 @@ public class CastleSiegeContext : IEventStateProvider
 
     /// <inheritdoc />
     public bool IsEventRunning => this.CurrentState == CastleSiegeState.Start;
+
+    /// <summary>
+    /// Gets the remaining time of the current state.
+    /// </summary>
+    public TimeSpan RemainingTime => this.GetRemainingTime(DateTime.UtcNow);
 
     /// <summary>
     /// Gets a value indicating whether the context has been initialized.
@@ -143,12 +147,6 @@ public class CastleSiegeContext : IEventStateProvider
 
     /// <inheritdoc />
     public bool IsSpawnWaveActive(byte waveNumber) => false;
-
-    /// <summary>
-    /// Gets the remaining time of the current state.
-    /// </summary>
-    /// <returns>The remaining time, or <see cref="TimeSpan.Zero"/> if the state already ended.</returns>
-    public TimeSpan GetRemainingTime() => this.GetRemainingTime(DateTime.UtcNow);
 
     /// <summary>
     /// Gets the side of a player in the current Castle Siege.

--- a/src/GameLogic/CastleSiege/CastleSiegeGuildParticipant.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeGuildParticipant.cs
@@ -1,0 +1,43 @@
+// <copyright file="CastleSiegeGuildParticipant.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege;
+
+using MUnique.OpenMU.DataModel.Configuration;
+
+/// <summary>
+/// Holds a guild's runtime participation data for the current Castle Siege cycle.
+/// </summary>
+public class CastleSiegeGuildParticipant
+{
+    /// <summary>
+    /// Gets or sets the runtime guild identifier.
+    /// </summary>
+    public uint GuildId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the persistent guild identifier.
+    /// </summary>
+    public Guid PersistentGuildId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the guild name.
+    /// </summary>
+    public string GuildName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the side assigned to the guild.
+    /// </summary>
+    public CastleSiegeJoinSide Side { get; set; }
+
+    /// <summary>
+    /// Gets or sets the selection score of the guild.
+    /// </summary>
+    public int Score { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the guild is the master guild of its alliance.
+    /// </summary>
+    public bool IsAllianceMaster { get; set; }
+}

--- a/src/GameLogic/CastleSiege/CastleSiegeNpcRuntime.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeNpcRuntime.cs
@@ -1,0 +1,34 @@
+// <copyright file="CastleSiegeNpcRuntime.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege;
+
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.DataModel.Entities;
+
+/// <summary>
+/// Holds the runtime state of a configured Castle Siege NPC.
+/// </summary>
+public class CastleSiegeNpcRuntime
+{
+    /// <summary>
+    /// Gets or sets the NPC definition.
+    /// </summary>
+    public CastleSiegeNpcDefinition Definition { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the persistent state, if this NPC is stored in the database.
+    /// </summary>
+    public CastleSiegeNpcState? PersistedState { get; set; }
+
+    /// <summary>
+    /// Gets or sets the spawned map object.
+    /// </summary>
+    public ILocateable? SpawnedInstance { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the NPC is alive.
+    /// </summary>
+    public bool IsAlive { get; set; }
+}

--- a/src/GameLogic/CastleSiege/CastleSiegeParticipant.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeParticipant.cs
@@ -1,0 +1,31 @@
+// <copyright file="CastleSiegeParticipant.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege;
+
+/// <summary>
+/// Tracks a character's participation in the active Castle Siege battle.
+/// </summary>
+public class CastleSiegeParticipant
+{
+    /// <summary>
+    /// Gets or sets the persistent character identifier.
+    /// </summary>
+    public Guid CharacterId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the character name.
+    /// </summary>
+    public string CharacterName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the runtime guild identifier.
+    /// </summary>
+    public uint GuildId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of seconds for which the character participated.
+    /// </summary>
+    public int Seconds { get; set; }
+}

--- a/src/GameLogic/CastleSiege/CastleSiegePlugIn.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegePlugIn.cs
@@ -238,6 +238,7 @@ public class CastleSiegePlugIn : IPeriodicTaskPlugIn
                 context.IsCrownAvailable = false;
                 break;
             default:
+                // The remaining states do not require an entry action.
                 break;
         }
 

--- a/src/GameLogic/CastleSiege/CastleSiegePlugIn.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegePlugIn.cs
@@ -1,0 +1,310 @@
+// <copyright file="CastleSiegePlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege;
+
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Threading;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.GameLogic.PlugIns;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Drives the weekly Castle Siege state cycle.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegePlugIn_Name), Description = nameof(PlugInResources.CastleSiegePlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("B7F62FA9-59E6-49E9-B499-0358A14957CF")]
+public class CastleSiegePlugIn : IPeriodicTaskPlugIn
+{
+    private static readonly TimeSpan NpcSaveInterval = TimeSpan.FromMinutes(2);
+
+    private readonly ConditionalWeakTable<IGameContext, CastleSiegeContext> _contexts = new();
+    private readonly TimeProvider _timeProvider;
+
+    private int _forceRequestVersion;
+    private int _forcedState = (int)CastleSiegeState.Start;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegePlugIn"/> class.
+    /// </summary>
+    public CastleSiegePlugIn()
+        : this(TimeProvider.System)
+    {
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegePlugIn"/> class.
+    /// </summary>
+    /// <param name="timeProvider">The time provider.</param>
+    internal CastleSiegePlugIn(TimeProvider timeProvider)
+    {
+        this._timeProvider = timeProvider;
+    }
+
+    /// <inheritdoc />
+    public ValueTask ExecuteTaskAsync(GameContext gameContext) => this.ExecuteTaskAsync((IGameContext)gameContext);
+
+    /// <inheritdoc />
+    public void ForceStart() => this.ForceState(CastleSiegeState.Start);
+
+    /// <summary>
+    /// Forces all Castle Siege contexts to enter a state on their next timer tick.
+    /// </summary>
+    /// <param name="state">The state to enter.</param>
+    public void ForceState(CastleSiegeState state)
+    {
+        Volatile.Write(ref this._forcedState, (int)state);
+        Interlocked.Increment(ref this._forceRequestVersion);
+    }
+
+    /// <summary>
+    /// Gets the Castle Siege runtime context for a game context, if it has already been initialized.
+    /// </summary>
+    /// <param name="gameContext">The game context.</param>
+    /// <returns>The Castle Siege context, or <see langword="null"/>.</returns>
+    public CastleSiegeContext? GetContext(IGameContext gameContext)
+    {
+        return this._contexts.TryGetValue(gameContext, out var context) ? context : null;
+    }
+
+    /// <summary>
+    /// Executes the periodic task against an abstract game context.
+    /// </summary>
+    /// <param name="gameContext">The game context.</param>
+    internal async ValueTask ExecuteTaskAsync(IGameContext gameContext)
+    {
+        var configuration = gameContext.Configuration.CastleSiegeConfiguration;
+        if (configuration is not { Enabled: true })
+        {
+            return;
+        }
+
+        var logger = gameContext.LoggerFactory.CreateLogger(this.GetType().Name);
+        using var scope = logger.BeginScope(gameContext);
+        CastleSiegeContext context;
+        try
+        {
+            context = this._contexts.GetValue(gameContext, key => new CastleSiegeContext(key, configuration));
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "The Castle Siege context could not be created.");
+            return;
+        }
+
+        if (!await context.ExecutionLock.WaitAsync(0).ConfigureAwait(false))
+        {
+            return;
+        }
+
+        try
+        {
+            var utcNow = this._timeProvider.GetUtcNow().UtcDateTime;
+            if (!context.IsInitialized)
+            {
+                await context.InitializeAsync(utcNow).ConfigureAwait(false);
+                this.ConfigureNotifications(context, utcNow);
+                await this.OnEnterStateAsync(context, true).ConfigureAwait(false);
+                await this.BroadcastStateUpdateAsync(context).ConfigureAwait(false);
+                logger.LogInformation(
+                    "Castle Siege initialized in state {state}; the state ends at {stateEndUtc}.",
+                    context.CurrentState,
+                    context.StateEndTimeUtc);
+            }
+
+            var forceRequestVersion = Volatile.Read(ref this._forceRequestVersion);
+            if (context.LastForceRequestVersion != forceRequestVersion)
+            {
+                context.LastForceRequestVersion = forceRequestVersion;
+                var forcedState = (CastleSiegeState)Volatile.Read(ref this._forcedState);
+                await this.ChangeStateAsync(context, context.Schedule.CreatePeriod(forcedState, utcNow), logger).ConfigureAwait(false);
+            }
+
+            await this.AdvanceExpiredStatesAsync(context, utcNow, logger).ConfigureAwait(false);
+            await this.OnTickAsync(context, utcNow).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "Unexpected error while executing the Castle Siege state machine.");
+        }
+        finally
+        {
+            context.ExecutionLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Broadcasts a state update to players on the Castle Siege map.
+    /// </summary>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <remarks>The packet-backed implementation is added with the Castle Siege network view phase.</remarks>
+    protected virtual ValueTask BroadcastStateUpdateAsync(CastleSiegeContext context) => ValueTask.CompletedTask;
+
+    private static TimeSpan? GetNotificationInterval(CastleSiegeState state)
+    {
+        return state switch
+        {
+            CastleSiegeState.RegisterGuild or CastleSiegeState.RegisterMark or CastleSiegeState.Start => TimeSpan.FromMinutes(30),
+            CastleSiegeState.Idle3 or CastleSiegeState.Notify => TimeSpan.FromMinutes(120),
+            _ => null,
+        };
+    }
+
+    private static DateTime GetNextInterval(DateTime stateStartUtc, DateTime utcNow, TimeSpan interval)
+    {
+        if (utcNow < stateStartUtc)
+        {
+            return stateStartUtc + interval;
+        }
+
+        var elapsedTicks = utcNow.Ticks - stateStartUtc.Ticks;
+        var completedIntervals = elapsedTicks / interval.Ticks;
+        return stateStartUtc.AddTicks((completedIntervals + 1) * interval.Ticks);
+    }
+
+    private async ValueTask AdvanceExpiredStatesAsync(CastleSiegeContext context, DateTime utcNow, ILogger logger)
+    {
+        var maximumTransitions = context.Schedule.Count + 1;
+        for (var transition = 0; context.StateEndTimeUtc <= utcNow && transition < maximumTransitions; transition++)
+        {
+            var nextState = context.Schedule.GetNextState(context.CurrentState);
+            var nextPeriod = context.Schedule.CreatePeriod(nextState, context.StateEndTimeUtc);
+            await this.ChangeStateAsync(context, nextPeriod, logger).ConfigureAwait(false);
+        }
+    }
+
+    private async ValueTask ChangeStateAsync(CastleSiegeContext context, CastleSiegeStatePeriod period, ILogger logger)
+    {
+        var previousState = context.CurrentState;
+        await this.OnExitStateAsync(context).ConfigureAwait(false);
+
+        context.SetPeriod(period);
+        this.ConfigureNotifications(context, period.StartUtc);
+        await this.OnEnterStateAsync(context, false).ConfigureAwait(false);
+        await context.SaveOwnerAsync().ConfigureAwait(false);
+        await this.BroadcastStateUpdateAsync(context).ConfigureAwait(false);
+
+        logger.LogInformation(
+            "Castle Siege changed from state {previousState} to {state}; the state ends at {stateEndUtc}.",
+            previousState,
+            context.CurrentState,
+            context.StateEndTimeUtc);
+
+        if (period.State == CastleSiegeState.EndCycle)
+        {
+            var registrationPeriod = context.Schedule.CreateEarlyStartPeriod(CastleSiegeState.RegisterGuild, period.StartUtc);
+            await this.ChangeStateAsync(context, registrationPeriod, logger).ConfigureAwait(false);
+        }
+    }
+
+    private void ConfigureNotifications(CastleSiegeContext context, DateTime utcNow)
+    {
+        context.NextNotificationUtc = GetNotificationInterval(context.CurrentState) is { } interval
+            ? GetNextInterval(context.StateStartTimeUtc, utcNow, interval)
+            : DateTime.MaxValue;
+        context.SentReadyCountdownMinutes.Clear();
+    }
+
+    private async ValueTask OnEnterStateAsync(CastleSiegeContext context, bool isStartup)
+    {
+        switch (context.CurrentState)
+        {
+            case CastleSiegeState.RegisterGuild:
+                if (!isStartup)
+                {
+                    await context.LoadAsync().ConfigureAwait(false);
+                }
+
+                await this.SendStateNotificationAsync(context).ConfigureAwait(false);
+                break;
+            case CastleSiegeState.RegisterMark:
+                await this.SendStateNotificationAsync(context).ConfigureAwait(false);
+                break;
+            case CastleSiegeState.End:
+                await context.SaveNpcStatesAsync().ConfigureAwait(false);
+                break;
+            case CastleSiegeState.EndCycle:
+                await context.ClearRegistrationsAsync().ConfigureAwait(false);
+                context.FinalGuildList.Clear();
+                context.ParticipantTracking.Clear();
+                context.ActiveNpcs.Clear();
+                context.MiddleOwnerGuildId = null;
+                context.CrownUser = null;
+                Array.Clear(context.SwitchUsers);
+                context.CrownAccumulatedTime = TimeSpan.Zero;
+                context.IsCrownAvailable = false;
+                break;
+        }
+
+        if (!isStartup)
+        {
+            context.NextNpcSaveUtc = this._timeProvider.GetUtcNow().UtcDateTime + NpcSaveInterval;
+        }
+    }
+
+    private ValueTask OnExitStateAsync(CastleSiegeContext context) => ValueTask.CompletedTask;
+
+    private async ValueTask OnTickAsync(CastleSiegeContext context, DateTime utcNow)
+    {
+        if (context.NextNotificationUtc <= utcNow)
+        {
+            await this.SendStateNotificationAsync(context).ConfigureAwait(false);
+            if (GetNotificationInterval(context.CurrentState) is { } interval)
+            {
+                context.NextNotificationUtc = GetNextInterval(context.StateStartTimeUtc, utcNow, interval);
+            }
+        }
+
+        if (context.CurrentState == CastleSiegeState.Ready)
+        {
+            await this.SendReadyCountdownIfDueAsync(context, utcNow).ConfigureAwait(false);
+        }
+
+        if (!context.IsEventRunning && context.NextNpcSaveUtc <= utcNow)
+        {
+            await context.SaveNpcStatesAsync().ConfigureAwait(false);
+            context.NextNpcSaveUtc = utcNow + NpcSaveInterval;
+        }
+
+        // Start-state Crown, switch, mini-map and participant ticks are implemented by their dedicated phases.
+    }
+
+    private async ValueTask SendReadyCountdownIfDueAsync(CastleSiegeContext context, DateTime utcNow)
+    {
+        var remaining = context.GetRemainingTime(utcNow);
+        if (remaining <= TimeSpan.Zero)
+        {
+            return;
+        }
+
+        var remainingMinutes = (int)Math.Ceiling(remaining.TotalMinutes);
+        if (remainingMinutes != 30 && remainingMinutes is not (>= 1 and <= 5))
+        {
+            return;
+        }
+
+        if (context.SentReadyCountdownMinutes.Add(remainingMinutes))
+        {
+            await context.GameContext.SendGlobalNotificationAsync($"Castle Siege starts in {remainingMinutes} minute(s).").ConfigureAwait(false);
+        }
+    }
+
+    private ValueTask SendStateNotificationAsync(CastleSiegeContext context)
+    {
+        var message = context.CurrentState switch
+        {
+            CastleSiegeState.RegisterGuild => "Castle Siege guild registration is open.",
+            CastleSiegeState.RegisterMark => "Castle Siege mark registration is open.",
+            CastleSiegeState.Idle3 or CastleSiegeState.Notify => "Castle Siege preparations are in progress.",
+            CastleSiegeState.Start => "Castle Siege is in progress.",
+            _ => string.Empty,
+        };
+
+        return string.IsNullOrEmpty(message)
+            ? ValueTask.CompletedTask
+            : context.GameContext.SendGlobalNotificationAsync(message);
+    }
+}

--- a/src/GameLogic/CastleSiege/CastleSiegePlugIn.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegePlugIn.cs
@@ -179,7 +179,7 @@ public class CastleSiegePlugIn : IPeriodicTaskPlugIn
     private async ValueTask ChangeStateAsync(CastleSiegeContext context, CastleSiegeStatePeriod period, ILogger logger)
     {
         var previousState = context.CurrentState;
-        await this.OnExitStateAsync(context).ConfigureAwait(false);
+        await this.OnExitStateAsync().ConfigureAwait(false);
 
         context.SetPeriod(period);
         this.ConfigureNotifications(context, period.StartUtc);
@@ -237,6 +237,8 @@ public class CastleSiegePlugIn : IPeriodicTaskPlugIn
                 context.CrownAccumulatedTime = TimeSpan.Zero;
                 context.IsCrownAvailable = false;
                 break;
+            default:
+                break;
         }
 
         if (!isStartup)
@@ -245,7 +247,7 @@ public class CastleSiegePlugIn : IPeriodicTaskPlugIn
         }
     }
 
-    private ValueTask OnExitStateAsync(CastleSiegeContext context) => ValueTask.CompletedTask;
+    private ValueTask OnExitStateAsync() => ValueTask.CompletedTask;
 
     private async ValueTask OnTickAsync(CastleSiegeContext context, DateTime utcNow)
     {

--- a/src/GameLogic/CastleSiege/CastleSiegeSchedule.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeSchedule.cs
@@ -1,0 +1,222 @@
+// <copyright file="CastleSiegeSchedule.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege;
+
+using MUnique.OpenMU.DataModel.Configuration;
+
+/// <summary>
+/// Provides calculations for the weekly Castle Siege state schedule.
+/// </summary>
+internal sealed class CastleSiegeSchedule
+{
+    private static readonly TimeSpan WeekDuration = TimeSpan.FromDays(7);
+
+    private readonly IReadOnlyList<ScheduledState> _states;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeSchedule"/> class.
+    /// </summary>
+    /// <param name="entries">The configured state schedule.</param>
+    public CastleSiegeSchedule(IEnumerable<CastleSiegeStateScheduleEntry> entries)
+    {
+        this._states = entries
+            .Select(entry => new ScheduledState(entry.State, GetStartOfWeek(entry)))
+            .OrderBy(entry => entry.StartOfWeek)
+            .ToList();
+
+        if (this._states.Count < 2)
+        {
+            throw new InvalidOperationException("The Castle Siege schedule must contain at least two states.");
+        }
+
+        if (this._states.Select(entry => entry.State).Distinct().Count() != this._states.Count)
+        {
+            throw new InvalidOperationException("The Castle Siege schedule must not contain a state more than once.");
+        }
+
+        if (this._states.Select(entry => entry.StartOfWeek).Distinct().Count() != this._states.Count)
+        {
+            throw new InvalidOperationException("The Castle Siege schedule must not contain multiple states with the same start time.");
+        }
+    }
+
+    /// <summary>
+    /// Gets the number of configured states.
+    /// </summary>
+    public int Count => this._states.Count;
+
+    /// <summary>
+    /// Calculates the state period which contains <paramref name="utcNow"/>.
+    /// </summary>
+    /// <param name="utcNow">The current UTC time.</param>
+    /// <returns>The current state period.</returns>
+    public CastleSiegeStatePeriod GetCurrentPeriod(DateTime utcNow)
+    {
+        utcNow = EnsureUtc(utcNow);
+        var weekStart = utcNow.Date.AddDays(-(int)utcNow.DayOfWeek);
+        var elapsedInWeek = utcNow - weekStart;
+        var stateIndex = -1;
+        for (var i = this._states.Count - 1; i >= 0; i--)
+        {
+            if (this._states[i].StartOfWeek <= elapsedInWeek)
+            {
+                stateIndex = i;
+                break;
+            }
+        }
+
+        if (stateIndex < 0)
+        {
+            stateIndex = this._states.Count - 1;
+            weekStart -= WeekDuration;
+        }
+
+        var scheduledState = this._states[stateIndex];
+        var stateStartUtc = weekStart + scheduledState.StartOfWeek;
+        return new(scheduledState.State, stateStartUtc, stateStartUtc + this.GetDuration(scheduledState.State));
+    }
+
+    /// <summary>
+    /// Calculates the active event period, including the early registration phase after a completed cycle.
+    /// </summary>
+    /// <param name="utcNow">The current UTC time.</param>
+    /// <returns>The active Castle Siege period.</returns>
+    public CastleSiegeStatePeriod GetCurrentEventPeriod(DateTime utcNow)
+    {
+        var scheduledPeriod = this.GetCurrentPeriod(utcNow);
+        if (scheduledPeriod.State is not (CastleSiegeState.EndCycle or CastleSiegeState.Idle1 or CastleSiegeState.RegisterGuild))
+        {
+            return scheduledPeriod;
+        }
+
+        if (!this.ContainsState(CastleSiegeState.EndCycle)
+            || !this.ContainsState(CastleSiegeState.RegisterGuild)
+            || !this.ContainsState(this.GetNextState(CastleSiegeState.RegisterGuild)))
+        {
+            return scheduledPeriod;
+        }
+
+        var endCycleStart = this.GetPreviousOrCurrentStateStart(CastleSiegeState.EndCycle, utcNow);
+        return this.CreateEarlyStartPeriod(CastleSiegeState.RegisterGuild, endCycleStart);
+    }
+
+    /// <summary>
+    /// Creates a period which starts immediately and uses the configured duration of the state.
+    /// </summary>
+    /// <param name="state">The state.</param>
+    /// <param name="startUtc">The UTC start time.</param>
+    /// <returns>The created state period.</returns>
+    public CastleSiegeStatePeriod CreatePeriod(CastleSiegeState state, DateTime startUtc)
+    {
+        startUtc = EnsureUtc(startUtc);
+        return new(state, startUtc, startUtc + this.GetDuration(state));
+    }
+
+    /// <summary>
+    /// Creates an early-start period which ends at the next scheduled successor state.
+    /// </summary>
+    /// <param name="state">The state which starts early.</param>
+    /// <param name="startUtc">The UTC start time.</param>
+    /// <returns>The created state period.</returns>
+    public CastleSiegeStatePeriod CreateEarlyStartPeriod(CastleSiegeState state, DateTime startUtc)
+    {
+        startUtc = EnsureUtc(startUtc);
+        var successor = this.GetScheduledState(this.GetNextState(state));
+        var weekStart = startUtc.Date.AddDays(-(int)startUtc.DayOfWeek);
+        var endUtc = weekStart + successor.StartOfWeek;
+        if (endUtc <= startUtc)
+        {
+            endUtc += WeekDuration;
+        }
+
+        return new(state, startUtc, endUtc);
+    }
+
+    /// <summary>
+    /// Gets the state after <paramref name="state"/>.
+    /// </summary>
+    /// <param name="state">The current state.</param>
+    /// <returns>The next configured state.</returns>
+    public CastleSiegeState GetNextState(CastleSiegeState state)
+    {
+        var index = this.GetStateIndex(state);
+        return this._states[(index + 1) % this._states.Count].State;
+    }
+
+    /// <summary>
+    /// Gets the configured duration of a state.
+    /// </summary>
+    /// <param name="state">The state.</param>
+    /// <returns>The duration.</returns>
+    public TimeSpan GetDuration(CastleSiegeState state)
+    {
+        var index = this.GetStateIndex(state);
+        var start = this._states[index].StartOfWeek;
+        var end = this._states[(index + 1) % this._states.Count].StartOfWeek;
+        var duration = end - start;
+        return duration > TimeSpan.Zero ? duration : duration + WeekDuration;
+    }
+
+    /// <summary>
+    /// Gets the most recent start of a configured state.
+    /// </summary>
+    /// <param name="state">The state.</param>
+    /// <param name="utcNow">The reference time.</param>
+    /// <returns>The most recent state start, including <paramref name="utcNow"/>.</returns>
+    private DateTime GetPreviousOrCurrentStateStart(CastleSiegeState state, DateTime utcNow)
+    {
+        utcNow = EnsureUtc(utcNow);
+        var scheduledState = this.GetScheduledState(state);
+        var weekStart = utcNow.Date.AddDays(-(int)utcNow.DayOfWeek);
+        var startUtc = weekStart + scheduledState.StartOfWeek;
+        return startUtc <= utcNow ? startUtc : startUtc - WeekDuration;
+    }
+
+    private static TimeSpan GetStartOfWeek(CastleSiegeStateScheduleEntry entry)
+    {
+        if (entry.Hour > 23)
+        {
+            throw new InvalidOperationException($"The Castle Siege schedule contains an invalid hour for state {entry.State}.");
+        }
+
+        if (entry.Minute > 59)
+        {
+            throw new InvalidOperationException($"The Castle Siege schedule contains an invalid minute for state {entry.State}.");
+        }
+
+        return TimeSpan.FromDays((int)entry.DayOfWeek)
+               + TimeSpan.FromHours(entry.Hour)
+               + TimeSpan.FromMinutes(entry.Minute);
+    }
+
+    private static DateTime EnsureUtc(DateTime value)
+    {
+        return value.Kind switch
+        {
+            DateTimeKind.Utc => value,
+            DateTimeKind.Local => value.ToUniversalTime(),
+            _ => DateTime.SpecifyKind(value, DateTimeKind.Utc),
+        };
+    }
+
+    private int GetStateIndex(CastleSiegeState state)
+    {
+        for (var i = 0; i < this._states.Count; i++)
+        {
+            if (this._states[i].State == state)
+            {
+                return i;
+            }
+        }
+
+        throw new InvalidOperationException($"The Castle Siege schedule does not contain state {state}.");
+    }
+
+    private bool ContainsState(CastleSiegeState state) => this._states.Any(entry => entry.State == state);
+
+    private ScheduledState GetScheduledState(CastleSiegeState state) => this._states[this.GetStateIndex(state)];
+
+    private readonly record struct ScheduledState(CastleSiegeState State, TimeSpan StartOfWeek);
+}

--- a/src/GameLogic/CastleSiege/CastleSiegeSchedule.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeSchedule.cs
@@ -159,21 +159,6 @@ internal sealed class CastleSiegeSchedule
         return duration > TimeSpan.Zero ? duration : duration + WeekDuration;
     }
 
-    /// <summary>
-    /// Gets the most recent start of a configured state.
-    /// </summary>
-    /// <param name="state">The state.</param>
-    /// <param name="utcNow">The reference time.</param>
-    /// <returns>The most recent state start, including <paramref name="utcNow"/>.</returns>
-    private DateTime GetPreviousOrCurrentStateStart(CastleSiegeState state, DateTime utcNow)
-    {
-        utcNow = EnsureUtc(utcNow);
-        var scheduledState = this.GetScheduledState(state);
-        var weekStart = utcNow.Date.AddDays(-(int)utcNow.DayOfWeek);
-        var startUtc = weekStart + scheduledState.StartOfWeek;
-        return startUtc <= utcNow ? startUtc : startUtc - WeekDuration;
-    }
-
     private static TimeSpan GetStartOfWeek(CastleSiegeStateScheduleEntry entry)
     {
         if (entry.Hour > 23)
@@ -199,6 +184,21 @@ internal sealed class CastleSiegeSchedule
             DateTimeKind.Local => value.ToUniversalTime(),
             _ => DateTime.SpecifyKind(value, DateTimeKind.Utc),
         };
+    }
+
+    /// <summary>
+    /// Gets the most recent start of a configured state.
+    /// </summary>
+    /// <param name="state">The state.</param>
+    /// <param name="utcNow">The reference time.</param>
+    /// <returns>The most recent state start, including <paramref name="utcNow"/>.</returns>
+    private DateTime GetPreviousOrCurrentStateStart(CastleSiegeState state, DateTime utcNow)
+    {
+        utcNow = EnsureUtc(utcNow);
+        var scheduledState = this.GetScheduledState(state);
+        var weekStart = utcNow.Date.AddDays(-(int)utcNow.DayOfWeek);
+        var startUtc = weekStart + scheduledState.StartOfWeek;
+        return startUtc <= utcNow ? startUtc : startUtc - WeekDuration;
     }
 
     private int GetStateIndex(CastleSiegeState state)

--- a/src/GameLogic/CastleSiege/CastleSiegeStatePeriod.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeStatePeriod.cs
@@ -1,0 +1,15 @@
+// <copyright file="CastleSiegeStatePeriod.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege;
+
+using MUnique.OpenMU.DataModel.Configuration;
+
+/// <summary>
+/// A calculated Castle Siege state period.
+/// </summary>
+/// <param name="State">The state.</param>
+/// <param name="StartUtc">The UTC start time.</param>
+/// <param name="EndUtc">The UTC end time.</param>
+internal readonly record struct CastleSiegeStatePeriod(CastleSiegeState State, DateTime StartUtc, DateTime EndUtc);

--- a/src/GameLogic/Properties/PlugInResources.Designer.cs
+++ b/src/GameLogic/Properties/PlugInResources.Designer.cs
@@ -284,6 +284,24 @@ namespace MUnique.OpenMU.GameLogic.Properties {
                 return ResourceManager.GetString("BlessJewelConsumeHandlerPlugIn_Name", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Drives the weekly Castle Siege state cycle..
+        /// </summary>
+        public static string CastleSiegePlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegePlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege.
+        /// </summary>
+        public static string CastleSiegePlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegePlugIn_Name", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Handles the chain lightning skill of the summoner class. Additionally to the attacked target, it will hit up to two additional targets..

--- a/src/GameLogic/Properties/PlugInResources.resx
+++ b/src/GameLogic/Properties/PlugInResources.resx
@@ -117,6 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="CastleSiegePlugIn_Name" xml:space="preserve">
+    <value>Castle Siege</value>
+  </data>
+  <data name="CastleSiegePlugIn_Description" xml:space="preserve">
+    <value>Drives the weekly Castle Siege state cycle.</value>
+  </data>
   <data name="MuHelperFeaturePlugIn_Name" xml:space="preserve">
     <value>MU Helper Feature</value>
   </data>

--- a/tests/MUnique.OpenMU.Tests/CastleSiegeStateMachineTests.cs
+++ b/tests/MUnique.OpenMU.Tests/CastleSiegeStateMachineTests.cs
@@ -136,12 +136,51 @@ public class CastleSiegeStateMachineTests
     }
 
     /// <summary>
+    /// Verifies that loading does not silently create a missing persistent state.
+    /// </summary>
+    [Test]
+    public async ValueTask ContextLoadDoesNotCreateMissingPersistentStateAsync()
+    {
+        var fixture = await CreateFixtureAsync(false).ConfigureAwait(false);
+        var context = new CastleSiegeContext(fixture.GameContext.Object, fixture.CastleSiegeConfiguration);
+
+        Assert.ThrowsAsync<InvalidOperationException>(async () => await context.LoadAsync().ConfigureAwait(false));
+
+        using var persistenceContext = fixture.PersistenceContextProvider.CreateNewTypedContext(
+            typeof(CastleSiegeData),
+            false,
+            fixture.GameConfiguration);
+        Assert.That(await persistenceContext.GetAsync<CastleSiegeData>().ConfigureAwait(false), Is.Empty);
+    }
+
+    /// <summary>
+    /// Verifies that initialization explicitly creates a missing persistent state.
+    /// </summary>
+    [Test]
+    public async ValueTask ContextInitializationCreatesMissingPersistentStateAsync()
+    {
+        var fixture = await CreateFixtureAsync(false).ConfigureAwait(false);
+        var context = new CastleSiegeContext(fixture.GameContext.Object, fixture.CastleSiegeConfiguration);
+
+        await context.InitializeAsync(new DateTime(2026, 8, 3, 12, 0, 0, DateTimeKind.Utc)).ConfigureAwait(false);
+
+        using var persistenceContext = fixture.PersistenceContextProvider.CreateNewTypedContext(
+            typeof(CastleSiegeData),
+            false,
+            fixture.GameConfiguration);
+        var savedData = (await persistenceContext.GetAsync<CastleSiegeData>().ConfigureAwait(false)).Single();
+        Assert.That(context.SiegeData.Id, Is.EqualTo(savedData.Id));
+    }
+
+    /// <summary>
     /// Verifies that only alive database-persisted NPC runtime states are stored.
     /// </summary>
     [Test]
     public async ValueTask ContextSavesAlivePersistentNpcStatesAsync()
     {
         var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var gateStateId = await AddNpcStateAsync(fixture, 277, 0, 250_000).ConfigureAwait(false);
+        await AddNpcStateAsync(fixture, 283, 0, 300_000).ConfigureAwait(false);
         var context = new CastleSiegeContext(fixture.GameContext.Object, fixture.CastleSiegeConfiguration);
         await context.InitializeAsync(new DateTime(2026, 8, 3, 12, 0, 0, DateTimeKind.Utc)).ConfigureAwait(false);
         context.ActiveNpcs.Add(CreateNpcRuntime(277, 0, 125_000, true, true));
@@ -156,8 +195,47 @@ public class CastleSiegeStateMachineTests
             fixture.GameConfiguration);
         var savedData = (await persistenceContext.GetAsync<CastleSiegeData>().ConfigureAwait(false)).Single();
         Assert.That(savedData.NpcStates, Has.Count.EqualTo(1));
+        Assert.That(savedData.NpcStates.Single().Id, Is.EqualTo(gateStateId));
         Assert.That(savedData.NpcStates.Single().MonsterNumber, Is.EqualTo(277));
         Assert.That(savedData.NpcStates.Single().CurrentHp, Is.EqualTo(125_000));
+    }
+
+    /// <summary>
+    /// Verifies that an incomplete runtime snapshot does not delete persistent NPC states.
+    /// </summary>
+    [Test]
+    public async ValueTask ContextPreservesNpcStatesForIncompleteRuntimeSnapshotAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var gateStateId = await AddNpcStateAsync(fixture, 277, 0, 250_000).ConfigureAwait(false);
+        var context = new CastleSiegeContext(fixture.GameContext.Object, fixture.CastleSiegeConfiguration);
+        await context.InitializeAsync(new DateTime(2026, 8, 3, 12, 0, 0, DateTimeKind.Utc)).ConfigureAwait(false);
+        context.ActiveNpcs.Add(new CastleSiegeNpcRuntime
+        {
+            Definition = new CastleSiegeNpcDefinition
+            {
+                MonsterDefinition = new MonsterDefinition { Number = 277 },
+                InstanceId = 0,
+                IsPersistedToDatabase = true,
+            },
+            IsAlive = true,
+        });
+
+        await context.SaveNpcStatesAsync().ConfigureAwait(false);
+
+        using var persistenceContext = fixture.PersistenceContextProvider.CreateNewTypedContext(
+            typeof(CastleSiegeData),
+            false,
+            fixture.GameConfiguration);
+        var savedState = (await persistenceContext.GetAsync<CastleSiegeData>().ConfigureAwait(false))
+            .Single()
+            .NpcStates
+            .Single();
+        Assert.Multiple(() =>
+        {
+            Assert.That(savedState.Id, Is.EqualTo(gateStateId));
+            Assert.That(savedState.CurrentHp, Is.EqualTo(250_000));
+        });
     }
 
     /// <summary>
@@ -380,7 +458,27 @@ public class CastleSiegeStateMachineTests
         };
     }
 
-    private static async ValueTask<TestFixture> CreateFixtureAsync()
+    private static async ValueTask<Guid> AddNpcStateAsync(
+        TestFixture fixture,
+        short monsterNumber,
+        byte instanceId,
+        int currentHp)
+    {
+        using var context = fixture.PersistenceContextProvider.CreateNewTypedContext(
+            typeof(CastleSiegeData),
+            false,
+            fixture.GameConfiguration);
+        var siegeData = (await context.GetAsync<CastleSiegeData>().ConfigureAwait(false)).Single();
+        var npcState = context.CreateNew<CastleSiegeNpcState>();
+        npcState.MonsterNumber = monsterNumber;
+        npcState.InstanceId = instanceId;
+        npcState.CurrentHp = currentHp;
+        siegeData.NpcStates.Add(npcState);
+        await context.SaveChangesAsync().ConfigureAwait(false);
+        return npcState.Id;
+    }
+
+    private static async ValueTask<TestFixture> CreateFixtureAsync(bool createSiegeData = true)
     {
         var persistenceContextProvider = new InMemoryPersistenceContextProvider();
         using var context = persistenceContextProvider.CreateNewContext();
@@ -399,8 +497,11 @@ public class CastleSiegeStateMachineTests
 
         gameConfiguration.CastleSiegeConfiguration = castleSiegeConfiguration;
 
-        var siegeData = context.CreateNew<CastleSiegeData>();
-        siegeData.TributeMoney = 42;
+        if (createSiegeData)
+        {
+            var siegeData = context.CreateNew<CastleSiegeData>();
+            siegeData.TributeMoney = 42;
+        }
 
         var registeredGuildId = Guid.NewGuid();
         var registration = context.CreateNew<CastleSiegeGuildRegistration>();

--- a/tests/MUnique.OpenMU.Tests/CastleSiegeStateMachineTests.cs
+++ b/tests/MUnique.OpenMU.Tests/CastleSiegeStateMachineTests.cs
@@ -1,0 +1,454 @@
+// <copyright file="CastleSiegeStateMachineTests.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Tests;
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.DataModel.Entities;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.CastleSiege;
+using MUnique.OpenMU.GameLogic.PlugIns;
+using MUnique.OpenMU.Persistence;
+using MUnique.OpenMU.Persistence.InMemory;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Tests the Castle Siege weekly state machine.
+/// </summary>
+[TestFixture]
+public class CastleSiegeStateMachineTests
+{
+    /// <summary>
+    /// Verifies that the plug-in manager discovers and activates the Castle Siege periodic task.
+    /// </summary>
+    [Test]
+    public void PlugInIsDiscoveredAndActivated()
+    {
+        var manager = new PlugInManager(null, NullLoggerFactory.Instance, null, null);
+
+        manager.DiscoverAndRegisterPlugIns(typeof(CastleSiegePlugIn).Assembly);
+        manager.ActivatePlugIn<CastleSiegePlugIn>();
+
+        Assert.That(manager.GetKnownPlugInsOf<IPeriodicTaskPlugIn>(), Does.Contain(typeof(CastleSiegePlugIn)));
+        Assert.That(manager.GetActivePlugInsOf<IPeriodicTaskPlugIn>(), Has.Some.InstanceOf<CastleSiegePlugIn>());
+    }
+
+    /// <summary>
+    /// Verifies that the current state is calculated from the configured UTC week.
+    /// </summary>
+    /// <param name="utcTime">The current UTC time.</param>
+    /// <param name="expectedState">The expected state.</param>
+    [TestCase("2026-08-02T12:00:00Z", CastleSiegeState.Idle1)]
+    [TestCase("2026-08-03T12:00:00Z", CastleSiegeState.RegisterGuild)]
+    [TestCase("2026-08-08T19:00:00Z", CastleSiegeState.Ready)]
+    [TestCase("2026-08-08T21:00:00Z", CastleSiegeState.Start)]
+    [TestCase("2026-08-08T22:03:00Z", CastleSiegeState.End)]
+    [TestCase("2026-08-08T23:00:00Z", CastleSiegeState.EndCycle)]
+    public void CurrentStateIsCalculatedFromWeeklySchedule(string utcTime, CastleSiegeState expectedState)
+    {
+        var schedule = new CastleSiegeSchedule(CreateSchedule());
+
+        var period = schedule.GetCurrentPeriod(DateTime.Parse(utcTime, null, System.Globalization.DateTimeStyles.AdjustToUniversal));
+
+        Assert.That(period.State, Is.EqualTo(expectedState));
+        Assert.That(period.StartUtc, Is.LessThanOrEqualTo(DateTime.Parse(utcTime, null, System.Globalization.DateTimeStyles.AdjustToUniversal)));
+        Assert.That(period.EndUtc, Is.GreaterThan(DateTime.Parse(utcTime, null, System.Globalization.DateTimeStyles.AdjustToUniversal)));
+    }
+
+    /// <summary>
+    /// Verifies that the early registration period survives a restart through the scheduled idle and registration states.
+    /// </summary>
+    /// <param name="utcTime">The restart time.</param>
+    [TestCase("2026-08-09T12:00:00Z")]
+    [TestCase("2026-08-10T12:00:00Z")]
+    public void EarlyRegistrationPeriodIsRecoveredAcrossRestart(string utcTime)
+    {
+        var schedule = new CastleSiegeSchedule(CreateSchedule());
+        var period = schedule.GetCurrentEventPeriod(
+            DateTime.Parse(utcTime, null, System.Globalization.DateTimeStyles.AdjustToUniversal));
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(period.State, Is.EqualTo(CastleSiegeState.RegisterGuild));
+            Assert.That(period.StartUtc, Is.EqualTo(new DateTime(2026, 8, 8, 22, 5, 0, DateTimeKind.Utc)));
+            Assert.That(period.EndUtc, Is.EqualTo(new DateTime(2026, 8, 11, 0, 0, 0, DateTimeKind.Utc)));
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the schedule wraps from the last state to Sunday.
+    /// </summary>
+    [Test]
+    public void LastStateEndsAtStartOfNextWeek()
+    {
+        var schedule = new CastleSiegeSchedule(CreateSchedule());
+        var utcNow = new DateTime(2026, 8, 8, 23, 0, 0, DateTimeKind.Utc);
+
+        var period = schedule.GetCurrentPeriod(utcNow);
+
+        Assert.That(period.State, Is.EqualTo(CastleSiegeState.EndCycle));
+        Assert.That(period.EndUtc, Is.EqualTo(new DateTime(2026, 8, 9, 0, 0, 0, DateTimeKind.Utc)));
+    }
+
+    /// <summary>
+    /// Verifies that duplicate schedule states are rejected.
+    /// </summary>
+    [Test]
+    public void DuplicateScheduleStateIsRejected()
+    {
+        var schedule = CreateSchedule().ToList();
+        schedule.Add(new CastleSiegeStateScheduleEntry
+        {
+            State = CastleSiegeState.Start,
+            DayOfWeek = DayOfWeek.Saturday,
+            Hour = 23,
+        });
+
+        Assert.That(() => new CastleSiegeSchedule(schedule), Throws.InvalidOperationException);
+    }
+
+    /// <summary>
+    /// Verifies that persistent state and registrations are loaded and state changes can be saved.
+    /// </summary>
+    [Test]
+    public async ValueTask ContextLoadsAndSavesPersistentStateAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var context = new CastleSiegeContext(fixture.GameContext.Object, fixture.CastleSiegeConfiguration);
+
+        await context.InitializeAsync(new DateTime(2026, 8, 3, 12, 0, 0, DateTimeKind.Utc)).ConfigureAwait(false);
+
+        Assert.That(context.SiegeData.TributeMoney, Is.EqualTo(42));
+        Assert.That(context.RegisteredGuilds.ContainsKey(fixture.RegisteredGuildId), Is.True);
+
+        context.SiegeData.TributeMoney = 1234;
+        await context.SaveOwnerAsync().ConfigureAwait(false);
+
+        using var persistenceContext = fixture.PersistenceContextProvider.CreateNewTypedContext(
+            typeof(CastleSiegeData),
+            false,
+            fixture.GameConfiguration);
+        var savedData = (await persistenceContext.GetAsync<CastleSiegeData>().ConfigureAwait(false)).Single();
+        Assert.That(savedData.TributeMoney, Is.EqualTo(1234));
+    }
+
+    /// <summary>
+    /// Verifies that only alive database-persisted NPC runtime states are stored.
+    /// </summary>
+    [Test]
+    public async ValueTask ContextSavesAlivePersistentNpcStatesAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var context = new CastleSiegeContext(fixture.GameContext.Object, fixture.CastleSiegeConfiguration);
+        await context.InitializeAsync(new DateTime(2026, 8, 3, 12, 0, 0, DateTimeKind.Utc)).ConfigureAwait(false);
+        context.ActiveNpcs.Add(CreateNpcRuntime(277, 0, 125_000, true, true));
+        context.ActiveNpcs.Add(CreateNpcRuntime(283, 0, 0, true, false));
+        context.ActiveNpcs.Add(CreateNpcRuntime(216, 0, 1_000, false, true));
+
+        await context.SaveNpcStatesAsync().ConfigureAwait(false);
+
+        using var persistenceContext = fixture.PersistenceContextProvider.CreateNewTypedContext(
+            typeof(CastleSiegeData),
+            false,
+            fixture.GameConfiguration);
+        var savedData = (await persistenceContext.GetAsync<CastleSiegeData>().ConfigureAwait(false)).Single();
+        Assert.That(savedData.NpcStates, Has.Count.EqualTo(1));
+        Assert.That(savedData.NpcStates.Single().MonsterNumber, Is.EqualTo(277));
+        Assert.That(savedData.NpcStates.Single().CurrentHp, Is.EqualTo(125_000));
+    }
+
+    /// <summary>
+    /// Verifies startup state calculation and an automatic state transition.
+    /// </summary>
+    [Test]
+    public async ValueTask PlugInCalculatesAndAdvancesStateAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var timeProvider = new ManualTimeProvider(new DateTimeOffset(2026, 8, 3, 12, 0, 0, TimeSpan.Zero));
+        var plugIn = new CastleSiegePlugIn(timeProvider);
+
+        await plugIn.ExecuteTaskAsync(fixture.GameContext.Object).ConfigureAwait(false);
+        var context = plugIn.GetContext(fixture.GameContext.Object);
+
+        Assert.That(context, Is.Not.Null);
+        Assert.That(context!.CurrentState, Is.EqualTo(CastleSiegeState.RegisterGuild));
+        Assert.That(context.StateEndTimeUtc, Is.EqualTo(new DateTime(2026, 8, 4, 0, 0, 0, DateTimeKind.Utc)));
+
+        timeProvider.Advance(TimeSpan.FromHours(12));
+        await plugIn.ExecuteTaskAsync(fixture.GameContext.Object).ConfigureAwait(false);
+
+        Assert.That(context.CurrentState, Is.EqualTo(CastleSiegeState.Idle2));
+    }
+
+    /// <summary>
+    /// Verifies that plug-in initialization restores the early registration period after a restart.
+    /// </summary>
+    [Test]
+    public async ValueTask PlugInRecoversEarlyRegistrationAfterRestartAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var timeProvider = new ManualTimeProvider(new DateTimeOffset(2026, 8, 9, 12, 0, 0, TimeSpan.Zero));
+        var plugIn = new CastleSiegePlugIn(timeProvider);
+
+        await plugIn.ExecuteTaskAsync(fixture.GameContext.Object).ConfigureAwait(false);
+        var context = plugIn.GetContext(fixture.GameContext.Object);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(context, Is.Not.Null);
+            Assert.That(context!.CurrentState, Is.EqualTo(CastleSiegeState.RegisterGuild));
+            Assert.That(context.StateStartTimeUtc, Is.EqualTo(new DateTime(2026, 8, 8, 22, 5, 0, DateTimeKind.Utc)));
+            Assert.That(context.StateEndTimeUtc, Is.EqualTo(new DateTime(2026, 8, 11, 0, 0, 0, DateTimeKind.Utc)));
+        });
+    }
+
+    /// <summary>
+    /// Verifies that forcing the event starts the battle for its configured duration.
+    /// </summary>
+    [Test]
+    public async ValueTask ForceStartEntersStartStateAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var utcNow = new DateTimeOffset(2026, 8, 3, 12, 0, 0, TimeSpan.Zero);
+        var timeProvider = new ManualTimeProvider(utcNow);
+        var plugIn = new CastleSiegePlugIn(timeProvider);
+        await plugIn.ExecuteTaskAsync(fixture.GameContext.Object).ConfigureAwait(false);
+
+        plugIn.ForceStart();
+        await plugIn.ExecuteTaskAsync(fixture.GameContext.Object).ConfigureAwait(false);
+        var context = plugIn.GetContext(fixture.GameContext.Object)!;
+
+        Assert.That(context.CurrentState, Is.EqualTo(CastleSiegeState.Start));
+        Assert.That(context.IsEventRunning, Is.True);
+        Assert.That(context.StateStartTimeUtc, Is.EqualTo(utcNow.UtcDateTime));
+        Assert.That(context.StateEndTimeUtc, Is.EqualTo(utcNow.AddHours(2).UtcDateTime));
+    }
+
+    /// <summary>
+    /// Verifies that the event-running flag is set exclusively for the battle state.
+    /// </summary>
+    [Test]
+    public async ValueTask EventIsRunningOnlyDuringStartStateAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var context = new CastleSiegeContext(fixture.GameContext.Object, fixture.CastleSiegeConfiguration);
+        await context.InitializeAsync(new DateTime(2026, 8, 3, 12, 0, 0, DateTimeKind.Utc)).ConfigureAwait(false);
+
+        foreach (var state in Enum.GetValues<CastleSiegeState>())
+        {
+            context.CurrentState = state;
+            Assert.That(
+                context.IsEventRunning,
+                Is.EqualTo(state == CastleSiegeState.Start),
+                $"Unexpected event-running value for state {state}.");
+        }
+    }
+
+    /// <summary>
+    /// Verifies that EndCycle clears registrations and immediately opens the next registration phase.
+    /// </summary>
+    [Test]
+    public async ValueTask EndCycleTransitionsDirectlyToRegistrationAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var timeProvider = new ManualTimeProvider(new DateTimeOffset(2026, 8, 8, 22, 4, 0, TimeSpan.Zero));
+        var plugIn = new CastleSiegePlugIn(timeProvider);
+        await plugIn.ExecuteTaskAsync(fixture.GameContext.Object).ConfigureAwait(false);
+
+        timeProvider.Advance(TimeSpan.FromMinutes(2));
+        await plugIn.ExecuteTaskAsync(fixture.GameContext.Object).ConfigureAwait(false);
+        var context = plugIn.GetContext(fixture.GameContext.Object)!;
+
+        Assert.That(context.CurrentState, Is.EqualTo(CastleSiegeState.RegisterGuild));
+        Assert.That(context.StateStartTimeUtc, Is.EqualTo(new DateTime(2026, 8, 8, 22, 5, 0, DateTimeKind.Utc)));
+        Assert.That(context.StateEndTimeUtc, Is.EqualTo(new DateTime(2026, 8, 11, 0, 0, 0, DateTimeKind.Utc)));
+        Assert.That(context.RegisteredGuilds, Is.Empty);
+
+        using var persistenceContext = fixture.PersistenceContextProvider.CreateNewTypedContext(
+            typeof(CastleSiegeGuildRegistration),
+            false,
+            fixture.GameConfiguration);
+        Assert.That(await persistenceContext.GetAsync<CastleSiegeGuildRegistration>().ConfigureAwait(false), Is.Empty);
+    }
+
+    /// <summary>
+    /// Verifies that regular notifications are not repeated on every timer tick.
+    /// </summary>
+    [Test]
+    public async ValueTask RegistrationNotificationUsesConfiguredIntervalAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var timeProvider = new ManualTimeProvider(new DateTimeOffset(2026, 8, 3, 0, 15, 0, TimeSpan.Zero));
+        var plugIn = new CastleSiegePlugIn(timeProvider);
+
+        await plugIn.ExecuteTaskAsync(fixture.GameContext.Object).ConfigureAwait(false);
+        timeProvider.Advance(TimeSpan.FromMinutes(19));
+        await plugIn.ExecuteTaskAsync(fixture.GameContext.Object).ConfigureAwait(false);
+        timeProvider.Advance(TimeSpan.FromMinutes(1));
+        await plugIn.ExecuteTaskAsync(fixture.GameContext.Object).ConfigureAwait(false);
+
+        Assert.That(fixture.Notifications, Has.Count.EqualTo(2));
+        Assert.That(fixture.Notifications, Has.All.Contains("registration"));
+    }
+
+    /// <summary>
+    /// Verifies the Ready-state notification at 30 minutes and every minute during the final five minutes.
+    /// </summary>
+    [Test]
+    public async ValueTask ReadyNotificationsUseCountdownIntervalsAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var timeProvider = new ManualTimeProvider(new DateTimeOffset(2026, 8, 8, 19, 29, 0, TimeSpan.Zero));
+        var plugIn = new CastleSiegePlugIn(timeProvider);
+        await plugIn.ExecuteTaskAsync(fixture.GameContext.Object).ConfigureAwait(false);
+
+        timeProvider.Advance(TimeSpan.FromMinutes(1));
+        await plugIn.ExecuteTaskAsync(fixture.GameContext.Object).ConfigureAwait(false);
+        timeProvider.Advance(TimeSpan.FromMinutes(24));
+        await plugIn.ExecuteTaskAsync(fixture.GameContext.Object).ConfigureAwait(false);
+        for (var minute = 0; minute < 5; minute++)
+        {
+            timeProvider.Advance(TimeSpan.FromMinutes(1));
+            await plugIn.ExecuteTaskAsync(fixture.GameContext.Object).ConfigureAwait(false);
+        }
+
+        Assert.That(fixture.Notifications, Has.Count.EqualTo(6));
+        Assert.That(fixture.Notifications, Has.All.Contains("starts in"));
+    }
+
+    /// <summary>
+    /// Verifies that a disabled or missing configuration is handled without creating runtime state.
+    /// </summary>
+    [Test]
+    public async ValueTask MissingConfigurationIsIgnoredAsync()
+    {
+        var gameConfiguration = new MUnique.OpenMU.Persistence.BasicModel.GameConfiguration();
+        var gameContext = new Mock<IGameContext>();
+        gameContext.SetupGet(context => context.Configuration).Returns(gameConfiguration);
+        var plugIn = new CastleSiegePlugIn();
+
+        await plugIn.ExecuteTaskAsync(gameContext.Object).ConfigureAwait(false);
+
+        Assert.That(plugIn.GetContext(gameContext.Object), Is.Null);
+    }
+
+    private static IEnumerable<CastleSiegeStateScheduleEntry> CreateSchedule()
+    {
+        yield return CreateScheduleEntry(CastleSiegeState.Idle1, DayOfWeek.Sunday, 0, 0);
+        yield return CreateScheduleEntry(CastleSiegeState.RegisterGuild, DayOfWeek.Monday, 0, 0);
+        yield return CreateScheduleEntry(CastleSiegeState.Idle2, DayOfWeek.Tuesday, 0, 0);
+        yield return CreateScheduleEntry(CastleSiegeState.RegisterMark, DayOfWeek.Wednesday, 0, 0);
+        yield return CreateScheduleEntry(CastleSiegeState.Idle3, DayOfWeek.Thursday, 0, 0);
+        yield return CreateScheduleEntry(CastleSiegeState.Notify, DayOfWeek.Friday, 0, 0);
+        yield return CreateScheduleEntry(CastleSiegeState.Ready, DayOfWeek.Saturday, 18, 0);
+        yield return CreateScheduleEntry(CastleSiegeState.Start, DayOfWeek.Saturday, 20, 0);
+        yield return CreateScheduleEntry(CastleSiegeState.End, DayOfWeek.Saturday, 22, 0);
+        yield return CreateScheduleEntry(CastleSiegeState.EndCycle, DayOfWeek.Saturday, 22, 5);
+    }
+
+    private static CastleSiegeStateScheduleEntry CreateScheduleEntry(CastleSiegeState state, DayOfWeek dayOfWeek, byte hour, byte minute)
+    {
+        return new CastleSiegeStateScheduleEntry
+        {
+            State = state,
+            DayOfWeek = dayOfWeek,
+            Hour = hour,
+            Minute = minute,
+        };
+    }
+
+    private static CastleSiegeNpcRuntime CreateNpcRuntime(short monsterNumber, byte instanceId, int currentHp, bool isPersisted, bool isAlive)
+    {
+        return new CastleSiegeNpcRuntime
+        {
+            Definition = new CastleSiegeNpcDefinition
+            {
+                MonsterDefinition = new MonsterDefinition { Number = monsterNumber },
+                InstanceId = instanceId,
+                IsPersistedToDatabase = isPersisted,
+            },
+            PersistedState = new CastleSiegeNpcState
+            {
+                MonsterNumber = monsterNumber,
+                InstanceId = instanceId,
+                CurrentHp = currentHp,
+            },
+            IsAlive = isAlive,
+        };
+    }
+
+    private static async ValueTask<TestFixture> CreateFixtureAsync()
+    {
+        var persistenceContextProvider = new InMemoryPersistenceContextProvider();
+        using var context = persistenceContextProvider.CreateNewContext();
+        var gameConfiguration = context.CreateNew<MUnique.OpenMU.Persistence.BasicModel.GameConfiguration>();
+        var castleSiegeConfiguration = context.CreateNew<MUnique.OpenMU.Persistence.BasicModel.CastleSiegeConfiguration>();
+        castleSiegeConfiguration.Enabled = true;
+        foreach (var scheduleEntry in CreateSchedule())
+        {
+            var persistentEntry = context.CreateNew<CastleSiegeStateScheduleEntry>();
+            persistentEntry.State = scheduleEntry.State;
+            persistentEntry.DayOfWeek = scheduleEntry.DayOfWeek;
+            persistentEntry.Hour = scheduleEntry.Hour;
+            persistentEntry.Minute = scheduleEntry.Minute;
+            castleSiegeConfiguration.StateSchedule.Add(persistentEntry);
+        }
+
+        gameConfiguration.CastleSiegeConfiguration = castleSiegeConfiguration;
+
+        var siegeData = context.CreateNew<CastleSiegeData>();
+        siegeData.TributeMoney = 42;
+
+        var registeredGuildId = Guid.NewGuid();
+        var registration = context.CreateNew<CastleSiegeGuildRegistration>();
+        registration.GuildId = registeredGuildId;
+        registration.GuildName = "Test";
+        await context.SaveChangesAsync().ConfigureAwait(false);
+
+        var notifications = new List<string>();
+        var gameContext = new Mock<IGameContext>();
+        gameContext.SetupGet(game => game.Configuration).Returns(gameConfiguration);
+        gameContext.SetupGet(game => game.PersistenceContextProvider).Returns(persistenceContextProvider);
+        gameContext.SetupGet(game => game.LoggerFactory).Returns(NullLoggerFactory.Instance);
+        gameContext
+            .Setup(game => game.SendGlobalNotificationAsync(It.IsAny<string>()))
+            .Callback<string>(notifications.Add)
+            .Returns(ValueTask.CompletedTask);
+
+        return new(
+            persistenceContextProvider,
+            gameConfiguration,
+            castleSiegeConfiguration,
+            gameContext,
+            registeredGuildId,
+            notifications);
+    }
+
+    private sealed record TestFixture(
+        InMemoryPersistenceContextProvider PersistenceContextProvider,
+        GameConfiguration GameConfiguration,
+        CastleSiegeConfiguration CastleSiegeConfiguration,
+        Mock<IGameContext> GameContext,
+        Guid RegisteredGuildId,
+        List<string> Notifications);
+
+    private sealed class ManualTimeProvider : TimeProvider
+    {
+        private DateTimeOffset _utcNow;
+
+        public ManualTimeProvider(DateTimeOffset utcNow)
+        {
+            this._utcNow = utcNow;
+        }
+
+        public override DateTimeOffset GetUtcNow() => this._utcNow;
+
+        public void Advance(TimeSpan duration)
+        {
+            this._utcNow += duration;
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- add a per-game-context `CastleSiegeContext` for runtime and persistent event state
- implement the weekly 10-state Castle Siege schedule
- add the periodic task plug-in which initializes, advances, and force-transitions states
- load and save Castle Siege ownership, registration, and NPC state
- preserve persisted NPC states when the runtime snapshot is incomplete
- update matching NPC-state rows in place and remove only confirmed stale rows
- separate read-only reloads from explicit creation of a missing default state
- implement scheduled registration, preparation, battle, and countdown notifications
- transition directly from `EndCycle` to `RegisterGuild`
- recover the early registration period correctly after a server restart
- add the runtime participant, guild, and NPC holder types required by later phases
- add comprehensive state-machine regression coverage

Packet-backed state broadcasts and phase-specific battle mechanics remain intentionally separated for their corresponding Castle Siege issues.

## Testing

- `CastleSiegeStateMachineTests`: 24 passed
- complete `MUnique.OpenMU.Tests` project: 671 passed
- formatter and analyzer verification passed
- clean-diff and NoctraMU-contamination checks passed

Closes #722
Part of #735