### PR TITLE
Implement Castle Siege registration and mark system

### DIFF
--- a/src/Dapr/GuildServer.Host/GuildServerController.cs
+++ b/src/Dapr/GuildServer.Host/GuildServerController.cs
@@ -68,6 +68,17 @@ public class GuildServerController : ControllerBase
     }
 
     /// <summary>
+    /// Gets the persistent alliance master identifier of a guild by its runtime identifier.
+    /// </summary>
+    /// <param name="guildId">The runtime guild identifier.</param>
+    /// <returns>The persistent alliance master guild identifier, or <see langword="null"/> if the guild was not found.</returns>
+    [HttpPost(nameof(IGuildServer.GetPersistentAllianceMasterGuildIdAsync))]
+    public ValueTask<Guid?> GetPersistentAllianceMasterGuildIdAsync([FromBody] uint guildId)
+    {
+        return this._guildServer.GetPersistentAllianceMasterGuildIdAsync(guildId);
+    }
+
+    /// <summary>
     /// Gets the guild id by the guild name.
     /// </summary>
     /// <param name="guildName">The guild name.</param>

--- a/src/Dapr/GuildServer.Host/GuildServerController.cs
+++ b/src/Dapr/GuildServer.Host/GuildServerController.cs
@@ -57,6 +57,17 @@ public class GuildServerController : ControllerBase
     }
 
     /// <summary>
+    /// Gets the persistent identifier of a guild by its runtime identifier.
+    /// </summary>
+    /// <param name="guildId">The runtime guild identifier.</param>
+    /// <returns>The persistent guild identifier, or <see langword="null"/> if the guild was not found.</returns>
+    [HttpPost(nameof(IGuildServer.GetPersistentGuildIdAsync))]
+    public ValueTask<Guid?> GetPersistentGuildIdAsync([FromBody] uint guildId)
+    {
+        return this._guildServer.GetPersistentGuildIdAsync(guildId);
+    }
+
+    /// <summary>
     /// Gets the guild id by the guild name.
     /// </summary>
     /// <param name="guildName">The guild name.</param>

--- a/src/Dapr/ServerClients/GuildServer.cs
+++ b/src/Dapr/ServerClients/GuildServer.cs
@@ -59,6 +59,20 @@ public class GuildServer : IGuildServer
     }
 
     /// <inheritdoc />
+    public async ValueTask<Guid?> GetPersistentGuildIdAsync(uint guildId)
+    {
+        try
+        {
+            return await this._daprClient.InvokeMethodAsync<uint, Guid?>(this._targetAppId, nameof(this.GetPersistentGuildIdAsync), guildId).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            this._logger.LogError(ex, "Unexpected error when retrieving a persistent guild identifier.");
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
     public async ValueTask<uint> GetGuildIdByNameAsync(string guildName)
     {
         try

--- a/src/Dapr/ServerClients/GuildServer.cs
+++ b/src/Dapr/ServerClients/GuildServer.cs
@@ -73,6 +73,20 @@ public class GuildServer : IGuildServer
     }
 
     /// <inheritdoc />
+    public async ValueTask<Guid?> GetPersistentAllianceMasterGuildIdAsync(uint guildId)
+    {
+        try
+        {
+            return await this._daprClient.InvokeMethodAsync<uint, Guid?>(this._targetAppId, nameof(this.GetPersistentAllianceMasterGuildIdAsync), guildId).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            this._logger.LogError(ex, "Unexpected error when retrieving a persistent alliance master guild identifier.");
+            return null;
+        }
+    }
+
+    /// <inheritdoc />
     public async ValueTask<uint> GetGuildIdByNameAsync(string guildName)
     {
         try

--- a/src/DataModel/Configuration/CastleSiegeConfiguration.cs
+++ b/src/DataModel/Configuration/CastleSiegeConfiguration.cs
@@ -34,6 +34,16 @@ public partial class CastleSiegeConfiguration
     public int RegisterMinMembers { get; set; } = 20;
 
     /// <summary>
+    /// Gets or sets the item definition used for Sign of Lord registration.
+    /// </summary>
+    public virtual ItemDefinition? SignOfLordItemDefinition { get; set; }
+
+    /// <summary>
+    /// Gets or sets the required level of a Sign of Lord item.
+    /// </summary>
+    public byte SignOfLordItemLevel { get; set; } = 3;
+
+    /// <summary>
     /// Gets or sets the minimum number of seconds a participant must be present in the battle to be eligible for a reward.
     /// </summary>
     public int ParticipantRewardMinSeconds { get; set; }

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeGuildReference.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeGuildReference.cs
@@ -1,0 +1,13 @@
+// <copyright file="CastleSiegeGuildReference.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+
+/// <summary>
+/// A Castle Siege guild identity spanning runtime and persistent identifiers.
+/// </summary>
+/// <param name="RuntimeId">The runtime guild identifier.</param>
+/// <param name="PersistentId">The persistent guild identifier.</param>
+/// <param name="Name">The guild name.</param>
+internal sealed record CastleSiegeGuildReference(uint RuntimeId, Guid PersistentId, string Name);

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeGuildResolver.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeGuildResolver.cs
@@ -16,11 +16,9 @@ internal static class CastleSiegeGuildResolver
     /// Resolves a guild which is allowed to mutate a Castle Siege registration.
     /// </summary>
     /// <param name="player">The requesting player.</param>
-    /// <param name="context">The Castle Siege context.</param>
     /// <returns>The resolved guild and validation result.</returns>
     public static async ValueTask<(CastleSiegeGuildReference? Guild, CastleSiegeRegistrationResult Result)> ResolveAuthorizedGuildAsync(
-        Player player,
-        CastleSiegeContext context)
+        Player player)
     {
         if (player.GuildStatus is not { } guildStatus)
         {
@@ -44,7 +42,7 @@ internal static class CastleSiegeGuildResolver
             return (null, CastleSiegeRegistrationResult.InvalidGuild);
         }
 
-        if (await context.GetPersistentGuildIdAsync(guild.Name).ConfigureAwait(false) is not { } persistentGuildId)
+        if (await gameServerContext.GuildServer.GetPersistentGuildIdAsync(guildStatus.GuildId).ConfigureAwait(false) is not { } persistentGuildId)
         {
             return (null, CastleSiegeRegistrationResult.InvalidGuild);
         }
@@ -56,9 +54,8 @@ internal static class CastleSiegeGuildResolver
     /// Resolves the registration identity visible to any member of a guild or alliance.
     /// </summary>
     /// <param name="player">The requesting player.</param>
-    /// <param name="context">The Castle Siege context.</param>
-    /// <returns>The resolved registration identity, or <see langword="null"/>.</returns>
-    public static async ValueTask<CastleSiegeGuildReference?> ResolveRegistrationGuildAsync(Player player, CastleSiegeContext context)
+    /// <returns>The persistent registration guild identifier, or <see langword="null"/>.</returns>
+    public static async ValueTask<Guid?> ResolveRegistrationGuildIdAsync(Player player)
     {
         if (player.GuildStatus is not { } guildStatus
             || player.GameContext is not IGameServerContext gameServerContext
@@ -67,15 +64,11 @@ internal static class CastleSiegeGuildResolver
             return null;
         }
 
-        var registrationGuildName = guild.AllianceGuild?.Name ?? guild.Name;
-        if (await context.GetPersistentGuildIdAsync(registrationGuildName).ConfigureAwait(false) is not { } persistentGuildId)
-        {
-            return null;
-        }
-
-        var registrationGuildId = string.Equals(registrationGuildName, guild.Name, StringComparison.OrdinalIgnoreCase)
+        var registrationGuildId = guild.AllianceGuild is null
             ? guildStatus.GuildId
-            : await gameServerContext.GuildServer.GetGuildIdByNameAsync(registrationGuildName).ConfigureAwait(false);
-        return new(registrationGuildId, persistentGuildId, registrationGuildName);
+            : await gameServerContext.GuildServer.GetGuildIdByNameAsync(guild.AllianceGuild.Name!).ConfigureAwait(false);
+        return registrationGuildId == 0
+            ? null
+            : await gameServerContext.GuildServer.GetPersistentGuildIdAsync(registrationGuildId).ConfigureAwait(false);
     }
 }

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeGuildResolver.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeGuildResolver.cs
@@ -58,17 +58,13 @@ internal static class CastleSiegeGuildResolver
     public static async ValueTask<Guid?> ResolveRegistrationGuildIdAsync(Player player)
     {
         if (player.GuildStatus is not { } guildStatus
-            || player.GameContext is not IGameServerContext gameServerContext
-            || await gameServerContext.GuildServer.GetGuildAsync(guildStatus.GuildId).ConfigureAwait(false) is not { Name: not null } guild)
+            || player.GameContext is not IGameServerContext gameServerContext)
         {
             return null;
         }
 
-        var registrationGuildId = guild.AllianceGuild is null
-            ? guildStatus.GuildId
-            : await gameServerContext.GuildServer.GetGuildIdByNameAsync(guild.AllianceGuild.Name!).ConfigureAwait(false);
-        return registrationGuildId == 0
-            ? null
-            : await gameServerContext.GuildServer.GetPersistentGuildIdAsync(registrationGuildId).ConfigureAwait(false);
+        return await gameServerContext.GuildServer
+            .GetPersistentAllianceMasterGuildIdAsync(guildStatus.GuildId)
+            .ConfigureAwait(false);
     }
 }

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeGuildResolver.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeGuildResolver.cs
@@ -1,0 +1,81 @@
+// <copyright file="CastleSiegeGuildResolver.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+using MUnique.OpenMU.Interfaces;
+
+/// <summary>
+/// Resolves runtime guild information to its persistent Castle Siege identity.
+/// </summary>
+internal static class CastleSiegeGuildResolver
+{
+    /// <summary>
+    /// Resolves a guild which is allowed to mutate a Castle Siege registration.
+    /// </summary>
+    /// <param name="player">The requesting player.</param>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <returns>The resolved guild and validation result.</returns>
+    public static async ValueTask<(CastleSiegeGuildReference? Guild, CastleSiegeRegistrationResult Result)> ResolveAuthorizedGuildAsync(
+        Player player,
+        CastleSiegeContext context)
+    {
+        if (player.GuildStatus is not { } guildStatus)
+        {
+            return (null, CastleSiegeRegistrationResult.NoGuild);
+        }
+
+        if (guildStatus.Position != GuildPosition.GuildMaster
+            || player.GameContext is not IGameServerContext gameServerContext)
+        {
+            return (null, CastleSiegeRegistrationResult.InvalidGuild);
+        }
+
+        if (await gameServerContext.GuildServer.GetGuildAsync(guildStatus.GuildId).ConfigureAwait(false) is not { Name: not null } guild)
+        {
+            return (null, CastleSiegeRegistrationResult.InvalidGuild);
+        }
+
+        if (guild.AllianceGuild is not null
+            && !await gameServerContext.GuildServer.IsAllianceMasterAsync(guildStatus.GuildId).ConfigureAwait(false))
+        {
+            return (null, CastleSiegeRegistrationResult.InvalidGuild);
+        }
+
+        if (await context.GetPersistentGuildIdAsync(guild.Name).ConfigureAwait(false) is not { } persistentGuildId)
+        {
+            return (null, CastleSiegeRegistrationResult.InvalidGuild);
+        }
+
+        return (new(guildStatus.GuildId, persistentGuildId, guild.Name), CastleSiegeRegistrationResult.Success);
+    }
+
+    /// <summary>
+    /// Resolves the registration identity visible to any member of a guild or alliance.
+    /// </summary>
+    /// <param name="player">The requesting player.</param>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <returns>The resolved registration identity, or <see langword="null"/>.</returns>
+    public static async ValueTask<CastleSiegeGuildReference?> ResolveRegistrationGuildAsync(Player player, CastleSiegeContext context)
+    {
+        if (player.GuildStatus is not { } guildStatus
+            || player.GameContext is not IGameServerContext gameServerContext
+            || await gameServerContext.GuildServer.GetGuildAsync(guildStatus.GuildId).ConfigureAwait(false) is not { Name: not null } guild)
+        {
+            return null;
+        }
+
+        var registrationGuildName = guild.AllianceGuild?.Name ?? guild.Name;
+        if (await context.GetPersistentGuildIdAsync(registrationGuildName).ConfigureAwait(false) is not { } persistentGuildId)
+        {
+            return null;
+        }
+
+        var registrationGuildId = string.Equals(registrationGuildName, guild.Name, StringComparison.OrdinalIgnoreCase)
+            ? guildStatus.GuildId
+            : await gameServerContext.GuildServer.GetGuildIdByNameAsync(registrationGuildName).ConfigureAwait(false);
+        return new(registrationGuildId, persistentGuildId, registrationGuildName);
+    }
+}

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeRegisterGuildAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeRegisterGuildAction.cs
@@ -18,6 +18,7 @@ public class CastleSiegeRegisterGuildAction
     /// </summary>
     /// <param name="player">The requesting player.</param>
     /// <param name="context">The Castle Siege context, if initialized.</param>
+    /// <returns>A task which represents the asynchronous operation.</returns>
     public async ValueTask RegisterAsync(Player player, CastleSiegeContext? context)
     {
         var (result, guildName) = await RegisterCoreAsync(player, context).ConfigureAwait(false);
@@ -42,7 +43,7 @@ public class CastleSiegeRegisterGuildAction
                 return (CastleSiegeRegistrationResult.NotRegistrationPeriod, string.Empty);
             }
 
-            var (guild, resolutionResult) = await CastleSiegeGuildResolver.ResolveAuthorizedGuildAsync(player, context).ConfigureAwait(false);
+            var (guild, resolutionResult) = await CastleSiegeGuildResolver.ResolveAuthorizedGuildAsync(player).ConfigureAwait(false);
             if (guild is null)
             {
                 return (resolutionResult, string.Empty);

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeRegisterGuildAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeRegisterGuildAction.cs
@@ -1,0 +1,86 @@
+// <copyright file="CastleSiegeRegisterGuildAction.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.GameLogic.Attributes;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// Validates and processes Castle Siege guild registrations.
+/// </summary>
+public class CastleSiegeRegisterGuildAction
+{
+    /// <summary>
+    /// Tries to register the player's guild or alliance for Castle Siege.
+    /// </summary>
+    /// <param name="player">The requesting player.</param>
+    /// <param name="context">The Castle Siege context, if initialized.</param>
+    public async ValueTask RegisterAsync(Player player, CastleSiegeContext? context)
+    {
+        var (result, guildName) = await RegisterCoreAsync(player, context).ConfigureAwait(false);
+        await player.InvokeViewPlugInAsync<ICastleSiegeRegistrationResultPlugIn>(
+            view => view.ShowRegistrationResultAsync(result, guildName)).ConfigureAwait(false);
+    }
+
+    private static async ValueTask<(CastleSiegeRegistrationResult Result, string GuildName)> RegisterCoreAsync(
+        Player player,
+        CastleSiegeContext? context)
+    {
+        if (context is not { Configuration.Enabled: true })
+        {
+            return (CastleSiegeRegistrationResult.Failed, string.Empty);
+        }
+
+        await context.ExecutionLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (context.CurrentState != CastleSiegeState.RegisterGuild)
+            {
+                return (CastleSiegeRegistrationResult.NotRegistrationPeriod, string.Empty);
+            }
+
+            var (guild, resolutionResult) = await CastleSiegeGuildResolver.ResolveAuthorizedGuildAsync(player, context).ConfigureAwait(false);
+            if (guild is null)
+            {
+                return (resolutionResult, string.Empty);
+            }
+
+            var combinedLevel = player.Level + (int)(player.Attributes?[Stats.MasterLevel] ?? 0);
+            if (combinedLevel < context.Configuration.RegisterMinLevel)
+            {
+                return (CastleSiegeRegistrationResult.LevelInsufficient, guild.Name);
+            }
+
+            if (player.GameContext is not IGameServerContext gameServerContext)
+            {
+                return (CastleSiegeRegistrationResult.InvalidGuild, guild.Name);
+            }
+
+            var members = await gameServerContext.GuildServer.GetGuildListAsync(guild.RuntimeId).ConfigureAwait(false);
+            if (members.Count < context.Configuration.RegisterMinMembers)
+            {
+                return (CastleSiegeRegistrationResult.NotEnoughMembers, guild.Name);
+            }
+
+            if (context.RegisteredGuilds.ContainsKey(guild.PersistentId))
+            {
+                return (CastleSiegeRegistrationResult.AlreadyRegistered, guild.Name);
+            }
+
+            if (context.SiegeData.OwnerGuildId == guild.PersistentId)
+            {
+                return (CastleSiegeRegistrationResult.IsDefender, guild.Name);
+            }
+
+            await context.AddRegistrationAsync(guild.PersistentId, guild.Name).ConfigureAwait(false);
+            return (CastleSiegeRegistrationResult.Success, guild.Name);
+        }
+        finally
+        {
+            context.ExecutionLock.Release();
+        }
+    }
+}

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeRegisterMarkAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeRegisterMarkAction.cs
@@ -8,35 +8,32 @@ using MUnique.OpenMU.DataModel.Configuration;
 using MUnique.OpenMU.GameLogic.Views.CastleSiege;
 
 /// <summary>
-/// Validates and processes Emblem of Lord submissions.
+/// Validates and processes Sign of Lord submissions.
 /// </summary>
 public class CastleSiegeRegisterMarkAction
 {
-    private const byte EmblemGroup = 14;
-    private const short EmblemNumber = 21;
-    private const byte EmblemLevel = 3;
-
     /// <summary>
-    /// Tries to submit the Emblem of Lord from an inventory slot.
+    /// Tries to submit the Sign of Lord from an inventory slot.
     /// </summary>
     /// <param name="player">The requesting player.</param>
     /// <param name="context">The Castle Siege context, if initialized.</param>
     /// <param name="inventorySlot">The inventory slot.</param>
+    /// <returns>A task which represents the asynchronous operation.</returns>
     public async ValueTask RegisterMarkAsync(Player player, CastleSiegeContext? context, byte inventorySlot)
     {
-        var (success, guildName, marks) = await RegisterMarkCoreAsync(player, context, inventorySlot).ConfigureAwait(false);
+        var (result, guildName, marks) = await RegisterMarkCoreAsync(player, context, inventorySlot).ConfigureAwait(false);
         await player.InvokeViewPlugInAsync<ICastleSiegeMarkRegistrationResultPlugIn>(
-            view => view.ShowMarkRegistrationResultAsync(success, guildName, marks)).ConfigureAwait(false);
+            view => view.ShowMarkRegistrationResultAsync(result, guildName, marks)).ConfigureAwait(false);
     }
 
-    private static async ValueTask<(bool Success, string GuildName, int Marks)> RegisterMarkCoreAsync(
+    private static async ValueTask<(CastleSiegeMarkRegistrationResult Result, string GuildName, int Marks)> RegisterMarkCoreAsync(
         Player player,
         CastleSiegeContext? context,
         byte inventorySlot)
     {
         if (context is not { Configuration.Enabled: true })
         {
-            return (false, string.Empty, 0);
+            return (CastleSiegeMarkRegistrationResult.Failed, string.Empty, 0);
         }
 
         await context.ExecutionLock.WaitAsync().ConfigureAwait(false);
@@ -44,27 +41,31 @@ public class CastleSiegeRegisterMarkAction
         {
             if (context.CurrentState != CastleSiegeState.RegisterMark)
             {
-                return (false, string.Empty, 0);
+                return (CastleSiegeMarkRegistrationResult.Failed, string.Empty, 0);
             }
 
-            var (guild, _) = await CastleSiegeGuildResolver.ResolveAuthorizedGuildAsync(player, context).ConfigureAwait(false);
+            var (guild, _) = await CastleSiegeGuildResolver.ResolveAuthorizedGuildAsync(player).ConfigureAwait(false);
             if (guild is null
                 || !context.RegisteredGuilds.TryGetValue(guild.PersistentId, out var registration))
             {
-                return (false, guild?.Name ?? string.Empty, 0);
+                return (CastleSiegeMarkRegistrationResult.GuildNotRegistered, guild?.Name ?? string.Empty, 0);
             }
 
-            var emblem = player.Inventory?.GetItem(inventorySlot);
-            if (emblem is null
-                || emblem.Definition is not { Group: EmblemGroup, Number: EmblemNumber }
-                || emblem.Level != EmblemLevel)
+            var signOfLord = player.Inventory?.GetItem(inventorySlot);
+            if (signOfLord is null
+                || signOfLord.Definition != context.Configuration.SignOfLordItemDefinition
+                || signOfLord.Level != context.Configuration.SignOfLordItemLevel)
             {
-                return (false, guild.Name, registration.Marks);
+                return (CastleSiegeMarkRegistrationResult.IncorrectItem, guild.Name, registration.Marks);
             }
 
-            await player.DestroyInventoryItemAsync(emblem).ConfigureAwait(false);
-            var marks = await context.IncrementMarksAsync(registration).ConfigureAwait(false);
-            return (true, guild.Name, marks);
+            if (await context.IncrementMarksAsync(registration).ConfigureAwait(false) is not { } marks)
+            {
+                return (CastleSiegeMarkRegistrationResult.GuildNotRegistered, guild.Name, registration.Marks);
+            }
+
+            await player.DestroyInventoryItemAsync(signOfLord).ConfigureAwait(false);
+            return (CastleSiegeMarkRegistrationResult.Success, guild.Name, marks);
         }
         finally
         {

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeRegisterMarkAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeRegisterMarkAction.cs
@@ -1,0 +1,74 @@
+// <copyright file="CastleSiegeRegisterMarkAction.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// Validates and processes Emblem of Lord submissions.
+/// </summary>
+public class CastleSiegeRegisterMarkAction
+{
+    private const byte EmblemGroup = 14;
+    private const short EmblemNumber = 21;
+    private const byte EmblemLevel = 3;
+
+    /// <summary>
+    /// Tries to submit the Emblem of Lord from an inventory slot.
+    /// </summary>
+    /// <param name="player">The requesting player.</param>
+    /// <param name="context">The Castle Siege context, if initialized.</param>
+    /// <param name="inventorySlot">The inventory slot.</param>
+    public async ValueTask RegisterMarkAsync(Player player, CastleSiegeContext? context, byte inventorySlot)
+    {
+        var (success, guildName, marks) = await RegisterMarkCoreAsync(player, context, inventorySlot).ConfigureAwait(false);
+        await player.InvokeViewPlugInAsync<ICastleSiegeMarkRegistrationResultPlugIn>(
+            view => view.ShowMarkRegistrationResultAsync(success, guildName, marks)).ConfigureAwait(false);
+    }
+
+    private static async ValueTask<(bool Success, string GuildName, int Marks)> RegisterMarkCoreAsync(
+        Player player,
+        CastleSiegeContext? context,
+        byte inventorySlot)
+    {
+        if (context is not { Configuration.Enabled: true })
+        {
+            return (false, string.Empty, 0);
+        }
+
+        await context.ExecutionLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (context.CurrentState != CastleSiegeState.RegisterMark)
+            {
+                return (false, string.Empty, 0);
+            }
+
+            var (guild, _) = await CastleSiegeGuildResolver.ResolveAuthorizedGuildAsync(player, context).ConfigureAwait(false);
+            if (guild is null
+                || !context.RegisteredGuilds.TryGetValue(guild.PersistentId, out var registration))
+            {
+                return (false, guild?.Name ?? string.Empty, 0);
+            }
+
+            var emblem = player.Inventory?.GetItem(inventorySlot);
+            if (emblem is null
+                || emblem.Definition is not { Group: EmblemGroup, Number: EmblemNumber }
+                || emblem.Level != EmblemLevel)
+            {
+                return (false, guild.Name, registration.Marks);
+            }
+
+            await player.DestroyInventoryItemAsync(emblem).ConfigureAwait(false);
+            var marks = await context.IncrementMarksAsync(registration).ConfigureAwait(false);
+            return (true, guild.Name, marks);
+        }
+        finally
+        {
+            context.ExecutionLock.Release();
+        }
+    }
+}

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeRegisterMarkAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeRegisterMarkAction.cs
@@ -59,6 +59,8 @@ public class CastleSiegeRegisterMarkAction
                 return (CastleSiegeMarkRegistrationResult.IncorrectItem, guild.Name, registration.Marks);
             }
 
+            // Persist first so a failed registration never consumes the player's item. If item removal fails afterward,
+            // the durable mark is preferred over losing an item without receiving credit.
             if (await context.IncrementMarksAsync(registration).ConfigureAwait(false) is not { } marks)
             {
                 return (CastleSiegeMarkRegistrationResult.GuildNotRegistered, guild.Name, registration.Marks);

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeRegistrationStateAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeRegistrationStateAction.cs
@@ -1,0 +1,57 @@
+// <copyright file="CastleSiegeRegistrationStateAction.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// Returns the Castle Siege registration state visible to a player.
+/// </summary>
+public class CastleSiegeRegistrationStateAction
+{
+    /// <summary>
+    /// Sends the player's guild or alliance registration state.
+    /// </summary>
+    /// <param name="player">The requesting player.</param>
+    /// <param name="context">The Castle Siege context, if initialized.</param>
+    public async ValueTask ShowStateAsync(Player player, CastleSiegeContext? context)
+    {
+        var (result, guildName, marks, registrationRank) = await GetStateAsync(player, context).ConfigureAwait(false);
+        await player.InvokeViewPlugInAsync<ICastleSiegeRegistrationStatePlugIn>(
+            view => view.ShowRegistrationStateAsync(result, guildName, marks, false, registrationRank)).ConfigureAwait(false);
+    }
+
+    private static async ValueTask<(
+        CastleSiegeRegistrationStateResult Result,
+        string GuildName,
+        int Marks,
+        byte RegistrationRank)> GetStateAsync(
+        Player player,
+        CastleSiegeContext? context)
+    {
+        if (context is not { Configuration.Enabled: true })
+        {
+            return (CastleSiegeRegistrationStateResult.Unavailable, string.Empty, 0, 0);
+        }
+
+        await context.ExecutionLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            var guild = await CastleSiegeGuildResolver.ResolveRegistrationGuildAsync(player, context).ConfigureAwait(false);
+            return guild is not null
+                   && context.RegisteredGuilds.TryGetValue(guild.PersistentId, out var registration)
+                ? (
+                    CastleSiegeRegistrationStateResult.Registered,
+                    registration.GuildName,
+                    registration.Marks,
+                    checked((byte)Math.Min(registration.RegistrationOrder, byte.MaxValue)))
+                : (CastleSiegeRegistrationStateResult.NotRegistered, string.Empty, 0, (byte)0);
+        }
+        finally
+        {
+            context.ExecutionLock.Release();
+        }
+    }
+}

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeRegistrationStateAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeRegistrationStateAction.cs
@@ -16,6 +16,7 @@ public class CastleSiegeRegistrationStateAction
     /// </summary>
     /// <param name="player">The requesting player.</param>
     /// <param name="context">The Castle Siege context, if initialized.</param>
+    /// <returns>A task which represents the asynchronous operation.</returns>
     public async ValueTask ShowStateAsync(Player player, CastleSiegeContext? context)
     {
         var (result, guildName, marks, registrationRank) = await GetStateAsync(player, context).ConfigureAwait(false);
@@ -39,15 +40,20 @@ public class CastleSiegeRegistrationStateAction
         await context.ExecutionLock.WaitAsync().ConfigureAwait(false);
         try
         {
-            var guild = await CastleSiegeGuildResolver.ResolveRegistrationGuildAsync(player, context).ConfigureAwait(false);
-            return guild is not null
-                   && context.RegisteredGuilds.TryGetValue(guild.PersistentId, out var registration)
-                ? (
-                    CastleSiegeRegistrationStateResult.Registered,
-                    registration.GuildName,
-                    registration.Marks,
-                    checked((byte)Math.Min(registration.RegistrationOrder, byte.MaxValue)))
-                : (CastleSiegeRegistrationStateResult.NotRegistered, string.Empty, 0, (byte)0);
+            var guildId = await CastleSiegeGuildResolver.ResolveRegistrationGuildIdAsync(player).ConfigureAwait(false);
+            if (guildId is null
+                || !context.RegisteredGuilds.TryGetValue(guildId.Value, out var registration))
+            {
+                return (CastleSiegeRegistrationStateResult.NotRegistered, string.Empty, 0, (byte)0);
+            }
+
+            // MuMain carries the rank in one byte, so later registrations use the highest representable rank.
+            var registrationRank = (byte)Math.Min(registration.RegistrationOrder, byte.MaxValue);
+            return (
+                CastleSiegeRegistrationStateResult.Registered,
+                registration.GuildName,
+                registration.Marks,
+                registrationRank);
         }
         finally
         {

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeUnregisterGuildAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeUnregisterGuildAction.cs
@@ -18,6 +18,7 @@ public class CastleSiegeUnregisterGuildAction
     /// <param name="player">The requesting player.</param>
     /// <param name="context">The Castle Siege context, if initialized.</param>
     /// <param name="isGivingUp">Whether the guild requests to give up its registration.</param>
+    /// <returns>A task which represents the asynchronous operation.</returns>
     public async ValueTask UnregisterAsync(
         Player player,
         CastleSiegeContext? context,
@@ -45,9 +46,10 @@ public class CastleSiegeUnregisterGuildAction
                 return (CastleSiegeUnregistrationResult.WrongState, string.Empty);
             }
 
-            var (guild, _) = await CastleSiegeGuildResolver.ResolveAuthorizedGuildAsync(player, context).ConfigureAwait(false);
+            var (guild, _) = await CastleSiegeGuildResolver.ResolveAuthorizedGuildAsync(player).ConfigureAwait(false);
             if (guild is null)
             {
+                // The client protocol has no separate NoGuild or InvalidGuild result for unregistration.
                 return (CastleSiegeUnregistrationResult.Failed, string.Empty);
             }
 

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeUnregisterGuildAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeUnregisterGuildAction.cs
@@ -1,0 +1,67 @@
+// <copyright file="CastleSiegeUnregisterGuildAction.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// Validates and processes Castle Siege guild unregistrations.
+/// </summary>
+public class CastleSiegeUnregisterGuildAction
+{
+    /// <summary>
+    /// Tries to unregister the player's guild or alliance.
+    /// </summary>
+    /// <param name="player">The requesting player.</param>
+    /// <param name="context">The Castle Siege context, if initialized.</param>
+    /// <param name="isGivingUp">Whether the guild requests to give up its registration.</param>
+    public async ValueTask UnregisterAsync(
+        Player player,
+        CastleSiegeContext? context,
+        bool isGivingUp)
+    {
+        var (result, guildName) = await UnregisterCoreAsync(player, context).ConfigureAwait(false);
+        await player.InvokeViewPlugInAsync<ICastleSiegeRegistrationResultPlugIn>(
+            view => view.ShowUnregistrationResultAsync(result, isGivingUp, guildName)).ConfigureAwait(false);
+    }
+
+    private static async ValueTask<(CastleSiegeUnregistrationResult Result, string GuildName)> UnregisterCoreAsync(
+        Player player,
+        CastleSiegeContext? context)
+    {
+        if (context is not { Configuration.Enabled: true })
+        {
+            return (CastleSiegeUnregistrationResult.Failed, string.Empty);
+        }
+
+        await context.ExecutionLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (context.CurrentState != CastleSiegeState.RegisterGuild)
+            {
+                return (CastleSiegeUnregistrationResult.WrongState, string.Empty);
+            }
+
+            var (guild, _) = await CastleSiegeGuildResolver.ResolveAuthorizedGuildAsync(player, context).ConfigureAwait(false);
+            if (guild is null)
+            {
+                return (CastleSiegeUnregistrationResult.Failed, string.Empty);
+            }
+
+            if (!context.RegisteredGuilds.TryGetValue(guild.PersistentId, out var registration))
+            {
+                return (CastleSiegeUnregistrationResult.NotRegistered, guild.Name);
+            }
+
+            await context.RemoveRegistrationAsync(registration).ConfigureAwait(false);
+            return (CastleSiegeUnregistrationResult.Success, guild.Name);
+        }
+        finally
+        {
+            context.ExecutionLock.Release();
+        }
+    }
+}

--- a/src/GameLogic/CastleSiege/CastleSiegeContext.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeContext.cs
@@ -11,6 +11,10 @@ using MUnique.OpenMU.DataModel.Entities;
 /// <summary>
 /// Holds the runtime state of Castle Siege for one game context.
 /// </summary>
+/// <remarks>
+/// Runtime registrations and <see cref="ExecutionLock"/> are scoped to this game context. Deployments which run
+/// multiple game-server processes require external coordination when registrations are changed concurrently.
+/// </remarks>
 public class CastleSiegeContext : IEventStateProvider
 {
     private readonly IGameContext _gameContext;
@@ -255,22 +259,6 @@ public class CastleSiegeContext : IEventStateProvider
     }
 
     /// <summary>
-    /// Resolves the persistent identifier of a guild by its unique name.
-    /// </summary>
-    /// <param name="guildName">The guild name.</param>
-    /// <returns>The persistent identifier, or <see langword="null"/> if the guild was not found.</returns>
-    internal async ValueTask<Guid?> GetPersistentGuildIdAsync(string guildName)
-    {
-        using var context = this._gameContext.PersistenceContextProvider.CreateNewTypedContext(
-            typeof(Guild),
-            false,
-            this._gameContext.Configuration);
-        return (await context.GetAsync<Guild>().ConfigureAwait(false))
-            .FirstOrDefault(guild => string.Equals(guild.Name, guildName, StringComparison.OrdinalIgnoreCase))
-            ?.Id;
-    }
-
-    /// <summary>
     /// Creates and persists a guild registration.
     /// </summary>
     /// <param name="guildId">The persistent guild identifier.</param>
@@ -285,7 +273,9 @@ public class CastleSiegeContext : IEventStateProvider
         var registration = context.CreateNew<CastleSiegeGuildRegistration>();
         registration.GuildId = guildId;
         registration.GuildName = guildName;
-        registration.RegistrationOrder = this.RegisteredGuilds.Count == 0
+
+        // Registration orders stay monotonic for one cycle and are intentionally not compacted after unregistration.
+        registration.RegistrationOrder = this.RegisteredGuilds.IsEmpty
             ? 1
             : this.RegisteredGuilds.Values.Max(entry => entry.RegistrationOrder) + 1;
         await context.SaveChangesAsync().ConfigureAwait(false);
@@ -316,15 +306,19 @@ public class CastleSiegeContext : IEventStateProvider
     /// Increments and persists the submitted mark count.
     /// </summary>
     /// <param name="registration">The registration.</param>
-    /// <returns>The updated mark count.</returns>
-    internal async ValueTask<int> IncrementMarksAsync(CastleSiegeGuildRegistration registration)
+    /// <returns>The updated mark count, or <see langword="null"/> if the registration no longer exists.</returns>
+    internal async ValueTask<int?> IncrementMarksAsync(CastleSiegeGuildRegistration registration)
     {
         using var context = this._gameContext.PersistenceContextProvider.CreateNewTypedContext(
             typeof(CastleSiegeGuildRegistration),
             false,
             this._gameContext.Configuration);
-        var persistentRegistration = await context.GetByIdAsync<CastleSiegeGuildRegistration>(registration.Id).ConfigureAwait(false)
-            ?? throw new InvalidOperationException("The Castle Siege guild registration no longer exists.");
+        if (await context.GetByIdAsync<CastleSiegeGuildRegistration>(registration.Id).ConfigureAwait(false) is not { } persistentRegistration)
+        {
+            this.RegisteredGuilds.TryRemove(registration.GuildId, out _);
+            return null;
+        }
+
         persistentRegistration.Marks++;
         await context.SaveChangesAsync().ConfigureAwait(false);
         registration.Marks = persistentRegistration.Marks;

--- a/src/GameLogic/CastleSiege/CastleSiegeContext.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeContext.cs
@@ -255,6 +255,83 @@ public class CastleSiegeContext : IEventStateProvider
     }
 
     /// <summary>
+    /// Resolves the persistent identifier of a guild by its unique name.
+    /// </summary>
+    /// <param name="guildName">The guild name.</param>
+    /// <returns>The persistent identifier, or <see langword="null"/> if the guild was not found.</returns>
+    internal async ValueTask<Guid?> GetPersistentGuildIdAsync(string guildName)
+    {
+        using var context = this._gameContext.PersistenceContextProvider.CreateNewTypedContext(
+            typeof(Guild),
+            false,
+            this._gameContext.Configuration);
+        return (await context.GetAsync<Guild>().ConfigureAwait(false))
+            .FirstOrDefault(guild => string.Equals(guild.Name, guildName, StringComparison.OrdinalIgnoreCase))
+            ?.Id;
+    }
+
+    /// <summary>
+    /// Creates and persists a guild registration.
+    /// </summary>
+    /// <param name="guildId">The persistent guild identifier.</param>
+    /// <param name="guildName">The guild name.</param>
+    /// <returns>The created registration.</returns>
+    internal async ValueTask<CastleSiegeGuildRegistration> AddRegistrationAsync(Guid guildId, string guildName)
+    {
+        using var context = this._gameContext.PersistenceContextProvider.CreateNewTypedContext(
+            typeof(CastleSiegeGuildRegistration),
+            false,
+            this._gameContext.Configuration);
+        var registration = context.CreateNew<CastleSiegeGuildRegistration>();
+        registration.GuildId = guildId;
+        registration.GuildName = guildName;
+        registration.RegistrationOrder = this.RegisteredGuilds.Count == 0
+            ? 1
+            : this.RegisteredGuilds.Values.Max(entry => entry.RegistrationOrder) + 1;
+        await context.SaveChangesAsync().ConfigureAwait(false);
+        this.RegisteredGuilds[guildId] = registration;
+        return registration;
+    }
+
+    /// <summary>
+    /// Deletes a persisted guild registration.
+    /// </summary>
+    /// <param name="registration">The registration.</param>
+    internal async ValueTask RemoveRegistrationAsync(CastleSiegeGuildRegistration registration)
+    {
+        using var context = this._gameContext.PersistenceContextProvider.CreateNewTypedContext(
+            typeof(CastleSiegeGuildRegistration),
+            false,
+            this._gameContext.Configuration);
+        if (await context.GetByIdAsync<CastleSiegeGuildRegistration>(registration.Id).ConfigureAwait(false) is { } persistentRegistration)
+        {
+            await context.DeleteAsync(persistentRegistration).ConfigureAwait(false);
+            await context.SaveChangesAsync().ConfigureAwait(false);
+        }
+
+        this.RegisteredGuilds.TryRemove(registration.GuildId, out _);
+    }
+
+    /// <summary>
+    /// Increments and persists the submitted mark count.
+    /// </summary>
+    /// <param name="registration">The registration.</param>
+    /// <returns>The updated mark count.</returns>
+    internal async ValueTask<int> IncrementMarksAsync(CastleSiegeGuildRegistration registration)
+    {
+        using var context = this._gameContext.PersistenceContextProvider.CreateNewTypedContext(
+            typeof(CastleSiegeGuildRegistration),
+            false,
+            this._gameContext.Configuration);
+        var persistentRegistration = await context.GetByIdAsync<CastleSiegeGuildRegistration>(registration.Id).ConfigureAwait(false)
+            ?? throw new InvalidOperationException("The Castle Siege guild registration no longer exists.");
+        persistentRegistration.Marks++;
+        await context.SaveChangesAsync().ConfigureAwait(false);
+        registration.Marks = persistentRegistration.Marks;
+        return registration.Marks;
+    }
+
+    /// <summary>
     /// Initializes the context at the state which contains <paramref name="utcNow"/>.
     /// </summary>
     /// <param name="utcNow">The current UTC time.</param>

--- a/src/GameLogic/Views/CastleSiege/CastleSiegeMarkRegistrationResult.cs
+++ b/src/GameLogic/Views/CastleSiege/CastleSiegeMarkRegistrationResult.cs
@@ -1,0 +1,31 @@
+// <copyright file="CastleSiegeMarkRegistrationResult.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// The result of a Sign of Lord registration request.
+/// </summary>
+public enum CastleSiegeMarkRegistrationResult : byte
+{
+    /// <summary>
+    /// The registration failed for an unspecified reason.
+    /// </summary>
+    Failed = 0,
+
+    /// <summary>
+    /// The Sign of Lord was registered successfully.
+    /// </summary>
+    Success = 1,
+
+    /// <summary>
+    /// The guild does not participate in the Castle Siege.
+    /// </summary>
+    GuildNotRegistered = 2,
+
+    /// <summary>
+    /// The selected inventory item is not a Sign of Lord.
+    /// </summary>
+    IncorrectItem = 3,
+}

--- a/src/GameLogic/Views/CastleSiege/CastleSiegeRegistrationResult.cs
+++ b/src/GameLogic/Views/CastleSiege/CastleSiegeRegistrationResult.cs
@@ -1,0 +1,56 @@
+// <copyright file="CastleSiegeRegistrationResult.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// The result of a Castle Siege guild registration request.
+/// </summary>
+public enum CastleSiegeRegistrationResult : byte
+{
+    /// <summary>
+    /// The request failed for an unspecified reason.
+    /// </summary>
+    Failed = 0,
+
+    /// <summary>
+    /// The guild was registered successfully.
+    /// </summary>
+    Success = 1,
+
+    /// <summary>
+    /// The guild is already registered.
+    /// </summary>
+    AlreadyRegistered = 2,
+
+    /// <summary>
+    /// The guild is the current castle defender.
+    /// </summary>
+    IsDefender = 3,
+
+    /// <summary>
+    /// The guild or the requesting guild member is invalid.
+    /// </summary>
+    InvalidGuild = 4,
+
+    /// <summary>
+    /// The player's combined level is insufficient.
+    /// </summary>
+    LevelInsufficient = 5,
+
+    /// <summary>
+    /// The player is not a guild member.
+    /// </summary>
+    NoGuild = 6,
+
+    /// <summary>
+    /// Guild registration is currently closed.
+    /// </summary>
+    NotRegistrationPeriod = 7,
+
+    /// <summary>
+    /// The guild has too few members.
+    /// </summary>
+    NotEnoughMembers = 8,
+}

--- a/src/GameLogic/Views/CastleSiege/CastleSiegeRegistrationStateResult.cs
+++ b/src/GameLogic/Views/CastleSiege/CastleSiegeRegistrationStateResult.cs
@@ -1,0 +1,26 @@
+// <copyright file="CastleSiegeRegistrationStateResult.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// The result of a Castle Siege registration-state request.
+/// </summary>
+public enum CastleSiegeRegistrationStateResult : byte
+{
+    /// <summary>
+    /// The guild is not registered.
+    /// </summary>
+    NotRegistered,
+
+    /// <summary>
+    /// The guild is registered.
+    /// </summary>
+    Registered,
+
+    /// <summary>
+    /// The registration state is unavailable.
+    /// </summary>
+    Unavailable,
+}

--- a/src/GameLogic/Views/CastleSiege/CastleSiegeUnregistrationResult.cs
+++ b/src/GameLogic/Views/CastleSiege/CastleSiegeUnregistrationResult.cs
@@ -1,0 +1,31 @@
+// <copyright file="CastleSiegeUnregistrationResult.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// The result of a Castle Siege guild-unregistration request.
+/// </summary>
+public enum CastleSiegeUnregistrationResult : byte
+{
+    /// <summary>
+    /// The request failed.
+    /// </summary>
+    Failed,
+
+    /// <summary>
+    /// The guild was unregistered.
+    /// </summary>
+    Success,
+
+    /// <summary>
+    /// The guild was not registered.
+    /// </summary>
+    NotRegistered,
+
+    /// <summary>
+    /// Guilds cannot unregister during the current state.
+    /// </summary>
+    WrongState,
+}

--- a/src/GameLogic/Views/CastleSiege/ICastleSiegeMarkRegistrationResultPlugIn.cs
+++ b/src/GameLogic/Views/CastleSiege/ICastleSiegeMarkRegistrationResultPlugIn.cs
@@ -1,0 +1,19 @@
+// <copyright file="ICastleSiegeMarkRegistrationResultPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// A view which reports Emblem of Lord submission results.
+/// </summary>
+public interface ICastleSiegeMarkRegistrationResultPlugIn : IViewPlugIn
+{
+    /// <summary>
+    /// Shows the mark registration result.
+    /// </summary>
+    /// <param name="success">Whether an Emblem of Lord was submitted.</param>
+    /// <param name="guildName">The registered guild name.</param>
+    /// <param name="marks">The updated mark count.</param>
+    ValueTask ShowMarkRegistrationResultAsync(bool success, string guildName, int marks);
+}

--- a/src/GameLogic/Views/CastleSiege/ICastleSiegeMarkRegistrationResultPlugIn.cs
+++ b/src/GameLogic/Views/CastleSiege/ICastleSiegeMarkRegistrationResultPlugIn.cs
@@ -5,15 +5,16 @@
 namespace MUnique.OpenMU.GameLogic.Views.CastleSiege;
 
 /// <summary>
-/// A view which reports Emblem of Lord submission results.
+/// A view which reports Sign of Lord submission results.
 /// </summary>
 public interface ICastleSiegeMarkRegistrationResultPlugIn : IViewPlugIn
 {
     /// <summary>
     /// Shows the mark registration result.
     /// </summary>
-    /// <param name="success">Whether an Emblem of Lord was submitted.</param>
+    /// <param name="result">The registration result.</param>
     /// <param name="guildName">The registered guild name.</param>
     /// <param name="marks">The updated mark count.</param>
-    ValueTask ShowMarkRegistrationResultAsync(bool success, string guildName, int marks);
+    /// <returns>A task which represents the asynchronous operation.</returns>
+    ValueTask ShowMarkRegistrationResultAsync(CastleSiegeMarkRegistrationResult result, string guildName, int marks);
 }

--- a/src/GameLogic/Views/CastleSiege/ICastleSiegeRegistrationResultPlugIn.cs
+++ b/src/GameLogic/Views/CastleSiege/ICastleSiegeRegistrationResultPlugIn.cs
@@ -14,6 +14,7 @@ public interface ICastleSiegeRegistrationResultPlugIn : IViewPlugIn
     /// </summary>
     /// <param name="result">The result.</param>
     /// <param name="guildName">The guild name.</param>
+    /// <returns>A task which represents the asynchronous operation.</returns>
     ValueTask ShowRegistrationResultAsync(CastleSiegeRegistrationResult result, string guildName);
 
     /// <summary>
@@ -22,6 +23,7 @@ public interface ICastleSiegeRegistrationResultPlugIn : IViewPlugIn
     /// <param name="result">The result.</param>
     /// <param name="isGivingUp">Whether the guild requested to give up its registration.</param>
     /// <param name="guildName">The guild name.</param>
+    /// <returns>A task which represents the asynchronous operation.</returns>
     ValueTask ShowUnregistrationResultAsync(
         CastleSiegeUnregistrationResult result,
         bool isGivingUp,

--- a/src/GameLogic/Views/CastleSiege/ICastleSiegeRegistrationResultPlugIn.cs
+++ b/src/GameLogic/Views/CastleSiege/ICastleSiegeRegistrationResultPlugIn.cs
@@ -1,0 +1,29 @@
+// <copyright file="ICastleSiegeRegistrationResultPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// A view which reports Castle Siege guild registration results.
+/// </summary>
+public interface ICastleSiegeRegistrationResultPlugIn : IViewPlugIn
+{
+    /// <summary>
+    /// Shows a guild registration result.
+    /// </summary>
+    /// <param name="result">The result.</param>
+    /// <param name="guildName">The guild name.</param>
+    ValueTask ShowRegistrationResultAsync(CastleSiegeRegistrationResult result, string guildName);
+
+    /// <summary>
+    /// Shows a guild unregistration result.
+    /// </summary>
+    /// <param name="result">The result.</param>
+    /// <param name="isGivingUp">Whether the guild requested to give up its registration.</param>
+    /// <param name="guildName">The guild name.</param>
+    ValueTask ShowUnregistrationResultAsync(
+        CastleSiegeUnregistrationResult result,
+        bool isGivingUp,
+        string guildName);
+}

--- a/src/GameLogic/Views/CastleSiege/ICastleSiegeRegistrationStatePlugIn.cs
+++ b/src/GameLogic/Views/CastleSiege/ICastleSiegeRegistrationStatePlugIn.cs
@@ -14,9 +14,10 @@ public interface ICastleSiegeRegistrationStatePlugIn : IViewPlugIn
     /// </summary>
     /// <param name="result">The query result.</param>
     /// <param name="guildName">The registered guild name, or an empty string.</param>
-    /// <param name="marks">The number of submitted Emblems of Lord.</param>
+    /// <param name="marks">The number of submitted Signs of Lord.</param>
     /// <param name="isGivingUp">Whether the guild gave up its registration.</param>
     /// <param name="registrationRank">The registration rank, or zero when not registered.</param>
+    /// <returns>A task which represents the asynchronous operation.</returns>
     ValueTask ShowRegistrationStateAsync(
         CastleSiegeRegistrationStateResult result,
         string guildName,

--- a/src/GameLogic/Views/CastleSiege/ICastleSiegeRegistrationStatePlugIn.cs
+++ b/src/GameLogic/Views/CastleSiege/ICastleSiegeRegistrationStatePlugIn.cs
@@ -1,0 +1,26 @@
+// <copyright file="ICastleSiegeRegistrationStatePlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// A view which reports the registration state of a guild.
+/// </summary>
+public interface ICastleSiegeRegistrationStatePlugIn : IViewPlugIn
+{
+    /// <summary>
+    /// Shows the registration state.
+    /// </summary>
+    /// <param name="result">The query result.</param>
+    /// <param name="guildName">The registered guild name, or an empty string.</param>
+    /// <param name="marks">The number of submitted Emblems of Lord.</param>
+    /// <param name="isGivingUp">Whether the guild gave up its registration.</param>
+    /// <param name="registrationRank">The registration rank, or zero when not registered.</param>
+    ValueTask ShowRegistrationStateAsync(
+        CastleSiegeRegistrationStateResult result,
+        string guildName,
+        int marks,
+        bool isGivingUp,
+        byte registrationRank);
+}

--- a/src/GameServer/MessageHandler/CastleSiege/CastleSiegeGroupHandlerPlugIn.cs
+++ b/src/GameServer/MessageHandler/CastleSiege/CastleSiegeGroupHandlerPlugIn.cs
@@ -1,0 +1,40 @@
+// <copyright file="CastleSiegeGroupHandlerPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.MessageHandler.CastleSiege;
+
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Packet handler for Castle Siege packets with the 0xB2 identifier.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeGroupHandlerPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeGroupHandlerPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("2438FBA6-4962-4BC7-8784-69F89AB53D8F")]
+internal class CastleSiegeGroupHandlerPlugIn : GroupPacketHandlerPlugIn
+{
+    /// <summary>
+    /// The group key.
+    /// </summary>
+    internal const byte GroupKey = 0xB2;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeGroupHandlerPlugIn"/> class.
+    /// </summary>
+    /// <param name="clientVersionProvider">The client version provider.</param>
+    /// <param name="manager">The plugin manager.</param>
+    /// <param name="loggerFactory">The logger factory.</param>
+    public CastleSiegeGroupHandlerPlugIn(IClientVersionProvider clientVersionProvider, PlugInManager manager, ILoggerFactory loggerFactory)
+        : base(clientVersionProvider, manager, loggerFactory)
+    {
+    }
+
+    /// <inheritdoc/>
+    public override bool IsEncryptionExpected => false;
+
+    /// <inheritdoc/>
+    public override byte Key => GroupKey;
+}

--- a/src/GameServer/MessageHandler/CastleSiege/CastleSiegeHandlerContext.cs
+++ b/src/GameServer/MessageHandler/CastleSiege/CastleSiegeHandlerContext.cs
@@ -1,0 +1,29 @@
+// <copyright file="CastleSiegeHandlerContext.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.MessageHandler.CastleSiege;
+
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.CastleSiege;
+using MUnique.OpenMU.GameLogic.PlugIns;
+
+/// <summary>
+/// Resolves the active Castle Siege context for packet handlers.
+/// </summary>
+internal static class CastleSiegeHandlerContext
+{
+    /// <summary>
+    /// Gets the initialized context for a player's game context.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <returns>The Castle Siege context, or <see langword="null"/>.</returns>
+    public static CastleSiegeContext? Get(Player player)
+    {
+        return player.GameContext.PlugInManager
+            .GetActivePlugInsOf<IPeriodicTaskPlugIn>()
+            .OfType<CastleSiegePlugIn>()
+            .FirstOrDefault()
+            ?.GetContext(player.GameContext);
+    }
+}

--- a/src/GameServer/MessageHandler/CastleSiege/CastleSiegeMarkRegistrationHandlerPlugIn.cs
+++ b/src/GameServer/MessageHandler/CastleSiege/CastleSiegeMarkRegistrationHandlerPlugIn.cs
@@ -1,0 +1,61 @@
+// <copyright file="CastleSiegeMarkRegistrationHandlerPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.MessageHandler.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.DataModel;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+using MUnique.OpenMU.Network.Packets.ClientToServer;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Handles Emblem of Lord registration requests.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeMarkRegistrationHandlerPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeMarkRegistrationHandlerPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("676913C3-502D-409D-84FA-6BA283ACF349")]
+[BelongsToGroup(CastleSiegeGroupHandlerPlugIn.GroupKey)]
+internal class CastleSiegeMarkRegistrationHandlerPlugIn : ISubPacketHandlerPlugIn
+{
+    private readonly CastleSiegeRegisterMarkAction _action = new();
+
+    /// <inheritdoc/>
+    public bool IsEncryptionExpected => false;
+
+    /// <inheritdoc/>
+    public byte Key => CastleSiegeMarkRegistration.SubCode;
+
+    /// <inheritdoc/>
+    public ValueTask HandlePacketAsync(Player player, Memory<byte> packet)
+    {
+        CastleSiegeMarkRegistration request = packet;
+        if (!TryGetInventorySlot(request.ItemIndex, out var inventorySlot))
+        {
+            return ValueTask.CompletedTask;
+        }
+
+        return this._action.RegisterMarkAsync(player, CastleSiegeHandlerContext.Get(player), inventorySlot);
+    }
+
+    /// <summary>
+    /// Translates the client-side backpack-grid index to OpenMU's inventory slot, which includes equipment slots.
+    /// </summary>
+    /// <param name="clientItemIndex">The zero-based backpack-grid index sent by the client.</param>
+    /// <param name="inventorySlot">The translated OpenMU inventory slot.</param>
+    /// <returns><see langword="true"/> if the translated slot fits into the packet slot range; otherwise, <see langword="false"/>.</returns>
+    internal static bool TryGetInventorySlot(byte clientItemIndex, out byte inventorySlot)
+    {
+        var translatedSlot = clientItemIndex + InventoryConstants.EquippableSlotsCount;
+        if (translatedSlot > byte.MaxValue)
+        {
+            inventorySlot = default;
+            return false;
+        }
+
+        inventorySlot = (byte)translatedSlot;
+        return true;
+    }
+}

--- a/src/GameServer/MessageHandler/CastleSiege/CastleSiegeMarkRegistrationHandlerPlugIn.cs
+++ b/src/GameServer/MessageHandler/CastleSiege/CastleSiegeMarkRegistrationHandlerPlugIn.cs
@@ -12,7 +12,7 @@ using MUnique.OpenMU.Network.Packets.ClientToServer;
 using MUnique.OpenMU.PlugIns;
 
 /// <summary>
-/// Handles Emblem of Lord registration requests.
+/// Handles Sign of Lord registration requests.
 /// </summary>
 [PlugIn]
 [Display(Name = nameof(PlugInResources.CastleSiegeMarkRegistrationHandlerPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeMarkRegistrationHandlerPlugIn_Description), ResourceType = typeof(PlugInResources))]
@@ -31,6 +31,11 @@ internal class CastleSiegeMarkRegistrationHandlerPlugIn : ISubPacketHandlerPlugI
     /// <inheritdoc/>
     public ValueTask HandlePacketAsync(Player player, Memory<byte> packet)
     {
+        if (packet.Length < CastleSiegeMarkRegistration.Length)
+        {
+            return ValueTask.CompletedTask;
+        }
+
         CastleSiegeMarkRegistration request = packet;
         if (!TryGetInventorySlot(request.ItemIndex, out var inventorySlot))
         {

--- a/src/GameServer/MessageHandler/CastleSiege/CastleSiegeRegistrationHandlerPlugIn.cs
+++ b/src/GameServer/MessageHandler/CastleSiege/CastleSiegeRegistrationHandlerPlugIn.cs
@@ -1,0 +1,35 @@
+// <copyright file="CastleSiegeRegistrationHandlerPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.MessageHandler.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+using MUnique.OpenMU.Network.Packets.ClientToServer;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Handles Castle Siege guild registration requests.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeRegistrationHandlerPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeRegistrationHandlerPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("7315C1FD-EE79-490E-B9ED-E0ECC6E87F37")]
+[BelongsToGroup(CastleSiegeGroupHandlerPlugIn.GroupKey)]
+internal class CastleSiegeRegistrationHandlerPlugIn : ISubPacketHandlerPlugIn
+{
+    private readonly CastleSiegeRegisterGuildAction _action = new();
+
+    /// <inheritdoc/>
+    public bool IsEncryptionExpected => false;
+
+    /// <inheritdoc/>
+    public byte Key => CastleSiegeRegistrationRequest.SubCode;
+
+    /// <inheritdoc/>
+    public ValueTask HandlePacketAsync(Player player, Memory<byte> packet)
+    {
+        return this._action.RegisterAsync(player, CastleSiegeHandlerContext.Get(player));
+    }
+}

--- a/src/GameServer/MessageHandler/CastleSiege/CastleSiegeRegistrationStateHandlerPlugIn.cs
+++ b/src/GameServer/MessageHandler/CastleSiege/CastleSiegeRegistrationStateHandlerPlugIn.cs
@@ -1,0 +1,35 @@
+// <copyright file="CastleSiegeRegistrationStateHandlerPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.MessageHandler.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+using MUnique.OpenMU.Network.Packets.ClientToServer;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Handles Castle Siege registration-state requests.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeRegistrationStateHandlerPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeRegistrationStateHandlerPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("94E8D09A-7DBC-41B0-8A85-CA31F032B0FF")]
+[BelongsToGroup(CastleSiegeGroupHandlerPlugIn.GroupKey)]
+internal class CastleSiegeRegistrationStateHandlerPlugIn : ISubPacketHandlerPlugIn
+{
+    private readonly CastleSiegeRegistrationStateAction _action = new();
+
+    /// <inheritdoc/>
+    public bool IsEncryptionExpected => false;
+
+    /// <inheritdoc/>
+    public byte Key => CastleSiegeRegistrationStateRequest.SubCode;
+
+    /// <inheritdoc/>
+    public ValueTask HandlePacketAsync(Player player, Memory<byte> packet)
+    {
+        return this._action.ShowStateAsync(player, CastleSiegeHandlerContext.Get(player));
+    }
+}

--- a/src/GameServer/MessageHandler/CastleSiege/CastleSiegeUnregisterHandlerPlugIn.cs
+++ b/src/GameServer/MessageHandler/CastleSiege/CastleSiegeUnregisterHandlerPlugIn.cs
@@ -1,0 +1,39 @@
+// <copyright file="CastleSiegeUnregisterHandlerPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.MessageHandler.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+using MUnique.OpenMU.Network.Packets.ClientToServer;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Handles Castle Siege guild unregistration requests.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeUnregisterHandlerPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeUnregisterHandlerPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("F8DFF1B0-1DDA-4988-AAC4-65004A7FF087")]
+[BelongsToGroup(CastleSiegeGroupHandlerPlugIn.GroupKey)]
+internal class CastleSiegeUnregisterHandlerPlugIn : ISubPacketHandlerPlugIn
+{
+    private readonly CastleSiegeUnregisterGuildAction _action = new();
+
+    /// <inheritdoc/>
+    public bool IsEncryptionExpected => false;
+
+    /// <inheritdoc/>
+    public byte Key => CastleSiegeUnregisterRequest.SubCode;
+
+    /// <inheritdoc/>
+    public ValueTask HandlePacketAsync(Player player, Memory<byte> packet)
+    {
+        var request = new CastleSiegeUnregisterRequest(packet);
+        return this._action.UnregisterAsync(
+            player,
+            CastleSiegeHandlerContext.Get(player),
+            request.IsGivingUp);
+    }
+}

--- a/src/GameServer/Properties/PlugInResources.Designer.cs
+++ b/src/GameServer/Properties/PlugInResources.Designer.cs
@@ -617,6 +617,96 @@ namespace MUnique.OpenMU.GameServer.Properties {
                 return ResourceManager.GetString("CancelGuildCreationHandlerPlugIn_Name", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Routes Castle Siege packet subcodes..
+        /// </summary>
+        public static string CastleSiegeGroupHandlerPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeGroupHandlerPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege Packet Group Handler.
+        /// </summary>
+        public static string CastleSiegeGroupHandlerPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeGroupHandlerPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Handles Castle Siege Emblem of Lord registration requests..
+        /// </summary>
+        public static string CastleSiegeMarkRegistrationHandlerPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeMarkRegistrationHandlerPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege Mark Registration Handler.
+        /// </summary>
+        public static string CastleSiegeMarkRegistrationHandlerPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeMarkRegistrationHandlerPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Handles Castle Siege guild registration requests..
+        /// </summary>
+        public static string CastleSiegeRegistrationHandlerPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeRegistrationHandlerPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege Registration Handler.
+        /// </summary>
+        public static string CastleSiegeRegistrationHandlerPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeRegistrationHandlerPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Handles Castle Siege registration-state requests..
+        /// </summary>
+        public static string CastleSiegeRegistrationStateHandlerPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeRegistrationStateHandlerPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege Registration State Handler.
+        /// </summary>
+        public static string CastleSiegeRegistrationStateHandlerPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeRegistrationStateHandlerPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Handles Castle Siege guild unregistration requests..
+        /// </summary>
+        public static string CastleSiegeUnregisterHandlerPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeUnregisterHandlerPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege Unregister Handler.
+        /// </summary>
+        public static string CastleSiegeUnregisterHandlerPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeUnregisterHandlerPlugIn_Name", resourceCulture);
+            }
+        }
         
         /// <summary>
         ///   Looks up a localized string similar to Handler for online state change packets..

--- a/src/GameServer/Properties/PlugInResources.Designer.cs
+++ b/src/GameServer/Properties/PlugInResources.Designer.cs
@@ -637,7 +637,7 @@ namespace MUnique.OpenMU.GameServer.Properties {
         }
 
         /// <summary>
-        ///   Looks up a localized string similar to Handles Castle Siege Emblem of Lord registration requests..
+        ///   Looks up a localized string similar to Handles Castle Siege Sign of Lord registration requests..
         /// </summary>
         public static string CastleSiegeMarkRegistrationHandlerPlugIn_Description {
             get {
@@ -651,6 +651,24 @@ namespace MUnique.OpenMU.GameServer.Properties {
         public static string CastleSiegeMarkRegistrationHandlerPlugIn_Name {
             get {
                 return ResourceManager.GetString("CastleSiegeMarkRegistrationHandlerPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Sends Sign of Lord registration results to the game client..
+        /// </summary>
+        public static string CastleSiegeMarkRegistrationResultPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeMarkRegistrationResultPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege Mark Registration View.
+        /// </summary>
+        public static string CastleSiegeMarkRegistrationResultPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeMarkRegistrationResultPlugIn_Name", resourceCulture);
             }
         }
 
@@ -673,6 +691,24 @@ namespace MUnique.OpenMU.GameServer.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Sends Castle Siege registration results to the game client..
+        /// </summary>
+        public static string CastleSiegeRegistrationResultPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeRegistrationResultPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege Registration Result View.
+        /// </summary>
+        public static string CastleSiegeRegistrationResultPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeRegistrationResultPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Handles Castle Siege registration-state requests..
         /// </summary>
         public static string CastleSiegeRegistrationStateHandlerPlugIn_Description {
@@ -687,6 +723,24 @@ namespace MUnique.OpenMU.GameServer.Properties {
         public static string CastleSiegeRegistrationStateHandlerPlugIn_Name {
             get {
                 return ResourceManager.GetString("CastleSiegeRegistrationStateHandlerPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Sends Castle Siege registration state to the game client..
+        /// </summary>
+        public static string CastleSiegeRegistrationStatePlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeRegistrationStatePlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege Registration State View.
+        /// </summary>
+        public static string CastleSiegeRegistrationStatePlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeRegistrationStatePlugIn_Name", resourceCulture);
             }
         }
 

--- a/src/GameServer/Properties/PlugInResources.resx
+++ b/src/GameServer/Properties/PlugInResources.resx
@@ -1975,7 +1975,25 @@
     <value>Castle Siege Mark Registration Handler</value>
   </data>
   <data name="CastleSiegeMarkRegistrationHandlerPlugIn_Description" xml:space="preserve">
-    <value>Handles Castle Siege Emblem of Lord registration requests.</value>
+    <value>Handles Castle Siege Sign of Lord registration requests.</value>
+  </data>
+  <data name="CastleSiegeMarkRegistrationResultPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege Mark Registration View</value>
+  </data>
+  <data name="CastleSiegeMarkRegistrationResultPlugIn_Description" xml:space="preserve">
+    <value>Sends Sign of Lord registration results to the game client.</value>
+  </data>
+  <data name="CastleSiegeRegistrationResultPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege Registration Result View</value>
+  </data>
+  <data name="CastleSiegeRegistrationResultPlugIn_Description" xml:space="preserve">
+    <value>Sends Castle Siege registration results to the game client.</value>
+  </data>
+  <data name="CastleSiegeRegistrationStatePlugIn_Name" xml:space="preserve">
+    <value>Castle Siege Registration State View</value>
+  </data>
+  <data name="CastleSiegeRegistrationStatePlugIn_Description" xml:space="preserve">
+    <value>Sends Castle Siege registration state to the game client.</value>
   </data>
   <data name="CharacterKeyConfigurationPacketHandlerPlugIn_Name" xml:space="preserve">
     <value>Character - Key Configuration</value>

--- a/src/GameServer/Properties/PlugInResources.resx
+++ b/src/GameServer/Properties/PlugInResources.resx
@@ -1947,6 +1947,36 @@
   <data name="CharacterGroupHandlerPlugIn_Description" xml:space="preserve">
     <value>Packet handler for character packets (0xF3 identifier).</value>
   </data>
+  <data name="CastleSiegeGroupHandlerPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege Packet Group Handler</value>
+  </data>
+  <data name="CastleSiegeGroupHandlerPlugIn_Description" xml:space="preserve">
+    <value>Routes Castle Siege packet subcodes.</value>
+  </data>
+  <data name="CastleSiegeRegistrationHandlerPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege Registration Handler</value>
+  </data>
+  <data name="CastleSiegeRegistrationHandlerPlugIn_Description" xml:space="preserve">
+    <value>Handles Castle Siege guild registration requests.</value>
+  </data>
+  <data name="CastleSiegeUnregisterHandlerPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege Unregister Handler</value>
+  </data>
+  <data name="CastleSiegeUnregisterHandlerPlugIn_Description" xml:space="preserve">
+    <value>Handles Castle Siege guild unregistration requests.</value>
+  </data>
+  <data name="CastleSiegeRegistrationStateHandlerPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege Registration State Handler</value>
+  </data>
+  <data name="CastleSiegeRegistrationStateHandlerPlugIn_Description" xml:space="preserve">
+    <value>Handles Castle Siege registration-state requests.</value>
+  </data>
+  <data name="CastleSiegeMarkRegistrationHandlerPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege Mark Registration Handler</value>
+  </data>
+  <data name="CastleSiegeMarkRegistrationHandlerPlugIn_Description" xml:space="preserve">
+    <value>Handles Castle Siege Emblem of Lord registration requests.</value>
+  </data>
   <data name="CharacterKeyConfigurationPacketHandlerPlugIn_Name" xml:space="preserve">
     <value>Character - Key Configuration</value>
   </data>

--- a/src/GameServer/RemoteView/CastleSiege/CastleSiegeMarkRegistrationResultPlugIn.cs
+++ b/src/GameServer/RemoteView/CastleSiege/CastleSiegeMarkRegistrationResultPlugIn.cs
@@ -14,6 +14,7 @@ using MUnique.OpenMU.PlugIns;
 /// which forwards mark registration results to the game client.
 /// </summary>
 [PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeMarkRegistrationResultPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeMarkRegistrationResultPlugIn_Description), ResourceType = typeof(PlugInResources))]
 [Guid("12ED701D-B865-4D2B-B044-445E662BFE0E")]
 public class CastleSiegeMarkRegistrationResultPlugIn : ICastleSiegeMarkRegistrationResultPlugIn
 {
@@ -26,9 +27,9 @@ public class CastleSiegeMarkRegistrationResultPlugIn : ICastleSiegeMarkRegistrat
     public CastleSiegeMarkRegistrationResultPlugIn(RemotePlayer player) => this._player = player;
 
     /// <inheritdoc />
-    public ValueTask ShowMarkRegistrationResultAsync(bool success, string guildName, int marks)
+    public ValueTask ShowMarkRegistrationResultAsync(CastleSiegeMarkRegistrationResult result, string guildName, int marks)
         => this._player.Connection.SendCastleSiegeMarkRegistrationResponseAsync(
-            success ? (byte)1 : (byte)0,
+            (byte)result,
             guildName,
             checked((uint)marks));
 }

--- a/src/GameServer/RemoteView/CastleSiege/CastleSiegeMarkRegistrationResultPlugIn.cs
+++ b/src/GameServer/RemoteView/CastleSiege/CastleSiegeMarkRegistrationResultPlugIn.cs
@@ -1,0 +1,34 @@
+// <copyright file="CastleSiegeMarkRegistrationResultPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.RemoteView.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+using MUnique.OpenMU.Network.Packets.ServerToClient;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// The default implementation of the <see cref="ICastleSiegeMarkRegistrationResultPlugIn"/>
+/// which forwards mark registration results to the game client.
+/// </summary>
+[PlugIn]
+[Guid("12ED701D-B865-4D2B-B044-445E662BFE0E")]
+public class CastleSiegeMarkRegistrationResultPlugIn : ICastleSiegeMarkRegistrationResultPlugIn
+{
+    private readonly RemotePlayer _player;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeMarkRegistrationResultPlugIn"/> class.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    public CastleSiegeMarkRegistrationResultPlugIn(RemotePlayer player) => this._player = player;
+
+    /// <inheritdoc />
+    public ValueTask ShowMarkRegistrationResultAsync(bool success, string guildName, int marks)
+        => this._player.Connection.SendCastleSiegeMarkRegistrationResponseAsync(
+            success ? (byte)1 : (byte)0,
+            guildName,
+            checked((uint)marks));
+}

--- a/src/GameServer/RemoteView/CastleSiege/CastleSiegeRegistrationResultPlugIn.cs
+++ b/src/GameServer/RemoteView/CastleSiege/CastleSiegeRegistrationResultPlugIn.cs
@@ -1,0 +1,41 @@
+// <copyright file="CastleSiegeRegistrationResultPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.RemoteView.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+using MUnique.OpenMU.Network.Packets.ServerToClient;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// The default implementation of the <see cref="ICastleSiegeRegistrationResultPlugIn"/>
+/// which forwards registration results to the game client.
+/// </summary>
+[PlugIn]
+[Guid("1FF48BAE-9F33-4316-B4C0-D6082653C383")]
+public class CastleSiegeRegistrationResultPlugIn : ICastleSiegeRegistrationResultPlugIn
+{
+    private readonly RemotePlayer _player;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeRegistrationResultPlugIn"/> class.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    public CastleSiegeRegistrationResultPlugIn(RemotePlayer player) => this._player = player;
+
+    /// <inheritdoc />
+    public ValueTask ShowRegistrationResultAsync(CastleSiegeRegistrationResult result, string guildName)
+        => this._player.Connection.SendCastleSiegeRegistrationResponseAsync((byte)result, guildName);
+
+    /// <inheritdoc />
+    public ValueTask ShowUnregistrationResultAsync(
+        CastleSiegeUnregistrationResult result,
+        bool isGivingUp,
+        string guildName)
+        => this._player.Connection.SendCastleSiegeUnregisterResponseAsync(
+            (byte)result,
+            isGivingUp,
+            guildName);
+}

--- a/src/GameServer/RemoteView/CastleSiege/CastleSiegeRegistrationResultPlugIn.cs
+++ b/src/GameServer/RemoteView/CastleSiege/CastleSiegeRegistrationResultPlugIn.cs
@@ -14,6 +14,7 @@ using MUnique.OpenMU.PlugIns;
 /// which forwards registration results to the game client.
 /// </summary>
 [PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeRegistrationResultPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeRegistrationResultPlugIn_Description), ResourceType = typeof(PlugInResources))]
 [Guid("1FF48BAE-9F33-4316-B4C0-D6082653C383")]
 public class CastleSiegeRegistrationResultPlugIn : ICastleSiegeRegistrationResultPlugIn
 {

--- a/src/GameServer/RemoteView/CastleSiege/CastleSiegeRegistrationStatePlugIn.cs
+++ b/src/GameServer/RemoteView/CastleSiege/CastleSiegeRegistrationStatePlugIn.cs
@@ -14,6 +14,7 @@ using MUnique.OpenMU.PlugIns;
 /// which forwards registration state to the game client.
 /// </summary>
 [PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeRegistrationStatePlugIn_Name), Description = nameof(PlugInResources.CastleSiegeRegistrationStatePlugIn_Description), ResourceType = typeof(PlugInResources))]
 [Guid("1CE1AF15-92BB-4022-BC71-189C125F4531")]
 public class CastleSiegeRegistrationStatePlugIn : ICastleSiegeRegistrationStatePlugIn
 {

--- a/src/GameServer/RemoteView/CastleSiege/CastleSiegeRegistrationStatePlugIn.cs
+++ b/src/GameServer/RemoteView/CastleSiege/CastleSiegeRegistrationStatePlugIn.cs
@@ -1,0 +1,41 @@
+// <copyright file="CastleSiegeRegistrationStatePlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.RemoteView.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+using MUnique.OpenMU.Network.Packets.ServerToClient;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// The default implementation of the <see cref="ICastleSiegeRegistrationStatePlugIn"/>
+/// which forwards registration state to the game client.
+/// </summary>
+[PlugIn]
+[Guid("1CE1AF15-92BB-4022-BC71-189C125F4531")]
+public class CastleSiegeRegistrationStatePlugIn : ICastleSiegeRegistrationStatePlugIn
+{
+    private readonly RemotePlayer _player;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeRegistrationStatePlugIn"/> class.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    public CastleSiegeRegistrationStatePlugIn(RemotePlayer player) => this._player = player;
+
+    /// <inheritdoc />
+    public ValueTask ShowRegistrationStateAsync(
+        CastleSiegeRegistrationStateResult result,
+        string guildName,
+        int marks,
+        bool isGivingUp,
+        byte registrationRank)
+        => this._player.Connection.SendCastleSiegeRegistrationStateResponseAsync(
+            (byte)result,
+            guildName,
+            checked((uint)marks),
+            isGivingUp,
+            registrationRank);
+}

--- a/src/GuildServer/GuildServer.cs
+++ b/src/GuildServer/GuildServer.cs
@@ -71,6 +71,15 @@ public class GuildServer : IGuildServer
     }
 
     /// <inheritdoc/>
+    public ValueTask<Guid?> GetPersistentGuildIdAsync(uint guildId)
+    {
+        return ValueTask.FromResult(
+            this._guildDictionary.TryGetValue(guildId, out var guild)
+                ? (Guid?)guild.Guild.Id
+                : null);
+    }
+
+    /// <inheritdoc/>
     public async ValueTask<uint> GetGuildIdByNameAsync(string guildName)
     {
         var guild = this._guildDictionary

--- a/src/GuildServer/GuildServer.cs
+++ b/src/GuildServer/GuildServer.cs
@@ -80,6 +80,20 @@ public class GuildServer : IGuildServer
     }
 
     /// <inheritdoc/>
+    public ValueTask<Guid?> GetPersistentAllianceMasterGuildIdAsync(uint guildId)
+    {
+        if (!this._guildDictionary.TryGetValue(guildId, out var guild))
+        {
+            return ValueTask.FromResult<Guid?>(null);
+        }
+
+        return ValueTask.FromResult<Guid?>(
+            guild.Guild.AllianceGuild is Guild allianceMaster
+                ? allianceMaster.Id
+                : guild.Guild.Id);
+    }
+
+    /// <inheritdoc/>
     public async ValueTask<uint> GetGuildIdByNameAsync(string guildName)
     {
         var guild = this._guildDictionary

--- a/src/Interfaces/IGuildServer.cs
+++ b/src/Interfaces/IGuildServer.cs
@@ -98,6 +98,13 @@ public interface IGuildServer
     ValueTask<Guild?> GetGuildAsync(uint guildId);
 
     /// <summary>
+    /// Gets the persistent identifier of a guild by its runtime identifier.
+    /// </summary>
+    /// <param name="guildId">The runtime guild identifier.</param>
+    /// <returns>The persistent guild identifier, or <see langword="null"/> if the guild was not found.</returns>
+    ValueTask<Guid?> GetPersistentGuildIdAsync(uint guildId);
+
+    /// <summary>
     /// Gets the guild id by the guild name.
     /// </summary>
     /// <param name="guildName">The guild name.</param>

--- a/src/Interfaces/IGuildServer.cs
+++ b/src/Interfaces/IGuildServer.cs
@@ -105,6 +105,16 @@ public interface IGuildServer
     ValueTask<Guid?> GetPersistentGuildIdAsync(uint guildId);
 
     /// <summary>
+    /// Gets the persistent identifier under which a guild participates in an alliance event.
+    /// </summary>
+    /// <param name="guildId">The runtime guild identifier.</param>
+    /// <returns>
+    /// The persistent identifier of the alliance master guild, the guild's own persistent identifier when it has no alliance,
+    /// or <see langword="null"/> if the guild was not found.
+    /// </returns>
+    ValueTask<Guid?> GetPersistentAllianceMasterGuildIdAsync(uint guildId);
+
+    /// <summary>
     /// Gets the guild id by the guild name.
     /// </summary>
     /// <param name="guildName">The guild name.</param>

--- a/src/Persistence/BasicModel/CastleSiegeConfiguration.Generated.cs
+++ b/src/Persistence/BasicModel/CastleSiegeConfiguration.Generated.cs
@@ -215,6 +215,24 @@ public partial class CastleSiegeConfiguration : MUnique.OpenMU.DataModel.Configu
     }
 
     /// <summary>
+    /// Gets the raw object of <see cref="SignOfLordItemDefinition" />.
+    /// </summary>
+    [System.Text.Json.Serialization.JsonPropertyName("signOfLordItemDefinition")]
+    public ItemDefinition RawSignOfLordItemDefinition
+    {
+        get => base.SignOfLordItemDefinition as ItemDefinition;
+        set => base.SignOfLordItemDefinition = value;
+    }
+
+    /// <inheritdoc/>
+    [System.Text.Json.Serialization.JsonIgnore]
+    public override MUnique.OpenMU.DataModel.Configuration.Items.ItemDefinition SignOfLordItemDefinition
+    {
+        get => base.SignOfLordItemDefinition;
+        set => base.SignOfLordItemDefinition = value;
+    }
+
+    /// <summary>
     /// Gets the raw object of <see cref="CastleSiegeMapDefinition" />.
     /// </summary>
     [System.Text.Json.Serialization.JsonPropertyName("castleSiegeMapDefinition")]

--- a/src/Persistence/EntityFramework/Extensions/ModelBuilder/CastleSiegeExtensions.cs
+++ b/src/Persistence/EntityFramework/Extensions/ModelBuilder/CastleSiegeExtensions.cs
@@ -22,6 +22,7 @@ internal static class CastleSiegeExtensions
         builder.Property(configuration => configuration.CrownHoldTimeSeconds).HasDefaultValue(30);
         builder.Property(configuration => configuration.RegisterMinLevel).HasDefaultValue(200);
         builder.Property(configuration => configuration.RegisterMinMembers).HasDefaultValue(20);
+        builder.Property(configuration => configuration.SignOfLordItemLevel).HasDefaultValue((byte)3);
         builder.Property(configuration => configuration.MaxAttackingGuilds).HasDefaultValue(3);
 
         builder.HasOne(configuration => configuration.RawCastleSiegeMapDefinition)
@@ -31,6 +32,9 @@ internal static class CastleSiegeExtensions
             .WithMany()
             .OnDelete(DeleteBehavior.Restrict);
         builder.HasOne(configuration => configuration.RawRewardItemDefinition)
+            .WithMany()
+            .OnDelete(DeleteBehavior.Restrict);
+        builder.HasOne(configuration => configuration.RawSignOfLordItemDefinition)
             .WithMany()
             .OnDelete(DeleteBehavior.Restrict);
     }

--- a/src/Persistence/EntityFramework/Migrations/20260806161456_ConfigureCastleSiegeRegistration.Designer.cs
+++ b/src/Persistence/EntityFramework/Migrations/20260806161456_ConfigureCastleSiegeRegistration.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MUnique.OpenMU.Persistence.EntityFramework;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
     [DbContext(typeof(EntityDataContext))]
-    partial class EntityDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260806161456_ConfigureCastleSiegeRegistration")]
+    partial class ConfigureCastleSiegeRegistration
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Persistence/EntityFramework/Migrations/20260806161456_ConfigureCastleSiegeRegistration.cs
+++ b/src/Persistence/EntityFramework/Migrations/20260806161456_ConfigureCastleSiegeRegistration.cs
@@ -1,0 +1,74 @@
+// <copyright file="20260806161456_ConfigureCastleSiegeRegistration.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+#nullable disable
+
+namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
+{
+    using System;
+    using Microsoft.EntityFrameworkCore.Migrations;
+
+    /// <inheritdoc />
+    public partial class ConfigureCastleSiegeRegistration : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "SignOfLordItemDefinitionId",
+                schema: "config",
+                table: "CastleSiegeConfiguration",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<byte>(
+                name: "SignOfLordItemLevel",
+                schema: "config",
+                table: "CastleSiegeConfiguration",
+                type: "smallint",
+                nullable: false,
+                defaultValue: (byte)3);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_CastleSiegeConfiguration_SignOfLordItemDefinitionId",
+                schema: "config",
+                table: "CastleSiegeConfiguration",
+                column: "SignOfLordItemDefinitionId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_CastleSiegeConfiguration_ItemDefinition_SignOfLordItemDefin~",
+                schema: "config",
+                table: "CastleSiegeConfiguration",
+                column: "SignOfLordItemDefinitionId",
+                principalSchema: "config",
+                principalTable: "ItemDefinition",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_CastleSiegeConfiguration_ItemDefinition_SignOfLordItemDefin~",
+                schema: "config",
+                table: "CastleSiegeConfiguration");
+
+            migrationBuilder.DropIndex(
+                name: "IX_CastleSiegeConfiguration_SignOfLordItemDefinitionId",
+                schema: "config",
+                table: "CastleSiegeConfiguration");
+
+            migrationBuilder.DropColumn(
+                name: "SignOfLordItemDefinitionId",
+                schema: "config",
+                table: "CastleSiegeConfiguration");
+
+            migrationBuilder.DropColumn(
+                name: "SignOfLordItemLevel",
+                schema: "config",
+                table: "CastleSiegeConfiguration");
+        }
+    }
+}

--- a/src/Persistence/EntityFramework/Model/CastleSiegeConfiguration.Generated.cs
+++ b/src/Persistence/EntityFramework/Model/CastleSiegeConfiguration.Generated.cs
@@ -110,6 +110,32 @@ internal partial class CastleSiegeConfiguration : MUnique.OpenMU.DataModel.Confi
     public override ICollection<MUnique.OpenMU.DataModel.Configuration.CastleSiegeZoneDefinition> DefenseMachineZones => base.DefenseMachineZones ??= new CollectionAdapter<MUnique.OpenMU.DataModel.Configuration.CastleSiegeZoneDefinition, CastleSiegeZoneDefinition>(this.RawDefenseMachineZones);
 
     /// <summary>
+    /// Gets or sets the identifier of <see cref="SignOfLordItemDefinition"/>.
+    /// </summary>
+    public Guid? SignOfLordItemDefinitionId { get; set; }
+
+    /// <summary>
+    /// Gets the raw object of <see cref="SignOfLordItemDefinition" />.
+    /// </summary>
+    [ForeignKey(nameof(SignOfLordItemDefinitionId))]
+    public ItemDefinition RawSignOfLordItemDefinition
+    {
+        get => base.SignOfLordItemDefinition as ItemDefinition;
+        set => base.SignOfLordItemDefinition = value;
+    }
+
+    /// <inheritdoc/>
+    [NotMapped]
+    public override MUnique.OpenMU.DataModel.Configuration.Items.ItemDefinition SignOfLordItemDefinition
+    {
+        get => base.SignOfLordItemDefinition;set
+        {
+            base.SignOfLordItemDefinition = value;
+            this.SignOfLordItemDefinitionId = this.RawSignOfLordItemDefinition?.Id;
+        }
+    }
+
+    /// <summary>
     /// Gets or sets the identifier of <see cref="CastleSiegeMapDefinition"/>.
     /// </summary>
     public Guid? CastleSiegeMapDefinitionId { get; set; }

--- a/src/Persistence/Initialization/Updates/ConfigureCastleSiegeRegistrationUpdatePlugIn.cs
+++ b/src/Persistence/Initialization/Updates/ConfigureCastleSiegeRegistrationUpdatePlugIn.cs
@@ -1,0 +1,56 @@
+// <copyright file="ConfigureCastleSiegeRegistrationUpdatePlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Persistence.Initialization.Updates;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.Persistence.Initialization.VersionSeasonSix.Events;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Configures Sign of Lord registration for an existing Season 6 Castle Siege configuration.
+/// </summary>
+[PlugIn]
+[Display(Name = PlugInName, Description = PlugInDescription)]
+[Guid("D91757B1-0C3D-4336-8DEC-20438EDA7F09")]
+public class ConfigureCastleSiegeRegistrationUpdatePlugIn : UpdatePlugInBase
+{
+    /// <summary>
+    /// The plug-in name.
+    /// </summary>
+    internal const string PlugInName = "Configure Castle Siege registration";
+
+    /// <summary>
+    /// The plug-in description.
+    /// </summary>
+    internal const string PlugInDescription = "This update configures the item used for Castle Siege Sign of Lord registration.";
+
+    /// <inheritdoc />
+    public override string Name => PlugInName;
+
+    /// <inheritdoc />
+    public override string Description => PlugInDescription;
+
+    /// <inheritdoc />
+    public override UpdateVersion Version => UpdateVersion.ConfigureCastleSiegeRegistration;
+
+    /// <inheritdoc />
+    public override string DataInitializationKey => VersionSeasonSix.DataInitialization.Id;
+
+    /// <inheritdoc />
+    public override bool IsMandatory => true;
+
+    /// <inheritdoc />
+    public override DateTime CreatedAt => new(2026, 08, 06, 14, 30, 0, DateTimeKind.Utc);
+
+    /// <inheritdoc />
+    protected override ValueTask ApplyAsync(IContext context, GameConfiguration gameConfiguration)
+    {
+        var configuration = gameConfiguration.CastleSiegeConfiguration
+            ?? throw new InvalidOperationException("The Castle Siege configuration does not exist.");
+        new CastleSiegeInitializer(context, gameConfiguration).InitializeRegistration(configuration);
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Persistence/Initialization/Updates/UpdateVersion.cs
+++ b/src/Persistence/Initialization/Updates/UpdateVersion.cs
@@ -513,4 +513,9 @@ public enum UpdateVersion
     /// The version of the <see cref="FinishSummonerMasterTreePlugIn"/>.
     /// </summary>
     FinishSummonerMasterTree = 101,
+
+    /// <summary>
+    /// The version of the <see cref="ConfigureCastleSiegeRegistrationUpdatePlugIn"/>.
+    /// </summary>
+    ConfigureCastleSiegeRegistration = 102,
 }

--- a/src/Persistence/Initialization/VersionSeasonSix/Events/CastleSiegeInitializer.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Events/CastleSiegeInitializer.cs
@@ -80,8 +80,18 @@ internal sealed class CastleSiegeInitializer : InitializerBase
     /// <param name="configuration">The Castle Siege configuration.</param>
     internal void InitializeRegistration(CastleSiegeConfiguration configuration)
     {
-        var itemDefinition = this.GameConfiguration.Items.Single(
+        if (configuration.SignOfLordItemDefinition is not null)
+        {
+            return;
+        }
+
+        var itemDefinition = this.GameConfiguration.Items.SingleOrDefault(
             item => item.Group == SignOfLordItemGroup && item.Number == SignOfLordItemNumber);
+        if (itemDefinition is null)
+        {
+            return;
+        }
+
         itemDefinition.MaximumItemLevel = Math.Max(itemDefinition.MaximumItemLevel, SignOfLordItemLevel);
         configuration.SignOfLordItemDefinition = itemDefinition;
         configuration.SignOfLordItemLevel = SignOfLordItemLevel;

--- a/src/Persistence/Initialization/VersionSeasonSix/Events/CastleSiegeInitializer.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Events/CastleSiegeInitializer.cs
@@ -15,6 +15,9 @@ internal sealed class CastleSiegeInitializer : InitializerBase
 {
     private const short GateMonsterNumber = 277;
     private const short StatueMonsterNumber = 283;
+    private const byte SignOfLordItemGroup = 14;
+    private const short SignOfLordItemNumber = 21;
+    private const byte SignOfLordItemLevel = 3;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CastleSiegeInitializer"/> class.
@@ -41,6 +44,7 @@ internal sealed class CastleSiegeInitializer : InitializerBase
     {
         if (this.GameConfiguration.CastleSiegeConfiguration is { } existingConfiguration)
         {
+            this.InitializeRegistration(existingConfiguration);
             return existingConfiguration;
         }
 
@@ -49,6 +53,7 @@ internal sealed class CastleSiegeInitializer : InitializerBase
         configuration.CrownHoldTimeSeconds = 30;
         configuration.RegisterMinLevel = 200;
         configuration.RegisterMinMembers = 20;
+        this.InitializeRegistration(configuration);
         configuration.ParticipantRewardMinSeconds = 60;
         configuration.MaxAttackingGuilds = 3;
         configuration.GuildScoreCastleSiege = 0;
@@ -67,6 +72,19 @@ internal sealed class CastleSiegeInitializer : InitializerBase
 
         this.GameConfiguration.CastleSiegeConfiguration = configuration;
         return configuration;
+    }
+
+    /// <summary>
+    /// Initializes the item configuration used for Sign of Lord registration.
+    /// </summary>
+    /// <param name="configuration">The Castle Siege configuration.</param>
+    internal void InitializeRegistration(CastleSiegeConfiguration configuration)
+    {
+        var itemDefinition = this.GameConfiguration.Items.Single(
+            item => item.Group == SignOfLordItemGroup && item.Number == SignOfLordItemNumber);
+        itemDefinition.MaximumItemLevel = Math.Max(itemDefinition.MaximumItemLevel, SignOfLordItemLevel);
+        configuration.SignOfLordItemDefinition = itemDefinition;
+        configuration.SignOfLordItemLevel = SignOfLordItemLevel;
     }
 
     /// <summary>

--- a/tests/MUnique.OpenMU.Persistence.Initialization.Tests/TestInitializationWithEfCore.cs
+++ b/tests/MUnique.OpenMU.Persistence.Initialization.Tests/TestInitializationWithEfCore.cs
@@ -345,6 +345,30 @@ internal class TestInitializationWithEfCore
             Assert.That(configuration.SignOfLordItemLevel, Is.EqualTo(3));
             Assert.That(signOfLord.MaximumItemLevel, Is.EqualTo(3));
         });
+
+        var customSignOfLord = gameConfiguration.Items.First(item => item != signOfLord);
+        configuration.SignOfLordItemDefinition = customSignOfLord;
+        configuration.SignOfLordItemLevel = 1;
+        await registrationUpdate.ApplyUpdateAsync(context, gameConfiguration).ConfigureAwait(false);
+        Assert.Multiple(() =>
+        {
+            Assert.That(configuration.SignOfLordItemDefinition, Is.SameAs(customSignOfLord));
+            Assert.That(configuration.SignOfLordItemLevel, Is.EqualTo(1));
+        });
+
+        gameConfiguration.Items.Remove(signOfLord);
+        configuration.SignOfLordItemDefinition = null;
+        configuration.SignOfLordItemLevel = 0;
+        await registrationUpdate.ApplyUpdateAsync(context, gameConfiguration).ConfigureAwait(false);
+        Assert.Multiple(() =>
+        {
+            Assert.That(configuration.SignOfLordItemDefinition, Is.Null);
+            Assert.That(configuration.SignOfLordItemLevel, Is.Zero);
+        });
+
+        gameConfiguration.Items.Add(signOfLord);
+        configuration.SignOfLordItemDefinition = signOfLord;
+        configuration.SignOfLordItemLevel = 3;
     }
 
     private void AssertUpgrades(

--- a/tests/MUnique.OpenMU.Persistence.Initialization.Tests/TestInitializationWithEfCore.cs
+++ b/tests/MUnique.OpenMU.Persistence.Initialization.Tests/TestInitializationWithEfCore.cs
@@ -206,6 +206,10 @@ internal class TestInitializationWithEfCore
             Assert.That(configuration.StatueBuyPrice, Is.EqualTo(4_500_000));
             Assert.That(configuration.CastleSiegeMapDefinition?.Number, Is.EqualTo(30));
             Assert.That(configuration.LandOfTrialsMapDefinition?.Number, Is.EqualTo(31));
+            Assert.That(configuration.SignOfLordItemDefinition?.Group, Is.EqualTo(14));
+            Assert.That(configuration.SignOfLordItemDefinition?.Number, Is.EqualTo(21));
+            Assert.That(configuration.SignOfLordItemDefinition?.MaximumItemLevel, Is.GreaterThanOrEqualTo(3));
+            Assert.That(configuration.SignOfLordItemLevel, Is.EqualTo(3));
             Assert.That(configuration.DefenseRespawnArea, Is.Not.Null);
             Assert.That(configuration.AttackRespawnArea, Is.Not.Null);
         });
@@ -324,6 +328,23 @@ internal class TestInitializationWithEfCore
 
         Assert.That(gameConfiguration.CastleSiegeConfiguration, Is.Not.Null);
         Assert.That(await context.GetAsync<CastleSiegeData>().ConfigureAwait(false), Has.Exactly(1).Items);
+
+        var configuration = gameConfiguration.CastleSiegeConfiguration!;
+        var signOfLord = gameConfiguration.Items.Single(item => item.Group == 14 && item.Number == 21);
+        configuration.SignOfLordItemDefinition = null;
+        configuration.SignOfLordItemLevel = 0;
+        signOfLord.MaximumItemLevel = 0;
+
+        var registrationUpdate = new ConfigureCastleSiegeRegistrationUpdatePlugIn();
+        await registrationUpdate.ApplyUpdateAsync(context, gameConfiguration).ConfigureAwait(false);
+        await registrationUpdate.ApplyUpdateAsync(context, gameConfiguration).ConfigureAwait(false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(configuration.SignOfLordItemDefinition, Is.SameAs(signOfLord));
+            Assert.That(configuration.SignOfLordItemLevel, Is.EqualTo(3));
+            Assert.That(signOfLord.MaximumItemLevel, Is.EqualTo(3));
+        });
     }
 
     private void AssertUpgrades(

--- a/tests/MUnique.OpenMU.Tests/CastleSiegeRegistrationRemoteViewTests.cs
+++ b/tests/MUnique.OpenMU.Tests/CastleSiegeRegistrationRemoteViewTests.cs
@@ -37,7 +37,7 @@ public class CastleSiegeRegistrationRemoteViewTests
                 4)
             .ConfigureAwait(false);
         await new CastleSiegeMarkRegistrationResultPlugIn(player)
-            .ShowMarkRegistrationResultAsync(true, "GuildA", 22)
+            .ShowMarkRegistrationResultAsync(CastleSiegeMarkRegistrationResult.IncorrectItem, "GuildA", 22)
             .ConfigureAwait(false);
 
         var data = output.ToArray().AsMemory();
@@ -75,7 +75,7 @@ public class CastleSiegeRegistrationRemoteViewTests
         var mark = (CastleSiegeMarkRegistrationResponse)data.Slice(
             offset,
             CastleSiegeMarkRegistrationResponse.Length);
-        Assert.That(mark.Result, Is.EqualTo(1));
+        Assert.That(mark.Result, Is.EqualTo((byte)CastleSiegeMarkRegistrationResult.IncorrectItem));
         Assert.That(mark.GuildName, Is.EqualTo("GuildA"));
         Assert.That(mark.GuildMarkCount, Is.EqualTo(22));
     }

--- a/tests/MUnique.OpenMU.Tests/CastleSiegeRegistrationRemoteViewTests.cs
+++ b/tests/MUnique.OpenMU.Tests/CastleSiegeRegistrationRemoteViewTests.cs
@@ -1,0 +1,82 @@
+// <copyright file="CastleSiegeRegistrationRemoteViewTests.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Tests;
+
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+using MUnique.OpenMU.GameServer.RemoteView.CastleSiege;
+using MUnique.OpenMU.Network.Packets.ServerToClient;
+
+/// <summary>
+/// Tests Castle Siege registration remote-view packet serialization.
+/// </summary>
+[TestFixture]
+public class CastleSiegeRegistrationRemoteViewTests
+{
+    /// <summary>
+    /// Verifies registration, unregistration, state and mark response packets.
+    /// </summary>
+    [Test]
+    public async ValueTask SerializeRegistrationResponsesAsync()
+    {
+        var (player, output) = CastleSiegeRemoteViewTestHelper.CreatePlayer();
+
+        await new CastleSiegeRegistrationResultPlugIn(player)
+            .ShowRegistrationResultAsync(CastleSiegeRegistrationResult.AlreadyRegistered, "GuildA")
+            .ConfigureAwait(false);
+        await new CastleSiegeRegistrationResultPlugIn(player)
+            .ShowUnregistrationResultAsync(CastleSiegeUnregistrationResult.Success, true, "GuildA")
+            .ConfigureAwait(false);
+        await new CastleSiegeRegistrationStatePlugIn(player)
+            .ShowRegistrationStateAsync(
+                CastleSiegeRegistrationStateResult.Registered,
+                "GuildA",
+                21,
+                false,
+                4)
+            .ConfigureAwait(false);
+        await new CastleSiegeMarkRegistrationResultPlugIn(player)
+            .ShowMarkRegistrationResultAsync(true, "GuildA", 22)
+            .ConfigureAwait(false);
+
+        var data = output.ToArray().AsMemory();
+        Assert.That(
+            data.Length,
+            Is.EqualTo(
+                CastleSiegeRegistrationResponse.Length
+                + CastleSiegeUnregisterResponse.Length
+                + CastleSiegeRegistrationStateResponse.Length
+                + CastleSiegeMarkRegistrationResponse.Length));
+
+        var registration = (CastleSiegeRegistrationResponse)data[..CastleSiegeRegistrationResponse.Length];
+        Assert.That(registration.Result, Is.EqualTo((byte)CastleSiegeRegistrationResult.AlreadyRegistered));
+        Assert.That(registration.GuildName, Is.EqualTo("GuildA"));
+
+        var offset = CastleSiegeRegistrationResponse.Length;
+        var unregistration = (CastleSiegeUnregisterResponse)data.Slice(
+            offset,
+            CastleSiegeUnregisterResponse.Length);
+        Assert.That(unregistration.Result, Is.EqualTo((byte)CastleSiegeUnregistrationResult.Success));
+        Assert.That(unregistration.IsGivingUp, Is.True);
+        Assert.That(unregistration.GuildName, Is.EqualTo("GuildA"));
+
+        offset += CastleSiegeUnregisterResponse.Length;
+        var state = (CastleSiegeRegistrationStateResponse)data.Slice(
+            offset,
+            CastleSiegeRegistrationStateResponse.Length);
+        Assert.That(state.Result, Is.EqualTo((byte)CastleSiegeRegistrationStateResult.Registered));
+        Assert.That(state.GuildName, Is.EqualTo("GuildA"));
+        Assert.That(state.GuildMarkCount, Is.EqualTo(21));
+        Assert.That(state.IsGivingUp, Is.False);
+        Assert.That(state.RegistrationRank, Is.EqualTo(4));
+
+        offset += CastleSiegeRegistrationStateResponse.Length;
+        var mark = (CastleSiegeMarkRegistrationResponse)data.Slice(
+            offset,
+            CastleSiegeMarkRegistrationResponse.Length);
+        Assert.That(mark.Result, Is.EqualTo(1));
+        Assert.That(mark.GuildName, Is.EqualTo("GuildA"));
+        Assert.That(mark.GuildMarkCount, Is.EqualTo(22));
+    }
+}

--- a/tests/MUnique.OpenMU.Tests/CastleSiegeRegistrationTests.cs
+++ b/tests/MUnique.OpenMU.Tests/CastleSiegeRegistrationTests.cs
@@ -1,0 +1,408 @@
+// <copyright file="CastleSiegeRegistrationTests.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Tests;
+
+using System.Collections.Immutable;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.DataModel.Configuration.Items;
+using MUnique.OpenMU.DataModel.Entities;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.Attributes;
+using MUnique.OpenMU.GameLogic.CastleSiege;
+using MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+using MUnique.OpenMU.GameServer;
+using MUnique.OpenMU.GameServer.MessageHandler.CastleSiege;
+using MUnique.OpenMU.Interfaces;
+using MUnique.OpenMU.Persistence;
+using MUnique.OpenMU.Persistence.InMemory;
+using MUnique.OpenMU.PlugIns;
+using BasicModel = MUnique.OpenMU.Persistence.BasicModel;
+using RuntimeGuild = MUnique.OpenMU.Interfaces.Guild;
+
+/// <summary>
+/// Tests Castle Siege guild and Emblem of Lord registration.
+/// </summary>
+[TestFixture]
+public class CastleSiegeRegistrationTests
+{
+    private const uint RuntimeGuildId = 42;
+    private const string GuildName = "TestGuild";
+
+    /// <summary>
+    /// Verifies the protocol result values documented by the Castle Siege registration issue.
+    /// </summary>
+    [Test]
+    public void RegistrationResultValuesMatchProtocol()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That((byte)CastleSiegeRegistrationResult.Failed, Is.Zero);
+            Assert.That((byte)CastleSiegeRegistrationResult.Success, Is.EqualTo(1));
+            Assert.That((byte)CastleSiegeRegistrationResult.AlreadyRegistered, Is.EqualTo(2));
+            Assert.That((byte)CastleSiegeRegistrationResult.IsDefender, Is.EqualTo(3));
+            Assert.That((byte)CastleSiegeRegistrationResult.InvalidGuild, Is.EqualTo(4));
+            Assert.That((byte)CastleSiegeRegistrationResult.LevelInsufficient, Is.EqualTo(5));
+            Assert.That((byte)CastleSiegeRegistrationResult.NoGuild, Is.EqualTo(6));
+            Assert.That((byte)CastleSiegeRegistrationResult.NotRegistrationPeriod, Is.EqualTo(7));
+            Assert.That((byte)CastleSiegeRegistrationResult.NotEnoughMembers, Is.EqualTo(8));
+        });
+    }
+
+    /// <summary>
+    /// Verifies registration validation, persistence, and duplicate detection.
+    /// </summary>
+    [Test]
+    public async ValueTask RegistrationValidatesAndPersistsAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var view = fixture.Player.ViewPlugIns.GetPlugIn<ICastleSiegeRegistrationResultPlugIn>()!;
+        var action = new CastleSiegeRegisterGuildAction();
+
+        await action.RegisterAsync(fixture.Player, fixture.Context).ConfigureAwait(false);
+        Mock.Get(view).Verify(
+            plugIn => plugIn.ShowRegistrationResultAsync(CastleSiegeRegistrationResult.NoGuild, string.Empty),
+            Times.Once);
+
+        fixture.Player.GuildStatus = new GuildMemberStatus(RuntimeGuildId, GuildPosition.NormalMember);
+        await action.RegisterAsync(fixture.Player, fixture.Context).ConfigureAwait(false);
+        Mock.Get(view).Verify(
+            plugIn => plugIn.ShowRegistrationResultAsync(CastleSiegeRegistrationResult.InvalidGuild, string.Empty),
+            Times.Once);
+
+        fixture.Player.GuildStatus = new GuildMemberStatus(RuntimeGuildId, GuildPosition.GuildMaster);
+        await action.RegisterAsync(fixture.Player, fixture.Context).ConfigureAwait(false);
+        Mock.Get(view).Verify(
+            plugIn => plugIn.ShowRegistrationResultAsync(CastleSiegeRegistrationResult.LevelInsufficient, GuildName),
+            Times.Once);
+
+        fixture.Player.Attributes![Stats.Level] = 400;
+        fixture.GuildMembers.Clear();
+        await action.RegisterAsync(fixture.Player, fixture.Context).ConfigureAwait(false);
+        Mock.Get(view).Verify(
+            plugIn => plugIn.ShowRegistrationResultAsync(CastleSiegeRegistrationResult.NotEnoughMembers, GuildName),
+            Times.Once);
+
+        fixture.GuildMembers.AddRange([new(), new()]);
+        await action.RegisterAsync(fixture.Player, fixture.Context).ConfigureAwait(false);
+        await action.RegisterAsync(fixture.Player, fixture.Context).ConfigureAwait(false);
+        Mock.Get(view).Verify(
+            plugIn => plugIn.ShowRegistrationResultAsync(CastleSiegeRegistrationResult.Success, GuildName),
+            Times.Once);
+        Mock.Get(view).Verify(
+            plugIn => plugIn.ShowRegistrationResultAsync(CastleSiegeRegistrationResult.AlreadyRegistered, GuildName),
+            Times.Once);
+
+        Assert.That(fixture.Context.RegisteredGuilds, Contains.Key(fixture.PersistentGuildId));
+        Assert.That(fixture.Context.RegisteredGuilds[fixture.PersistentGuildId].RegistrationOrder, Is.EqualTo(1));
+
+        using var persistenceContext = fixture.PersistenceContextProvider.CreateNewTypedContext(
+            typeof(CastleSiegeGuildRegistration),
+            false,
+            fixture.GameConfiguration);
+        var registration = (await persistenceContext.GetAsync<CastleSiegeGuildRegistration>().ConfigureAwait(false)).Single();
+        Assert.That(registration.GuildId, Is.EqualTo(fixture.PersistentGuildId));
+        Assert.That(registration.GuildName, Is.EqualTo(GuildName));
+
+        var restartedContext = new CastleSiegeContext(fixture.GameServerContext, fixture.CastleSiegeConfiguration);
+        await restartedContext.InitializeAsync(new DateTime(2026, 8, 3, 12, 0, 0, DateTimeKind.Utc)).ConfigureAwait(false);
+        Assert.That(restartedContext.RegisteredGuilds, Contains.Key(fixture.PersistentGuildId));
+    }
+
+    /// <summary>
+    /// Verifies the registration-period and defender validation results.
+    /// </summary>
+    [Test]
+    public async ValueTask RegistrationRejectsClosedPeriodAndDefenderAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var view = fixture.Player.ViewPlugIns.GetPlugIn<ICastleSiegeRegistrationResultPlugIn>()!;
+        var action = new CastleSiegeRegisterGuildAction();
+
+        fixture.CastleSiegeConfiguration.Enabled = false;
+        await action.RegisterAsync(fixture.Player, fixture.Context).ConfigureAwait(false);
+        Mock.Get(view).Verify(
+            plugIn => plugIn.ShowRegistrationResultAsync(CastleSiegeRegistrationResult.Failed, string.Empty),
+            Times.Once);
+        fixture.CastleSiegeConfiguration.Enabled = true;
+
+        fixture.Player.GuildStatus = new GuildMemberStatus(RuntimeGuildId, GuildPosition.GuildMaster);
+        fixture.Player.Attributes![Stats.Level] = 400;
+
+        fixture.Context.SetPeriod(fixture.Context.Schedule.GetCurrentPeriod(new DateTime(2026, 8, 4, 12, 0, 0, DateTimeKind.Utc)));
+        await action.RegisterAsync(fixture.Player, fixture.Context).ConfigureAwait(false);
+        Mock.Get(view).Verify(
+            plugIn => plugIn.ShowRegistrationResultAsync(CastleSiegeRegistrationResult.NotRegistrationPeriod, string.Empty),
+            Times.Once);
+
+        fixture.Context.SetPeriod(fixture.Context.Schedule.GetCurrentPeriod(new DateTime(2026, 8, 3, 12, 0, 0, DateTimeKind.Utc)));
+        fixture.Context.SiegeData.OwnerGuildId = fixture.PersistentGuildId;
+        await action.RegisterAsync(fixture.Player, fixture.Context).ConfigureAwait(false);
+        Mock.Get(view).Verify(
+            plugIn => plugIn.ShowRegistrationResultAsync(CastleSiegeRegistrationResult.IsDefender, GuildName),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that unregistration removes both runtime and persistent registration state.
+    /// </summary>
+    [Test]
+    public async ValueTask UnregistrationRemovesPersistentRegistrationAsync()
+    {
+        var fixture = await CreateRegisteredFixtureAsync().ConfigureAwait(false);
+        var view = fixture.Player.ViewPlugIns.GetPlugIn<ICastleSiegeRegistrationResultPlugIn>()!;
+
+        await new CastleSiegeUnregisterGuildAction().UnregisterAsync(fixture.Player, fixture.Context, true).ConfigureAwait(false);
+
+        Mock.Get(view).Verify(
+            plugIn => plugIn.ShowUnregistrationResultAsync(
+                CastleSiegeUnregistrationResult.Success,
+                true,
+                GuildName),
+            Times.Once);
+        Assert.That(fixture.Context.RegisteredGuilds, Is.Empty);
+        using var persistenceContext = fixture.PersistenceContextProvider.CreateNewTypedContext(
+            typeof(CastleSiegeGuildRegistration),
+            false,
+            fixture.GameConfiguration);
+        Assert.That(await persistenceContext.GetAsync<CastleSiegeGuildRegistration>().ConfigureAwait(false), Is.Empty);
+    }
+
+    /// <summary>
+    /// Verifies Emblem validation, consumption, mark persistence, and registration-state queries.
+    /// </summary>
+    [Test]
+    public async ValueTask MarkRegistrationConsumesValidEmblemAndPersistsCountAsync()
+    {
+        const byte itemSlot = 20;
+        var fixture = await CreateRegisteredFixtureAsync().ConfigureAwait(false);
+        fixture.Context.SetPeriod(fixture.Context.Schedule.GetCurrentPeriod(new DateTime(2026, 8, 4, 12, 0, 0, DateTimeKind.Utc)));
+        var markView = fixture.Player.ViewPlugIns.GetPlugIn<ICastleSiegeMarkRegistrationResultPlugIn>()!;
+        var item = fixture.Player.PersistenceContext.CreateNew<Item>();
+        item.Definition = new ItemDefinition
+        {
+            Group = 14,
+            Number = 21,
+            Width = 1,
+            Height = 1,
+        };
+        item.Level = 2;
+        await fixture.Player.Inventory!.AddItemAsync(itemSlot, item).ConfigureAwait(false);
+
+        var action = new CastleSiegeRegisterMarkAction();
+        await action.RegisterMarkAsync(fixture.Player, fixture.Context, itemSlot).ConfigureAwait(false);
+        Mock.Get(markView).Verify(
+            plugIn => plugIn.ShowMarkRegistrationResultAsync(false, GuildName, 0),
+            Times.Once);
+        Assert.That(fixture.Player.Inventory.GetItem(itemSlot), Is.SameAs(item));
+
+        item.Level = 3;
+        await action.RegisterMarkAsync(fixture.Player, fixture.Context, itemSlot).ConfigureAwait(false);
+        Mock.Get(markView).Verify(
+            plugIn => plugIn.ShowMarkRegistrationResultAsync(true, GuildName, 1),
+            Times.Once);
+        Assert.That(fixture.Player.Inventory.GetItem(itemSlot), Is.Null);
+        Assert.That(fixture.Context.RegisteredGuilds[fixture.PersistentGuildId].Marks, Is.EqualTo(1));
+
+        using var persistenceContext = fixture.PersistenceContextProvider.CreateNewTypedContext(
+            typeof(CastleSiegeGuildRegistration),
+            false,
+            fixture.GameConfiguration);
+        var registration = (await persistenceContext.GetAsync<CastleSiegeGuildRegistration>().ConfigureAwait(false)).Single();
+        Assert.That(registration.Marks, Is.EqualTo(1));
+
+        var stateView = fixture.Player.ViewPlugIns.GetPlugIn<ICastleSiegeRegistrationStatePlugIn>()!;
+        await new CastleSiegeRegistrationStateAction().ShowStateAsync(fixture.Player, fixture.Context).ConfigureAwait(false);
+        Mock.Get(stateView).Verify(
+            plugIn => plugIn.ShowRegistrationStateAsync(
+                CastleSiegeRegistrationStateResult.Registered,
+                GuildName,
+                1,
+                false,
+                1),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that alliance members can query, but cannot mutate, the alliance master's registration.
+    /// </summary>
+    [Test]
+    public async ValueTask AllianceMemberUsesMasterRegistrationForQueriesOnlyAsync()
+    {
+        const uint allianceMemberGuildId = 43;
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var allianceMaster = new RuntimeGuild { Name = GuildName };
+        allianceMaster.AllianceGuild = allianceMaster;
+        fixture.GuildServer
+            .Setup(server => server.GetGuildAsync(RuntimeGuildId))
+            .Returns(new ValueTask<RuntimeGuild?>(allianceMaster));
+        fixture.Player.GuildStatus = new GuildMemberStatus(RuntimeGuildId, GuildPosition.GuildMaster);
+        fixture.Player.Attributes![Stats.Level] = 400;
+
+        var registrationView = fixture.Player.ViewPlugIns.GetPlugIn<ICastleSiegeRegistrationResultPlugIn>()!;
+        await new CastleSiegeRegisterGuildAction().RegisterAsync(fixture.Player, fixture.Context).ConfigureAwait(false);
+        Mock.Get(registrationView).Verify(
+            plugIn => plugIn.ShowRegistrationResultAsync(CastleSiegeRegistrationResult.Success, GuildName),
+            Times.Once);
+
+        var allianceMember = new RuntimeGuild { Name = "Member", AllianceGuild = allianceMaster };
+        fixture.GuildServer
+            .Setup(server => server.GetGuildAsync(allianceMemberGuildId))
+            .Returns(new ValueTask<RuntimeGuild?>(allianceMember));
+        fixture.GuildServer
+            .Setup(server => server.IsAllianceMasterAsync(allianceMemberGuildId))
+            .Returns(new ValueTask<bool>(false));
+        fixture.Player.GuildStatus = new GuildMemberStatus(allianceMemberGuildId, GuildPosition.GuildMaster);
+
+        await new CastleSiegeRegisterGuildAction().RegisterAsync(fixture.Player, fixture.Context).ConfigureAwait(false);
+        Mock.Get(registrationView).Verify(
+            plugIn => plugIn.ShowRegistrationResultAsync(CastleSiegeRegistrationResult.InvalidGuild, string.Empty),
+            Times.Once);
+
+        var stateView = fixture.Player.ViewPlugIns.GetPlugIn<ICastleSiegeRegistrationStatePlugIn>()!;
+        await new CastleSiegeRegistrationStateAction().ShowStateAsync(fixture.Player, fixture.Context).ConfigureAwait(false);
+        Mock.Get(stateView).Verify(
+            plugIn => plugIn.ShowRegistrationStateAsync(
+                CastleSiegeRegistrationStateResult.Registered,
+                GuildName,
+                0,
+                false,
+                1),
+            Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies the four client request subcodes handled by this issue.
+    /// </summary>
+    [Test]
+    public void RequestHandlersUseExpectedSubcodes()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(new CastleSiegeRegistrationHandlerPlugIn().Key, Is.EqualTo(0x01));
+            Assert.That(new CastleSiegeUnregisterHandlerPlugIn().Key, Is.EqualTo(0x02));
+            Assert.That(new CastleSiegeRegistrationStateHandlerPlugIn().Key, Is.EqualTo(0x03));
+            Assert.That(new CastleSiegeMarkRegistrationHandlerPlugIn().Key, Is.EqualTo(0x04));
+        });
+    }
+
+    /// <summary>
+    /// Verifies that the zero-based backpack-grid index sent by MuMain is translated past the equipment slots.
+    /// </summary>
+    [Test]
+    public void MarkRegistrationHandlerTranslatesClientBackpackIndex()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(CastleSiegeMarkRegistrationHandlerPlugIn.TryGetInventorySlot(8, out var inventorySlot), Is.True);
+            Assert.That(inventorySlot, Is.EqualTo(20));
+            Assert.That(CastleSiegeMarkRegistrationHandlerPlugIn.TryGetInventorySlot(byte.MaxValue, out _), Is.False);
+        });
+    }
+
+    private static async ValueTask<TestFixture> CreateRegisteredFixtureAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        fixture.Player.GuildStatus = new GuildMemberStatus(RuntimeGuildId, GuildPosition.GuildMaster);
+        fixture.Player.Attributes![Stats.Level] = 400;
+        await new CastleSiegeRegisterGuildAction().RegisterAsync(fixture.Player, fixture.Context).ConfigureAwait(false);
+        return fixture;
+    }
+
+    private static async ValueTask<TestFixture> CreateFixtureAsync()
+    {
+        var persistenceContextProvider = new InMemoryPersistenceContextProvider();
+        BasicModel.GameConfiguration gameConfiguration;
+        BasicModel.CastleSiegeConfiguration castleSiegeConfiguration;
+        Guid persistentGuildId;
+        using (var persistenceContext = persistenceContextProvider.CreateNewContext())
+        {
+            gameConfiguration = persistenceContext.CreateNew<BasicModel.GameConfiguration>();
+            gameConfiguration.Maps.Add(new BasicModel.GameMapDefinition());
+            castleSiegeConfiguration = persistenceContext.CreateNew<BasicModel.CastleSiegeConfiguration>();
+            castleSiegeConfiguration.Enabled = true;
+            castleSiegeConfiguration.RegisterMinLevel = 200;
+            castleSiegeConfiguration.RegisterMinMembers = 2;
+            castleSiegeConfiguration.StateSchedule.Add(new BasicModel.CastleSiegeStateScheduleEntry
+            {
+                State = CastleSiegeState.RegisterGuild,
+                DayOfWeek = DayOfWeek.Monday,
+            });
+            castleSiegeConfiguration.StateSchedule.Add(new BasicModel.CastleSiegeStateScheduleEntry
+            {
+                State = CastleSiegeState.RegisterMark,
+                DayOfWeek = DayOfWeek.Tuesday,
+            });
+            gameConfiguration.CastleSiegeConfiguration = castleSiegeConfiguration;
+            persistenceContext.CreateNew<CastleSiegeData>();
+            var persistentGuild = persistenceContext.CreateNew<MUnique.OpenMU.DataModel.Entities.Guild>();
+            persistentGuild.Name = GuildName;
+            persistentGuildId = persistentGuild.Id;
+            await persistenceContext.SaveChangesAsync().ConfigureAwait(false);
+        }
+
+        var guildMembers = new List<GuildListEntry> { new(), new() };
+        var guildServer = new Mock<IGuildServer>();
+        guildServer
+            .Setup(server => server.GetGuildAsync(RuntimeGuildId))
+            .Returns(new ValueTask<RuntimeGuild?>(new RuntimeGuild { Name = GuildName }));
+        guildServer
+            .Setup(server => server.GetGuildListAsync(RuntimeGuildId))
+            .Returns(() => new ValueTask<IImmutableList<GuildListEntry>>(guildMembers.ToImmutableList()));
+        guildServer
+            .Setup(server => server.IsAllianceMasterAsync(RuntimeGuildId))
+            .Returns(new ValueTask<bool>(true));
+        guildServer
+            .Setup(server => server.GetGuildIdByNameAsync(GuildName))
+            .Returns(new ValueTask<uint>(RuntimeGuildId));
+
+        var mapInitializer = new MapInitializer(gameConfiguration, new NullLogger<MapInitializer>(), NullDropGenerator.Instance, null);
+        var gameServerContext = new GameServerContext(
+            new BasicModel.GameServerDefinition
+            {
+                GameConfiguration = gameConfiguration,
+                ServerConfiguration = new BasicModel.GameServerConfiguration(),
+            },
+            guildServer.Object,
+            new Mock<IEventPublisher>().Object,
+            new Mock<ILoginServer>().Object,
+            new Mock<IFriendServer>().Object,
+            persistenceContextProvider,
+            mapInitializer,
+            NullLoggerFactory.Instance,
+            new PlugInManager([], NullLoggerFactory.Instance, null, null),
+            NullDropGenerator.Instance,
+            new ConfigurationChangeMediator());
+        mapInitializer.PlugInManager = gameServerContext.PlugInManager;
+        mapInitializer.PathFinderPool = gameServerContext.PathFinderPool;
+
+        var player = await PlayerTestHelper.CreatePlayerAsync(gameServerContext).ConfigureAwait(false);
+        var castleSiegeContext = new CastleSiegeContext(gameServerContext, castleSiegeConfiguration);
+        await castleSiegeContext.InitializeAsync(new DateTime(2026, 8, 3, 12, 0, 0, DateTimeKind.Utc)).ConfigureAwait(false);
+        return new(
+            persistenceContextProvider,
+            gameConfiguration,
+            castleSiegeConfiguration,
+            gameServerContext,
+            castleSiegeContext,
+            player,
+            persistentGuildId,
+            guildMembers,
+            guildServer);
+    }
+
+    private sealed record TestFixture(
+        InMemoryPersistenceContextProvider PersistenceContextProvider,
+        GameConfiguration GameConfiguration,
+        CastleSiegeConfiguration CastleSiegeConfiguration,
+        GameServerContext GameServerContext,
+        CastleSiegeContext Context,
+        Player Player,
+        Guid PersistentGuildId,
+        List<GuildListEntry> GuildMembers,
+        Mock<IGuildServer> GuildServer);
+}

--- a/tests/MUnique.OpenMU.Tests/CastleSiegeRegistrationTests.cs
+++ b/tests/MUnique.OpenMU.Tests/CastleSiegeRegistrationTests.cs
@@ -268,7 +268,7 @@ public class CastleSiegeRegistrationTests
     /// Verifies that alliance members can query, but cannot mutate, the alliance master's registration.
     /// </summary>
     [Test]
-    public async ValueTask AllianceMemberUsesMasterRegistrationForQueriesOnlyAsync()
+    public async ValueTask AllianceMemberUsesOfflineMasterRegistrationForQueriesOnlyAsync()
     {
         const uint allianceMemberGuildId = 43;
         var fixture = await CreateFixtureAsync().ConfigureAwait(false);
@@ -291,6 +291,9 @@ public class CastleSiegeRegistrationTests
             .Setup(server => server.GetGuildAsync(allianceMemberGuildId))
             .Returns(new ValueTask<RuntimeGuild?>(allianceMember));
         fixture.GuildServer
+            .Setup(server => server.GetPersistentAllianceMasterGuildIdAsync(allianceMemberGuildId))
+            .Returns(new ValueTask<Guid?>(fixture.PersistentGuildId));
+        fixture.GuildServer
             .Setup(server => server.IsAllianceMasterAsync(allianceMemberGuildId))
             .Returns(new ValueTask<bool>(false));
         fixture.Player.GuildStatus = new GuildMemberStatus(allianceMemberGuildId, GuildPosition.GuildMaster);
@@ -300,6 +303,9 @@ public class CastleSiegeRegistrationTests
             plugIn => plugIn.ShowRegistrationResultAsync(CastleSiegeRegistrationResult.InvalidGuild, string.Empty),
             Times.Once);
 
+        fixture.GuildServer
+            .Setup(server => server.GetGuildAsync(RuntimeGuildId))
+            .Returns(new ValueTask<RuntimeGuild?>((RuntimeGuild?)null));
         var stateView = fixture.Player.ViewPlugIns.GetPlugIn<ICastleSiegeRegistrationStatePlugIn>()!;
         await new CastleSiegeRegistrationStateAction().ShowStateAsync(fixture.Player, fixture.Context).ConfigureAwait(false);
         Mock.Get(stateView).Verify(
@@ -310,6 +316,7 @@ public class CastleSiegeRegistrationTests
                 false,
                 1),
             Times.Once);
+        fixture.GuildServer.Verify(server => server.GetGuildIdByNameAsync(It.IsAny<string>()), Times.Never);
     }
 
     /// <summary>
@@ -422,6 +429,9 @@ public class CastleSiegeRegistrationTests
             .Returns(new ValueTask<uint>(RuntimeGuildId));
         guildServer
             .Setup(server => server.GetPersistentGuildIdAsync(RuntimeGuildId))
+            .Returns(new ValueTask<Guid?>(persistentGuildId));
+        guildServer
+            .Setup(server => server.GetPersistentAllianceMasterGuildIdAsync(RuntimeGuildId))
             .Returns(new ValueTask<Guid?>(persistentGuildId));
 
         var mapInitializer = new MapInitializer(gameConfiguration, new NullLogger<MapInitializer>(), NullDropGenerator.Instance, null);

--- a/tests/MUnique.OpenMU.Tests/CastleSiegeRegistrationTests.cs
+++ b/tests/MUnique.OpenMU.Tests/CastleSiegeRegistrationTests.cs
@@ -8,7 +8,6 @@ using System.Collections.Immutable;
 using Microsoft.Extensions.Logging.Abstractions;
 using Moq;
 using MUnique.OpenMU.DataModel.Configuration;
-using MUnique.OpenMU.DataModel.Configuration.Items;
 using MUnique.OpenMU.DataModel.Entities;
 using MUnique.OpenMU.GameLogic;
 using MUnique.OpenMU.GameLogic.Attributes;
@@ -18,6 +17,7 @@ using MUnique.OpenMU.GameLogic.Views.CastleSiege;
 using MUnique.OpenMU.GameServer;
 using MUnique.OpenMU.GameServer.MessageHandler.CastleSiege;
 using MUnique.OpenMU.Interfaces;
+using MUnique.OpenMU.Network.Packets.ClientToServer;
 using MUnique.OpenMU.Persistence;
 using MUnique.OpenMU.Persistence.InMemory;
 using MUnique.OpenMU.PlugIns;
@@ -25,7 +25,7 @@ using BasicModel = MUnique.OpenMU.Persistence.BasicModel;
 using RuntimeGuild = MUnique.OpenMU.Interfaces.Guild;
 
 /// <summary>
-/// Tests Castle Siege guild and Emblem of Lord registration.
+/// Tests Castle Siege guild and Sign of Lord registration.
 /// </summary>
 [TestFixture]
 public class CastleSiegeRegistrationTests
@@ -50,6 +50,10 @@ public class CastleSiegeRegistrationTests
             Assert.That((byte)CastleSiegeRegistrationResult.NoGuild, Is.EqualTo(6));
             Assert.That((byte)CastleSiegeRegistrationResult.NotRegistrationPeriod, Is.EqualTo(7));
             Assert.That((byte)CastleSiegeRegistrationResult.NotEnoughMembers, Is.EqualTo(8));
+            Assert.That((byte)CastleSiegeMarkRegistrationResult.Failed, Is.Zero);
+            Assert.That((byte)CastleSiegeMarkRegistrationResult.Success, Is.EqualTo(1));
+            Assert.That((byte)CastleSiegeMarkRegistrationResult.GuildNotRegistered, Is.EqualTo(2));
+            Assert.That((byte)CastleSiegeMarkRegistrationResult.IncorrectItem, Is.EqualTo(3));
         });
     }
 
@@ -173,37 +177,31 @@ public class CastleSiegeRegistrationTests
     }
 
     /// <summary>
-    /// Verifies Emblem validation, consumption, mark persistence, and registration-state queries.
+    /// Verifies Sign of Lord validation, consumption, mark persistence, and registration-state queries.
     /// </summary>
     [Test]
-    public async ValueTask MarkRegistrationConsumesValidEmblemAndPersistsCountAsync()
+    public async ValueTask MarkRegistrationConsumesValidSignOfLordAndPersistsCountAsync()
     {
         const byte itemSlot = 20;
         var fixture = await CreateRegisteredFixtureAsync().ConfigureAwait(false);
         fixture.Context.SetPeriod(fixture.Context.Schedule.GetCurrentPeriod(new DateTime(2026, 8, 4, 12, 0, 0, DateTimeKind.Utc)));
         var markView = fixture.Player.ViewPlugIns.GetPlugIn<ICastleSiegeMarkRegistrationResultPlugIn>()!;
         var item = fixture.Player.PersistenceContext.CreateNew<Item>();
-        item.Definition = new ItemDefinition
-        {
-            Group = 14,
-            Number = 21,
-            Width = 1,
-            Height = 1,
-        };
+        item.Definition = fixture.CastleSiegeConfiguration.SignOfLordItemDefinition;
         item.Level = 2;
         await fixture.Player.Inventory!.AddItemAsync(itemSlot, item).ConfigureAwait(false);
 
         var action = new CastleSiegeRegisterMarkAction();
         await action.RegisterMarkAsync(fixture.Player, fixture.Context, itemSlot).ConfigureAwait(false);
         Mock.Get(markView).Verify(
-            plugIn => plugIn.ShowMarkRegistrationResultAsync(false, GuildName, 0),
+            plugIn => plugIn.ShowMarkRegistrationResultAsync(CastleSiegeMarkRegistrationResult.IncorrectItem, GuildName, 0),
             Times.Once);
         Assert.That(fixture.Player.Inventory.GetItem(itemSlot), Is.SameAs(item));
 
-        item.Level = 3;
+        item.Level = fixture.CastleSiegeConfiguration.SignOfLordItemLevel;
         await action.RegisterMarkAsync(fixture.Player, fixture.Context, itemSlot).ConfigureAwait(false);
         Mock.Get(markView).Verify(
-            plugIn => plugIn.ShowMarkRegistrationResultAsync(true, GuildName, 1),
+            plugIn => plugIn.ShowMarkRegistrationResultAsync(CastleSiegeMarkRegistrationResult.Success, GuildName, 1),
             Times.Once);
         Assert.That(fixture.Player.Inventory.GetItem(itemSlot), Is.Null);
         Assert.That(fixture.Context.RegisteredGuilds[fixture.PersistentGuildId].Marks, Is.EqualTo(1));
@@ -225,6 +223,45 @@ public class CastleSiegeRegistrationTests
                 false,
                 1),
             Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that a Sign of Lord is preserved if the persistent guild registration disappeared.
+    /// </summary>
+    [Test]
+    public async ValueTask MarkRegistrationPreservesItemWhenRegistrationDisappearedAsync()
+    {
+        const byte itemSlot = 20;
+        var fixture = await CreateRegisteredFixtureAsync().ConfigureAwait(false);
+        fixture.Context.SetPeriod(fixture.Context.Schedule.GetCurrentPeriod(new DateTime(2026, 8, 4, 12, 0, 0, DateTimeKind.Utc)));
+        var cachedRegistration = fixture.Context.RegisteredGuilds[fixture.PersistentGuildId];
+        using (var persistenceContext = fixture.PersistenceContextProvider.CreateNewTypedContext(
+                   typeof(CastleSiegeGuildRegistration),
+                   false,
+                   fixture.GameConfiguration))
+        {
+            var persistentRegistration = await persistenceContext.GetByIdAsync<CastleSiegeGuildRegistration>(cachedRegistration.Id).ConfigureAwait(false);
+            Assert.That(persistentRegistration, Is.Not.Null);
+            await persistenceContext.DeleteAsync(persistentRegistration!).ConfigureAwait(false);
+            await persistenceContext.SaveChangesAsync().ConfigureAwait(false);
+        }
+
+        var signOfLord = fixture.Player.PersistenceContext.CreateNew<Item>();
+        signOfLord.Definition = fixture.CastleSiegeConfiguration.SignOfLordItemDefinition;
+        signOfLord.Level = fixture.CastleSiegeConfiguration.SignOfLordItemLevel;
+        await fixture.Player.Inventory!.AddItemAsync(itemSlot, signOfLord).ConfigureAwait(false);
+
+        await new CastleSiegeRegisterMarkAction().RegisterMarkAsync(fixture.Player, fixture.Context, itemSlot).ConfigureAwait(false);
+
+        var view = fixture.Player.ViewPlugIns.GetPlugIn<ICastleSiegeMarkRegistrationResultPlugIn>()!;
+        Mock.Get(view).Verify(
+            plugIn => plugIn.ShowMarkRegistrationResultAsync(
+                CastleSiegeMarkRegistrationResult.GuildNotRegistered,
+                GuildName,
+                0),
+            Times.Once);
+        Assert.That(fixture.Player.Inventory.GetItem(itemSlot), Is.SameAs(signOfLord));
+        Assert.That(fixture.Context.RegisteredGuilds, Does.Not.ContainKey(fixture.PersistentGuildId));
     }
 
     /// <summary>
@@ -304,6 +341,20 @@ public class CastleSiegeRegistrationTests
         });
     }
 
+    /// <summary>
+    /// Verifies that a truncated mark-registration packet is ignored.
+    /// </summary>
+    [Test]
+    public async ValueTask MarkRegistrationHandlerIgnoresTruncatedPacketAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var packet = new byte[CastleSiegeMarkRegistration.Length - 1];
+
+        await new CastleSiegeMarkRegistrationHandlerPlugIn()
+            .HandlePacketAsync(fixture.Player, packet)
+            .ConfigureAwait(false);
+    }
+
     private static async ValueTask<TestFixture> CreateRegisteredFixtureAsync()
     {
         var fixture = await CreateFixtureAsync().ConfigureAwait(false);
@@ -327,6 +378,16 @@ public class CastleSiegeRegistrationTests
             castleSiegeConfiguration.Enabled = true;
             castleSiegeConfiguration.RegisterMinLevel = 200;
             castleSiegeConfiguration.RegisterMinMembers = 2;
+            var signOfLordDefinition = persistenceContext.CreateNew<BasicModel.ItemDefinition>();
+            signOfLordDefinition.Name = "Rena";
+            signOfLordDefinition.Group = 14;
+            signOfLordDefinition.Number = 21;
+            signOfLordDefinition.MaximumItemLevel = 3;
+            signOfLordDefinition.Width = 1;
+            signOfLordDefinition.Height = 1;
+            gameConfiguration.Items.Add(signOfLordDefinition);
+            castleSiegeConfiguration.SignOfLordItemDefinition = signOfLordDefinition;
+            castleSiegeConfiguration.SignOfLordItemLevel = 3;
             castleSiegeConfiguration.StateSchedule.Add(new BasicModel.CastleSiegeStateScheduleEntry
             {
                 State = CastleSiegeState.RegisterGuild,
@@ -359,6 +420,9 @@ public class CastleSiegeRegistrationTests
         guildServer
             .Setup(server => server.GetGuildIdByNameAsync(GuildName))
             .Returns(new ValueTask<uint>(RuntimeGuildId));
+        guildServer
+            .Setup(server => server.GetPersistentGuildIdAsync(RuntimeGuildId))
+            .Returns(new ValueTask<Guid?>(persistentGuildId));
 
         var mapInitializer = new MapInitializer(gameConfiguration, new NullLogger<MapInitializer>(), NullDropGenerator.Instance, null);
         var gameServerContext = new GameServerContext(

--- a/tests/MUnique.OpenMU.Tests/CastleSiegeRemoteViewTestHelper.cs
+++ b/tests/MUnique.OpenMU.Tests/CastleSiegeRemoteViewTestHelper.cs
@@ -1,0 +1,47 @@
+// <copyright file="CastleSiegeRemoteViewTestHelper.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Tests;
+
+using System.IO;
+using System.IO.Pipelines;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameServer;
+using MUnique.OpenMU.GameServer.RemoteView;
+using MUnique.OpenMU.Network;
+using MUnique.OpenMU.Persistence;
+using MUnique.OpenMU.PlugIns;
+using Nito.AsyncEx;
+
+/// <summary>
+/// Creates remote players with an in-memory packet output for Castle Siege view tests.
+/// </summary>
+internal static class CastleSiegeRemoteViewTestHelper
+{
+    /// <summary>
+    /// Creates a remote player and its packet output stream.
+    /// </summary>
+    /// <returns>The remote player and output stream.</returns>
+    internal static (RemotePlayer Player, MemoryStream Output) CreatePlayer()
+    {
+        var output = new MemoryStream();
+        var writer = PipeWriter.Create(output, new StreamPipeWriterOptions(leaveOpen: true));
+        var connection = new Mock<IConnection>();
+        connection.SetupGet(c => c.Connected).Returns(true);
+        connection.SetupGet(c => c.Output).Returns(writer);
+        connection.SetupGet(c => c.OutputLock).Returns(new AsyncLock());
+
+        var manager = new PlugInManager(null, new NullLoggerFactory(), null, null);
+        var gameContext = new Mock<IGameServerContext>();
+        gameContext.Setup(c => c.PersistenceContextProvider)
+            .Returns(new Mock<IPersistenceContextProvider>().Object);
+        gameContext.Setup(c => c.Configuration).Returns(new GameConfiguration());
+        gameContext.Setup(c => c.PlugInManager).Returns(manager);
+        gameContext.Setup(c => c.LoggerFactory).Returns(new NullLoggerFactory());
+        return (new RemotePlayer(gameContext.Object, connection.Object, default), output);
+    }
+}

--- a/tests/MUnique.OpenMU.Tests/GuildAllianceTest.cs
+++ b/tests/MUnique.OpenMU.Tests/GuildAllianceTest.cs
@@ -147,6 +147,26 @@ public class GuildAllianceTest : GuildTestBase
         Assert.That(isMaster, Is.False);
     }
 
+    /// <summary>
+    /// An online alliance member can resolve the persistent master guild after the master's last member went offline.
+    /// </summary>
+    [Test]
+    public async ValueTask GetPersistentAllianceMasterGuildId_MasterOffline_ReturnsMasterId()
+    {
+        await this.GuildServer.CreateAllianceAsync(this._firstGuildId, this._secondGuildId).ConfigureAwait(false);
+        var masterPersistentId = await this.GuildServer.GetPersistentGuildIdAsync(this._firstGuildId).ConfigureAwait(false);
+
+        await this.GuildServer.GuildMemberLeftGameAsync(this._firstGuildId, this.GuildMaster.Id, 0).ConfigureAwait(false);
+        var masterGuildMember = (await this.GuildServer.GetGuildListAsync(this._firstGuildId).ConfigureAwait(false)).Single();
+        var resolvedMasterId = await this.GuildServer.GetPersistentAllianceMasterGuildIdAsync(this._secondGuildId).ConfigureAwait(false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(masterGuildMember.ServerId, Is.EqualTo(MUnique.OpenMU.GuildServer.GuildServer.OfflineServerId));
+            Assert.That(resolvedMasterId, Is.EqualTo(masterPersistentId));
+        });
+    }
+
     // -------------------------------------------------------------------------
     // GetAllianceGuildsAsync
     // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements the Castle Siege guild registration and Sign of Lord registration system.

- Adds guild and alliance registration with the required validation and result codes.
- Adds guild unregistration during the registration period.
- Adds Sign of Lord submission, inventory consumption, and persistent mark counting.
- Preserves the Sign of Lord when registration persistence fails.
- Adds registration-state queries for guild and alliance members, including when the alliance master is offline.
- Adds the B2 registration request handlers, view interfaces, and remote-view implementations.
- Restores persistent registrations after a server restart.
- Adds configurable Sign of Lord item definition and level settings.
- Adds an EF migration and an update plug-in for existing Season 6 databases.
- Adds focused handler, serialization, persistence, alliance, and initialization tests.

The 30-minute registration notifications are provided by the state-machine implementation merged in #861.

## Packet dependency

The complete Castle Siege packet definitions were merged into master through #863 as part of #731. This PR consumes those definitions and does not add or modify packet XML, generated packet artifacts, or packet documentation.

## Sign of Lord availability

The default Season 6 configuration uses item 14/21 at level 3 as the Sign of Lord and permits that item level.

This PR intentionally does not add a drop source. Obtaining the Sign of Lord remains a server-configuration, administrator-tooling, or follow-up gameplay concern.

## Validation

- Castle Siege registration result codes match protocol values `0`–`8`.
- Sign of Lord result codes match protocol values `0`–`3`.
- Alliance masters and standalone guild masters can register.
- Alliance members can query their master guild’s registration when the master is offline.
- Invalid registration scenarios are rejected.
- Unregistration removes the persistent registration.
- Sign of Lord submission consumes the configured inventory item.
- A Sign of Lord is preserved if mark persistence fails.
- Mark counts persist and survive context reloads.
- Existing customized Sign of Lord configuration is preserved.
- Configurations without the default item initialize without throwing.
- Focused registration, alliance, serialization, and initialization tests pass.
- The complete solution builds without errors.
- Changed-file formatting and analyzer checks pass.

Closes #723