### PR TITLE
Implement Castle Siege NPC lifecycle and management

### DIFF
--- a/src/DataModel/Configuration/CastleSiegeConfiguration.cs
+++ b/src/DataModel/Configuration/CastleSiegeConfiguration.cs
@@ -74,6 +74,21 @@ public partial class CastleSiegeConfiguration
     public int StatueBuyPrice { get; set; }
 
     /// <summary>
+    /// Gets or sets the gate repair cost in Zen per restored health point.
+    /// </summary>
+    public int GateRepairCostPerHealthPoint { get; set; } = 5;
+
+    /// <summary>
+    /// Gets or sets the Guardian Statue repair cost in Zen per restored health point.
+    /// </summary>
+    public int StatueRepairCostPerHealthPoint { get; set; } = 3;
+
+    /// <summary>
+    /// Gets or sets the additional repair cost in Zen per applied defense or regeneration level.
+    /// </summary>
+    public int RepairCostPerUpgradeLevel { get; set; } = 1_000_000;
+
+    /// <summary>
     /// Gets or sets the map definition for the Valley of Loren (map 30), where the siege takes place.
     /// </summary>
     public virtual GameMapDefinition? CastleSiegeMapDefinition { get; set; }

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeGateOperateAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeGateOperateAction.cs
@@ -1,0 +1,129 @@
+// <copyright file="CastleSiegeGateOperateAction.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// Opens and closes Castle Siege gates after validating the requesting player's side.
+/// </summary>
+public static class CastleSiegeGateOperateAction
+{
+    /// <summary>
+    /// Tries to open the Castle Siege gate-operation interface.
+    /// </summary>
+    /// <param name="player">The requesting player.</param>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <param name="gateId">The target gate identifier.</param>
+    /// <returns>A task that represents the asynchronous operation.</returns>
+    public static async ValueTask ShowInterfaceAsync(
+        Player player,
+        CastleSiegeContext? context,
+        ushort gateId)
+    {
+        var result = await ValidateAsync(player, context, gateId).ConfigureAwait(false);
+        await player.InvokeViewPlugInAsync<ICastleSiegeNpcOperationResultPlugIn>(
+                view => view.ShowGateInterfaceAsync(result, gateId))
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Tries to open or close a Castle Siege gate.
+    /// </summary>
+    /// <param name="player">The requesting player.</param>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <param name="gateId">The target gate identifier.</param>
+    /// <param name="open">Whether the gate should be opened.</param>
+    /// <returns>The operation result.</returns>
+    public static async ValueTask<CastleSiegeNpcOperationResult> OperateAsync(
+        Player player,
+        CastleSiegeContext? context,
+        ushort gateId,
+        bool open)
+    {
+        var (result, isOpen) = await OperateCoreAsync(player, context, gateId, open).ConfigureAwait(false);
+        await player.InvokeViewPlugInAsync<ICastleSiegeNpcOperationResultPlugIn>(
+                view => view.ShowGateOperationResultAsync(result, isOpen, gateId))
+            .ConfigureAwait(false);
+        return result;
+    }
+
+    private static async ValueTask<(CastleSiegeNpcOperationResult Result, bool IsOpen)> OperateCoreAsync(
+        Player player,
+        CastleSiegeContext? context,
+        ushort gateId,
+        bool open)
+    {
+        if (context is not { Configuration.Enabled: true })
+        {
+            return (CastleSiegeNpcOperationResult.Failed, open);
+        }
+
+        await context.ExecutionLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (!await IsAuthorizedAsync(player, context).ConfigureAwait(false))
+            {
+                return (CastleSiegeNpcOperationResult.NotAuthorized, open);
+            }
+
+            if (context.NpcController.FindGate(gateId) is not { IsAlive: true } gate)
+            {
+                return (CastleSiegeNpcOperationResult.Failed, open);
+            }
+
+            if (open)
+            {
+                await gate.OpenAsync().ConfigureAwait(false);
+            }
+            else
+            {
+                await gate.CloseAsync().ConfigureAwait(false);
+            }
+
+            return (CastleSiegeNpcOperationResult.Success, !gate.IsClosed);
+        }
+        finally
+        {
+            context.ExecutionLock.Release();
+        }
+    }
+
+    private static async ValueTask<CastleSiegeNpcOperationResult> ValidateAsync(
+        Player player,
+        CastleSiegeContext? context,
+        ushort gateId)
+    {
+        if (context is not { Configuration.Enabled: true })
+        {
+            return CastleSiegeNpcOperationResult.Failed;
+        }
+
+        await context.ExecutionLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (!await IsAuthorizedAsync(player, context).ConfigureAwait(false))
+            {
+                return CastleSiegeNpcOperationResult.NotAuthorized;
+            }
+
+            return context.NpcController.FindGate(gateId) is { IsAlive: true }
+                ? CastleSiegeNpcOperationResult.Success
+                : CastleSiegeNpcOperationResult.Failed;
+        }
+        finally
+        {
+            context.ExecutionLock.Release();
+        }
+    }
+
+    private static ValueTask<bool> IsAuthorizedAsync(Player player, CastleSiegeContext context)
+    {
+        return context.CurrentState == CastleSiegeState.Start
+            ? ValueTask.FromResult(context.GetPlayerJoinSide(player) == CastleSiegeJoinSide.Defense)
+            : CastleSiegeNpcAuthorization.IsOwnerAllianceMemberAsync(player, context);
+    }
+}

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeNpcAuthorization.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeNpcAuthorization.cs
@@ -1,0 +1,46 @@
+// <copyright file="CastleSiegeNpcAuthorization.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+
+using MUnique.OpenMU.Interfaces;
+
+/// <summary>
+/// Authorization checks shared by Castle Siege NPC management actions.
+/// </summary>
+internal static class CastleSiegeNpcAuthorization
+{
+    /// <summary>
+    /// Checks whether a player is a guild master or assistant master of the castle-owner guild.
+    /// </summary>
+    /// <param name="player">The player to check.</param>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <returns><see langword="true"/> when the player is an authorized owner-guild officer.</returns>
+    public static async ValueTask<bool> IsOwnerOfficerAsync(Player player, CastleSiegeContext context)
+    {
+        if (player.GuildStatus is not { } guildStatus
+            || guildStatus.Position is not (GuildPosition.GuildMaster or GuildPosition.AssistantMaster)
+            || player.GameContext is not IGameServerContext gameServerContext
+            || await gameServerContext.GuildServer
+                .GetPersistentGuildIdAsync(guildStatus.GuildId)
+                .ConfigureAwait(false) is not { } persistentGuildId)
+        {
+            return false;
+        }
+
+        return context.SiegeData.OwnerGuildId == persistentGuildId;
+    }
+
+    /// <summary>
+    /// Checks whether a player belongs to the castle-owner guild or one of its alliance guilds.
+    /// </summary>
+    /// <param name="player">The player to check.</param>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <returns><see langword="true"/> when the player belongs to the owner alliance.</returns>
+    public static async ValueTask<bool> IsOwnerAllianceMemberAsync(Player player, CastleSiegeContext context)
+    {
+        var guildId = await CastleSiegeGuildResolver.ResolveRegistrationGuildIdAsync(player).ConfigureAwait(false);
+        return guildId is not null && context.SiegeData.OwnerGuildId == guildId;
+    }
+}

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeNpcBuyAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeNpcBuyAction.cs
@@ -70,10 +70,10 @@ public static class CastleSiegeNpcBuyAction
 
             var (price, initialHealth) = runtime.Definition.MonsterDefinition?.Number switch
             {
-                CastleSiegeGate.MonsterNumber => (
+                var number when number == CastleSiegeGate.MonsterNumber => (
                     context.Configuration.GateBuyPrice,
                     GetInitialValue(context.Configuration.GateLifeUpgrades)),
-                CastleSiegeStatue.MonsterNumber => (
+                var number when number == CastleSiegeStatue.MonsterNumber => (
                     context.Configuration.StatueBuyPrice,
                     GetInitialValue(context.Configuration.StatueLifeUpgrades)),
                 _ => (0, 0),

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeNpcBuyAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeNpcBuyAction.cs
@@ -1,0 +1,114 @@
+// <copyright file="CastleSiegeNpcBuyAction.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+
+using MUnique.OpenMU.GameLogic.CastleSiege.NPC;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// Re-purchases destroyed Castle Siege gates and Guardian Statues.
+/// </summary>
+public static class CastleSiegeNpcBuyAction
+{
+    /// <summary>
+    /// Tries to re-purchase a destroyed defense structure.
+    /// </summary>
+    /// <param name="player">The requesting player.</param>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <param name="npcNumber">The target NPC number.</param>
+    /// <param name="npcIndex">The target NPC instance identifier.</param>
+    /// <returns>The operation result.</returns>
+    public static async ValueTask<CastleSiegeNpcOperationResult> BuyAsync(
+        Player player,
+        CastleSiegeContext? context,
+        uint npcNumber,
+        uint npcIndex)
+    {
+        var result = await BuyCoreAsync(player, context, npcNumber, npcIndex).ConfigureAwait(false);
+        await player.InvokeViewPlugInAsync<ICastleSiegeNpcOperationResultPlugIn>(
+                view => view.ShowBuyResultAsync(result, npcNumber, npcIndex))
+            .ConfigureAwait(false);
+        return result;
+    }
+
+    private static async ValueTask<CastleSiegeNpcOperationResult> BuyCoreAsync(
+        Player player,
+        CastleSiegeContext? context,
+        uint npcNumber,
+        uint npcIndex)
+    {
+        if (context is not { Configuration.Enabled: true })
+        {
+            return CastleSiegeNpcOperationResult.Failed;
+        }
+
+        await context.ExecutionLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (context.CurrentState == CastleSiegeState.Start)
+            {
+                return CastleSiegeNpcOperationResult.Failed;
+            }
+
+            if (!await CastleSiegeNpcAuthorization.IsOwnerOfficerAsync(player, context).ConfigureAwait(false))
+            {
+                return CastleSiegeNpcOperationResult.NotAuthorized;
+            }
+
+            var runtime = context.NpcController.FindDefenseStructure(npcNumber, npcIndex);
+            if (runtime is { IsAlive: true })
+            {
+                return CastleSiegeNpcOperationResult.RequirementNotMet;
+            }
+
+            if (runtime is not { PersistedState: { } state })
+            {
+                return CastleSiegeNpcOperationResult.Failed;
+            }
+
+            var (price, initialHealth) = runtime.Definition.MonsterDefinition?.Number switch
+            {
+                CastleSiegeGate.MonsterNumber => (
+                    context.Configuration.GateBuyPrice,
+                    GetInitialValue(context.Configuration.GateLifeUpgrades)),
+                CastleSiegeStatue.MonsterNumber => (
+                    context.Configuration.StatueBuyPrice,
+                    GetInitialValue(context.Configuration.StatueLifeUpgrades)),
+                _ => (0, 0),
+            };
+            if (price <= 0 || initialHealth <= 0)
+            {
+                return CastleSiegeNpcOperationResult.Failed;
+            }
+
+            if (!player.TryRemoveMoney(price))
+            {
+                return CastleSiegeNpcOperationResult.InsufficientMoney;
+            }
+
+            state.DefenseLevel = 0;
+            state.LifeLevel = 0;
+            state.RegenLevel = 0;
+            state.CurrentHp = initialHealth;
+            await context.NpcController.RespawnAsync(runtime).ConfigureAwait(false);
+            if (runtime.SpawnedInstance is CastleSiegeGate gate)
+            {
+                await gate.CloseAsync().ConfigureAwait(false);
+            }
+
+            await context.SaveNpcStatesAsync().ConfigureAwait(false);
+            return CastleSiegeNpcOperationResult.Success;
+        }
+        finally
+        {
+            context.ExecutionLock.Release();
+        }
+    }
+
+    private static int GetInitialValue(IEnumerable<CastleSiegeUpgradeDefinition> definitions)
+    {
+        return definitions.FirstOrDefault(definition => definition.Level == 0)?.Value ?? 0;
+    }
+}

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeNpcBuyAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeNpcBuyAction.cs
@@ -70,10 +70,10 @@ public static class CastleSiegeNpcBuyAction
 
             var (price, initialHealth) = runtime.Definition.MonsterDefinition?.Number switch
             {
-                CastleSiegeGate.MonsterNumber => (
+                var number when number == CastleSiegeGate.MonsterNumber => (
                     context.Configuration.GateBuyPrice,
                     context.Configuration.GetUpgrades(CastleSiegeGate.MonsterNumber, CastleSiegeUpgradeType.Life)?.GetValue(0) ?? 0),
-                CastleSiegeStatue.MonsterNumber => (
+                var number when number == CastleSiegeStatue.MonsterNumber => (
                     context.Configuration.StatueBuyPrice,
                     context.Configuration.GetUpgrades(CastleSiegeStatue.MonsterNumber, CastleSiegeUpgradeType.Life)?.GetValue(0) ?? 0),
                 _ => (0, 0),

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeNpcBuyAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeNpcBuyAction.cs
@@ -70,12 +70,12 @@ public static class CastleSiegeNpcBuyAction
 
             var (price, initialHealth) = runtime.Definition.MonsterDefinition?.Number switch
             {
-                var number when number == CastleSiegeGate.MonsterNumber => (
+                CastleSiegeGate.MonsterNumber => (
                     context.Configuration.GateBuyPrice,
-                    GetInitialValue(context.Configuration.GateLifeUpgrades)),
-                var number when number == CastleSiegeStatue.MonsterNumber => (
+                    context.Configuration.GetUpgrades(CastleSiegeGate.MonsterNumber, CastleSiegeUpgradeType.Life)?.GetValue(0) ?? 0),
+                CastleSiegeStatue.MonsterNumber => (
                     context.Configuration.StatueBuyPrice,
-                    GetInitialValue(context.Configuration.StatueLifeUpgrades)),
+                    context.Configuration.GetUpgrades(CastleSiegeStatue.MonsterNumber, CastleSiegeUpgradeType.Life)?.GetValue(0) ?? 0),
                 _ => (0, 0),
             };
             if (price <= 0 || initialHealth <= 0)
@@ -105,10 +105,5 @@ public static class CastleSiegeNpcBuyAction
         {
             context.ExecutionLock.Release();
         }
-    }
-
-    private static int GetInitialValue(IEnumerable<CastleSiegeUpgradeDefinition> definitions)
-    {
-        return definitions.FirstOrDefault(definition => definition.Level == 0)?.Value ?? 0;
     }
 }

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeNpcRepairAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeNpcRepairAction.cs
@@ -87,9 +87,10 @@ public static class CastleSiegeNpcRepairAction
             var missingHealth = Math.Max(0L, (long)maximumHealth - currentHealth);
             var cost = runtime.Definition.MonsterDefinition?.Number switch
             {
-                CastleSiegeGate.MonsterNumber => (missingHealth * 5) + ((long)state.DefenseLevel * 1_000_000),
-                CastleSiegeStatue.MonsterNumber => (missingHealth * 3)
-                                                        + ((long)(state.DefenseLevel + state.RegenLevel) * 1_000_000),
+                var number when number == CastleSiegeGate.MonsterNumber =>
+                    (missingHealth * 5) + ((long)state.DefenseLevel * 1_000_000),
+                var number when number == CastleSiegeStatue.MonsterNumber =>
+                    (missingHealth * 3) + ((long)(state.DefenseLevel + state.RegenLevel) * 1_000_000),
                 _ => -1,
             };
             if (cost is < 0 or > int.MaxValue)

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeNpcRepairAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeNpcRepairAction.cs
@@ -87,10 +87,10 @@ public static class CastleSiegeNpcRepairAction
             var missingHealth = Math.Max(0L, (long)maximumHealth - currentHealth);
             var cost = runtime.Definition.MonsterDefinition?.Number switch
             {
-                CastleSiegeGate.MonsterNumber =>
+                var number when number == CastleSiegeGate.MonsterNumber =>
                     (missingHealth * context.Configuration.GateRepairCostPerHealthPoint)
                     + ((long)state.DefenseLevel * context.Configuration.RepairCostPerUpgradeLevel),
-                CastleSiegeStatue.MonsterNumber =>
+                var number when number == CastleSiegeStatue.MonsterNumber =>
                     (missingHealth * context.Configuration.StatueRepairCostPerHealthPoint)
                     + ((long)(state.DefenseLevel + state.RegenLevel) * context.Configuration.RepairCostPerUpgradeLevel),
                 _ => -1,

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeNpcRepairAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeNpcRepairAction.cs
@@ -1,0 +1,123 @@
+// <copyright file="CastleSiegeNpcRepairAction.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+
+using MUnique.OpenMU.GameLogic.CastleSiege.NPC;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// Repairs Castle Siege gates and Guardian Statues.
+/// </summary>
+public static class CastleSiegeNpcRepairAction
+{
+    /// <summary>
+    /// Tries to restore a defense structure to full health.
+    /// </summary>
+    /// <param name="player">The requesting player.</param>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <param name="npcNumber">The target NPC number.</param>
+    /// <param name="npcIndex">The target NPC instance identifier.</param>
+    /// <returns>The operation result.</returns>
+    public static async ValueTask<CastleSiegeNpcOperationResult> RepairAsync(
+        Player player,
+        CastleSiegeContext? context,
+        uint npcNumber,
+        uint npcIndex)
+    {
+        var (result, currentHealth, maximumHealth) = await RepairCoreAsync(
+                player,
+                context,
+                npcNumber,
+                npcIndex)
+            .ConfigureAwait(false);
+        await player.InvokeViewPlugInAsync<ICastleSiegeNpcOperationResultPlugIn>(
+                view => view.ShowRepairResultAsync(
+                    result,
+                    npcNumber,
+                    npcIndex,
+                    currentHealth,
+                    maximumHealth))
+            .ConfigureAwait(false);
+        return result;
+    }
+
+    private static async ValueTask<(
+        CastleSiegeNpcOperationResult Result,
+        int CurrentHealth,
+        int MaximumHealth)> RepairCoreAsync(
+        Player player,
+        CastleSiegeContext? context,
+        uint npcNumber,
+        uint npcIndex)
+    {
+        if (context is not { Configuration.Enabled: true })
+        {
+            return (CastleSiegeNpcOperationResult.Failed, 0, 0);
+        }
+
+        await context.ExecutionLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (context.CurrentState == CastleSiegeState.Start)
+            {
+                return (CastleSiegeNpcOperationResult.Failed, 0, 0);
+            }
+
+            if (!await CastleSiegeNpcAuthorization.IsOwnerOfficerAsync(player, context).ConfigureAwait(false))
+            {
+                return (CastleSiegeNpcOperationResult.NotAuthorized, 0, 0);
+            }
+
+            if (context.NpcController.FindDefenseStructure(npcNumber, npcIndex) is not { IsAlive: true } runtime
+                || runtime.PersistedState is not { } state)
+            {
+                return (CastleSiegeNpcOperationResult.Failed, 0, 0);
+            }
+
+            var structure = runtime.SpawnedInstance as CastleSiegeAttackableNpc;
+            var maximumHealth = structure?.MaximumHealth ?? context.NpcController.GetMaximumHealth(runtime);
+            var currentHealth = structure?.Health ?? state.CurrentHp;
+            if (maximumHealth <= 0)
+            {
+                return (CastleSiegeNpcOperationResult.Failed, currentHealth, maximumHealth);
+            }
+
+            var missingHealth = Math.Max(0L, (long)maximumHealth - currentHealth);
+            var cost = runtime.Definition.MonsterDefinition?.Number switch
+            {
+                CastleSiegeGate.MonsterNumber => (missingHealth * 5) + ((long)state.DefenseLevel * 1_000_000),
+                CastleSiegeStatue.MonsterNumber => (missingHealth * 3)
+                                                        + ((long)(state.DefenseLevel + state.RegenLevel) * 1_000_000),
+                _ => -1,
+            };
+            if (cost is < 0 or > int.MaxValue)
+            {
+                return (CastleSiegeNpcOperationResult.Failed, currentHealth, maximumHealth);
+            }
+
+            if (!player.TryRemoveMoney((int)cost))
+            {
+                return (CastleSiegeNpcOperationResult.InsufficientMoney, currentHealth, maximumHealth);
+            }
+
+            if (structure is null)
+            {
+                state.CurrentHp = maximumHealth;
+                runtime.IsAlive = true;
+            }
+            else
+            {
+                structure.RestoreFullHealth();
+            }
+
+            await context.SaveNpcStatesAsync().ConfigureAwait(false);
+            return (CastleSiegeNpcOperationResult.Success, state.CurrentHp, maximumHealth);
+        }
+        finally
+        {
+            context.ExecutionLock.Release();
+        }
+    }
+}

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeNpcRepairAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeNpcRepairAction.cs
@@ -87,10 +87,12 @@ public static class CastleSiegeNpcRepairAction
             var missingHealth = Math.Max(0L, (long)maximumHealth - currentHealth);
             var cost = runtime.Definition.MonsterDefinition?.Number switch
             {
-                var number when number == CastleSiegeGate.MonsterNumber =>
-                    (missingHealth * 5) + ((long)state.DefenseLevel * 1_000_000),
-                var number when number == CastleSiegeStatue.MonsterNumber =>
-                    (missingHealth * 3) + ((long)(state.DefenseLevel + state.RegenLevel) * 1_000_000),
+                CastleSiegeGate.MonsterNumber =>
+                    (missingHealth * context.Configuration.GateRepairCostPerHealthPoint)
+                    + ((long)state.DefenseLevel * context.Configuration.RepairCostPerUpgradeLevel),
+                CastleSiegeStatue.MonsterNumber =>
+                    (missingHealth * context.Configuration.StatueRepairCostPerHealthPoint)
+                    + ((long)(state.DefenseLevel + state.RegenLevel) * context.Configuration.RepairCostPerUpgradeLevel),
                 _ => -1,
             };
             if (cost is < 0 or > int.MaxValue)

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeNpcUpgradeAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeNpcUpgradeAction.cs
@@ -128,6 +128,10 @@ public static class CastleSiegeNpcUpgradeAction
                 var adjustedHealth = (long)state.CurrentHp + newMaximumHealth - oldMaximumHealth;
                 state.CurrentHp = (int)Math.Clamp(adjustedHealth, 0L, newMaximumHealth);
             }
+            else
+            {
+                // Defense and regeneration upgrades do not alter the persisted health of an unspawned structure.
+            }
 
             await context.SaveNpcStatesAsync().ConfigureAwait(false);
             return CastleSiegeNpcOperationResult.Success;
@@ -145,11 +149,16 @@ public static class CastleSiegeNpcUpgradeAction
     {
         return (runtime.Definition.MonsterDefinition?.Number, upgradeType) switch
         {
-            (CastleSiegeGate.MonsterNumber, CastleSiegeUpgradeType.Defense) => configuration.GateDefenseUpgrades,
-            (CastleSiegeGate.MonsterNumber, CastleSiegeUpgradeType.Life) => configuration.GateLifeUpgrades,
-            (CastleSiegeStatue.MonsterNumber, CastleSiegeUpgradeType.Defense) => configuration.StatueDefenseUpgrades,
-            (CastleSiegeStatue.MonsterNumber, CastleSiegeUpgradeType.Life) => configuration.StatueLifeUpgrades,
-            (CastleSiegeStatue.MonsterNumber, CastleSiegeUpgradeType.Regen) => configuration.StatueRegenUpgrades,
+            var (number, type) when number == CastleSiegeGate.MonsterNumber
+                                    && type == CastleSiegeUpgradeType.Defense => configuration.GateDefenseUpgrades,
+            var (number, type) when number == CastleSiegeGate.MonsterNumber
+                                    && type == CastleSiegeUpgradeType.Life => configuration.GateLifeUpgrades,
+            var (number, type) when number == CastleSiegeStatue.MonsterNumber
+                                    && type == CastleSiegeUpgradeType.Defense => configuration.StatueDefenseUpgrades,
+            var (number, type) when number == CastleSiegeStatue.MonsterNumber
+                                    && type == CastleSiegeUpgradeType.Life => configuration.StatueLifeUpgrades,
+            var (number, type) when number == CastleSiegeStatue.MonsterNumber
+                                    && type == CastleSiegeUpgradeType.Regen => configuration.StatueRegenUpgrades,
             _ => null,
         };
     }

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeNpcUpgradeAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeNpcUpgradeAction.cs
@@ -1,0 +1,185 @@
+// <copyright file="CastleSiegeNpcUpgradeAction.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.GameLogic.CastleSiege.NPC;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// Upgrades Castle Siege gates and Guardian Statues.
+/// </summary>
+public static class CastleSiegeNpcUpgradeAction
+{
+    /// <summary>
+    /// Tries to apply one NPC upgrade level.
+    /// </summary>
+    /// <param name="player">The requesting player.</param>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <param name="npcNumber">The target NPC number.</param>
+    /// <param name="npcIndex">The target NPC instance identifier.</param>
+    /// <param name="upgradeType">The requested upgrade type.</param>
+    /// <param name="requestedLevel">The requested target level.</param>
+    /// <returns>The operation result.</returns>
+    public static async ValueTask<CastleSiegeNpcOperationResult> UpgradeAsync(
+        Player player,
+        CastleSiegeContext? context,
+        uint npcNumber,
+        uint npcIndex,
+        CastleSiegeUpgradeType upgradeType,
+        byte requestedLevel)
+    {
+        var result = await UpgradeCoreAsync(
+                player,
+                context,
+                npcNumber,
+                npcIndex,
+                upgradeType,
+                requestedLevel)
+            .ConfigureAwait(false);
+        await player.InvokeViewPlugInAsync<ICastleSiegeNpcOperationResultPlugIn>(
+                view => view.ShowUpgradeResultAsync(result, npcNumber, npcIndex, upgradeType, requestedLevel))
+            .ConfigureAwait(false);
+        return result;
+    }
+
+    private static async ValueTask<CastleSiegeNpcOperationResult> UpgradeCoreAsync(
+        Player player,
+        CastleSiegeContext? context,
+        uint npcNumber,
+        uint npcIndex,
+        CastleSiegeUpgradeType upgradeType,
+        byte requestedLevel)
+    {
+        if (context is not { Configuration.Enabled: true })
+        {
+            return CastleSiegeNpcOperationResult.Failed;
+        }
+
+        await context.ExecutionLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (context.CurrentState == CastleSiegeState.Start)
+            {
+                return CastleSiegeNpcOperationResult.Failed;
+            }
+
+            if (!await CastleSiegeNpcAuthorization.IsOwnerOfficerAsync(player, context).ConfigureAwait(false))
+            {
+                return CastleSiegeNpcOperationResult.NotAuthorized;
+            }
+
+            if (context.NpcController.FindDefenseStructure(npcNumber, npcIndex) is not { IsAlive: true } runtime
+                || runtime.PersistedState is not { } state)
+            {
+                return CastleSiegeNpcOperationResult.NpcNotFound;
+            }
+
+            if (GetDefinitions(context.Configuration, runtime, upgradeType) is not { } definitions)
+            {
+                return CastleSiegeNpcOperationResult.InvalidUpgradeType;
+            }
+
+            var currentLevel = GetLevel(state, upgradeType);
+            if (requestedLevel != currentLevel + 1
+                || definitions.FirstOrDefault(definition => definition.Level == requestedLevel) is not { } upgrade)
+            {
+                return CastleSiegeNpcOperationResult.InvalidUpgradeValue;
+            }
+
+            var jewels = player.Inventory?.Items
+                .Where(item => item.Definition is { } definition
+                               && new ItemIdentifier(definition.Number, definition.Group) == ItemConstants.JewelOfGuardian)
+                .Take(upgrade.RequiredJewelOfGuardianCount)
+                .ToList()
+                ?? [];
+            if (player.Money < upgrade.RequiredZen)
+            {
+                return CastleSiegeNpcOperationResult.InsufficientMoney;
+            }
+
+            if (jewels.Count < upgrade.RequiredJewelOfGuardianCount)
+            {
+                return CastleSiegeNpcOperationResult.RequirementNotMet;
+            }
+
+            if (!player.TryRemoveMoney(upgrade.RequiredZen))
+            {
+                return CastleSiegeNpcOperationResult.InsufficientMoney;
+            }
+
+            foreach (var jewel in jewels)
+            {
+                await player.DestroyInventoryItemAsync(jewel).ConfigureAwait(false);
+            }
+
+            var oldMaximumHealth = context.NpcController.GetMaximumHealth(runtime);
+            SetLevel(state, upgradeType, requestedLevel);
+            if (runtime.SpawnedInstance is CastleSiegeAttackableNpc structure)
+            {
+                structure.ApplyPersistedUpgrades(true);
+                state.CurrentHp = structure.Health;
+            }
+            else if (upgradeType == CastleSiegeUpgradeType.Life)
+            {
+                var newMaximumHealth = context.NpcController.GetMaximumHealth(runtime);
+                var adjustedHealth = (long)state.CurrentHp + newMaximumHealth - oldMaximumHealth;
+                state.CurrentHp = (int)Math.Clamp(adjustedHealth, 0L, newMaximumHealth);
+            }
+
+            await context.SaveNpcStatesAsync().ConfigureAwait(false);
+            return CastleSiegeNpcOperationResult.Success;
+        }
+        finally
+        {
+            context.ExecutionLock.Release();
+        }
+    }
+
+    private static ICollection<CastleSiegeUpgradeDefinition>? GetDefinitions(
+        CastleSiegeConfiguration configuration,
+        CastleSiegeNpcRuntime runtime,
+        CastleSiegeUpgradeType upgradeType)
+    {
+        return (runtime.Definition.MonsterDefinition?.Number, upgradeType) switch
+        {
+            (CastleSiegeGate.MonsterNumber, CastleSiegeUpgradeType.Defense) => configuration.GateDefenseUpgrades,
+            (CastleSiegeGate.MonsterNumber, CastleSiegeUpgradeType.Life) => configuration.GateLifeUpgrades,
+            (CastleSiegeStatue.MonsterNumber, CastleSiegeUpgradeType.Defense) => configuration.StatueDefenseUpgrades,
+            (CastleSiegeStatue.MonsterNumber, CastleSiegeUpgradeType.Life) => configuration.StatueLifeUpgrades,
+            (CastleSiegeStatue.MonsterNumber, CastleSiegeUpgradeType.Regen) => configuration.StatueRegenUpgrades,
+            _ => null,
+        };
+    }
+
+    private static byte GetLevel(CastleSiegeNpcState state, CastleSiegeUpgradeType type)
+    {
+        return type switch
+        {
+            CastleSiegeUpgradeType.Defense => state.DefenseLevel,
+            CastleSiegeUpgradeType.Regen => state.RegenLevel,
+            CastleSiegeUpgradeType.Life => state.LifeLevel,
+            _ => byte.MaxValue,
+        };
+    }
+
+    private static void SetLevel(CastleSiegeNpcState state, CastleSiegeUpgradeType type, byte level)
+    {
+        switch (type)
+        {
+            case CastleSiegeUpgradeType.Defense:
+                state.DefenseLevel = level;
+                break;
+            case CastleSiegeUpgradeType.Regen:
+                state.RegenLevel = level;
+                break;
+            case CastleSiegeUpgradeType.Life:
+                state.LifeLevel = level;
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(type), type, "Unknown Castle Siege upgrade type.");
+        }
+    }
+}

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeNpcUpgradeAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeNpcUpgradeAction.cs
@@ -77,7 +77,8 @@ public static class CastleSiegeNpcUpgradeAction
                 return CastleSiegeNpcOperationResult.NpcNotFound;
             }
 
-            if (GetDefinitions(context.Configuration, runtime, upgradeType) is not { } definitions)
+            var monsterNumber = runtime.Definition.MonsterDefinition?.Number ?? 0;
+            if (context.Configuration.GetUpgrades(monsterNumber, upgradeType) is not { } definitions)
             {
                 return CastleSiegeNpcOperationResult.InvalidUpgradeType;
             }
@@ -140,27 +141,6 @@ public static class CastleSiegeNpcUpgradeAction
         {
             context.ExecutionLock.Release();
         }
-    }
-
-    private static ICollection<CastleSiegeUpgradeDefinition>? GetDefinitions(
-        CastleSiegeConfiguration configuration,
-        CastleSiegeNpcRuntime runtime,
-        CastleSiegeUpgradeType upgradeType)
-    {
-        return (runtime.Definition.MonsterDefinition?.Number, upgradeType) switch
-        {
-            var (number, type) when number == CastleSiegeGate.MonsterNumber
-                                    && type == CastleSiegeUpgradeType.Defense => configuration.GateDefenseUpgrades,
-            var (number, type) when number == CastleSiegeGate.MonsterNumber
-                                    && type == CastleSiegeUpgradeType.Life => configuration.GateLifeUpgrades,
-            var (number, type) when number == CastleSiegeStatue.MonsterNumber
-                                    && type == CastleSiegeUpgradeType.Defense => configuration.StatueDefenseUpgrades,
-            var (number, type) when number == CastleSiegeStatue.MonsterNumber
-                                    && type == CastleSiegeUpgradeType.Life => configuration.StatueLifeUpgrades,
-            var (number, type) when number == CastleSiegeStatue.MonsterNumber
-                                    && type == CastleSiegeUpgradeType.Regen => configuration.StatueRegenUpgrades,
-            _ => null,
-        };
     }
 
     private static byte GetLevel(CastleSiegeNpcState state, CastleSiegeUpgradeType type)

--- a/src/GameLogic/CastleSiege/CastleSiegeConfigurationExtensions.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeConfigurationExtensions.cs
@@ -26,11 +26,16 @@ internal static class CastleSiegeConfigurationExtensions
     {
         return (monsterNumber, upgradeType) switch
         {
-            (CastleSiegeGate.MonsterNumber, CastleSiegeUpgradeType.Defense) => configuration.GateDefenseUpgrades,
-            (CastleSiegeGate.MonsterNumber, CastleSiegeUpgradeType.Life) => configuration.GateLifeUpgrades,
-            (CastleSiegeStatue.MonsterNumber, CastleSiegeUpgradeType.Defense) => configuration.StatueDefenseUpgrades,
-            (CastleSiegeStatue.MonsterNumber, CastleSiegeUpgradeType.Life) => configuration.StatueLifeUpgrades,
-            (CastleSiegeStatue.MonsterNumber, CastleSiegeUpgradeType.Regen) => configuration.StatueRegenUpgrades,
+            var (number, type) when number == CastleSiegeGate.MonsterNumber
+                                    && type == CastleSiegeUpgradeType.Defense => configuration.GateDefenseUpgrades,
+            var (number, type) when number == CastleSiegeGate.MonsterNumber
+                                    && type == CastleSiegeUpgradeType.Life => configuration.GateLifeUpgrades,
+            var (number, type) when number == CastleSiegeStatue.MonsterNumber
+                                    && type == CastleSiegeUpgradeType.Defense => configuration.StatueDefenseUpgrades,
+            var (number, type) when number == CastleSiegeStatue.MonsterNumber
+                                    && type == CastleSiegeUpgradeType.Life => configuration.StatueLifeUpgrades,
+            var (number, type) when number == CastleSiegeStatue.MonsterNumber
+                                    && type == CastleSiegeUpgradeType.Regen => configuration.StatueRegenUpgrades,
             _ => null,
         };
     }

--- a/src/GameLogic/CastleSiege/CastleSiegeConfigurationExtensions.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeConfigurationExtensions.cs
@@ -1,0 +1,48 @@
+// <copyright file="CastleSiegeConfigurationExtensions.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege;
+
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.GameLogic.CastleSiege.NPC;
+
+/// <summary>
+/// Provides access to Castle Siege structure-upgrade configuration.
+/// </summary>
+internal static class CastleSiegeConfigurationExtensions
+{
+    /// <summary>
+    /// Gets the upgrade definitions for a structure and upgrade type.
+    /// </summary>
+    /// <param name="configuration">The Castle Siege configuration.</param>
+    /// <param name="monsterNumber">The structure monster number.</param>
+    /// <param name="upgradeType">The upgrade type.</param>
+    /// <returns>The matching definitions, or <see langword="null"/> when the combination is unsupported.</returns>
+    internal static ICollection<CastleSiegeUpgradeDefinition>? GetUpgrades(
+        this CastleSiegeConfiguration configuration,
+        short monsterNumber,
+        CastleSiegeUpgradeType upgradeType)
+    {
+        return (monsterNumber, upgradeType) switch
+        {
+            (CastleSiegeGate.MonsterNumber, CastleSiegeUpgradeType.Defense) => configuration.GateDefenseUpgrades,
+            (CastleSiegeGate.MonsterNumber, CastleSiegeUpgradeType.Life) => configuration.GateLifeUpgrades,
+            (CastleSiegeStatue.MonsterNumber, CastleSiegeUpgradeType.Defense) => configuration.StatueDefenseUpgrades,
+            (CastleSiegeStatue.MonsterNumber, CastleSiegeUpgradeType.Life) => configuration.StatueLifeUpgrades,
+            (CastleSiegeStatue.MonsterNumber, CastleSiegeUpgradeType.Regen) => configuration.StatueRegenUpgrades,
+            _ => null,
+        };
+    }
+
+    /// <summary>
+    /// Gets the configured value of an upgrade level.
+    /// </summary>
+    /// <param name="definitions">The upgrade definitions.</param>
+    /// <param name="level">The upgrade level.</param>
+    /// <returns>The configured value, or <see langword="null"/> when the level is missing.</returns>
+    internal static int? GetValue(this IEnumerable<CastleSiegeUpgradeDefinition> definitions, byte level)
+    {
+        return definitions.FirstOrDefault(definition => definition.Level == level)?.Value;
+    }
+}

--- a/src/GameLogic/CastleSiege/CastleSiegeContext.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeContext.cs
@@ -29,6 +29,7 @@ public class CastleSiegeContext : IEventStateProvider
         this._gameContext = gameContext;
         this.Configuration = configuration;
         this.Schedule = new CastleSiegeSchedule(configuration.StateSchedule);
+        this.NpcController = new CastleSiegeNpcController(this);
     }
 
     /// <summary>
@@ -80,6 +81,11 @@ public class CastleSiegeContext : IEventStateProvider
     /// Gets the active Castle Siege NPCs.
     /// </summary>
     public List<CastleSiegeNpcRuntime> ActiveNpcs { get; } = new();
+
+    /// <summary>
+    /// Gets the controller for Castle Siege NPC lifecycle and lookup operations.
+    /// </summary>
+    public CastleSiegeNpcController NpcController { get; }
 
     /// <summary>
     /// Gets or sets the player which currently operates the Crown.
@@ -172,6 +178,7 @@ public class CastleSiegeContext : IEventStateProvider
     {
         this.SiegeData = await this.LoadDataAsync().ConfigureAwait(false)
             ?? throw new InvalidOperationException("The persistent Castle Siege state does not exist.");
+        this.NpcController.InitializePersistentStructures();
         await this.LoadRegistrationsAsync().ConfigureAwait(false);
     }
 
@@ -203,6 +210,7 @@ public class CastleSiegeContext : IEventStateProvider
             return;
         }
 
+        this.NpcController.SynchronizeNpcStates();
         var persistedNpcs = this.ActiveNpcs
             .Where(npc => npc.Definition.IsPersistedToDatabase)
             .ToList();
@@ -212,7 +220,6 @@ public class CastleSiegeContext : IEventStateProvider
         }
 
         var statesToSave = persistedNpcs
-            .Where(npc => npc.IsAlive)
             .Select(npc => npc.PersistedState!)
             .ToDictionary(GetNpcKey);
 
@@ -334,6 +341,7 @@ public class CastleSiegeContext : IEventStateProvider
     {
         this.SiegeData = await this.LoadDataAsync().ConfigureAwait(false)
             ?? await this.CreateDataAsync().ConfigureAwait(false);
+        this.NpcController.InitializePersistentStructures();
         await this.LoadRegistrationsAsync().ConfigureAwait(false);
         var period = this.Schedule.GetCurrentEventPeriod(utcNow);
         this.SetPeriod(period);

--- a/src/GameLogic/CastleSiege/CastleSiegeContext.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeContext.cs
@@ -4,6 +4,7 @@
 
 namespace MUnique.OpenMU.GameLogic.CastleSiege;
 
+using System.Collections.Concurrent;
 using System.Threading;
 using MUnique.OpenMU.DataModel.Configuration;
 using MUnique.OpenMU.DataModel.Entities;
@@ -18,6 +19,7 @@ using MUnique.OpenMU.DataModel.Entities;
 public class CastleSiegeContext : IEventStateProvider
 {
     private readonly IGameContext _gameContext;
+    private readonly ConcurrentDictionary<Player, byte> _siegeMapPlayers = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CastleSiegeContext"/> class.
@@ -266,6 +268,46 @@ public class CastleSiegeContext : IEventStateProvider
     }
 
     /// <summary>
+    /// Tracks a player after a map entry operation.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="map">The entered map.</param>
+    internal void TrackPlayer(Player player, GameMap map)
+    {
+        if (this.Configuration.CastleSiegeMapDefinition?.Number == map.Definition.Number)
+        {
+            this._siegeMapPlayers[player] = 0;
+        }
+        else
+        {
+            this._siegeMapPlayers.TryRemove(player, out _);
+        }
+    }
+
+    /// <summary>
+    /// Stops tracking a player after a map exit operation.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    internal void UntrackPlayer(Player player)
+    {
+        this._siegeMapPlayers.TryRemove(player, out _);
+    }
+
+    /// <summary>
+    /// Executes an action concurrently for players currently on the Castle Siege map.
+    /// </summary>
+    /// <param name="action">The action to execute.</param>
+    /// <returns>A task that represents the asynchronous fan-out operation.</returns>
+    internal async ValueTask ForEachSiegePlayerAsync(Func<Player, Task> action)
+    {
+        var mapNumber = this.Configuration.CastleSiegeMapDefinition?.Number;
+        var actions = this._siegeMapPlayers.Keys
+            .Where(player => player.CurrentMap?.Definition.Number == mapNumber)
+            .Select(action);
+        await Task.WhenAll(actions).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Creates and persists a guild registration.
     /// </summary>
     /// <param name="guildId">The persistent guild identifier.</param>
@@ -345,6 +387,7 @@ public class CastleSiegeContext : IEventStateProvider
         await this.LoadRegistrationsAsync().ConfigureAwait(false);
         var period = this.Schedule.GetCurrentEventPeriod(utcNow);
         this.SetPeriod(period);
+        await this.InitializeSiegeMapPlayersAsync().ConfigureAwait(false);
         this.NextNpcSaveUtc = utcNow.AddMinutes(2);
         this.IsInitialized = true;
         return period;
@@ -398,6 +441,23 @@ public class CastleSiegeContext : IEventStateProvider
     private static (short MonsterNumber, byte InstanceId) GetNpcKey(CastleSiegeNpcState state)
     {
         return (state.MonsterNumber, state.InstanceId);
+    }
+
+    private async ValueTask InitializeSiegeMapPlayersAsync()
+    {
+        this._siegeMapPlayers.Clear();
+        if (this.Configuration.CastleSiegeMapDefinition is not { } siegeMapDefinition)
+        {
+            return;
+        }
+
+        foreach (var player in await this._gameContext.GetPlayersAsync().ConfigureAwait(false))
+        {
+            if (player.CurrentMap?.Definition.Number == siegeMapDefinition.Number)
+            {
+                this._siegeMapPlayers[player] = 0;
+            }
+        }
     }
 
     private async ValueTask<CastleSiegeData?> LoadDataAsync()

--- a/src/GameLogic/CastleSiege/CastleSiegeContext.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeContext.cs
@@ -4,7 +4,6 @@
 
 namespace MUnique.OpenMU.GameLogic.CastleSiege;
 
-using System.Collections.Concurrent;
 using System.Threading;
 using MUnique.OpenMU.DataModel.Configuration;
 using MUnique.OpenMU.DataModel.Entities;
@@ -19,7 +18,7 @@ using MUnique.OpenMU.DataModel.Entities;
 public class CastleSiegeContext : IEventStateProvider
 {
     private readonly IGameContext _gameContext;
-    private readonly ConcurrentDictionary<Player, byte> _siegeMapPlayers = new();
+    private readonly System.Collections.Concurrent.ConcurrentDictionary<Player, byte> _siegeMapPlayers = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CastleSiegeContext"/> class.

--- a/src/GameLogic/CastleSiege/CastleSiegeLeverTalkPlugIn.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeLeverTalkPlugIn.cs
@@ -1,0 +1,37 @@
+// <copyright file="CastleSiegeLeverTalkPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+using MUnique.OpenMU.GameLogic.CastleSiege.NPC;
+using MUnique.OpenMU.GameLogic.NPC;
+using MUnique.OpenMU.GameLogic.PlugIns;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Opens the operation interface of the gate associated with a Castle Siege lever.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeLeverTalkPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeLeverTalkPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("92DC9090-A4B1-4431-BF12-280DCDB8877B")]
+public sealed class CastleSiegeLeverTalkPlugIn : IPlayerTalkToNpcPlugIn
+{
+    /// <inheritdoc />
+    public async ValueTask PlayerTalksToNpcAsync(
+        Player player,
+        NonPlayerCharacter npc,
+        NpcTalkEventArgs eventArgs)
+    {
+        if (npc is not CastleSiegeLever lever || lever.Gate is not { } gate)
+        {
+            return;
+        }
+
+        eventArgs.HasBeenHandled = true;
+        eventArgs.LeavesDialogOpen = true;
+        await CastleSiegeGateOperateAction.ShowInterfaceAsync(player, lever.Context, gate.Id).ConfigureAwait(false);
+    }
+}

--- a/src/GameLogic/CastleSiege/CastleSiegeNpcController.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeNpcController.cs
@@ -18,6 +18,8 @@ using MUnique.OpenMU.Pathfinding;
 public sealed class CastleSiegeNpcController
 {
     private readonly CastleSiegeContext _context;
+    private readonly object _gateTerrainLock = new();
+    private readonly Dictionary<Point, (bool WasWalkable, int ReferenceCount)> _gateTerrain = new();
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CastleSiegeNpcController"/> class.
@@ -113,6 +115,7 @@ public sealed class CastleSiegeNpcController
     /// <returns>The matching runtime, or <see langword="null"/>.</returns>
     public CastleSiegeNpcRuntime? FindDefenseStructure(uint monsterNumber, uint npcIndex)
     {
+        // Management packets use the configured instance id, while the gate interface returns the live map object id.
         return this._context.ActiveNpcs.FirstOrDefault(runtime =>
             runtime.Definition.MonsterDefinition?.Number == monsterNumber
             && (runtime.Definition.InstanceId == npcIndex || runtime.SpawnedInstance?.Id == npcIndex));
@@ -145,13 +148,9 @@ public sealed class CastleSiegeNpcController
     /// <returns>The configured maximum health, or 0 when no matching level exists.</returns>
     public int GetMaximumHealth(CastleSiegeNpcRuntime runtime)
     {
-        IEnumerable<CastleSiegeUpgradeDefinition> definitions = runtime.Definition.MonsterDefinition?.Number switch
-        {
-            var number when number == CastleSiegeGate.MonsterNumber => this._context.Configuration.GateLifeUpgrades,
-            var number when number == CastleSiegeStatue.MonsterNumber => this._context.Configuration.StatueLifeUpgrades,
-            _ => [],
-        };
-        return definitions.FirstOrDefault(definition => definition.Level == runtime.PersistedState?.LifeLevel)?.Value ?? 0;
+        var monsterNumber = runtime.Definition.MonsterDefinition?.Number ?? 0;
+        var lifeLevel = runtime.PersistedState?.LifeLevel ?? byte.MaxValue;
+        return this._context.Configuration.GetUpgrades(monsterNumber, CastleSiegeUpgradeType.Life)?.GetValue(lifeLevel) ?? 0;
     }
 
     /// <summary>
@@ -207,6 +206,83 @@ public sealed class CastleSiegeNpcController
     }
 
     /// <summary>
+    /// Applies a reference-counted terrain block for one gate area.
+    /// </summary>
+    /// <param name="map">The Castle Siege map.</param>
+    /// <param name="area">The gate terrain area.</param>
+    internal void BlockGateTerrain(
+        GameMap map,
+        (byte StartX, byte StartY, byte EndX, byte EndY) area)
+    {
+        lock (this._gateTerrainLock)
+        {
+            for (var x = area.StartX; x <= area.EndX; x++)
+            {
+                for (var y = area.StartY; y <= area.EndY; y++)
+                {
+                    var point = new Point(x, y);
+                    if (this._gateTerrain.TryGetValue(point, out var state))
+                    {
+                        this._gateTerrain[point] = (state.WasWalkable, state.ReferenceCount + 1);
+                    }
+                    else
+                    {
+                        this._gateTerrain[point] = (map.Terrain.WalkMap[x, y], 1);
+                    }
+
+                    map.Terrain.WalkMap[x, y] = false;
+                    map.Terrain.UpdateAiGridValue(x, y);
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Releases one gate's terrain block and returns tiles which must remain blocked.
+    /// </summary>
+    /// <param name="map">The Castle Siege map.</param>
+    /// <param name="area">The gate terrain area.</param>
+    /// <returns>Tiles which were originally blocked or are still covered by another closed gate.</returns>
+    internal IReadOnlyCollection<(byte StartX, byte StartY, byte EndX, byte EndY)> ReleaseGateTerrain(
+        GameMap map,
+        (byte StartX, byte StartY, byte EndX, byte EndY) area)
+    {
+        var blockedAreas = new List<(byte StartX, byte StartY, byte EndX, byte EndY)>();
+        lock (this._gateTerrainLock)
+        {
+            for (var x = area.StartX; x <= area.EndX; x++)
+            {
+                for (var y = area.StartY; y <= area.EndY; y++)
+                {
+                    var point = new Point(x, y);
+                    if (!this._gateTerrain.Remove(point, out var state))
+                    {
+                        continue;
+                    }
+
+                    if (state.ReferenceCount > 1)
+                    {
+                        this._gateTerrain[point] = (state.WasWalkable, state.ReferenceCount - 1);
+                        map.Terrain.WalkMap[x, y] = false;
+                    }
+                    else
+                    {
+                        map.Terrain.WalkMap[x, y] = state.WasWalkable;
+                    }
+
+                    map.Terrain.UpdateAiGridValue(x, y);
+                    if (!map.Terrain.WalkMap[x, y])
+                    {
+                        blockedAreas.Add((x, y, x, y));
+                    }
+                }
+            }
+        }
+
+        return blockedAreas;
+    }
+
+    /// <summary>
     /// Initializes the persistent defense-structure runtimes after the siege data has been loaded.
     /// </summary>
     internal void InitializePersistentStructures()
@@ -243,8 +319,8 @@ public sealed class CastleSiegeNpcController
     private static async ValueTask RemoveConfiguredDuplicateAsync(GameMap map, CastleSiegeNpcRuntime runtime)
     {
         var position = new Point(
-            checked((byte)runtime.Definition.SpawnX),
-            checked((byte)runtime.Definition.SpawnY));
+            runtime.Definition.SpawnX,
+            runtime.Definition.SpawnY);
         var duplicates = map.GetNpcsInRange(position, 1)
             .Where(npc => npc is not ICastleSiegeNpc
                           && npc.Definition.Number == runtime.Definition.MonsterDefinition?.Number
@@ -300,8 +376,8 @@ public sealed class CastleSiegeNpcController
             state?.RegenLevel ?? 0,
             attackable?.MaximumHealth ?? this.GetMaximumHealth(runtime),
             attackable?.Health ?? state?.CurrentHp ?? 0,
-            checked((byte)runtime.Definition.SpawnX),
-            checked((byte)runtime.Definition.SpawnY),
+            runtime.Definition.SpawnX,
+            runtime.Definition.SpawnY,
             runtime.IsAlive);
     }
 
@@ -347,13 +423,12 @@ public sealed class CastleSiegeNpcController
 
     private int GetInitialHealth(short monsterNumber)
     {
-        var upgrades = monsterNumber switch
+        if (monsterNumber is not (CastleSiegeGate.MonsterNumber or CastleSiegeStatue.MonsterNumber))
         {
-            var number when number == CastleSiegeGate.MonsterNumber => this._context.Configuration.GateLifeUpgrades,
-            var number when number == CastleSiegeStatue.MonsterNumber => this._context.Configuration.StatueLifeUpgrades,
-            _ => throw new ArgumentOutOfRangeException(nameof(monsterNumber), monsterNumber, "Not a persistent Castle Siege structure."),
-        };
-        return upgrades.FirstOrDefault(upgrade => upgrade.Level == 0)?.Value
+            throw new ArgumentOutOfRangeException(nameof(monsterNumber), monsterNumber, "Not a persistent Castle Siege structure.");
+        }
+
+        return this._context.Configuration.GetUpgrades(monsterNumber, CastleSiegeUpgradeType.Life)?.GetValue(0)
                ?? throw new InvalidOperationException($"Initial health for Castle Siege NPC {monsterNumber} is not configured.");
     }
 
@@ -376,10 +451,10 @@ public sealed class CastleSiegeNpcController
         {
             MonsterDefinition = monsterDefinition,
             GameMap = map.Definition,
-            X1 = checked((byte)definition.SpawnX),
-            X2 = checked((byte)definition.SpawnX),
-            Y1 = checked((byte)definition.SpawnY),
-            Y2 = checked((byte)definition.SpawnY),
+            X1 = definition.SpawnX,
+            X2 = definition.SpawnX,
+            Y1 = definition.SpawnY,
+            Y2 = definition.SpawnY,
             Direction = definition.Direction,
             Quantity = 1,
             SpawnTrigger = SpawnTrigger.ManuallyForEvent,
@@ -402,7 +477,7 @@ public sealed class CastleSiegeNpcController
         var definition = spawnArea.MonsterDefinition!;
         return definition.Number switch
         {
-            var number when number == CastleSiegeGate.MonsterNumber => new CastleSiegeGate(
+            CastleSiegeGate.MonsterNumber => new CastleSiegeGate(
                 spawnArea,
                 definition,
                 map,
@@ -411,7 +486,7 @@ public sealed class CastleSiegeNpcController
                 new CastleSiegeGateIntelligence(),
                 this._context.GameContext.DropGenerator,
                 this._context.GameContext.PlugInManager),
-            var number when number == CastleSiegeStatue.MonsterNumber => new CastleSiegeStatue(
+            CastleSiegeStatue.MonsterNumber => new CastleSiegeStatue(
                 spawnArea,
                 definition,
                 map,
@@ -420,35 +495,34 @@ public sealed class CastleSiegeNpcController
                 new CastleSiegeStatueIntelligence(),
                 this._context.GameContext.DropGenerator,
                 this._context.GameContext.PlugInManager),
-            var number when number == CastleSiegeCrown.MonsterNumber => new CastleSiegeCrown(
+            CastleSiegeCrown.MonsterNumber => new CastleSiegeCrown(
                 spawnArea,
                 definition,
                 map,
                 runtime,
                 new CastleSiegeCrownIntelligence(this._context)),
-            var number when number == CastleSiegeSwitch.FirstMonsterNumber => new CastleSiegeSwitch(
+            CastleSiegeSwitch.FirstMonsterNumber => new CastleSiegeSwitch(
                 spawnArea,
                 definition,
                 map,
                 runtime,
                 new CastleSiegeSwitchIntelligence(this._context),
                 0),
-            var number when number == CastleSiegeSwitch.SecondMonsterNumber => new CastleSiegeSwitch(
+            CastleSiegeSwitch.SecondMonsterNumber => new CastleSiegeSwitch(
                 spawnArea,
                 definition,
                 map,
                 runtime,
                 new CastleSiegeSwitchIntelligence(this._context),
                 1),
-            var number when number == CastleSiegeLever.MonsterNumber => new CastleSiegeLever(
+            CastleSiegeLever.MonsterNumber => new CastleSiegeLever(
                 spawnArea,
                 definition,
                 map,
                 this._context,
                 runtime,
                 new CastleSiegeLeverIntelligence()),
-            var number when number == CastleSiegeMachine.AttackMonsterNumber
-                            || number == CastleSiegeMachine.DefenseMonsterNumber => new CastleSiegeMachine(
+            CastleSiegeMachine.AttackMonsterNumber or CastleSiegeMachine.DefenseMonsterNumber => new CastleSiegeMachine(
                 spawnArea,
                 definition,
                 map,

--- a/src/GameLogic/CastleSiege/CastleSiegeNpcController.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeNpcController.cs
@@ -147,8 +147,8 @@ public sealed class CastleSiegeNpcController
     {
         IEnumerable<CastleSiegeUpgradeDefinition> definitions = runtime.Definition.MonsterDefinition?.Number switch
         {
-            CastleSiegeGate.MonsterNumber => this._context.Configuration.GateLifeUpgrades,
-            CastleSiegeStatue.MonsterNumber => this._context.Configuration.StatueLifeUpgrades,
+            var number when number == CastleSiegeGate.MonsterNumber => this._context.Configuration.GateLifeUpgrades,
+            var number when number == CastleSiegeStatue.MonsterNumber => this._context.Configuration.StatueLifeUpgrades,
             _ => [],
         };
         return definitions.FirstOrDefault(definition => definition.Level == runtime.PersistedState?.LifeLevel)?.Value ?? 0;
@@ -235,8 +235,9 @@ public sealed class CastleSiegeNpcController
 
     private static bool IsMachine(CastleSiegeNpcDefinition definition)
     {
-        return definition.MonsterDefinition?.Number
-            is CastleSiegeMachine.AttackMonsterNumber or CastleSiegeMachine.DefenseMonsterNumber;
+        var monsterNumber = definition.MonsterDefinition?.Number;
+        return monsterNumber == CastleSiegeMachine.AttackMonsterNumber
+               || monsterNumber == CastleSiegeMachine.DefenseMonsterNumber;
     }
 
     private static async ValueTask RemoveConfiguredDuplicateAsync(GameMap map, CastleSiegeNpcRuntime runtime)
@@ -275,7 +276,8 @@ public sealed class CastleSiegeNpcController
 
     private List<CastleSiegeNpcRuntime> GetDefenseStructures(short monsterNumber)
     {
-        if (monsterNumber is not (CastleSiegeGate.MonsterNumber or CastleSiegeStatue.MonsterNumber))
+        if (monsterNumber != CastleSiegeGate.MonsterNumber
+            && monsterNumber != CastleSiegeStatue.MonsterNumber)
         {
             return [];
         }
@@ -347,8 +349,8 @@ public sealed class CastleSiegeNpcController
     {
         var upgrades = monsterNumber switch
         {
-            CastleSiegeGate.MonsterNumber => this._context.Configuration.GateLifeUpgrades,
-            CastleSiegeStatue.MonsterNumber => this._context.Configuration.StatueLifeUpgrades,
+            var number when number == CastleSiegeGate.MonsterNumber => this._context.Configuration.GateLifeUpgrades,
+            var number when number == CastleSiegeStatue.MonsterNumber => this._context.Configuration.StatueLifeUpgrades,
             _ => throw new ArgumentOutOfRangeException(nameof(monsterNumber), monsterNumber, "Not a persistent Castle Siege structure."),
         };
         return upgrades.FirstOrDefault(upgrade => upgrade.Level == 0)?.Value
@@ -400,7 +402,7 @@ public sealed class CastleSiegeNpcController
         var definition = spawnArea.MonsterDefinition!;
         return definition.Number switch
         {
-            CastleSiegeGate.MonsterNumber => new CastleSiegeGate(
+            var number when number == CastleSiegeGate.MonsterNumber => new CastleSiegeGate(
                 spawnArea,
                 definition,
                 map,
@@ -409,7 +411,7 @@ public sealed class CastleSiegeNpcController
                 new CastleSiegeGateIntelligence(),
                 this._context.GameContext.DropGenerator,
                 this._context.GameContext.PlugInManager),
-            CastleSiegeStatue.MonsterNumber => new CastleSiegeStatue(
+            var number when number == CastleSiegeStatue.MonsterNumber => new CastleSiegeStatue(
                 spawnArea,
                 definition,
                 map,
@@ -418,34 +420,35 @@ public sealed class CastleSiegeNpcController
                 new CastleSiegeStatueIntelligence(),
                 this._context.GameContext.DropGenerator,
                 this._context.GameContext.PlugInManager),
-            CastleSiegeCrown.MonsterNumber => new CastleSiegeCrown(
+            var number when number == CastleSiegeCrown.MonsterNumber => new CastleSiegeCrown(
                 spawnArea,
                 definition,
                 map,
                 runtime,
                 new CastleSiegeCrownIntelligence(this._context)),
-            CastleSiegeSwitch.FirstMonsterNumber => new CastleSiegeSwitch(
+            var number when number == CastleSiegeSwitch.FirstMonsterNumber => new CastleSiegeSwitch(
                 spawnArea,
                 definition,
                 map,
                 runtime,
                 new CastleSiegeSwitchIntelligence(this._context),
                 0),
-            CastleSiegeSwitch.SecondMonsterNumber => new CastleSiegeSwitch(
+            var number when number == CastleSiegeSwitch.SecondMonsterNumber => new CastleSiegeSwitch(
                 spawnArea,
                 definition,
                 map,
                 runtime,
                 new CastleSiegeSwitchIntelligence(this._context),
                 1),
-            CastleSiegeLever.MonsterNumber => new CastleSiegeLever(
+            var number when number == CastleSiegeLever.MonsterNumber => new CastleSiegeLever(
                 spawnArea,
                 definition,
                 map,
                 this._context,
                 runtime,
                 new CastleSiegeLeverIntelligence()),
-            CastleSiegeMachine.AttackMonsterNumber or CastleSiegeMachine.DefenseMonsterNumber => new CastleSiegeMachine(
+            var number when number == CastleSiegeMachine.AttackMonsterNumber
+                            || number == CastleSiegeMachine.DefenseMonsterNumber => new CastleSiegeMachine(
                 spawnArea,
                 definition,
                 map,

--- a/src/GameLogic/CastleSiege/CastleSiegeNpcController.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeNpcController.cs
@@ -1,0 +1,471 @@
+// <copyright file="CastleSiegeNpcController.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege;
+
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.DataModel.Entities;
+using MUnique.OpenMU.GameLogic.CastleSiege.Intelligence;
+using MUnique.OpenMU.GameLogic.CastleSiege.NPC;
+using MUnique.OpenMU.GameLogic.NPC;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+using MUnique.OpenMU.Pathfinding;
+
+/// <summary>
+/// Creates and synchronizes the configured Castle Siege NPCs.
+/// </summary>
+public sealed class CastleSiegeNpcController
+{
+    private readonly CastleSiegeContext _context;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeNpcController"/> class.
+    /// </summary>
+    /// <param name="context">The Castle Siege context.</param>
+    public CastleSiegeNpcController(CastleSiegeContext context)
+    {
+        this._context = context;
+    }
+
+    /// <summary>
+    /// Spawns persistent structures and static interactive NPCs for the Ready phase.
+    /// Siege machines are intentionally excluded.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous preparation.</returns>
+    public async ValueTask PrepareAsync()
+    {
+        foreach (var definition in this._context.Configuration.NpcDefinitions
+                     .Where(definition => !IsMachine(definition)))
+        {
+            var runtime = this.GetOrCreateRuntime(definition);
+            if (runtime.Definition.IsPersistedToDatabase
+                && runtime.PersistedState is { CurrentHp: <= 0 })
+            {
+                runtime.IsAlive = false;
+                continue;
+            }
+
+            await this.EnsureSpawnedAsync(runtime).ConfigureAwait(false);
+        }
+
+        this.AssociateLevers();
+    }
+
+    /// <summary>
+    /// Spawns the non-persistent siege machines at battle start.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous spawn operation.</returns>
+    public async ValueTask SpawnMachinesAsync()
+    {
+        foreach (var definition in this._context.Configuration.NpcDefinitions.Where(IsMachine))
+        {
+            var runtime = this.GetOrCreateRuntime(definition);
+            await this.EnsureSpawnedAsync(runtime).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Closes every alive Castle Siege gate.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous close operation.</returns>
+    public async ValueTask CloseGatesAsync()
+    {
+        foreach (var gate in this._context.ActiveNpcs
+                     .Select(runtime => runtime.SpawnedInstance)
+                     .OfType<CastleSiegeGate>())
+        {
+            await gate.CloseAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Synchronizes persisted HP and alive flags with spawned NPC objects.
+    /// </summary>
+    public void SynchronizeNpcStates()
+    {
+        foreach (var runtime in this._context.ActiveNpcs)
+        {
+            if (runtime.SpawnedInstance is CastleSiegeAttackableNpc attackable)
+            {
+                runtime.IsAlive = attackable.IsAlive;
+                if (runtime.PersistedState is { } state)
+                {
+                    state.CurrentHp = attackable.Health;
+                }
+            }
+            else if (runtime.Definition.IsPersistedToDatabase)
+            {
+                runtime.IsAlive = runtime.PersistedState is { CurrentHp: > 0 };
+            }
+            else
+            {
+                runtime.IsAlive = runtime.SpawnedInstance is not null;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets an attackable NPC runtime by its packet identity.
+    /// </summary>
+    /// <param name="monsterNumber">The monster number.</param>
+    /// <param name="npcIndex">The spawned object or configured instance identifier.</param>
+    /// <returns>The matching runtime, or <see langword="null"/>.</returns>
+    public CastleSiegeNpcRuntime? FindDefenseStructure(uint monsterNumber, uint npcIndex)
+    {
+        return this._context.ActiveNpcs.FirstOrDefault(runtime =>
+            runtime.Definition.MonsterDefinition?.Number == monsterNumber
+            && (runtime.Definition.InstanceId == npcIndex || runtime.SpawnedInstance?.Id == npcIndex));
+    }
+
+    /// <summary>
+    /// Gets an immutable management snapshot of one defense-structure type.
+    /// </summary>
+    /// <param name="monsterNumber">The gate or Guardian Statue monster number.</param>
+    /// <returns>The configured defense structures in management-index order.</returns>
+    public async ValueTask<IReadOnlyList<CastleSiegeNpcInfo>> GetDefenseStructureSnapshotAsync(short monsterNumber)
+    {
+        await this._context.ExecutionLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            return this.GetDefenseStructures(monsterNumber)
+                .Select(this.CreateInfo)
+                .ToList();
+        }
+        finally
+        {
+            this._context.ExecutionLock.Release();
+        }
+    }
+
+    /// <summary>
+    /// Gets the configured maximum health of a defense structure at its persisted life level.
+    /// </summary>
+    /// <param name="runtime">The defense-structure runtime.</param>
+    /// <returns>The configured maximum health, or 0 when no matching level exists.</returns>
+    public int GetMaximumHealth(CastleSiegeNpcRuntime runtime)
+    {
+        IEnumerable<CastleSiegeUpgradeDefinition> definitions = runtime.Definition.MonsterDefinition?.Number switch
+        {
+            CastleSiegeGate.MonsterNumber => this._context.Configuration.GateLifeUpgrades,
+            CastleSiegeStatue.MonsterNumber => this._context.Configuration.StatueLifeUpgrades,
+            _ => [],
+        };
+        return definitions.FirstOrDefault(definition => definition.Level == runtime.PersistedState?.LifeLevel)?.Value ?? 0;
+    }
+
+    /// <summary>
+    /// Gets a gate by its spawned object or configured instance identifier.
+    /// </summary>
+    /// <param name="gateId">The gate identifier.</param>
+    /// <returns>The matching gate, or <see langword="null"/>.</returns>
+    public CastleSiegeGate? FindGate(ushort gateId)
+    {
+        return this._context.ActiveNpcs
+            .Where(runtime => runtime.Definition.MonsterDefinition?.Number == CastleSiegeGate.MonsterNumber)
+            .Where(runtime => runtime.Definition.InstanceId == gateId || runtime.SpawnedInstance?.Id == gateId)
+            .Select(runtime => runtime.SpawnedInstance)
+            .OfType<CastleSiegeGate>()
+            .FirstOrDefault();
+    }
+
+    /// <summary>
+    /// Spawns a re-purchased defense structure.
+    /// </summary>
+    /// <param name="runtime">The structure runtime.</param>
+    /// <returns>A task that represents the asynchronous respawn operation.</returns>
+    public ValueTask RespawnAsync(CastleSiegeNpcRuntime runtime)
+    {
+        return this.EnsureSpawnedAsync(runtime);
+    }
+
+    /// <summary>
+    /// Despawns all battle-only siege machines.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous despawn operation.</returns>
+    public async ValueTask DespawnMachinesAsync()
+    {
+        foreach (var runtime in this._context.ActiveNpcs.Where(runtime => IsMachine(runtime.Definition)).ToList())
+        {
+            await DespawnAsync(runtime).ConfigureAwait(false);
+            this._context.ActiveNpcs.Remove(runtime);
+        }
+    }
+
+    /// <summary>
+    /// Despawns all Castle Siege-owned NPC objects.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous despawn operation.</returns>
+    public async ValueTask DespawnAllAsync()
+    {
+        foreach (var runtime in this._context.ActiveNpcs.ToList())
+        {
+            await DespawnAsync(runtime).ConfigureAwait(false);
+        }
+
+        this._context.ActiveNpcs.RemoveAll(runtime => !runtime.Definition.IsPersistedToDatabase);
+    }
+
+    /// <summary>
+    /// Initializes the persistent defense-structure runtimes after the siege data has been loaded.
+    /// </summary>
+    internal void InitializePersistentStructures()
+    {
+        foreach (var definition in this._context.Configuration.NpcDefinitions
+                     .Where(definition => definition.IsPersistedToDatabase))
+        {
+            this.GetOrCreateRuntime(definition);
+        }
+    }
+
+    /// <summary>
+    /// Sends the current state of all Castle Siege structures which affect a player's client.
+    /// </summary>
+    /// <param name="player">The player entering the Castle Siege map.</param>
+    /// <returns>A task that represents the asynchronous synchronization.</returns>
+    internal async ValueTask SynchronizePlayerAsync(Player player)
+    {
+        foreach (var gate in this._context.ActiveNpcs
+                     .Select(runtime => runtime.SpawnedInstance)
+                     .OfType<CastleSiegeGate>())
+        {
+            await gate.SynchronizeStateAsync(player).ConfigureAwait(false);
+        }
+    }
+
+    private static bool IsMachine(CastleSiegeNpcDefinition definition)
+    {
+        return definition.MonsterDefinition?.Number
+            is CastleSiegeMachine.AttackMonsterNumber or CastleSiegeMachine.DefenseMonsterNumber;
+    }
+
+    private static async ValueTask RemoveConfiguredDuplicateAsync(GameMap map, CastleSiegeNpcRuntime runtime)
+    {
+        var position = new Point(
+            checked((byte)runtime.Definition.SpawnX),
+            checked((byte)runtime.Definition.SpawnY));
+        var duplicates = map.GetNpcsInRange(position, 1)
+            .Where(npc => npc is not ICastleSiegeNpc
+                          && npc.Definition.Number == runtime.Definition.MonsterDefinition?.Number
+                          && npc.Position == position)
+            .ToList();
+        foreach (var duplicate in duplicates)
+        {
+            await map.RemoveAsync(duplicate).ConfigureAwait(false);
+            duplicate.Dispose();
+        }
+    }
+
+    private static async ValueTask DespawnAsync(CastleSiegeNpcRuntime runtime)
+    {
+        if (runtime.SpawnedInstance is CastleSiegeGate gate)
+        {
+            await gate.OpenAsync().ConfigureAwait(false);
+        }
+
+        if (runtime.SpawnedInstance is NonPlayerCharacter npc)
+        {
+            await npc.CurrentMap.RemoveAsync(npc).ConfigureAwait(false);
+            npc.Dispose();
+        }
+
+        runtime.SpawnedInstance = null;
+        runtime.IsAlive = runtime.PersistedState is { CurrentHp: > 0 };
+    }
+
+    private List<CastleSiegeNpcRuntime> GetDefenseStructures(short monsterNumber)
+    {
+        if (monsterNumber is not (CastleSiegeGate.MonsterNumber or CastleSiegeStatue.MonsterNumber))
+        {
+            return [];
+        }
+
+        return this._context.ActiveNpcs
+            .Where(runtime => runtime.Definition.IsPersistedToDatabase
+                              && runtime.Definition.MonsterDefinition?.Number == monsterNumber)
+            .OrderBy(runtime => runtime.Definition.InstanceId)
+            .ToList();
+    }
+
+    private CastleSiegeNpcInfo CreateInfo(CastleSiegeNpcRuntime runtime)
+    {
+        var state = runtime.PersistedState;
+        var attackable = runtime.SpawnedInstance as CastleSiegeAttackableNpc;
+        return new CastleSiegeNpcInfo(
+            (uint)(runtime.Definition.MonsterDefinition?.Number ?? 0),
+            runtime.Definition.InstanceId,
+            state?.DefenseLevel ?? 0,
+            state?.RegenLevel ?? 0,
+            attackable?.MaximumHealth ?? this.GetMaximumHealth(runtime),
+            attackable?.Health ?? state?.CurrentHp ?? 0,
+            checked((byte)runtime.Definition.SpawnX),
+            checked((byte)runtime.Definition.SpawnY),
+            runtime.IsAlive);
+    }
+
+    private CastleSiegeNpcRuntime GetOrCreateRuntime(CastleSiegeNpcDefinition definition)
+    {
+        var runtime = this._context.ActiveNpcs.FirstOrDefault(candidate =>
+            candidate.Definition.MonsterDefinition?.Number == definition.MonsterDefinition?.Number
+            && candidate.Definition.InstanceId == definition.InstanceId);
+        if (runtime is not null)
+        {
+            return runtime;
+        }
+
+        CastleSiegeNpcState? state = null;
+        if (definition.IsPersistedToDatabase)
+        {
+            var monsterNumber = definition.MonsterDefinition?.Number
+                                ?? throw Error.NotInitializedProperty(definition, nameof(definition.MonsterDefinition));
+            state = this._context.SiegeData.NpcStates.FirstOrDefault(candidate =>
+                candidate.MonsterNumber == monsterNumber
+                && candidate.InstanceId == definition.InstanceId);
+            if (state is null)
+            {
+                state = new CastleSiegeNpcState
+                {
+                    MonsterNumber = monsterNumber,
+                    InstanceId = definition.InstanceId,
+                    CurrentHp = this.GetInitialHealth(monsterNumber),
+                };
+                this._context.SiegeData.NpcStates.Add(state);
+            }
+        }
+
+        runtime = new CastleSiegeNpcRuntime
+        {
+            Definition = definition,
+            PersistedState = state,
+            IsAlive = state?.CurrentHp > 0 || !definition.IsPersistedToDatabase,
+        };
+        this._context.ActiveNpcs.Add(runtime);
+        return runtime;
+    }
+
+    private int GetInitialHealth(short monsterNumber)
+    {
+        var upgrades = monsterNumber switch
+        {
+            CastleSiegeGate.MonsterNumber => this._context.Configuration.GateLifeUpgrades,
+            CastleSiegeStatue.MonsterNumber => this._context.Configuration.StatueLifeUpgrades,
+            _ => throw new ArgumentOutOfRangeException(nameof(monsterNumber), monsterNumber, "Not a persistent Castle Siege structure."),
+        };
+        return upgrades.FirstOrDefault(upgrade => upgrade.Level == 0)?.Value
+               ?? throw new InvalidOperationException($"Initial health for Castle Siege NPC {monsterNumber} is not configured.");
+    }
+
+    private async ValueTask EnsureSpawnedAsync(CastleSiegeNpcRuntime runtime)
+    {
+        if (runtime.SpawnedInstance is { })
+        {
+            runtime.IsAlive = true;
+            return;
+        }
+
+        var mapNumber = this._context.Configuration.CastleSiegeMapDefinition?.Number
+                        ?? throw Error.NotInitializedProperty(this._context.Configuration, nameof(this._context.Configuration.CastleSiegeMapDefinition));
+        var map = await this._context.GameContext.GetMapAsync(checked((ushort)mapNumber)).ConfigureAwait(false)
+                  ?? throw new InvalidOperationException($"Castle Siege map {mapNumber} is not hosted by this game context.");
+        var definition = runtime.Definition;
+        var monsterDefinition = definition.MonsterDefinition
+                                ?? throw Error.NotInitializedProperty(definition, nameof(definition.MonsterDefinition));
+        var spawnArea = new MonsterSpawnArea
+        {
+            MonsterDefinition = monsterDefinition,
+            GameMap = map.Definition,
+            X1 = checked((byte)definition.SpawnX),
+            X2 = checked((byte)definition.SpawnX),
+            Y1 = checked((byte)definition.SpawnY),
+            Y2 = checked((byte)definition.SpawnY),
+            Direction = definition.Direction,
+            Quantity = 1,
+            SpawnTrigger = SpawnTrigger.ManuallyForEvent,
+        };
+
+        await RemoveConfiguredDuplicateAsync(map, runtime).ConfigureAwait(false);
+        var npc = this.CreateNpc(spawnArea, map, runtime);
+        npc.Initialize();
+        await map.AddAsync(npc).ConfigureAwait(false);
+        npc.OnSpawn();
+        runtime.SpawnedInstance = npc;
+        runtime.IsAlive = true;
+    }
+
+    private NonPlayerCharacter CreateNpc(
+        MonsterSpawnArea spawnArea,
+        GameMap map,
+        CastleSiegeNpcRuntime runtime)
+    {
+        var definition = spawnArea.MonsterDefinition!;
+        return definition.Number switch
+        {
+            CastleSiegeGate.MonsterNumber => new CastleSiegeGate(
+                spawnArea,
+                definition,
+                map,
+                this._context,
+                runtime,
+                new CastleSiegeGateIntelligence(),
+                this._context.GameContext.DropGenerator,
+                this._context.GameContext.PlugInManager),
+            CastleSiegeStatue.MonsterNumber => new CastleSiegeStatue(
+                spawnArea,
+                definition,
+                map,
+                this._context,
+                runtime,
+                new CastleSiegeStatueIntelligence(),
+                this._context.GameContext.DropGenerator,
+                this._context.GameContext.PlugInManager),
+            CastleSiegeCrown.MonsterNumber => new CastleSiegeCrown(
+                spawnArea,
+                definition,
+                map,
+                runtime,
+                new CastleSiegeCrownIntelligence(this._context)),
+            CastleSiegeSwitch.FirstMonsterNumber => new CastleSiegeSwitch(
+                spawnArea,
+                definition,
+                map,
+                runtime,
+                new CastleSiegeSwitchIntelligence(this._context),
+                0),
+            CastleSiegeSwitch.SecondMonsterNumber => new CastleSiegeSwitch(
+                spawnArea,
+                definition,
+                map,
+                runtime,
+                new CastleSiegeSwitchIntelligence(this._context),
+                1),
+            CastleSiegeLever.MonsterNumber => new CastleSiegeLever(
+                spawnArea,
+                definition,
+                map,
+                this._context,
+                runtime,
+                new CastleSiegeLeverIntelligence()),
+            CastleSiegeMachine.AttackMonsterNumber or CastleSiegeMachine.DefenseMonsterNumber => new CastleSiegeMachine(
+                spawnArea,
+                definition,
+                map,
+                runtime,
+                new CastleSiegeMachineIntelligence()),
+            _ => throw new NotSupportedException($"Castle Siege NPC {definition.Number} is not supported."),
+        };
+    }
+
+    private void AssociateLevers()
+    {
+        var gatesByInstance = this._context.ActiveNpcs
+            .Where(runtime => runtime.Definition.MonsterDefinition?.Number == CastleSiegeGate.MonsterNumber)
+            .Where(runtime => runtime.SpawnedInstance is CastleSiegeGate)
+            .ToDictionary(runtime => runtime.Definition.InstanceId, runtime => (CastleSiegeGate)runtime.SpawnedInstance!);
+        foreach (var runtime in this._context.ActiveNpcs
+                     .Where(runtime => runtime.SpawnedInstance is CastleSiegeLever))
+        {
+            ((CastleSiegeLever)runtime.SpawnedInstance!).Gate =
+                gatesByInstance.GetValueOrDefault(runtime.Definition.InstanceId);
+        }
+    }
+}

--- a/src/GameLogic/CastleSiege/CastleSiegeNpcController.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeNpcController.cs
@@ -423,7 +423,8 @@ public sealed class CastleSiegeNpcController
 
     private int GetInitialHealth(short monsterNumber)
     {
-        if (monsterNumber is not (CastleSiegeGate.MonsterNumber or CastleSiegeStatue.MonsterNumber))
+        if (monsterNumber != CastleSiegeGate.MonsterNumber
+            && monsterNumber != CastleSiegeStatue.MonsterNumber)
         {
             throw new ArgumentOutOfRangeException(nameof(monsterNumber), monsterNumber, "Not a persistent Castle Siege structure.");
         }
@@ -477,7 +478,7 @@ public sealed class CastleSiegeNpcController
         var definition = spawnArea.MonsterDefinition!;
         return definition.Number switch
         {
-            CastleSiegeGate.MonsterNumber => new CastleSiegeGate(
+            var number when number == CastleSiegeGate.MonsterNumber => new CastleSiegeGate(
                 spawnArea,
                 definition,
                 map,
@@ -486,7 +487,7 @@ public sealed class CastleSiegeNpcController
                 new CastleSiegeGateIntelligence(),
                 this._context.GameContext.DropGenerator,
                 this._context.GameContext.PlugInManager),
-            CastleSiegeStatue.MonsterNumber => new CastleSiegeStatue(
+            var number when number == CastleSiegeStatue.MonsterNumber => new CastleSiegeStatue(
                 spawnArea,
                 definition,
                 map,
@@ -495,34 +496,35 @@ public sealed class CastleSiegeNpcController
                 new CastleSiegeStatueIntelligence(),
                 this._context.GameContext.DropGenerator,
                 this._context.GameContext.PlugInManager),
-            CastleSiegeCrown.MonsterNumber => new CastleSiegeCrown(
+            var number when number == CastleSiegeCrown.MonsterNumber => new CastleSiegeCrown(
                 spawnArea,
                 definition,
                 map,
                 runtime,
                 new CastleSiegeCrownIntelligence(this._context)),
-            CastleSiegeSwitch.FirstMonsterNumber => new CastleSiegeSwitch(
+            var number when number == CastleSiegeSwitch.FirstMonsterNumber => new CastleSiegeSwitch(
                 spawnArea,
                 definition,
                 map,
                 runtime,
                 new CastleSiegeSwitchIntelligence(this._context),
                 0),
-            CastleSiegeSwitch.SecondMonsterNumber => new CastleSiegeSwitch(
+            var number when number == CastleSiegeSwitch.SecondMonsterNumber => new CastleSiegeSwitch(
                 spawnArea,
                 definition,
                 map,
                 runtime,
                 new CastleSiegeSwitchIntelligence(this._context),
                 1),
-            CastleSiegeLever.MonsterNumber => new CastleSiegeLever(
+            var number when number == CastleSiegeLever.MonsterNumber => new CastleSiegeLever(
                 spawnArea,
                 definition,
                 map,
                 this._context,
                 runtime,
                 new CastleSiegeLeverIntelligence()),
-            CastleSiegeMachine.AttackMonsterNumber or CastleSiegeMachine.DefenseMonsterNumber => new CastleSiegeMachine(
+            var number when number == CastleSiegeMachine.AttackMonsterNumber
+                            || number == CastleSiegeMachine.DefenseMonsterNumber => new CastleSiegeMachine(
                 spawnArea,
                 definition,
                 map,

--- a/src/GameLogic/CastleSiege/CastleSiegePlugIn.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegePlugIn.cs
@@ -17,7 +17,7 @@ using MUnique.OpenMU.PlugIns;
 [PlugIn]
 [Display(Name = nameof(PlugInResources.CastleSiegePlugIn_Name), Description = nameof(PlugInResources.CastleSiegePlugIn_Description), ResourceType = typeof(PlugInResources))]
 [Guid("B7F62FA9-59E6-49E9-B499-0358A14957CF")]
-public class CastleSiegePlugIn : IPeriodicTaskPlugIn
+public class CastleSiegePlugIn : IPeriodicTaskPlugIn, IObjectAddedToMapPlugIn
 {
     private static readonly TimeSpan NpcSaveInterval = TimeSpan.FromMinutes(2);
 
@@ -49,6 +49,16 @@ public class CastleSiegePlugIn : IPeriodicTaskPlugIn
 
     /// <inheritdoc />
     public void ForceStart() => this.ForceState(CastleSiegeState.Start);
+
+    /// <inheritdoc />
+    public async ValueTask ObjectAddedToMapAsync(GameMap map, ILocateable addedObject)
+    {
+        if (addedObject is Player player
+            && this.GetContext(player.GameContext) is { } context)
+        {
+            await SynchronizePlayerAsync(player, map, context).ConfigureAwait(false);
+        }
+    }
 
     /// <summary>
     /// Forces all Castle Siege contexts to enter a state on their next timer tick.
@@ -165,6 +175,28 @@ public class CastleSiegePlugIn : IPeriodicTaskPlugIn
         return stateStartUtc.AddTicks((completedIntervals + 1) * interval.Ticks);
     }
 
+    private static async ValueTask SynchronizePlayerAsync(
+        Player player,
+        GameMap map,
+        CastleSiegeContext context)
+    {
+        if (context.CurrentState is not (CastleSiegeState.Ready or CastleSiegeState.Start)
+            || context.Configuration.CastleSiegeMapDefinition?.Number != map.Definition.Number)
+        {
+            return;
+        }
+
+        await context.ExecutionLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            await context.NpcController.SynchronizePlayerAsync(player).ConfigureAwait(false);
+        }
+        finally
+        {
+            context.ExecutionLock.Release();
+        }
+    }
+
     private async ValueTask AdvanceExpiredStatesAsync(CastleSiegeContext context, DateTime utcNow, ILogger logger)
     {
         var maximumTransitions = context.Schedule.Count + 1;
@@ -223,14 +255,23 @@ public class CastleSiegePlugIn : IPeriodicTaskPlugIn
             case CastleSiegeState.RegisterMark:
                 await this.SendStateNotificationAsync(context).ConfigureAwait(false);
                 break;
+            case CastleSiegeState.Ready:
+                await context.NpcController.PrepareAsync().ConfigureAwait(false);
+                await context.NpcController.CloseGatesAsync().ConfigureAwait(false);
+                break;
+            case CastleSiegeState.Start:
+                await context.NpcController.PrepareAsync().ConfigureAwait(false);
+                await context.NpcController.SpawnMachinesAsync().ConfigureAwait(false);
+                break;
             case CastleSiegeState.End:
                 await context.SaveNpcStatesAsync().ConfigureAwait(false);
+                await context.NpcController.DespawnMachinesAsync().ConfigureAwait(false);
                 break;
             case CastleSiegeState.EndCycle:
                 await context.ClearRegistrationsAsync().ConfigureAwait(false);
                 context.FinalGuildList.Clear();
                 context.ParticipantTracking.Clear();
-                context.ActiveNpcs.Clear();
+                await context.NpcController.DespawnAllAsync().ConfigureAwait(false);
                 context.MiddleOwnerGuildId = null;
                 context.CrownUser = null;
                 Array.Clear(context.SwitchUsers);
@@ -242,10 +283,7 @@ public class CastleSiegePlugIn : IPeriodicTaskPlugIn
                 break;
         }
 
-        if (!isStartup)
-        {
-            context.NextNpcSaveUtc = this._timeProvider.GetUtcNow().UtcDateTime + NpcSaveInterval;
-        }
+        context.NextNpcSaveUtc = this._timeProvider.GetUtcNow().UtcDateTime + NpcSaveInterval;
     }
 
     private ValueTask OnExitStateAsync() => ValueTask.CompletedTask;

--- a/src/GameLogic/CastleSiege/CastleSiegePlugIn.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegePlugIn.cs
@@ -17,7 +17,7 @@ using MUnique.OpenMU.PlugIns;
 [PlugIn]
 [Display(Name = nameof(PlugInResources.CastleSiegePlugIn_Name), Description = nameof(PlugInResources.CastleSiegePlugIn_Description), ResourceType = typeof(PlugInResources))]
 [Guid("B7F62FA9-59E6-49E9-B499-0358A14957CF")]
-public class CastleSiegePlugIn : IPeriodicTaskPlugIn, IObjectAddedToMapPlugIn
+public class CastleSiegePlugIn : IPeriodicTaskPlugIn, IObjectAddedToMapPlugIn, IObjectRemovedFromMapPlugIn
 {
     private static readonly TimeSpan NpcSaveInterval = TimeSpan.FromMinutes(2);
 
@@ -56,8 +56,21 @@ public class CastleSiegePlugIn : IPeriodicTaskPlugIn, IObjectAddedToMapPlugIn
         if (addedObject is Player player
             && this.GetContext(player.GameContext) is { } context)
         {
+            context.TrackPlayer(player, map);
             await SynchronizePlayerAsync(player, map, context).ConfigureAwait(false);
         }
+    }
+
+    /// <inheritdoc />
+    public ValueTask ObjectRemovedFromMapAsync(GameMap map, ILocateable removedObject)
+    {
+        if (removedObject is Player player
+            && this.GetContext(player.GameContext) is { } context)
+        {
+            context.UntrackPlayer(player);
+        }
+
+        return ValueTask.CompletedTask;
     }
 
     /// <summary>
@@ -261,6 +274,7 @@ public class CastleSiegePlugIn : IPeriodicTaskPlugIn, IObjectAddedToMapPlugIn
                 break;
             case CastleSiegeState.Start:
                 await context.NpcController.PrepareAsync().ConfigureAwait(false);
+                await context.NpcController.CloseGatesAsync().ConfigureAwait(false);
                 await context.NpcController.SpawnMachinesAsync().ConfigureAwait(false);
                 break;
             case CastleSiegeState.End:

--- a/src/GameLogic/CastleSiege/Intelligence/CastleSiegeCrownIntelligence.cs
+++ b/src/GameLogic/CastleSiege/Intelligence/CastleSiegeCrownIntelligence.cs
@@ -1,0 +1,99 @@
+// <copyright file="CastleSiegeCrownIntelligence.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.Intelligence;
+
+using System.Diagnostics;
+using System.Threading;
+using MUnique.OpenMU.GameLogic.CastleSiege.NPC;
+
+/// <summary>
+/// Tracks the player operating the Castle Siege Crown.
+/// </summary>
+public sealed class CastleSiegeCrownIntelligence : CastleSiegeNpcIntelligenceBase, IDisposable
+{
+    private static readonly TimeSpan TrackingInterval = TimeSpan.FromSeconds(1);
+    private readonly CastleSiegeContext _context;
+    private Timer? _timer;
+    private int _isTicking;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeCrownIntelligence"/> class.
+    /// </summary>
+    /// <param name="context">The Castle Siege context.</param>
+    public CastleSiegeCrownIntelligence(CastleSiegeContext context)
+    {
+        this._context = context;
+    }
+
+    /// <inheritdoc />
+    public override void Start()
+    {
+        this._timer ??= new Timer(_ => this.SafeTick(), null, TrackingInterval, TrackingInterval);
+    }
+
+    /// <inheritdoc />
+    public override void Pause()
+    {
+        this._timer?.Dispose();
+        this._timer = null;
+    }
+
+    /// <summary>
+    /// Executes one player-tracking tick.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous tracking operation.</returns>
+    public async ValueTask TickAsync()
+    {
+        if (this.Npc is not CastleSiegeCrown crown)
+        {
+            return;
+        }
+
+        if (this._context.CurrentState != CastleSiegeState.Start)
+        {
+            this._context.CrownUser = null;
+            crown.State = CastleSiegeCrownState.Locked;
+            return;
+        }
+
+        var candidate = (await this._context.GameContext.GetPlayersAsync().ConfigureAwait(false))
+            .Where(player => player.IsAlive
+                             && player.CurrentMap == crown.CurrentMap
+                             && player.GetDistanceTo(crown.Position) <= 1)
+            .MinBy(player => player.Id);
+        this._context.CrownUser = candidate;
+        crown.State = this._context.IsCrownAvailable
+            ? CastleSiegeCrownState.Idle
+            : CastleSiegeCrownState.Locked;
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        this.Pause();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD100:Avoid async void methods", Justification = "All exceptions are caught.")]
+    private async void SafeTick()
+    {
+        if (Interlocked.Exchange(ref this._isTicking, 1) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            await this.TickAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Debug.Fail(ex.Message, ex.StackTrace);
+        }
+        finally
+        {
+            Volatile.Write(ref this._isTicking, 0);
+        }
+    }
+}

--- a/src/GameLogic/CastleSiege/Intelligence/CastleSiegeCrownIntelligence.cs
+++ b/src/GameLogic/CastleSiege/Intelligence/CastleSiegeCrownIntelligence.cs
@@ -30,7 +30,11 @@ public sealed class CastleSiegeCrownIntelligence : CastleSiegeNpcIntelligenceBas
     /// <inheritdoc />
     public override void Start()
     {
-        this._timer ??= new Timer(_ => this.SafeTick(), null, TrackingInterval, TrackingInterval);
+        this._timer ??= new Timer(
+            static state => _ = ((CastleSiegeCrownIntelligence)state!).SafeTickAsync(),
+            this,
+            TrackingInterval,
+            TrackingInterval);
     }
 
     /// <inheritdoc />
@@ -75,8 +79,7 @@ public sealed class CastleSiegeCrownIntelligence : CastleSiegeNpcIntelligenceBas
         this.Pause();
     }
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD100:Avoid async void methods", Justification = "All exceptions are caught.")]
-    private async void SafeTick()
+    private async Task SafeTickAsync()
     {
         if (Interlocked.Exchange(ref this._isTicking, 1) != 0)
         {

--- a/src/GameLogic/CastleSiege/Intelligence/CastleSiegeCrownIntelligence.cs
+++ b/src/GameLogic/CastleSiege/Intelligence/CastleSiegeCrownIntelligence.cs
@@ -48,29 +48,30 @@ public sealed class CastleSiegeCrownIntelligence : CastleSiegeNpcIntelligenceBas
     /// Executes one player-tracking tick.
     /// </summary>
     /// <returns>A task that represents the asynchronous tracking operation.</returns>
-    public async ValueTask TickAsync()
+    public ValueTask TickAsync()
     {
         if (this.Npc is not CastleSiegeCrown crown)
         {
-            return;
+            return ValueTask.CompletedTask;
         }
 
         if (this._context.CurrentState != CastleSiegeState.Start)
         {
             this._context.CrownUser = null;
             crown.State = CastleSiegeCrownState.Locked;
-            return;
+            return ValueTask.CompletedTask;
         }
 
-        var candidate = (await this._context.GameContext.GetPlayersAsync().ConfigureAwait(false))
+        var candidate = crown.CurrentMap.GetAttackablesInRange(crown.Position, 1)
+            .OfType<Player>()
             .Where(player => player.IsAlive
-                             && player.CurrentMap == crown.CurrentMap
-                             && player.GetDistanceTo(crown.Position) <= 1)
+                             && player.CurrentMap == crown.CurrentMap)
             .MinBy(player => player.Id);
         this._context.CrownUser = candidate;
         crown.State = this._context.IsCrownAvailable
             ? CastleSiegeCrownState.Idle
             : CastleSiegeCrownState.Locked;
+        return ValueTask.CompletedTask;
     }
 
     /// <inheritdoc />

--- a/src/GameLogic/CastleSiege/Intelligence/CastleSiegeGateIntelligence.cs
+++ b/src/GameLogic/CastleSiege/Intelligence/CastleSiegeGateIntelligence.cs
@@ -1,0 +1,12 @@
+// <copyright file="CastleSiegeGateIntelligence.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.Intelligence;
+
+/// <summary>
+/// Intelligence of a stationary Castle Siege gate.
+/// </summary>
+public sealed class CastleSiegeGateIntelligence : CastleSiegeNpcIntelligenceBase
+{
+}

--- a/src/GameLogic/CastleSiege/Intelligence/CastleSiegeLeverIntelligence.cs
+++ b/src/GameLogic/CastleSiege/Intelligence/CastleSiegeLeverIntelligence.cs
@@ -1,0 +1,12 @@
+// <copyright file="CastleSiegeLeverIntelligence.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.Intelligence;
+
+/// <summary>
+/// Intelligence of a Castle Siege gate lever.
+/// </summary>
+public sealed class CastleSiegeLeverIntelligence : CastleSiegeNpcIntelligenceBase
+{
+}

--- a/src/GameLogic/CastleSiege/Intelligence/CastleSiegeMachineIntelligence.cs
+++ b/src/GameLogic/CastleSiege/Intelligence/CastleSiegeMachineIntelligence.cs
@@ -1,0 +1,12 @@
+// <copyright file="CastleSiegeMachineIntelligence.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.Intelligence;
+
+/// <summary>
+/// Intelligence of a Castle Siege machine.
+/// </summary>
+public sealed class CastleSiegeMachineIntelligence : CastleSiegeNpcIntelligenceBase
+{
+}

--- a/src/GameLogic/CastleSiege/Intelligence/CastleSiegeNpcIntelligenceBase.cs
+++ b/src/GameLogic/CastleSiege/Intelligence/CastleSiegeNpcIntelligenceBase.cs
@@ -1,0 +1,47 @@
+// <copyright file="CastleSiegeNpcIntelligenceBase.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.Intelligence;
+
+using MUnique.OpenMU.GameLogic.NPC;
+using MUnique.OpenMU.Pathfinding;
+
+/// <summary>
+/// Base intelligence for stationary Castle Siege NPCs.
+/// </summary>
+public abstract class CastleSiegeNpcIntelligenceBase : INpcIntelligence
+{
+    private NonPlayerCharacter? _npc;
+
+    /// <inheritdoc />
+    public NonPlayerCharacter Npc
+    {
+        get => this._npc ?? throw Error.NotInitializedProperty(this);
+        set => this._npc = value;
+    }
+
+    /// <inheritdoc />
+    public bool CanWalkOnSafezone => false;
+
+    /// <inheritdoc />
+    public virtual void RegisterHit(IAttacker attacker)
+    {
+        // Castle Siege structures don't retaliate.
+    }
+
+    /// <inheritdoc />
+    public virtual void Start()
+    {
+        // Most Castle Siege NPCs don't have autonomous behavior.
+    }
+
+    /// <inheritdoc />
+    public virtual void Pause()
+    {
+        // Most Castle Siege NPCs don't have autonomous behavior.
+    }
+
+    /// <inheritdoc />
+    public bool CanWalkOn(Point target) => false;
+}

--- a/src/GameLogic/CastleSiege/Intelligence/CastleSiegeStatueIntelligence.cs
+++ b/src/GameLogic/CastleSiege/Intelligence/CastleSiegeStatueIntelligence.cs
@@ -1,0 +1,47 @@
+// <copyright file="CastleSiegeStatueIntelligence.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.Intelligence;
+
+using System.Threading;
+using MUnique.OpenMU.GameLogic.CastleSiege.NPC;
+
+/// <summary>
+/// Regenerates the health of an upgraded Guardian Statue.
+/// </summary>
+public sealed class CastleSiegeStatueIntelligence : CastleSiegeNpcIntelligenceBase, IDisposable
+{
+    private static readonly TimeSpan RegenerationInterval = TimeSpan.FromSeconds(5);
+    private Timer? _timer;
+
+    /// <inheritdoc />
+    public override void Start()
+    {
+        this._timer ??= new Timer(_ => this.Regenerate(), null, RegenerationInterval, RegenerationInterval);
+    }
+
+    /// <inheritdoc />
+    public override void Pause()
+    {
+        this._timer?.Dispose();
+        this._timer = null;
+    }
+
+    /// <summary>
+    /// Executes one regeneration tick.
+    /// </summary>
+    /// <returns>The restored hit points.</returns>
+    public int Regenerate()
+    {
+        return this.Npc is CastleSiegeStatue statue
+            ? statue.Regenerate()
+            : 0;
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        this.Pause();
+    }
+}

--- a/src/GameLogic/CastleSiege/Intelligence/CastleSiegeSwitchIntelligence.cs
+++ b/src/GameLogic/CastleSiege/Intelligence/CastleSiegeSwitchIntelligence.cs
@@ -1,0 +1,92 @@
+// <copyright file="CastleSiegeSwitchIntelligence.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.Intelligence;
+
+using System.Diagnostics;
+using System.Threading;
+using MUnique.OpenMU.GameLogic.CastleSiege.NPC;
+
+/// <summary>
+/// Tracks the player standing at a Castle Siege Crown switch.
+/// </summary>
+public sealed class CastleSiegeSwitchIntelligence : CastleSiegeNpcIntelligenceBase, IDisposable
+{
+    private static readonly TimeSpan TrackingInterval = TimeSpan.FromSeconds(1);
+    private readonly CastleSiegeContext _context;
+    private Timer? _timer;
+    private int _isTicking;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeSwitchIntelligence"/> class.
+    /// </summary>
+    /// <param name="context">The Castle Siege context.</param>
+    public CastleSiegeSwitchIntelligence(CastleSiegeContext context)
+    {
+        this._context = context;
+    }
+
+    /// <inheritdoc />
+    public override void Start()
+    {
+        this._timer ??= new Timer(_ => this.SafeTick(), null, TrackingInterval, TrackingInterval);
+    }
+
+    /// <inheritdoc />
+    public override void Pause()
+    {
+        this._timer?.Dispose();
+        this._timer = null;
+    }
+
+    /// <summary>
+    /// Executes one player-tracking tick.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous tracking operation.</returns>
+    public async ValueTask TickAsync()
+    {
+        if (this.Npc is not CastleSiegeSwitch siegeSwitch)
+        {
+            return;
+        }
+
+        var candidate = this._context.CurrentState == CastleSiegeState.Start
+            ? (await this._context.GameContext.GetPlayersAsync().ConfigureAwait(false))
+                .Where(player => player.IsAlive
+                                 && player.CurrentMap == siegeSwitch.CurrentMap
+                                 && player.GetDistanceTo(siegeSwitch.Position) <= 1)
+                .MinBy(player => player.Id)
+            : null;
+        siegeSwitch.Occupant = candidate;
+        this._context.SwitchUsers[siegeSwitch.SwitchIndex] = candidate;
+    }
+
+    /// <inheritdoc />
+    public void Dispose()
+    {
+        this.Pause();
+    }
+
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD100:Avoid async void methods", Justification = "All exceptions are caught.")]
+    private async void SafeTick()
+    {
+        if (Interlocked.Exchange(ref this._isTicking, 1) != 0)
+        {
+            return;
+        }
+
+        try
+        {
+            await this.TickAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            Debug.Fail(ex.Message, ex.StackTrace);
+        }
+        finally
+        {
+            Volatile.Write(ref this._isTicking, 0);
+        }
+    }
+}

--- a/src/GameLogic/CastleSiege/Intelligence/CastleSiegeSwitchIntelligence.cs
+++ b/src/GameLogic/CastleSiege/Intelligence/CastleSiegeSwitchIntelligence.cs
@@ -48,22 +48,23 @@ public sealed class CastleSiegeSwitchIntelligence : CastleSiegeNpcIntelligenceBa
     /// Executes one player-tracking tick.
     /// </summary>
     /// <returns>A task that represents the asynchronous tracking operation.</returns>
-    public async ValueTask TickAsync()
+    public ValueTask TickAsync()
     {
         if (this.Npc is not CastleSiegeSwitch siegeSwitch)
         {
-            return;
+            return ValueTask.CompletedTask;
         }
 
         var candidate = this._context.CurrentState == CastleSiegeState.Start
-            ? (await this._context.GameContext.GetPlayersAsync().ConfigureAwait(false))
+            ? siegeSwitch.CurrentMap.GetAttackablesInRange(siegeSwitch.Position, 1)
+                .OfType<Player>()
                 .Where(player => player.IsAlive
-                                 && player.CurrentMap == siegeSwitch.CurrentMap
-                                 && player.GetDistanceTo(siegeSwitch.Position) <= 1)
+                                 && player.CurrentMap == siegeSwitch.CurrentMap)
                 .MinBy(player => player.Id)
             : null;
         siegeSwitch.Occupant = candidate;
         this._context.SwitchUsers[siegeSwitch.SwitchIndex] = candidate;
+        return ValueTask.CompletedTask;
     }
 
     /// <inheritdoc />

--- a/src/GameLogic/CastleSiege/Intelligence/CastleSiegeSwitchIntelligence.cs
+++ b/src/GameLogic/CastleSiege/Intelligence/CastleSiegeSwitchIntelligence.cs
@@ -30,7 +30,11 @@ public sealed class CastleSiegeSwitchIntelligence : CastleSiegeNpcIntelligenceBa
     /// <inheritdoc />
     public override void Start()
     {
-        this._timer ??= new Timer(_ => this.SafeTick(), null, TrackingInterval, TrackingInterval);
+        this._timer ??= new Timer(
+            static state => _ = ((CastleSiegeSwitchIntelligence)state!).SafeTickAsync(),
+            this,
+            TrackingInterval,
+            TrackingInterval);
     }
 
     /// <inheritdoc />
@@ -68,8 +72,7 @@ public sealed class CastleSiegeSwitchIntelligence : CastleSiegeNpcIntelligenceBa
         this.Pause();
     }
 
-    [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD100:Avoid async void methods", Justification = "All exceptions are caught.")]
-    private async void SafeTick()
+    private async Task SafeTickAsync()
     {
         if (Interlocked.Exchange(ref this._isTicking, 1) != 0)
         {

--- a/src/GameLogic/CastleSiege/NPC/CastleSiegeAttackableNpc.cs
+++ b/src/GameLogic/CastleSiege/NPC/CastleSiegeAttackableNpc.cs
@@ -1,0 +1,199 @@
+// <copyright file="CastleSiegeAttackableNpc.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.NPC;
+
+using MUnique.OpenMU.AttributeSystem;
+using MUnique.OpenMU.GameLogic.Attributes;
+using MUnique.OpenMU.GameLogic.NPC;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Base class for attackable Castle Siege structures.
+/// </summary>
+public abstract class CastleSiegeAttackableNpc : AttackableNpcBase, ICastleSiegeNpc
+{
+    private readonly INpcIntelligence _intelligence;
+    private readonly SimpleElement _defenseElement = new(0, AggregateType.AddRaw);
+    private readonly SimpleElement _maximumHealthElement = new(0, AggregateType.AddRaw);
+    private float _baseDefense;
+    private float _baseMaximumHealth;
+    private bool _statElementsAdded;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeAttackableNpc"/> class.
+    /// </summary>
+    /// <param name="spawnInfo">The spawn information.</param>
+    /// <param name="stats">The NPC definition.</param>
+    /// <param name="map">The map on which the NPC is spawned.</param>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <param name="runtime">The Castle Siege runtime entry.</param>
+    /// <param name="intelligence">The NPC intelligence.</param>
+    /// <param name="dropGenerator">The drop generator.</param>
+    /// <param name="plugInManager">The plugin manager.</param>
+    protected CastleSiegeAttackableNpc(
+        MonsterSpawnArea spawnInfo,
+        MonsterDefinition stats,
+        GameMap map,
+        CastleSiegeContext context,
+        CastleSiegeNpcRuntime runtime,
+        INpcIntelligence intelligence,
+        IDropGenerator dropGenerator,
+        PlugInManager plugInManager)
+        : base(spawnInfo, stats, map, context, dropGenerator, plugInManager)
+    {
+        this.Context = context;
+        this.Runtime = runtime;
+        this._intelligence = intelligence;
+        this._intelligence.Npc = this;
+    }
+
+    /// <inheritdoc />
+    public CastleSiegeNpcRuntime Runtime { get; }
+
+    /// <summary>
+    /// Gets the persistent state of this structure.
+    /// </summary>
+    public CastleSiegeNpcState State =>
+        this.Runtime.PersistedState
+        ?? throw new InvalidOperationException("An attackable Castle Siege NPC requires a persistent state.");
+
+    /// <summary>
+    /// Gets the configured maximum health.
+    /// </summary>
+    public int MaximumHealth => Math.Max(0, (int)this.Attributes[Stats.MaximumHealth]);
+
+    /// <summary>
+    /// Gets the Castle Siege context.
+    /// </summary>
+    protected CastleSiegeContext Context { get; }
+
+    /// <inheritdoc />
+    public override void Initialize()
+    {
+        base.Initialize();
+        var persistedHealth = this.State.CurrentHp;
+        if (!this._statElementsAdded)
+        {
+            this._baseDefense = this.Attributes[Stats.DefenseBase];
+            this._baseMaximumHealth = this.Attributes[Stats.MaximumHealth];
+            this.Attributes.AddElement(this._defenseElement, Stats.DefenseBase);
+            this.Attributes.AddElement(this._maximumHealthElement, Stats.MaximumHealth);
+            this._statElementsAdded = true;
+        }
+
+        this.ApplyPersistedUpgrades(false);
+        this.Health = Math.Clamp(persistedHealth, 0, this.MaximumHealth);
+        this.State.CurrentHp = this.Health;
+        this.Runtime.IsAlive = this.Health > 0;
+    }
+
+    /// <inheritdoc />
+    public override void OnSpawn()
+    {
+        base.OnSpawn();
+        this._intelligence.Start();
+    }
+
+    /// <summary>
+    /// Applies the currently persisted upgrade levels.
+    /// </summary>
+    /// <param name="preserveMissingHealth">
+    /// If set to <see langword="true"/>, a maximum-health increase also increases current health by the same amount.
+    /// </param>
+    public abstract void ApplyPersistedUpgrades(bool preserveMissingHealth);
+
+    /// <summary>
+    /// Restores this structure to full health.
+    /// </summary>
+    public void RestoreFullHealth()
+    {
+        this.Health = this.MaximumHealth;
+        this.State.CurrentHp = this.Health;
+        this.Runtime.IsAlive = true;
+    }
+
+    /// <inheritdoc />
+    public override ValueTask ReflectDamageAsync(IAttacker reflector, uint damage)
+    {
+        return ValueTask.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public override ValueTask ApplyPoisonDamageAsync(IAttacker initialAttacker, uint damage)
+    {
+        return ValueTask.CompletedTask;
+    }
+
+    /// <inheritdoc />
+    public override ValueTask ApplyBleedingDamageAsync(IAttacker initialAttacker, uint damage)
+    {
+        return ValueTask.CompletedTask;
+    }
+
+    /// <summary>
+    /// Applies the configured defense value to this instance.
+    /// </summary>
+    /// <param name="value">The target defense value.</param>
+    protected void SetDefense(int value)
+    {
+        this._defenseElement.Value = value - this._baseDefense;
+    }
+
+    /// <summary>
+    /// Applies the configured maximum-health value to this instance.
+    /// </summary>
+    /// <param name="value">The target maximum health.</param>
+    /// <param name="preserveMissingHealth">
+    /// If set to <see langword="true"/>, current health is increased by the maximum-health difference.
+    /// </param>
+    protected void SetMaximumHealth(int value, bool preserveMissingHealth)
+    {
+        var oldMaximumHealth = this.MaximumHealth;
+        this._maximumHealthElement.Value = value - this._baseMaximumHealth;
+        var newMaximumHealth = this.MaximumHealth;
+        this.Health = preserveMissingHealth
+            ? Math.Clamp(this.Health + newMaximumHealth - oldMaximumHealth, 0, newMaximumHealth)
+            : Math.Clamp(this.Health, 0, newMaximumHealth);
+        this.State.CurrentHp = this.Health;
+    }
+
+    /// <inheritdoc />
+    protected override bool CanBeAttackedBy(IAttacker attacker)
+    {
+        var player = attacker as Player ?? (attacker as IPlayerSurrogate)?.Owner;
+        return this.Context.CurrentState == CastleSiegeState.Start
+               && player is not null
+               && this.Context.GetPlayerJoinSide(player)
+                   is not CastleSiegeJoinSide.None and not CastleSiegeJoinSide.Defense;
+    }
+
+    /// <inheritdoc />
+    protected override async ValueTask OnDeathAsync(IAttacker attacker)
+    {
+        this.State.CurrentHp = 0;
+        this.Runtime.IsAlive = false;
+        this.Runtime.SpawnedInstance = null;
+        await base.OnDeathAsync(attacker).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    protected override void RegisterHit(IAttacker attacker)
+    {
+        base.RegisterHit(attacker);
+        this._intelligence.RegisterHit(attacker);
+    }
+
+    /// <inheritdoc />
+    protected override void Dispose(bool managed)
+    {
+        if (managed)
+        {
+            this._intelligence.Pause();
+            (this._intelligence as IDisposable)?.Dispose();
+        }
+
+        base.Dispose(managed);
+    }
+}

--- a/src/GameLogic/CastleSiege/NPC/CastleSiegeCrown.cs
+++ b/src/GameLogic/CastleSiege/NPC/CastleSiegeCrown.cs
@@ -12,6 +12,11 @@ using MUnique.OpenMU.GameLogic.CastleSiege.Intelligence;
 public sealed class CastleSiegeCrown : CastleSiegeNpcBase
 {
     /// <summary>
+    /// Gets the monster number of the Crown.
+    /// </summary>
+    public const short MonsterNumber = 216;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="CastleSiegeCrown"/> class.
     /// </summary>
     /// <param name="spawnInfo">The spawn information.</param>
@@ -28,11 +33,6 @@ public sealed class CastleSiegeCrown : CastleSiegeNpcBase
         : base(spawnInfo, stats, map, runtime, intelligence)
     {
     }
-
-    /// <summary>
-    /// Gets the monster number of the Crown.
-    /// </summary>
-    public static short MonsterNumber { get; } = 216;
 
     /// <summary>
     /// Gets or sets the Crown state.

--- a/src/GameLogic/CastleSiege/NPC/CastleSiegeCrown.cs
+++ b/src/GameLogic/CastleSiege/NPC/CastleSiegeCrown.cs
@@ -12,11 +12,6 @@ using MUnique.OpenMU.GameLogic.CastleSiege.Intelligence;
 public sealed class CastleSiegeCrown : CastleSiegeNpcBase
 {
     /// <summary>
-    /// Gets the monster number of the Crown.
-    /// </summary>
-    public const short MonsterNumber = 216;
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="CastleSiegeCrown"/> class.
     /// </summary>
     /// <param name="spawnInfo">The spawn information.</param>
@@ -33,6 +28,11 @@ public sealed class CastleSiegeCrown : CastleSiegeNpcBase
         : base(spawnInfo, stats, map, runtime, intelligence)
     {
     }
+
+    /// <summary>
+    /// Gets the monster number of the Crown.
+    /// </summary>
+    public static short MonsterNumber { get; } = 216;
 
     /// <summary>
     /// Gets or sets the Crown state.

--- a/src/GameLogic/CastleSiege/NPC/CastleSiegeCrown.cs
+++ b/src/GameLogic/CastleSiege/NPC/CastleSiegeCrown.cs
@@ -12,11 +12,6 @@ using MUnique.OpenMU.GameLogic.CastleSiege.Intelligence;
 public sealed class CastleSiegeCrown : CastleSiegeNpcBase
 {
     /// <summary>
-    /// The monster number of the Crown.
-    /// </summary>
-    public const short MonsterNumber = 216;
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="CastleSiegeCrown"/> class.
     /// </summary>
     /// <param name="spawnInfo">The spawn information.</param>
@@ -33,6 +28,11 @@ public sealed class CastleSiegeCrown : CastleSiegeNpcBase
         : base(spawnInfo, stats, map, runtime, intelligence)
     {
     }
+
+    /// <summary>
+    /// Gets the monster number of the Crown.
+    /// </summary>
+    public static short MonsterNumber { get; } = 216;
 
     /// <summary>
     /// Gets or sets the Crown state.

--- a/src/GameLogic/CastleSiege/NPC/CastleSiegeCrown.cs
+++ b/src/GameLogic/CastleSiege/NPC/CastleSiegeCrown.cs
@@ -1,0 +1,41 @@
+// <copyright file="CastleSiegeCrown.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.NPC;
+
+using MUnique.OpenMU.GameLogic.CastleSiege.Intelligence;
+
+/// <summary>
+/// The interactive Castle Siege Crown.
+/// </summary>
+public sealed class CastleSiegeCrown : CastleSiegeNpcBase
+{
+    /// <summary>
+    /// The monster number of the Crown.
+    /// </summary>
+    public const short MonsterNumber = 216;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeCrown"/> class.
+    /// </summary>
+    /// <param name="spawnInfo">The spawn information.</param>
+    /// <param name="stats">The NPC definition.</param>
+    /// <param name="map">The map on which the Crown is spawned.</param>
+    /// <param name="runtime">The Castle Siege runtime entry.</param>
+    /// <param name="intelligence">The Crown intelligence.</param>
+    public CastleSiegeCrown(
+        MonsterSpawnArea spawnInfo,
+        MonsterDefinition stats,
+        GameMap map,
+        CastleSiegeNpcRuntime runtime,
+        CastleSiegeCrownIntelligence intelligence)
+        : base(spawnInfo, stats, map, runtime, intelligence)
+    {
+    }
+
+    /// <summary>
+    /// Gets or sets the Crown state.
+    /// </summary>
+    public CastleSiegeCrownState State { get; set; } = CastleSiegeCrownState.Locked;
+}

--- a/src/GameLogic/CastleSiege/NPC/CastleSiegeCrownState.cs
+++ b/src/GameLogic/CastleSiege/NPC/CastleSiegeCrownState.cs
@@ -1,0 +1,26 @@
+// <copyright file="CastleSiegeCrownState.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.NPC;
+
+/// <summary>
+/// Defines the state of the Castle Siege Crown.
+/// </summary>
+public enum CastleSiegeCrownState : byte
+{
+    /// <summary>
+    /// The Crown is idle.
+    /// </summary>
+    Idle,
+
+    /// <summary>
+    /// The Crown is locked.
+    /// </summary>
+    Locked,
+
+    /// <summary>
+    /// The Crown has been captured.
+    /// </summary>
+    Captured,
+}

--- a/src/GameLogic/CastleSiege/NPC/CastleSiegeGate.cs
+++ b/src/GameLogic/CastleSiege/NPC/CastleSiegeGate.cs
@@ -17,11 +17,6 @@ using MUnique.OpenMU.PlugIns;
 public sealed class CastleSiegeGate : CastleSiegeAttackableNpc
 {
     /// <summary>
-    /// Gets the monster number of Castle Siege gates.
-    /// </summary>
-    public const short MonsterNumber = 277;
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="CastleSiegeGate"/> class.
     /// </summary>
     /// <param name="spawnInfo">The spawn information.</param>
@@ -44,6 +39,11 @@ public sealed class CastleSiegeGate : CastleSiegeAttackableNpc
         : base(spawnInfo, stats, map, context, runtime, intelligence, dropGenerator, plugInManager)
     {
     }
+
+    /// <summary>
+    /// Gets the monster number of Castle Siege gates.
+    /// </summary>
+    public static short MonsterNumber { get; } = 277;
 
     /// <summary>
     /// Gets the defense upgrade level.

--- a/src/GameLogic/CastleSiege/NPC/CastleSiegeGate.cs
+++ b/src/GameLogic/CastleSiege/NPC/CastleSiegeGate.cs
@@ -16,7 +16,10 @@ using MUnique.OpenMU.PlugIns;
 /// </summary>
 public sealed class CastleSiegeGate : CastleSiegeAttackableNpc
 {
-    private readonly Dictionary<Point, bool> _originalTerrain = new();
+    /// <summary>
+    /// Gets the monster number of Castle Siege gates.
+    /// </summary>
+    public const short MonsterNumber = 277;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="CastleSiegeGate"/> class.
@@ -43,11 +46,6 @@ public sealed class CastleSiegeGate : CastleSiegeAttackableNpc
     }
 
     /// <summary>
-    /// Gets the monster number of Castle Siege gates.
-    /// </summary>
-    public static short MonsterNumber { get; } = 277;
-
-    /// <summary>
     /// Gets the defense upgrade level.
     /// </summary>
     public byte DefenseLevel => this.State.DefenseLevel;
@@ -65,9 +63,12 @@ public sealed class CastleSiegeGate : CastleSiegeAttackableNpc
     /// <inheritdoc />
     public override void ApplyPersistedUpgrades(bool preserveMissingHealth)
     {
-        this.SetDefense(GetValue(this.Context.Configuration.GateDefenseUpgrades, this.DefenseLevel));
+        this.SetDefense(
+            this.Context.Configuration.GetUpgrades(MonsterNumber, CastleSiegeUpgradeType.Defense)?.GetValue(this.DefenseLevel)
+            ?? throw new InvalidOperationException($"Castle Siege gate defense level {this.DefenseLevel} is not configured."));
         this.SetMaximumHealth(
-            GetValue(this.Context.Configuration.GateLifeUpgrades, this.LifeLevel),
+            this.Context.Configuration.GetUpgrades(MonsterNumber, CastleSiegeUpgradeType.Life)?.GetValue(this.LifeLevel)
+            ?? throw new InvalidOperationException($"Castle Siege gate life level {this.LifeLevel} is not configured."),
             preserveMissingHealth);
     }
 
@@ -83,20 +84,9 @@ public sealed class CastleSiegeGate : CastleSiegeAttackableNpc
         }
 
         var area = this.GetTerrainArea();
-        for (var x = area.StartX; x <= area.EndX; x++)
-        {
-            for (var y = area.StartY; y <= area.EndY; y++)
-            {
-                var point = new Point(x, y);
-                this._originalTerrain.TryAdd(point, this.CurrentMap.Terrain.WalkMap[x, y]);
-                this.CurrentMap.Terrain.WalkMap[x, y] = false;
-                this.CurrentMap.Terrain.UpdateAiGridValue(x, y);
-            }
-        }
-
+        this.Context.NpcController.BlockGateTerrain(this.CurrentMap, area);
         this.IsClosed = true;
-        await this.NotifyTerrainChangeAsync(true, [area]).ConfigureAwait(false);
-        await this.NotifyGateStateAsync().ConfigureAwait(false);
+        await this.NotifyStateAsync(true, [area], []).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -111,25 +101,9 @@ public sealed class CastleSiegeGate : CastleSiegeAttackableNpc
         }
 
         var area = this.GetTerrainArea();
-        var originallyBlockedAreas = this._originalTerrain
-            .Where(entry => !entry.Value)
-            .Select(entry => (entry.Key.X, entry.Key.Y, entry.Key.X, entry.Key.Y))
-            .ToList();
-        foreach (var (point, wasWalkable) in this._originalTerrain)
-        {
-            this.CurrentMap.Terrain.WalkMap[point.X, point.Y] = wasWalkable;
-            this.CurrentMap.Terrain.UpdateAiGridValue(point.X, point.Y);
-        }
-
-        this._originalTerrain.Clear();
+        var blockedAreas = this.Context.NpcController.ReleaseGateTerrain(this.CurrentMap, area);
         this.IsClosed = false;
-        await this.NotifyTerrainChangeAsync(false, [area]).ConfigureAwait(false);
-        if (originallyBlockedAreas.Count > 0)
-        {
-            await this.NotifyTerrainChangeAsync(true, originallyBlockedAreas).ConfigureAwait(false);
-        }
-
-        await this.NotifyGateStateAsync().ConfigureAwait(false);
+        await this.NotifyStateAsync(false, [area], blockedAreas).ConfigureAwait(false);
     }
 
     /// <summary>
@@ -156,12 +130,6 @@ public sealed class CastleSiegeGate : CastleSiegeAttackableNpc
         await base.OnDeathAsync(attacker).ConfigureAwait(false);
     }
 
-    private static int GetValue(IEnumerable<CastleSiegeUpgradeDefinition> definitions, byte level)
-    {
-        return definitions.FirstOrDefault(definition => definition.Level == level)?.Value
-               ?? throw new InvalidOperationException($"Castle Siege gate upgrade level {level} is not configured.");
-    }
-
     private static async ValueTask NotifyTerrainChangeAsync(
         Player player,
         bool setBlocked,
@@ -174,6 +142,8 @@ public sealed class CastleSiegeGate : CastleSiegeAttackableNpc
 
     private (byte StartX, byte StartY, byte EndX, byte EndY) GetTerrainArea()
     {
+        // The shipped map defines every gate horizontally. Its spawn X is the width center, while spawn Y is the
+        // lower edge of the two-tile blocked area; visual direction does not describe the collision rectangle.
         const int gateWidth = 6;
         const int gateHeight = 2;
         var startX = Math.Clamp(this.Position.X - (gateWidth / 2), byte.MinValue, byte.MaxValue - gateWidth + 1);
@@ -181,25 +151,22 @@ public sealed class CastleSiegeGate : CastleSiegeAttackableNpc
         return ((byte)startX, (byte)startY, (byte)(startX + gateWidth - 1), (byte)(startY + gateHeight - 1));
     }
 
-    private async ValueTask NotifyTerrainChangeAsync(
+    private ValueTask NotifyStateAsync(
         bool setBlocked,
-        IReadOnlyCollection<(byte StartX, byte StartY, byte EndX, byte EndY)> areas)
+        IReadOnlyCollection<(byte StartX, byte StartY, byte EndX, byte EndY)> areas,
+        IReadOnlyCollection<(byte StartX, byte StartY, byte EndX, byte EndY)> blockedAreas)
     {
-        var players = await this.Context.GameContext.GetPlayersAsync().ConfigureAwait(false);
-        foreach (var player in players.Where(player => player.CurrentMap == this.CurrentMap))
+        return this.Context.ForEachSiegePlayerAsync(async player =>
         {
             await NotifyTerrainChangeAsync(player, setBlocked, areas).ConfigureAwait(false);
-        }
-    }
+            if (blockedAreas.Count > 0)
+            {
+                await NotifyTerrainChangeAsync(player, true, blockedAreas).ConfigureAwait(false);
+            }
 
-    private async ValueTask NotifyGateStateAsync()
-    {
-        var players = await this.Context.GameContext.GetPlayersAsync().ConfigureAwait(false);
-        foreach (var player in players.Where(player => player.CurrentMap == this.CurrentMap))
-        {
             await player.InvokeViewPlugInAsync<ICastleSiegeNpcOperationResultPlugIn>(
                     view => view.ShowGateStateAsync(!this.IsClosed, this.Id))
                 .ConfigureAwait(false);
-        }
+        });
     }
 }

--- a/src/GameLogic/CastleSiege/NPC/CastleSiegeGate.cs
+++ b/src/GameLogic/CastleSiege/NPC/CastleSiegeGate.cs
@@ -16,11 +16,6 @@ using MUnique.OpenMU.PlugIns;
 /// </summary>
 public sealed class CastleSiegeGate : CastleSiegeAttackableNpc
 {
-    /// <summary>
-    /// The monster number of Castle Siege gates.
-    /// </summary>
-    public const short MonsterNumber = 277;
-
     private readonly Dictionary<Point, bool> _originalTerrain = new();
 
     /// <summary>
@@ -46,6 +41,11 @@ public sealed class CastleSiegeGate : CastleSiegeAttackableNpc
         : base(spawnInfo, stats, map, context, runtime, intelligence, dropGenerator, plugInManager)
     {
     }
+
+    /// <summary>
+    /// Gets the monster number of Castle Siege gates.
+    /// </summary>
+    public static short MonsterNumber { get; } = 277;
 
     /// <summary>
     /// Gets the defense upgrade level.

--- a/src/GameLogic/CastleSiege/NPC/CastleSiegeGate.cs
+++ b/src/GameLogic/CastleSiege/NPC/CastleSiegeGate.cs
@@ -1,0 +1,205 @@
+// <copyright file="CastleSiegeGate.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.NPC;
+
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.GameLogic.CastleSiege.Intelligence;
+using MUnique.OpenMU.GameLogic.MiniGames;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+using MUnique.OpenMU.Pathfinding;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// An attackable Castle Siege gate.
+/// </summary>
+public sealed class CastleSiegeGate : CastleSiegeAttackableNpc
+{
+    /// <summary>
+    /// The monster number of Castle Siege gates.
+    /// </summary>
+    public const short MonsterNumber = 277;
+
+    private readonly Dictionary<Point, bool> _originalTerrain = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeGate"/> class.
+    /// </summary>
+    /// <param name="spawnInfo">The spawn information.</param>
+    /// <param name="stats">The NPC definition.</param>
+    /// <param name="map">The map on which the gate is spawned.</param>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <param name="runtime">The Castle Siege runtime entry.</param>
+    /// <param name="intelligence">The gate intelligence.</param>
+    /// <param name="dropGenerator">The drop generator.</param>
+    /// <param name="plugInManager">The plugin manager.</param>
+    public CastleSiegeGate(
+        MonsterSpawnArea spawnInfo,
+        MonsterDefinition stats,
+        GameMap map,
+        CastleSiegeContext context,
+        CastleSiegeNpcRuntime runtime,
+        CastleSiegeGateIntelligence intelligence,
+        IDropGenerator dropGenerator,
+        PlugInManager plugInManager)
+        : base(spawnInfo, stats, map, context, runtime, intelligence, dropGenerator, plugInManager)
+    {
+    }
+
+    /// <summary>
+    /// Gets the defense upgrade level.
+    /// </summary>
+    public byte DefenseLevel => this.State.DefenseLevel;
+
+    /// <summary>
+    /// Gets the life upgrade level.
+    /// </summary>
+    public byte LifeLevel => this.State.LifeLevel;
+
+    /// <summary>
+    /// Gets a value indicating whether the gate is closed and blocking terrain.
+    /// </summary>
+    public bool IsClosed { get; private set; }
+
+    /// <inheritdoc />
+    public override void ApplyPersistedUpgrades(bool preserveMissingHealth)
+    {
+        this.SetDefense(GetValue(this.Context.Configuration.GateDefenseUpgrades, this.DefenseLevel));
+        this.SetMaximumHealth(
+            GetValue(this.Context.Configuration.GateLifeUpgrades, this.LifeLevel),
+            preserveMissingHealth);
+    }
+
+    /// <summary>
+    /// Closes the gate and blocks its six-by-two tile area.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous close operation.</returns>
+    public async ValueTask CloseAsync()
+    {
+        if (this.IsClosed || !this.IsAlive)
+        {
+            return;
+        }
+
+        var area = this.GetTerrainArea();
+        for (var x = area.StartX; x <= area.EndX; x++)
+        {
+            for (var y = area.StartY; y <= area.EndY; y++)
+            {
+                var point = new Point(x, y);
+                this._originalTerrain.TryAdd(point, this.CurrentMap.Terrain.WalkMap[x, y]);
+                this.CurrentMap.Terrain.WalkMap[x, y] = false;
+                this.CurrentMap.Terrain.UpdateAiGridValue(x, y);
+            }
+        }
+
+        this.IsClosed = true;
+        await this.NotifyTerrainChangeAsync(true, [area]).ConfigureAwait(false);
+        await this.NotifyGateStateAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Opens the gate and restores the terrain which existed before it was closed.
+    /// </summary>
+    /// <returns>A task that represents the asynchronous open operation.</returns>
+    public async ValueTask OpenAsync()
+    {
+        if (!this.IsClosed)
+        {
+            return;
+        }
+
+        var area = this.GetTerrainArea();
+        var originallyBlockedAreas = this._originalTerrain
+            .Where(entry => !entry.Value)
+            .Select(entry => (entry.Key.X, entry.Key.Y, entry.Key.X, entry.Key.Y))
+            .ToList();
+        foreach (var (point, wasWalkable) in this._originalTerrain)
+        {
+            this.CurrentMap.Terrain.WalkMap[point.X, point.Y] = wasWalkable;
+            this.CurrentMap.Terrain.UpdateAiGridValue(point.X, point.Y);
+        }
+
+        this._originalTerrain.Clear();
+        this.IsClosed = false;
+        await this.NotifyTerrainChangeAsync(false, [area]).ConfigureAwait(false);
+        if (originallyBlockedAreas.Count > 0)
+        {
+            await this.NotifyTerrainChangeAsync(true, originallyBlockedAreas).ConfigureAwait(false);
+        }
+
+        await this.NotifyGateStateAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Sends the current gate and terrain state to a player entering the Castle Siege map.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <returns>A task that represents the asynchronous synchronization.</returns>
+    internal async ValueTask SynchronizeStateAsync(Player player)
+    {
+        if (this.IsClosed)
+        {
+            await NotifyTerrainChangeAsync(player, true, [this.GetTerrainArea()]).ConfigureAwait(false);
+        }
+
+        await player.InvokeViewPlugInAsync<ICastleSiegeNpcOperationResultPlugIn>(
+                view => view.ShowGateStateAsync(!this.IsClosed, this.Id))
+            .ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    protected override async ValueTask OnDeathAsync(IAttacker attacker)
+    {
+        await this.OpenAsync().ConfigureAwait(false);
+        await base.OnDeathAsync(attacker).ConfigureAwait(false);
+    }
+
+    private static int GetValue(IEnumerable<CastleSiegeUpgradeDefinition> definitions, byte level)
+    {
+        return definitions.FirstOrDefault(definition => definition.Level == level)?.Value
+               ?? throw new InvalidOperationException($"Castle Siege gate upgrade level {level} is not configured.");
+    }
+
+    private static async ValueTask NotifyTerrainChangeAsync(
+        Player player,
+        bool setBlocked,
+        IReadOnlyCollection<(byte StartX, byte StartY, byte EndX, byte EndY)> areas)
+    {
+        await player.InvokeViewPlugInAsync<IChangeTerrainAttributesViewPlugin>(
+                view => view.ChangeAttributesAsync(TerrainAttributeType.Blocked, setBlocked, areas))
+            .ConfigureAwait(false);
+    }
+
+    private (byte StartX, byte StartY, byte EndX, byte EndY) GetTerrainArea()
+    {
+        const int gateWidth = 6;
+        const int gateHeight = 2;
+        var startX = Math.Clamp(this.Position.X - (gateWidth / 2), byte.MinValue, byte.MaxValue - gateWidth + 1);
+        var startY = Math.Clamp((int)this.Position.Y, byte.MinValue, byte.MaxValue - gateHeight + 1);
+        return ((byte)startX, (byte)startY, (byte)(startX + gateWidth - 1), (byte)(startY + gateHeight - 1));
+    }
+
+    private async ValueTask NotifyTerrainChangeAsync(
+        bool setBlocked,
+        IReadOnlyCollection<(byte StartX, byte StartY, byte EndX, byte EndY)> areas)
+    {
+        var players = await this.Context.GameContext.GetPlayersAsync().ConfigureAwait(false);
+        foreach (var player in players.Where(player => player.CurrentMap == this.CurrentMap))
+        {
+            await NotifyTerrainChangeAsync(player, setBlocked, areas).ConfigureAwait(false);
+        }
+    }
+
+    private async ValueTask NotifyGateStateAsync()
+    {
+        var players = await this.Context.GameContext.GetPlayersAsync().ConfigureAwait(false);
+        foreach (var player in players.Where(player => player.CurrentMap == this.CurrentMap))
+        {
+            await player.InvokeViewPlugInAsync<ICastleSiegeNpcOperationResultPlugIn>(
+                    view => view.ShowGateStateAsync(!this.IsClosed, this.Id))
+                .ConfigureAwait(false);
+        }
+    }
+}

--- a/src/GameLogic/CastleSiege/NPC/CastleSiegeLever.cs
+++ b/src/GameLogic/CastleSiege/NPC/CastleSiegeLever.cs
@@ -12,11 +12,6 @@ using MUnique.OpenMU.GameLogic.CastleSiege.Intelligence;
 public sealed class CastleSiegeLever : CastleSiegeNpcBase
 {
     /// <summary>
-    /// The monster number of gate levers.
-    /// </summary>
-    public const short MonsterNumber = 219;
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="CastleSiegeLever"/> class.
     /// </summary>
     /// <param name="spawnInfo">The spawn information.</param>
@@ -36,6 +31,11 @@ public sealed class CastleSiegeLever : CastleSiegeNpcBase
     {
         this.Context = context;
     }
+
+    /// <summary>
+    /// Gets the monster number of gate levers.
+    /// </summary>
+    public static short MonsterNumber { get; } = 219;
 
     /// <summary>
     /// Gets or sets the gate controlled by this lever.

--- a/src/GameLogic/CastleSiege/NPC/CastleSiegeLever.cs
+++ b/src/GameLogic/CastleSiege/NPC/CastleSiegeLever.cs
@@ -1,0 +1,49 @@
+// <copyright file="CastleSiegeLever.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.NPC;
+
+using MUnique.OpenMU.GameLogic.CastleSiege.Intelligence;
+
+/// <summary>
+/// An interactive Castle Siege gate lever.
+/// </summary>
+public sealed class CastleSiegeLever : CastleSiegeNpcBase
+{
+    /// <summary>
+    /// The monster number of gate levers.
+    /// </summary>
+    public const short MonsterNumber = 219;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeLever"/> class.
+    /// </summary>
+    /// <param name="spawnInfo">The spawn information.</param>
+    /// <param name="stats">The NPC definition.</param>
+    /// <param name="map">The map on which the lever is spawned.</param>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <param name="runtime">The Castle Siege runtime entry.</param>
+    /// <param name="intelligence">The lever intelligence.</param>
+    public CastleSiegeLever(
+        MonsterSpawnArea spawnInfo,
+        MonsterDefinition stats,
+        GameMap map,
+        CastleSiegeContext context,
+        CastleSiegeNpcRuntime runtime,
+        CastleSiegeLeverIntelligence intelligence)
+        : base(spawnInfo, stats, map, runtime, intelligence)
+    {
+        this.Context = context;
+    }
+
+    /// <summary>
+    /// Gets or sets the gate controlled by this lever.
+    /// </summary>
+    public CastleSiegeGate? Gate { get; set; }
+
+    /// <summary>
+    /// Gets the owning Castle Siege context.
+    /// </summary>
+    internal CastleSiegeContext Context { get; }
+}

--- a/src/GameLogic/CastleSiege/NPC/CastleSiegeLever.cs
+++ b/src/GameLogic/CastleSiege/NPC/CastleSiegeLever.cs
@@ -12,11 +12,6 @@ using MUnique.OpenMU.GameLogic.CastleSiege.Intelligence;
 public sealed class CastleSiegeLever : CastleSiegeNpcBase
 {
     /// <summary>
-    /// Gets the monster number of gate levers.
-    /// </summary>
-    public const short MonsterNumber = 219;
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="CastleSiegeLever"/> class.
     /// </summary>
     /// <param name="spawnInfo">The spawn information.</param>
@@ -36,6 +31,11 @@ public sealed class CastleSiegeLever : CastleSiegeNpcBase
     {
         this.Context = context;
     }
+
+    /// <summary>
+    /// Gets the monster number of gate levers.
+    /// </summary>
+    public static short MonsterNumber { get; } = 219;
 
     /// <summary>
     /// Gets or sets the gate controlled by this lever.

--- a/src/GameLogic/CastleSiege/NPC/CastleSiegeLever.cs
+++ b/src/GameLogic/CastleSiege/NPC/CastleSiegeLever.cs
@@ -12,6 +12,11 @@ using MUnique.OpenMU.GameLogic.CastleSiege.Intelligence;
 public sealed class CastleSiegeLever : CastleSiegeNpcBase
 {
     /// <summary>
+    /// Gets the monster number of gate levers.
+    /// </summary>
+    public const short MonsterNumber = 219;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="CastleSiegeLever"/> class.
     /// </summary>
     /// <param name="spawnInfo">The spawn information.</param>
@@ -31,11 +36,6 @@ public sealed class CastleSiegeLever : CastleSiegeNpcBase
     {
         this.Context = context;
     }
-
-    /// <summary>
-    /// Gets the monster number of gate levers.
-    /// </summary>
-    public static short MonsterNumber { get; } = 219;
 
     /// <summary>
     /// Gets or sets the gate controlled by this lever.

--- a/src/GameLogic/CastleSiege/NPC/CastleSiegeMachine.cs
+++ b/src/GameLogic/CastleSiege/NPC/CastleSiegeMachine.cs
@@ -1,0 +1,51 @@
+// <copyright file="CastleSiegeMachine.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.NPC;
+
+using MUnique.OpenMU.GameLogic.CastleSiege.Intelligence;
+
+/// <summary>
+/// An interactive Castle Siege attack or defense machine.
+/// </summary>
+public sealed class CastleSiegeMachine : CastleSiegeNpcBase
+{
+    /// <summary>
+    /// The attacking machine monster number.
+    /// </summary>
+    public const short AttackMonsterNumber = 221;
+
+    /// <summary>
+    /// The defending machine monster number.
+    /// </summary>
+    public const short DefenseMonsterNumber = 222;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeMachine"/> class.
+    /// </summary>
+    /// <param name="spawnInfo">The spawn information.</param>
+    /// <param name="stats">The NPC definition.</param>
+    /// <param name="map">The map on which the machine is spawned.</param>
+    /// <param name="runtime">The Castle Siege runtime entry.</param>
+    /// <param name="intelligence">The machine intelligence.</param>
+    public CastleSiegeMachine(
+        MonsterSpawnArea spawnInfo,
+        MonsterDefinition stats,
+        GameMap map,
+        CastleSiegeNpcRuntime runtime,
+        CastleSiegeMachineIntelligence intelligence)
+        : base(spawnInfo, stats, map, runtime, intelligence)
+    {
+    }
+
+    /// <summary>
+    /// Gets or sets the current operator.
+    /// </summary>
+    public Player? Operator { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether this machine is active.
+    /// </summary>
+    public bool IsActive { get; set; }
+}

--- a/src/GameLogic/CastleSiege/NPC/CastleSiegeMachine.cs
+++ b/src/GameLogic/CastleSiege/NPC/CastleSiegeMachine.cs
@@ -12,6 +12,16 @@ using MUnique.OpenMU.GameLogic.CastleSiege.Intelligence;
 public sealed class CastleSiegeMachine : CastleSiegeNpcBase
 {
     /// <summary>
+    /// Gets the attacking machine monster number.
+    /// </summary>
+    public const short AttackMonsterNumber = 221;
+
+    /// <summary>
+    /// Gets the defending machine monster number.
+    /// </summary>
+    public const short DefenseMonsterNumber = 222;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="CastleSiegeMachine"/> class.
     /// </summary>
     /// <param name="spawnInfo">The spawn information.</param>
@@ -28,16 +38,6 @@ public sealed class CastleSiegeMachine : CastleSiegeNpcBase
         : base(spawnInfo, stats, map, runtime, intelligence)
     {
     }
-
-    /// <summary>
-    /// Gets the attacking machine monster number.
-    /// </summary>
-    public static short AttackMonsterNumber { get; } = 221;
-
-    /// <summary>
-    /// Gets the defending machine monster number.
-    /// </summary>
-    public static short DefenseMonsterNumber { get; } = 222;
 
     /// <summary>
     /// Gets or sets the current operator.

--- a/src/GameLogic/CastleSiege/NPC/CastleSiegeMachine.cs
+++ b/src/GameLogic/CastleSiege/NPC/CastleSiegeMachine.cs
@@ -12,16 +12,6 @@ using MUnique.OpenMU.GameLogic.CastleSiege.Intelligence;
 public sealed class CastleSiegeMachine : CastleSiegeNpcBase
 {
     /// <summary>
-    /// The attacking machine monster number.
-    /// </summary>
-    public const short AttackMonsterNumber = 221;
-
-    /// <summary>
-    /// The defending machine monster number.
-    /// </summary>
-    public const short DefenseMonsterNumber = 222;
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="CastleSiegeMachine"/> class.
     /// </summary>
     /// <param name="spawnInfo">The spawn information.</param>
@@ -38,6 +28,16 @@ public sealed class CastleSiegeMachine : CastleSiegeNpcBase
         : base(spawnInfo, stats, map, runtime, intelligence)
     {
     }
+
+    /// <summary>
+    /// Gets the attacking machine monster number.
+    /// </summary>
+    public static short AttackMonsterNumber { get; } = 221;
+
+    /// <summary>
+    /// Gets the defending machine monster number.
+    /// </summary>
+    public static short DefenseMonsterNumber { get; } = 222;
 
     /// <summary>
     /// Gets or sets the current operator.

--- a/src/GameLogic/CastleSiege/NPC/CastleSiegeMachine.cs
+++ b/src/GameLogic/CastleSiege/NPC/CastleSiegeMachine.cs
@@ -12,16 +12,6 @@ using MUnique.OpenMU.GameLogic.CastleSiege.Intelligence;
 public sealed class CastleSiegeMachine : CastleSiegeNpcBase
 {
     /// <summary>
-    /// Gets the attacking machine monster number.
-    /// </summary>
-    public const short AttackMonsterNumber = 221;
-
-    /// <summary>
-    /// Gets the defending machine monster number.
-    /// </summary>
-    public const short DefenseMonsterNumber = 222;
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="CastleSiegeMachine"/> class.
     /// </summary>
     /// <param name="spawnInfo">The spawn information.</param>
@@ -38,6 +28,16 @@ public sealed class CastleSiegeMachine : CastleSiegeNpcBase
         : base(spawnInfo, stats, map, runtime, intelligence)
     {
     }
+
+    /// <summary>
+    /// Gets the attacking machine monster number.
+    /// </summary>
+    public static short AttackMonsterNumber { get; } = 221;
+
+    /// <summary>
+    /// Gets the defending machine monster number.
+    /// </summary>
+    public static short DefenseMonsterNumber { get; } = 222;
 
     /// <summary>
     /// Gets or sets the current operator.

--- a/src/GameLogic/CastleSiege/NPC/CastleSiegeNpcBase.cs
+++ b/src/GameLogic/CastleSiege/NPC/CastleSiegeNpcBase.cs
@@ -1,0 +1,58 @@
+// <copyright file="CastleSiegeNpcBase.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.NPC;
+
+using MUnique.OpenMU.GameLogic.NPC;
+
+/// <summary>
+/// Base class for non-attackable Castle Siege NPCs which own an intelligence instance.
+/// </summary>
+public abstract class CastleSiegeNpcBase : NonPlayerCharacter, ICastleSiegeNpc
+{
+    private readonly INpcIntelligence _intelligence;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeNpcBase"/> class.
+    /// </summary>
+    /// <param name="spawnInfo">The spawn information.</param>
+    /// <param name="stats">The NPC definition.</param>
+    /// <param name="map">The map on which the NPC is spawned.</param>
+    /// <param name="runtime">The Castle Siege runtime entry.</param>
+    /// <param name="intelligence">The NPC intelligence.</param>
+    protected CastleSiegeNpcBase(
+        MonsterSpawnArea spawnInfo,
+        MonsterDefinition stats,
+        GameMap map,
+        CastleSiegeNpcRuntime runtime,
+        INpcIntelligence intelligence)
+        : base(spawnInfo, stats, map)
+    {
+        this.Runtime = runtime;
+        this._intelligence = intelligence;
+        this._intelligence.Npc = this;
+    }
+
+    /// <inheritdoc />
+    public CastleSiegeNpcRuntime Runtime { get; }
+
+    /// <inheritdoc />
+    public override void OnSpawn()
+    {
+        base.OnSpawn();
+        this._intelligence.Start();
+    }
+
+    /// <inheritdoc />
+    protected override void Dispose(bool managed)
+    {
+        if (managed)
+        {
+            this._intelligence.Pause();
+            (this._intelligence as IDisposable)?.Dispose();
+        }
+
+        base.Dispose(managed);
+    }
+}

--- a/src/GameLogic/CastleSiege/NPC/CastleSiegeStatue.cs
+++ b/src/GameLogic/CastleSiege/NPC/CastleSiegeStatue.cs
@@ -14,6 +14,11 @@ using MUnique.OpenMU.PlugIns;
 public sealed class CastleSiegeStatue : CastleSiegeAttackableNpc
 {
     /// <summary>
+    /// Gets the monster number of Castle Siege Guardian Statues.
+    /// </summary>
+    public const short MonsterNumber = 283;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="CastleSiegeStatue"/> class.
     /// </summary>
     /// <param name="spawnInfo">The spawn information.</param>
@@ -38,11 +43,6 @@ public sealed class CastleSiegeStatue : CastleSiegeAttackableNpc
     }
 
     /// <summary>
-    /// Gets the monster number of Castle Siege Guardian Statues.
-    /// </summary>
-    public static short MonsterNumber { get; } = 283;
-
-    /// <summary>
     /// Gets the defense upgrade level.
     /// </summary>
     public byte DefenseLevel => this.State.DefenseLevel;
@@ -60,9 +60,12 @@ public sealed class CastleSiegeStatue : CastleSiegeAttackableNpc
     /// <inheritdoc />
     public override void ApplyPersistedUpgrades(bool preserveMissingHealth)
     {
-        this.SetDefense(GetValue(this.Context.Configuration.StatueDefenseUpgrades, this.DefenseLevel));
+        this.SetDefense(
+            this.Context.Configuration.GetUpgrades(MonsterNumber, CastleSiegeUpgradeType.Defense)?.GetValue(this.DefenseLevel)
+            ?? throw new InvalidOperationException($"Castle Siege statue defense level {this.DefenseLevel} is not configured."));
         this.SetMaximumHealth(
-            GetValue(this.Context.Configuration.StatueLifeUpgrades, this.LifeLevel),
+            this.Context.Configuration.GetUpgrades(MonsterNumber, CastleSiegeUpgradeType.Life)?.GetValue(this.LifeLevel)
+            ?? throw new InvalidOperationException($"Castle Siege statue life level {this.LifeLevel} is not configured."),
             preserveMissingHealth);
     }
 
@@ -77,19 +80,16 @@ public sealed class CastleSiegeStatue : CastleSiegeAttackableNpc
             return 0;
         }
 
-        var regenerationPercentage = GetValue(
-            this.Context.Configuration.StatueRegenUpgrades,
-            this.RegenLevel);
+        var regenerationPercentage = this.Context.Configuration
+            .GetUpgrades(MonsterNumber, CastleSiegeUpgradeType.Regen)
+            ?.GetValue(this.RegenLevel)
+            ?? throw new InvalidOperationException($"Castle Siege statue regeneration level {this.RegenLevel} is not configured.");
         var restored = Math.Max(1, this.MaximumHealth * regenerationPercentage / 100);
-        var previousHealth = this.Health;
-        this.Health = Math.Min(this.MaximumHealth, this.Health + restored);
-        this.State.CurrentHp = this.Health;
-        return this.Health - previousHealth;
-    }
+        restored = this.RestoreHealth(restored, this.MaximumHealth);
 
-    private static int GetValue(IEnumerable<CastleSiegeUpgradeDefinition> definitions, byte level)
-    {
-        return definitions.FirstOrDefault(definition => definition.Level == level)?.Value
-               ?? throw new InvalidOperationException($"Castle Siege statue upgrade level {level} is not configured.");
+        // There is no standalone structure-heal packet. Combat updates the client on the next hit, while the
+        // management interface receives the current value with its next structure-list response. The periodic
+        // NPC snapshot copies the atomic health value into the persisted state.
+        return restored;
     }
 }

--- a/src/GameLogic/CastleSiege/NPC/CastleSiegeStatue.cs
+++ b/src/GameLogic/CastleSiege/NPC/CastleSiegeStatue.cs
@@ -1,0 +1,95 @@
+// <copyright file="CastleSiegeStatue.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.NPC;
+
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.GameLogic.CastleSiege.Intelligence;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// An attackable Castle Siege Guardian Statue.
+/// </summary>
+public sealed class CastleSiegeStatue : CastleSiegeAttackableNpc
+{
+    /// <summary>
+    /// The monster number of Castle Siege Guardian Statues.
+    /// </summary>
+    public const short MonsterNumber = 283;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeStatue"/> class.
+    /// </summary>
+    /// <param name="spawnInfo">The spawn information.</param>
+    /// <param name="stats">The NPC definition.</param>
+    /// <param name="map">The map on which the statue is spawned.</param>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <param name="runtime">The Castle Siege runtime entry.</param>
+    /// <param name="intelligence">The statue intelligence.</param>
+    /// <param name="dropGenerator">The drop generator.</param>
+    /// <param name="plugInManager">The plugin manager.</param>
+    public CastleSiegeStatue(
+        MonsterSpawnArea spawnInfo,
+        MonsterDefinition stats,
+        GameMap map,
+        CastleSiegeContext context,
+        CastleSiegeNpcRuntime runtime,
+        CastleSiegeStatueIntelligence intelligence,
+        IDropGenerator dropGenerator,
+        PlugInManager plugInManager)
+        : base(spawnInfo, stats, map, context, runtime, intelligence, dropGenerator, plugInManager)
+    {
+    }
+
+    /// <summary>
+    /// Gets the defense upgrade level.
+    /// </summary>
+    public byte DefenseLevel => this.State.DefenseLevel;
+
+    /// <summary>
+    /// Gets the life upgrade level.
+    /// </summary>
+    public byte LifeLevel => this.State.LifeLevel;
+
+    /// <summary>
+    /// Gets the regeneration upgrade level.
+    /// </summary>
+    public byte RegenLevel => this.State.RegenLevel;
+
+    /// <inheritdoc />
+    public override void ApplyPersistedUpgrades(bool preserveMissingHealth)
+    {
+        this.SetDefense(GetValue(this.Context.Configuration.StatueDefenseUpgrades, this.DefenseLevel));
+        this.SetMaximumHealth(
+            GetValue(this.Context.Configuration.StatueLifeUpgrades, this.LifeLevel),
+            preserveMissingHealth);
+    }
+
+    /// <summary>
+    /// Executes one regeneration tick.
+    /// </summary>
+    /// <returns>The restored hit points.</returns>
+    public int Regenerate()
+    {
+        if (!this.IsAlive || this.RegenLevel == 0 || this.Health >= this.MaximumHealth)
+        {
+            return 0;
+        }
+
+        var regenerationPercentage = GetValue(
+            this.Context.Configuration.StatueRegenUpgrades,
+            this.RegenLevel);
+        var restored = Math.Max(1, this.MaximumHealth * regenerationPercentage / 100);
+        var previousHealth = this.Health;
+        this.Health = Math.Min(this.MaximumHealth, this.Health + restored);
+        this.State.CurrentHp = this.Health;
+        return this.Health - previousHealth;
+    }
+
+    private static int GetValue(IEnumerable<CastleSiegeUpgradeDefinition> definitions, byte level)
+    {
+        return definitions.FirstOrDefault(definition => definition.Level == level)?.Value
+               ?? throw new InvalidOperationException($"Castle Siege statue upgrade level {level} is not configured.");
+    }
+}

--- a/src/GameLogic/CastleSiege/NPC/CastleSiegeStatue.cs
+++ b/src/GameLogic/CastleSiege/NPC/CastleSiegeStatue.cs
@@ -14,11 +14,6 @@ using MUnique.OpenMU.PlugIns;
 public sealed class CastleSiegeStatue : CastleSiegeAttackableNpc
 {
     /// <summary>
-    /// Gets the monster number of Castle Siege Guardian Statues.
-    /// </summary>
-    public const short MonsterNumber = 283;
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="CastleSiegeStatue"/> class.
     /// </summary>
     /// <param name="spawnInfo">The spawn information.</param>
@@ -41,6 +36,11 @@ public sealed class CastleSiegeStatue : CastleSiegeAttackableNpc
         : base(spawnInfo, stats, map, context, runtime, intelligence, dropGenerator, plugInManager)
     {
     }
+
+    /// <summary>
+    /// Gets the monster number of Castle Siege Guardian Statues.
+    /// </summary>
+    public static short MonsterNumber { get; } = 283;
 
     /// <summary>
     /// Gets the defense upgrade level.

--- a/src/GameLogic/CastleSiege/NPC/CastleSiegeStatue.cs
+++ b/src/GameLogic/CastleSiege/NPC/CastleSiegeStatue.cs
@@ -14,11 +14,6 @@ using MUnique.OpenMU.PlugIns;
 public sealed class CastleSiegeStatue : CastleSiegeAttackableNpc
 {
     /// <summary>
-    /// The monster number of Castle Siege Guardian Statues.
-    /// </summary>
-    public const short MonsterNumber = 283;
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="CastleSiegeStatue"/> class.
     /// </summary>
     /// <param name="spawnInfo">The spawn information.</param>
@@ -41,6 +36,11 @@ public sealed class CastleSiegeStatue : CastleSiegeAttackableNpc
         : base(spawnInfo, stats, map, context, runtime, intelligence, dropGenerator, plugInManager)
     {
     }
+
+    /// <summary>
+    /// Gets the monster number of Castle Siege Guardian Statues.
+    /// </summary>
+    public static short MonsterNumber { get; } = 283;
 
     /// <summary>
     /// Gets the defense upgrade level.

--- a/src/GameLogic/CastleSiege/NPC/CastleSiegeSwitch.cs
+++ b/src/GameLogic/CastleSiege/NPC/CastleSiegeSwitch.cs
@@ -12,16 +12,6 @@ using MUnique.OpenMU.GameLogic.CastleSiege.Intelligence;
 public sealed class CastleSiegeSwitch : CastleSiegeNpcBase
 {
     /// <summary>
-    /// The first Crown switch monster number.
-    /// </summary>
-    public const short FirstMonsterNumber = 217;
-
-    /// <summary>
-    /// The second Crown switch monster number.
-    /// </summary>
-    public const short SecondMonsterNumber = 218;
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="CastleSiegeSwitch"/> class.
     /// </summary>
     /// <param name="spawnInfo">The spawn information.</param>
@@ -43,6 +33,16 @@ public sealed class CastleSiegeSwitch : CastleSiegeNpcBase
         ArgumentOutOfRangeException.ThrowIfGreaterThan(switchIndex, 1);
         this.SwitchIndex = switchIndex;
     }
+
+    /// <summary>
+    /// Gets the first Crown switch monster number.
+    /// </summary>
+    public static short FirstMonsterNumber { get; } = 217;
+
+    /// <summary>
+    /// Gets the second Crown switch monster number.
+    /// </summary>
+    public static short SecondMonsterNumber { get; } = 218;
 
     /// <summary>
     /// Gets the zero-based switch index.

--- a/src/GameLogic/CastleSiege/NPC/CastleSiegeSwitch.cs
+++ b/src/GameLogic/CastleSiege/NPC/CastleSiegeSwitch.cs
@@ -1,0 +1,56 @@
+// <copyright file="CastleSiegeSwitch.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.NPC;
+
+using MUnique.OpenMU.GameLogic.CastleSiege.Intelligence;
+
+/// <summary>
+/// One of the two Castle Siege Crown switches.
+/// </summary>
+public sealed class CastleSiegeSwitch : CastleSiegeNpcBase
+{
+    /// <summary>
+    /// The first Crown switch monster number.
+    /// </summary>
+    public const short FirstMonsterNumber = 217;
+
+    /// <summary>
+    /// The second Crown switch monster number.
+    /// </summary>
+    public const short SecondMonsterNumber = 218;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeSwitch"/> class.
+    /// </summary>
+    /// <param name="spawnInfo">The spawn information.</param>
+    /// <param name="stats">The NPC definition.</param>
+    /// <param name="map">The map on which the switch is spawned.</param>
+    /// <param name="runtime">The Castle Siege runtime entry.</param>
+    /// <param name="intelligence">The switch intelligence.</param>
+    /// <param name="switchIndex">The zero-based switch index.</param>
+    public CastleSiegeSwitch(
+        MonsterSpawnArea spawnInfo,
+        MonsterDefinition stats,
+        GameMap map,
+        CastleSiegeNpcRuntime runtime,
+        CastleSiegeSwitchIntelligence intelligence,
+        int switchIndex)
+        : base(spawnInfo, stats, map, runtime, intelligence)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(switchIndex);
+        ArgumentOutOfRangeException.ThrowIfGreaterThan(switchIndex, 1);
+        this.SwitchIndex = switchIndex;
+    }
+
+    /// <summary>
+    /// Gets the zero-based switch index.
+    /// </summary>
+    public int SwitchIndex { get; }
+
+    /// <summary>
+    /// Gets or sets the player currently occupying the switch.
+    /// </summary>
+    public Player? Occupant { get; set; }
+}

--- a/src/GameLogic/CastleSiege/NPC/CastleSiegeSwitch.cs
+++ b/src/GameLogic/CastleSiege/NPC/CastleSiegeSwitch.cs
@@ -12,16 +12,6 @@ using MUnique.OpenMU.GameLogic.CastleSiege.Intelligence;
 public sealed class CastleSiegeSwitch : CastleSiegeNpcBase
 {
     /// <summary>
-    /// Gets the first Crown switch monster number.
-    /// </summary>
-    public const short FirstMonsterNumber = 217;
-
-    /// <summary>
-    /// Gets the second Crown switch monster number.
-    /// </summary>
-    public const short SecondMonsterNumber = 218;
-
-    /// <summary>
     /// Initializes a new instance of the <see cref="CastleSiegeSwitch"/> class.
     /// </summary>
     /// <param name="spawnInfo">The spawn information.</param>
@@ -43,6 +33,16 @@ public sealed class CastleSiegeSwitch : CastleSiegeNpcBase
         ArgumentOutOfRangeException.ThrowIfGreaterThan(switchIndex, 1);
         this.SwitchIndex = switchIndex;
     }
+
+    /// <summary>
+    /// Gets the first Crown switch monster number.
+    /// </summary>
+    public static short FirstMonsterNumber { get; } = 217;
+
+    /// <summary>
+    /// Gets the second Crown switch monster number.
+    /// </summary>
+    public static short SecondMonsterNumber { get; } = 218;
 
     /// <summary>
     /// Gets the zero-based switch index.

--- a/src/GameLogic/CastleSiege/NPC/CastleSiegeSwitch.cs
+++ b/src/GameLogic/CastleSiege/NPC/CastleSiegeSwitch.cs
@@ -12,6 +12,16 @@ using MUnique.OpenMU.GameLogic.CastleSiege.Intelligence;
 public sealed class CastleSiegeSwitch : CastleSiegeNpcBase
 {
     /// <summary>
+    /// Gets the first Crown switch monster number.
+    /// </summary>
+    public const short FirstMonsterNumber = 217;
+
+    /// <summary>
+    /// Gets the second Crown switch monster number.
+    /// </summary>
+    public const short SecondMonsterNumber = 218;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="CastleSiegeSwitch"/> class.
     /// </summary>
     /// <param name="spawnInfo">The spawn information.</param>
@@ -33,16 +43,6 @@ public sealed class CastleSiegeSwitch : CastleSiegeNpcBase
         ArgumentOutOfRangeException.ThrowIfGreaterThan(switchIndex, 1);
         this.SwitchIndex = switchIndex;
     }
-
-    /// <summary>
-    /// Gets the first Crown switch monster number.
-    /// </summary>
-    public static short FirstMonsterNumber { get; } = 217;
-
-    /// <summary>
-    /// Gets the second Crown switch monster number.
-    /// </summary>
-    public static short SecondMonsterNumber { get; } = 218;
 
     /// <summary>
     /// Gets the zero-based switch index.

--- a/src/GameLogic/CastleSiege/NPC/ICastleSiegeNpc.cs
+++ b/src/GameLogic/CastleSiege/NPC/ICastleSiegeNpc.cs
@@ -1,0 +1,16 @@
+// <copyright file="ICastleSiegeNpc.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.NPC;
+
+/// <summary>
+/// Common contract of a configured Castle Siege NPC.
+/// </summary>
+public interface ICastleSiegeNpc
+{
+    /// <summary>
+    /// Gets the runtime entry which owns this NPC.
+    /// </summary>
+    CastleSiegeNpcRuntime Runtime { get; }
+}

--- a/src/GameLogic/NPC/AttackableNpcBase.cs
+++ b/src/GameLogic/NPC/AttackableNpcBase.cs
@@ -104,7 +104,9 @@ public abstract class AttackableNpcBase : NonPlayerCharacter, IAttackable
     /// <inheritdoc />
     public async ValueTask<HitInfo?> AttackByAsync(IAttacker attacker, SkillEntry? skill, bool isCombo, double damageFactor = 1.0, bool? isFinalStreakHit = null)
     {
-        if (this.Definition.ObjectKind == NpcObjectKind.Guard || this.IsAttackBlockedBySafezone(attacker))
+        if (this.Definition.ObjectKind == NpcObjectKind.Guard
+            || this.IsAttackBlockedBySafezone(attacker)
+            || !this.CanBeAttackedBy(attacker))
         {
             return null;
         }
@@ -270,6 +272,13 @@ public abstract class AttackableNpcBase : NonPlayerCharacter, IAttackable
     {
         return attacker as Player ?? (attacker as IPlayerSurrogate)?.Owner;
     }
+
+    /// <summary>
+    /// Determines whether the specified attacker may attack this NPC.
+    /// </summary>
+    /// <param name="attacker">The attacker.</param>
+    /// <returns><see langword="true"/> when the attack is allowed; otherwise, <see langword="false"/>.</returns>
+    protected virtual bool CanBeAttackedBy(IAttacker attacker) => true;
 
     /// <summary>
     /// Registers the hit.

--- a/src/GameLogic/NPC/AttackableNpcBase.cs
+++ b/src/GameLogic/NPC/AttackableNpcBase.cs
@@ -93,8 +93,8 @@ public abstract class AttackableNpcBase : NonPlayerCharacter, IAttackable
     /// </summary>
     public int Health
     {
-        get => Math.Max(this._health, 0);
-        set => this._health = value;
+        get => Math.Max(Volatile.Read(ref this._health), 0);
+        set => Interlocked.Exchange(ref this._health, value);
     }
 
     private bool ShouldRespawn => this.SpawnArea.SpawnTrigger == SpawnTrigger.Automatic
@@ -287,6 +287,38 @@ public abstract class AttackableNpcBase : NonPlayerCharacter, IAttackable
     protected virtual void RegisterHit(IAttacker attacker)
     {
         // can be overwritten
+    }
+
+    /// <summary>
+    /// Atomically restores health without exceeding the specified maximum.
+    /// </summary>
+    /// <param name="amount">The maximum amount of health to restore.</param>
+    /// <param name="maximumHealth">The maximum health after the restoration.</param>
+    /// <returns>The restored health.</returns>
+    protected int RestoreHealth(int amount, int maximumHealth)
+    {
+        if (amount <= 0 || maximumHealth <= 0)
+        {
+            return 0;
+        }
+
+        while (true)
+        {
+            var currentHealth = Volatile.Read(ref this._health);
+            if (currentHealth <= 0 || currentHealth >= maximumHealth)
+            {
+                return 0;
+            }
+
+            var restoredHealth = Math.Min(amount, maximumHealth - currentHealth);
+            if (Interlocked.CompareExchange(
+                    ref this._health,
+                    currentHealth + restoredHealth,
+                    currentHealth) == currentHealth)
+            {
+                return restoredHealth;
+            }
+        }
     }
 
     /// <summary>

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -1388,7 +1388,7 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
             return;
         }
 
-        var canWalkToTarget = currentMap.Terrain.WalkMap[target.X, target.Y];
+        var canWalkToTarget = CanWalkPath(currentMap.Terrain, target, steps.Span);
         if (canWalkToTarget)
         {
             this.Logger.LogDebug("WalkToAsync: Player is walking to {0}", target);
@@ -2042,6 +2042,24 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
     protected virtual ICustomPlugInContainer<IViewPlugIn> CreateViewPlugInContainer()
     {
         throw new NotImplementedException("CreateViewPlugInContainer must be overwritten in derived classes.");
+    }
+
+    private static bool CanWalkPath(GameMapTerrain terrain, Point target, ReadOnlySpan<WalkingStep> steps)
+    {
+        if (!terrain.WalkMap[target.X, target.Y])
+        {
+            return false;
+        }
+
+        foreach (var step in steps)
+        {
+            if (!terrain.WalkMap[step.To.X, step.To.Y])
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private async ValueTask AddMasterExperienceCoreAsync(int experience, IAttackable? killedObject)

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -1388,24 +1388,34 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
             return;
         }
 
-        var canWalkToTarget = CanWalkPath(currentMap.Terrain, target, steps.Span);
-        if (canWalkToTarget)
+        var requestedTarget = target;
+        var walkableStepCount = GetWalkableStepCount(currentMap.Terrain, steps.Span);
+        if (walkableStepCount == 0)
         {
-            this.Logger.LogDebug("WalkToAsync: Player is walking to {0}", target);
-
-            var token = await this._walker.InitializeWalkToAsync(target, steps).ConfigureAwait(false);
-            await currentMap.MoveAsync(this, target, this._moveLock, MoveType.Walk).ConfigureAwait(false);
-            await this._walker.StartWalkAsync(token).ConfigureAwait(false);
-
-            this.Logger.LogDebug("WalkToAsync: Observer Count: {0}", this.Observers.Count);
-        }
-        else
-        {
-            this.Logger.LogWarning("WalkToAsync: Player requested to walk to {0}, but it's not an allowed target", target);
-
-            // We'll send the current coordinates back to the client, so it doesn't appear in the invalid coordinates.
+            this.Logger.LogDebug(
+                "WalkToAsync: Player requested to walk to {0}, but the first path step is blocked. Resynchronizing client.",
+                requestedTarget);
             await this.InvokeViewPlugInAsync<IObjectMovedPlugIn>(p => p.ObjectMovedAsync(this, MoveType.Instant)).ConfigureAwait(false);
+            return;
         }
+
+        if (walkableStepCount < steps.Length)
+        {
+            steps = steps[..walkableStepCount];
+            target = steps.Span[^1].To;
+            this.Logger.LogDebug(
+                "WalkToAsync: Truncated path from {0} to the last reachable position {1} because a later step is blocked.",
+                requestedTarget,
+                target);
+        }
+
+        this.Logger.LogDebug("WalkToAsync: Player is walking to {0}", target);
+
+        var token = await this._walker.InitializeWalkToAsync(target, steps).ConfigureAwait(false);
+        await currentMap.MoveAsync(this, target, this._moveLock, MoveType.Walk).ConfigureAwait(false);
+        await this._walker.StartWalkAsync(token).ConfigureAwait(false);
+
+        this.Logger.LogDebug("WalkToAsync: Observer Count: {0}", this.Observers.Count);
     }
 
     /// <inheritdoc />
@@ -2044,22 +2054,18 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         throw new NotImplementedException("CreateViewPlugInContainer must be overwritten in derived classes.");
     }
 
-    private static bool CanWalkPath(GameMapTerrain terrain, Point target, ReadOnlySpan<WalkingStep> steps)
+    private static int GetWalkableStepCount(GameMapTerrain terrain, ReadOnlySpan<WalkingStep> steps)
     {
-        if (!terrain.WalkMap[target.X, target.Y])
+        for (var index = 0; index < steps.Length; index++)
         {
-            return false;
-        }
-
-        foreach (var step in steps)
-        {
-            if (!terrain.WalkMap[step.To.X, step.To.Y])
+            var target = steps[index].To;
+            if (!terrain.WalkMap[target.X, target.Y])
             {
-                return false;
+                return index;
             }
         }
 
-        return true;
+        return steps.Length;
     }
 
     private async ValueTask AddMasterExperienceCoreAsync(int experience, IAttackable? killedObject)

--- a/src/GameLogic/Properties/PlugInResources.Designer.cs
+++ b/src/GameLogic/Properties/PlugInResources.Designer.cs
@@ -286,6 +286,24 @@ namespace MUnique.OpenMU.GameLogic.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Opens the operation interface for a Castle Siege gate lever..
+        /// </summary>
+        public static string CastleSiegeLeverTalkPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeLeverTalkPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege Gate Lever.
+        /// </summary>
+        public static string CastleSiegeLeverTalkPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeLeverTalkPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Drives the weekly Castle Siege state cycle..
         /// </summary>
         public static string CastleSiegePlugIn_Description {

--- a/src/GameLogic/Properties/PlugInResources.resx
+++ b/src/GameLogic/Properties/PlugInResources.resx
@@ -117,6 +117,12 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="CastleSiegeLeverTalkPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege Gate Lever</value>
+  </data>
+  <data name="CastleSiegeLeverTalkPlugIn_Description" xml:space="preserve">
+    <value>Opens the operation interface for a Castle Siege gate lever.</value>
+  </data>
   <data name="CastleSiegePlugIn_Name" xml:space="preserve">
     <value>Castle Siege</value>
   </data>

--- a/src/GameLogic/Views/CastleSiege/CastleSiegeNpcInfo.cs
+++ b/src/GameLogic/Views/CastleSiege/CastleSiegeNpcInfo.cs
@@ -1,0 +1,28 @@
+// <copyright file="CastleSiegeNpcInfo.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// Information about a Castle Siege gate or Guardian Statue.
+/// </summary>
+/// <param name="NpcNumber">The NPC number.</param>
+/// <param name="NpcIndex">The NPC instance identifier.</param>
+/// <param name="DefenseLevel">The defense upgrade level.</param>
+/// <param name="RegenerationLevel">The regeneration upgrade level.</param>
+/// <param name="MaximumHealth">The maximum health.</param>
+/// <param name="CurrentHealth">The current health.</param>
+/// <param name="PositionX">The X coordinate.</param>
+/// <param name="PositionY">The Y coordinate.</param>
+/// <param name="IsAlive">Whether the NPC is alive.</param>
+public sealed record CastleSiegeNpcInfo(
+    uint NpcNumber,
+    uint NpcIndex,
+    byte DefenseLevel,
+    byte RegenerationLevel,
+    int MaximumHealth,
+    int CurrentHealth,
+    byte PositionX,
+    byte PositionY,
+    bool IsAlive);

--- a/src/GameLogic/Views/CastleSiege/CastleSiegeNpcOperationResult.cs
+++ b/src/GameLogic/Views/CastleSiege/CastleSiegeNpcOperationResult.cs
@@ -1,0 +1,52 @@
+// <copyright file="CastleSiegeNpcOperationResult.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// The result of a Castle Siege NPC management request.
+/// </summary>
+public enum CastleSiegeNpcOperationResult : byte
+{
+    /// <summary>
+    /// The request failed validation.
+    /// </summary>
+    Failed = 0,
+
+    /// <summary>
+    /// The request succeeded.
+    /// </summary>
+    Success = 1,
+
+    /// <summary>
+    /// The player is not authorized to manage the defense structure.
+    /// </summary>
+    NotAuthorized = 2,
+
+    /// <summary>
+    /// The player does not have enough Zen.
+    /// </summary>
+    InsufficientMoney = 3,
+
+    /// <summary>
+    /// An operation-specific requirement was not met.
+    /// For purchase requests, the structure already exists; for upgrades, required items are missing.
+    /// </summary>
+    RequirementNotMet = 4,
+
+    /// <summary>
+    /// The requested upgrade type is invalid for the structure.
+    /// </summary>
+    InvalidUpgradeType = 5,
+
+    /// <summary>
+    /// The requested upgrade value is invalid.
+    /// </summary>
+    InvalidUpgradeValue = 6,
+
+    /// <summary>
+    /// The requested defense structure does not exist.
+    /// </summary>
+    NpcNotFound = 7,
+}

--- a/src/GameLogic/Views/CastleSiege/ICastleSiegeNpcListPlugIn.cs
+++ b/src/GameLogic/Views/CastleSiege/ICastleSiegeNpcListPlugIn.cs
@@ -1,0 +1,18 @@
+// <copyright file="ICastleSiegeNpcListPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// A view which shows Castle Siege gates and Guardian Statues.
+/// </summary>
+public interface ICastleSiegeNpcListPlugIn : IViewPlugIn
+{
+    /// <summary>
+    /// Shows a Castle Siege NPC list.
+    /// </summary>
+    /// <param name="npcs">The NPC information.</param>
+    /// <returns>A task that represents the asynchronous view update.</returns>
+    ValueTask ShowNpcListAsync(IReadOnlyList<CastleSiegeNpcInfo> npcs);
+}

--- a/src/GameLogic/Views/CastleSiege/ICastleSiegeNpcOperationResultPlugIn.cs
+++ b/src/GameLogic/Views/CastleSiege/ICastleSiegeNpcOperationResultPlugIn.cs
@@ -1,0 +1,82 @@
+// <copyright file="ICastleSiegeNpcOperationResultPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+using MUnique.OpenMU.DataModel.Configuration;
+
+/// <summary>
+/// A view which reports Castle Siege NPC management results.
+/// </summary>
+public interface ICastleSiegeNpcOperationResultPlugIn : IViewPlugIn
+{
+    /// <summary>
+    /// Shows a defense-structure purchase result.
+    /// </summary>
+    /// <param name="result">The operation result.</param>
+    /// <param name="npcNumber">The NPC number.</param>
+    /// <param name="npcIndex">The NPC instance identifier.</param>
+    /// <returns>A task that represents the asynchronous view update.</returns>
+    ValueTask ShowBuyResultAsync(CastleSiegeNpcOperationResult result, uint npcNumber, uint npcIndex);
+
+    /// <summary>
+    /// Shows a defense-structure repair result.
+    /// </summary>
+    /// <param name="result">The operation result.</param>
+    /// <param name="npcNumber">The NPC number.</param>
+    /// <param name="npcIndex">The NPC instance identifier.</param>
+    /// <param name="currentHealth">The current NPC health.</param>
+    /// <param name="maximumHealth">The maximum NPC health.</param>
+    /// <returns>A task that represents the asynchronous view update.</returns>
+    ValueTask ShowRepairResultAsync(
+        CastleSiegeNpcOperationResult result,
+        uint npcNumber,
+        uint npcIndex,
+        int currentHealth,
+        int maximumHealth);
+
+    /// <summary>
+    /// Shows a defense-structure upgrade result.
+    /// </summary>
+    /// <param name="result">The operation result.</param>
+    /// <param name="npcNumber">The NPC number.</param>
+    /// <param name="npcIndex">The NPC instance identifier.</param>
+    /// <param name="upgradeType">The upgrade type.</param>
+    /// <param name="upgradeLevel">The requested upgrade level.</param>
+    /// <returns>A task that represents the asynchronous view update.</returns>
+    ValueTask ShowUpgradeResultAsync(
+        CastleSiegeNpcOperationResult result,
+        uint npcNumber,
+        uint npcIndex,
+        CastleSiegeUpgradeType upgradeType,
+        byte upgradeLevel);
+
+    /// <summary>
+    /// Opens the gate-operation interface.
+    /// </summary>
+    /// <param name="result">The operation result.</param>
+    /// <param name="gateIndex">The gate identifier.</param>
+    /// <returns>A task that represents the asynchronous view update.</returns>
+    ValueTask ShowGateInterfaceAsync(CastleSiegeNpcOperationResult result, ushort gateIndex);
+
+    /// <summary>
+    /// Shows a gate operation result.
+    /// </summary>
+    /// <param name="result">The operation result.</param>
+    /// <param name="isOpen">Whether the gate is open after the operation.</param>
+    /// <param name="gateIndex">The gate identifier.</param>
+    /// <returns>A task that represents the asynchronous view update.</returns>
+    ValueTask ShowGateOperationResultAsync(
+        CastleSiegeNpcOperationResult result,
+        bool isOpen,
+        ushort gateIndex);
+
+    /// <summary>
+    /// Updates the visible state of a gate.
+    /// </summary>
+    /// <param name="isOpen">Whether the gate is open.</param>
+    /// <param name="gateIndex">The gate identifier.</param>
+    /// <returns>A task that represents the asynchronous view update.</returns>
+    ValueTask ShowGateStateAsync(bool isOpen, ushort gateIndex);
+}

--- a/src/GameServer/MessageHandler/CastleSiege/CastleSiegeDefenseBuyHandlerPlugIn.cs
+++ b/src/GameServer/MessageHandler/CastleSiege/CastleSiegeDefenseBuyHandlerPlugIn.cs
@@ -1,0 +1,44 @@
+// <copyright file="CastleSiegeDefenseBuyHandlerPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.MessageHandler.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+using MUnique.OpenMU.Network.Packets.ClientToServer;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Handles requests to re-purchase destroyed Castle Siege defense structures.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeDefenseBuyHandlerPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeDefenseBuyHandlerPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("1FCBF012-63CA-4B76-971F-F5848D2281CF")]
+[BelongsToGroup(CastleSiegeGroupHandlerPlugIn.GroupKey)]
+internal sealed class CastleSiegeDefenseBuyHandlerPlugIn : ISubPacketHandlerPlugIn
+{
+    /// <inheritdoc />
+    public bool IsEncryptionExpected => false;
+
+    /// <inheritdoc />
+    public byte Key => CastleSiegeDefenseBuyRequest.SubCode;
+
+    /// <inheritdoc />
+    public async ValueTask HandlePacketAsync(Player player, Memory<byte> packet)
+    {
+        if (packet.Length < CastleSiegeDefenseBuyRequest.Length)
+        {
+            return;
+        }
+
+        var request = new CastleSiegeDefenseBuyRequest(packet);
+        await CastleSiegeNpcBuyAction.BuyAsync(
+                player,
+                CastleSiegeHandlerContext.Get(player),
+                request.NpcNumber,
+                request.NpcIndex)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/GameServer/MessageHandler/CastleSiege/CastleSiegeDefenseRepairHandlerPlugIn.cs
+++ b/src/GameServer/MessageHandler/CastleSiege/CastleSiegeDefenseRepairHandlerPlugIn.cs
@@ -1,0 +1,44 @@
+// <copyright file="CastleSiegeDefenseRepairHandlerPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.MessageHandler.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+using MUnique.OpenMU.Network.Packets.ClientToServer;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Handles requests to repair Castle Siege defense structures.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeDefenseRepairHandlerPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeDefenseRepairHandlerPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("2FDCA492-97D6-4972-B094-D94A71871717")]
+[BelongsToGroup(CastleSiegeGroupHandlerPlugIn.GroupKey)]
+internal sealed class CastleSiegeDefenseRepairHandlerPlugIn : ISubPacketHandlerPlugIn
+{
+    /// <inheritdoc />
+    public bool IsEncryptionExpected => false;
+
+    /// <inheritdoc />
+    public byte Key => CastleSiegeDefenseRepairRequest.SubCode;
+
+    /// <inheritdoc />
+    public async ValueTask HandlePacketAsync(Player player, Memory<byte> packet)
+    {
+        if (packet.Length < CastleSiegeDefenseRepairRequest.Length)
+        {
+            return;
+        }
+
+        var request = new CastleSiegeDefenseRepairRequest(packet);
+        await CastleSiegeNpcRepairAction.RepairAsync(
+                player,
+                CastleSiegeHandlerContext.Get(player),
+                request.NpcNumber,
+                request.NpcIndex)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/GameServer/MessageHandler/CastleSiege/CastleSiegeDefenseUpgradeHandlerPlugIn.cs
+++ b/src/GameServer/MessageHandler/CastleSiege/CastleSiegeDefenseUpgradeHandlerPlugIn.cs
@@ -1,0 +1,54 @@
+// <copyright file="CastleSiegeDefenseUpgradeHandlerPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.MessageHandler.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+using MUnique.OpenMU.Network.Packets.ClientToServer;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Handles requests to upgrade Castle Siege defense structures.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeDefenseUpgradeHandlerPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeDefenseUpgradeHandlerPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("6522CF58-6103-47D7-9ECF-B326EF2C9D88")]
+[BelongsToGroup(CastleSiegeGroupHandlerPlugIn.GroupKey)]
+internal sealed class CastleSiegeDefenseUpgradeHandlerPlugIn : ISubPacketHandlerPlugIn
+{
+    /// <inheritdoc />
+    public bool IsEncryptionExpected => false;
+
+    /// <inheritdoc />
+    public byte Key => CastleSiegeDefenseUpgradeRequest.SubCode;
+
+    /// <inheritdoc />
+    public async ValueTask HandlePacketAsync(Player player, Memory<byte> packet)
+    {
+        if (packet.Length < CastleSiegeDefenseUpgradeRequest.Length)
+        {
+            return;
+        }
+
+        var request = new CastleSiegeDefenseUpgradeRequest(packet);
+        var type = request.NpcUpgradeType <= byte.MaxValue
+                   && Enum.IsDefined((CastleSiegeUpgradeType)(byte)request.NpcUpgradeType)
+            ? (CastleSiegeUpgradeType)(byte)request.NpcUpgradeType
+            : (CastleSiegeUpgradeType)byte.MaxValue;
+        var requestedLevel = request.NpcUpgradeValue <= byte.MaxValue
+            ? (byte)request.NpcUpgradeValue
+            : byte.MaxValue;
+        await CastleSiegeNpcUpgradeAction.UpgradeAsync(
+                player,
+                CastleSiegeHandlerContext.Get(player),
+                request.NpcNumber,
+                request.NpcIndex,
+                type,
+                requestedLevel)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/GameServer/MessageHandler/CastleSiege/CastleSiegeGateListHandlerPlugIn.cs
+++ b/src/GameServer/MessageHandler/CastleSiege/CastleSiegeGateListHandlerPlugIn.cs
@@ -1,0 +1,27 @@
+// <copyright file="CastleSiegeGateListHandlerPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.MessageHandler.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.CastleSiege.NPC;
+using MUnique.OpenMU.Network.Packets.ClientToServer;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Handles requests for the Castle Siege gate list.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeGateListHandlerPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeGateListHandlerPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("904BE911-B46C-4C7A-BBC2-C5B845592C65")]
+[BelongsToGroup(CastleSiegeNpcGroupHandlerPlugIn.GroupKey)]
+internal sealed class CastleSiegeGateListHandlerPlugIn : CastleSiegeNpcListHandlerBase
+{
+    /// <inheritdoc />
+    public override byte Key => CastleSiegeGateListRequest.SubCode;
+
+    /// <inheritdoc />
+    protected override short MonsterNumber => CastleSiegeGate.MonsterNumber;
+}

--- a/src/GameServer/MessageHandler/CastleSiege/CastleSiegeGateOperateHandlerPlugIn.cs
+++ b/src/GameServer/MessageHandler/CastleSiege/CastleSiegeGateOperateHandlerPlugIn.cs
@@ -1,0 +1,44 @@
+// <copyright file="CastleSiegeGateOperateHandlerPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.MessageHandler.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+using MUnique.OpenMU.Network.Packets.ClientToServer;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Handles Castle Siege gate open and close requests.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeGateOperateHandlerPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeGateOperateHandlerPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("8B4ADE95-4BA9-4425-99AA-B2DBA03ACD88")]
+[BelongsToGroup(CastleSiegeGroupHandlerPlugIn.GroupKey)]
+internal sealed class CastleSiegeGateOperateHandlerPlugIn : ISubPacketHandlerPlugIn
+{
+    /// <inheritdoc />
+    public bool IsEncryptionExpected => false;
+
+    /// <inheritdoc />
+    public byte Key => ToggleCastleGateRequest.SubCode;
+
+    /// <inheritdoc />
+    public async ValueTask HandlePacketAsync(Player player, Memory<byte> packet)
+    {
+        if (packet.Length < ToggleCastleGateRequest.Length)
+        {
+            return;
+        }
+
+        var request = new ToggleCastleGateRequest(packet);
+        await CastleSiegeGateOperateAction.OperateAsync(
+                player,
+                CastleSiegeHandlerContext.Get(player),
+                request.GateId,
+                request.IsOpen)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/GameServer/MessageHandler/CastleSiege/CastleSiegeNpcGroupHandlerPlugIn.cs
+++ b/src/GameServer/MessageHandler/CastleSiege/CastleSiegeNpcGroupHandlerPlugIn.cs
@@ -1,0 +1,43 @@
+// <copyright file="CastleSiegeNpcGroupHandlerPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.MessageHandler.CastleSiege;
+
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Packet handler for Castle Siege NPC-list packets with the 0xB3 identifier.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeNpcGroupHandlerPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeNpcGroupHandlerPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("F40FD671-43DE-46B4-9527-F17B9A8A5A0D")]
+internal sealed class CastleSiegeNpcGroupHandlerPlugIn : GroupPacketHandlerPlugIn
+{
+    /// <summary>
+    /// The group key.
+    /// </summary>
+    internal const byte GroupKey = 0xB3;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeNpcGroupHandlerPlugIn"/> class.
+    /// </summary>
+    /// <param name="clientVersionProvider">The client-version provider.</param>
+    /// <param name="manager">The plugin manager.</param>
+    /// <param name="loggerFactory">The logger factory.</param>
+    public CastleSiegeNpcGroupHandlerPlugIn(
+        IClientVersionProvider clientVersionProvider,
+        PlugInManager manager,
+        ILoggerFactory loggerFactory)
+        : base(clientVersionProvider, manager, loggerFactory)
+    {
+    }
+
+    /// <inheritdoc />
+    public override bool IsEncryptionExpected => false;
+
+    /// <inheritdoc />
+    public override byte Key => GroupKey;
+}

--- a/src/GameServer/MessageHandler/CastleSiege/CastleSiegeNpcListHandlerBase.cs
+++ b/src/GameServer/MessageHandler/CastleSiege/CastleSiegeNpcListHandlerBase.cs
@@ -1,0 +1,37 @@
+// <copyright file="CastleSiegeNpcListHandlerBase.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.MessageHandler.CastleSiege;
+
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// Base packet handler for Castle Siege defense-structure lists.
+/// </summary>
+internal abstract class CastleSiegeNpcListHandlerBase : ISubPacketHandlerPlugIn
+{
+    /// <inheritdoc />
+    public bool IsEncryptionExpected => false;
+
+    /// <inheritdoc />
+    public abstract byte Key { get; }
+
+    /// <summary>
+    /// Gets the monster number returned by this handler.
+    /// </summary>
+    protected abstract short MonsterNumber { get; }
+
+    /// <inheritdoc />
+    public async ValueTask HandlePacketAsync(Player player, Memory<byte> packet)
+    {
+        var context = CastleSiegeHandlerContext.Get(player);
+        var npcs = context is null
+            ? []
+            : await context.NpcController.GetDefenseStructureSnapshotAsync(this.MonsterNumber).ConfigureAwait(false);
+        await player.InvokeViewPlugInAsync<ICastleSiegeNpcListPlugIn>(
+                view => view.ShowNpcListAsync(npcs))
+            .ConfigureAwait(false);
+    }
+}

--- a/src/GameServer/MessageHandler/CastleSiege/CastleSiegeStatueListHandlerPlugIn.cs
+++ b/src/GameServer/MessageHandler/CastleSiege/CastleSiegeStatueListHandlerPlugIn.cs
@@ -1,0 +1,26 @@
+// <copyright file="CastleSiegeStatueListHandlerPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.MessageHandler.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic.CastleSiege.NPC;
+using MUnique.OpenMU.Network.Packets.ClientToServer;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Handles requests for the Castle Siege Guardian Statue list.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeStatueListHandlerPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeStatueListHandlerPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("BC11A3E4-A72F-4484-8388-5A252B448B62")]
+[BelongsToGroup(CastleSiegeNpcGroupHandlerPlugIn.GroupKey)]
+internal sealed class CastleSiegeStatueListHandlerPlugIn : CastleSiegeNpcListHandlerBase
+{
+    /// <inheritdoc />
+    public override byte Key => CastleSiegeStatueListRequest.SubCode;
+
+    /// <inheritdoc />
+    protected override short MonsterNumber => CastleSiegeStatue.MonsterNumber;
+}

--- a/src/GameServer/Properties/PlugInResources.Designer.cs
+++ b/src/GameServer/Properties/PlugInResources.Designer.cs
@@ -619,6 +619,96 @@ namespace MUnique.OpenMU.GameServer.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Handles Castle Siege defense-structure purchase requests..
+        /// </summary>
+        public static string CastleSiegeDefenseBuyHandlerPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeDefenseBuyHandlerPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege Defense Purchase Handler.
+        /// </summary>
+        public static string CastleSiegeDefenseBuyHandlerPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeDefenseBuyHandlerPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Handles Castle Siege defense-structure repair requests..
+        /// </summary>
+        public static string CastleSiegeDefenseRepairHandlerPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeDefenseRepairHandlerPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege Defense Repair Handler.
+        /// </summary>
+        public static string CastleSiegeDefenseRepairHandlerPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeDefenseRepairHandlerPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Handles Castle Siege defense-structure upgrade requests..
+        /// </summary>
+        public static string CastleSiegeDefenseUpgradeHandlerPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeDefenseUpgradeHandlerPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege Defense Upgrade Handler.
+        /// </summary>
+        public static string CastleSiegeDefenseUpgradeHandlerPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeDefenseUpgradeHandlerPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Handles requests for the Castle Siege gate list..
+        /// </summary>
+        public static string CastleSiegeGateListHandlerPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeGateListHandlerPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege Gate List Handler.
+        /// </summary>
+        public static string CastleSiegeGateListHandlerPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeGateListHandlerPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Handles Castle Siege gate open and close requests..
+        /// </summary>
+        public static string CastleSiegeGateOperateHandlerPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeGateOperateHandlerPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege Gate Operation Handler.
+        /// </summary>
+        public static string CastleSiegeGateOperateHandlerPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeGateOperateHandlerPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Routes Castle Siege packet subcodes..
         /// </summary>
         public static string CastleSiegeGroupHandlerPlugIn_Description {
@@ -669,6 +759,60 @@ namespace MUnique.OpenMU.GameServer.Properties {
         public static string CastleSiegeMarkRegistrationResultPlugIn_Name {
             get {
                 return ResourceManager.GetString("CastleSiegeMarkRegistrationResultPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Routes Castle Siege NPC-list packet subcodes..
+        /// </summary>
+        public static string CastleSiegeNpcGroupHandlerPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeNpcGroupHandlerPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege NPC Packet Group Handler.
+        /// </summary>
+        public static string CastleSiegeNpcGroupHandlerPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeNpcGroupHandlerPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Sends Castle Siege defense-structure lists to the game client..
+        /// </summary>
+        public static string CastleSiegeNpcListPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeNpcListPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege NPC List View.
+        /// </summary>
+        public static string CastleSiegeNpcListPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeNpcListPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Sends Castle Siege defense-structure operation results to the game client..
+        /// </summary>
+        public static string CastleSiegeNpcOperationResultPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeNpcOperationResultPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege NPC Operation Result View.
+        /// </summary>
+        public static string CastleSiegeNpcOperationResultPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeNpcOperationResultPlugIn_Name", resourceCulture);
             }
         }
 
@@ -741,6 +885,24 @@ namespace MUnique.OpenMU.GameServer.Properties {
         public static string CastleSiegeRegistrationStatePlugIn_Name {
             get {
                 return ResourceManager.GetString("CastleSiegeRegistrationStatePlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Handles requests for the Castle Siege Guardian Statue list..
+        /// </summary>
+        public static string CastleSiegeStatueListHandlerPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeStatueListHandlerPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege Guardian Statue List Handler.
+        /// </summary>
+        public static string CastleSiegeStatueListHandlerPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeStatueListHandlerPlugIn_Name", resourceCulture);
             }
         }
 

--- a/src/GameServer/Properties/PlugInResources.resx
+++ b/src/GameServer/Properties/PlugInResources.resx
@@ -1953,6 +1953,60 @@
   <data name="CastleSiegeGroupHandlerPlugIn_Description" xml:space="preserve">
     <value>Routes Castle Siege packet subcodes.</value>
   </data>
+  <data name="CastleSiegeDefenseBuyHandlerPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege Defense Purchase Handler</value>
+  </data>
+  <data name="CastleSiegeDefenseBuyHandlerPlugIn_Description" xml:space="preserve">
+    <value>Handles Castle Siege defense-structure purchase requests.</value>
+  </data>
+  <data name="CastleSiegeDefenseRepairHandlerPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege Defense Repair Handler</value>
+  </data>
+  <data name="CastleSiegeDefenseRepairHandlerPlugIn_Description" xml:space="preserve">
+    <value>Handles Castle Siege defense-structure repair requests.</value>
+  </data>
+  <data name="CastleSiegeDefenseUpgradeHandlerPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege Defense Upgrade Handler</value>
+  </data>
+  <data name="CastleSiegeDefenseUpgradeHandlerPlugIn_Description" xml:space="preserve">
+    <value>Handles Castle Siege defense-structure upgrade requests.</value>
+  </data>
+  <data name="CastleSiegeGateListHandlerPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege Gate List Handler</value>
+  </data>
+  <data name="CastleSiegeGateListHandlerPlugIn_Description" xml:space="preserve">
+    <value>Handles requests for the Castle Siege gate list.</value>
+  </data>
+  <data name="CastleSiegeGateOperateHandlerPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege Gate Operation Handler</value>
+  </data>
+  <data name="CastleSiegeGateOperateHandlerPlugIn_Description" xml:space="preserve">
+    <value>Handles Castle Siege gate open and close requests.</value>
+  </data>
+  <data name="CastleSiegeNpcGroupHandlerPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege NPC Packet Group Handler</value>
+  </data>
+  <data name="CastleSiegeNpcGroupHandlerPlugIn_Description" xml:space="preserve">
+    <value>Routes Castle Siege NPC-list packet subcodes.</value>
+  </data>
+  <data name="CastleSiegeStatueListHandlerPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege Guardian Statue List Handler</value>
+  </data>
+  <data name="CastleSiegeStatueListHandlerPlugIn_Description" xml:space="preserve">
+    <value>Handles requests for the Castle Siege Guardian Statue list.</value>
+  </data>
+  <data name="CastleSiegeNpcListPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege NPC List View</value>
+  </data>
+  <data name="CastleSiegeNpcListPlugIn_Description" xml:space="preserve">
+    <value>Sends Castle Siege defense-structure lists to the game client.</value>
+  </data>
+  <data name="CastleSiegeNpcOperationResultPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege NPC Operation Result View</value>
+  </data>
+  <data name="CastleSiegeNpcOperationResultPlugIn_Description" xml:space="preserve">
+    <value>Sends Castle Siege defense-structure operation results to the game client.</value>
+  </data>
   <data name="CastleSiegeRegistrationHandlerPlugIn_Name" xml:space="preserve">
     <value>Castle Siege Registration Handler</value>
   </data>

--- a/src/GameServer/RemoteView/CastleSiege/CastleSiegeNpcListPlugIn.cs
+++ b/src/GameServer/RemoteView/CastleSiege/CastleSiegeNpcListPlugIn.cs
@@ -1,0 +1,67 @@
+// <copyright file="CastleSiegeNpcListPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.RemoteView.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+using MUnique.OpenMU.Network;
+using MUnique.OpenMU.Network.Packets.ServerToClient;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// The default implementation of the <see cref="ICastleSiegeNpcListPlugIn"/>
+/// which forwards defense-structure information to the game client.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeNpcListPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeNpcListPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("FF326700-AB94-44BB-AF03-A3068C28004B")]
+public class CastleSiegeNpcListPlugIn : ICastleSiegeNpcListPlugIn
+{
+    private readonly RemotePlayer _player;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeNpcListPlugIn"/> class.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    public CastleSiegeNpcListPlugIn(RemotePlayer player) => this._player = player;
+
+    /// <inheritdoc />
+    public async ValueTask ShowNpcListAsync(IReadOnlyList<CastleSiegeNpcInfo> npcs)
+    {
+        if (this._player.Connection is not { } connection)
+        {
+            return;
+        }
+
+        int Write()
+        {
+            var size = CastleSiegeNpcListRef.GetRequiredSize(npcs.Count);
+            var packet = new CastleSiegeNpcListRef(connection.Output.GetSpan(size)[..size])
+            {
+                Result = 1,
+                NpcCount = checked((uint)npcs.Count),
+            };
+
+            for (var i = 0; i < npcs.Count; i++)
+            {
+                var npc = npcs[i];
+                var entry = packet[i];
+                entry.NpcNumber = npc.NpcNumber;
+                entry.NpcIndex = npc.NpcIndex;
+                entry.DefenseUpgradeLevel = npc.DefenseLevel;
+                entry.RegenerationLevel = npc.RegenerationLevel;
+                entry.MaxHp = checked((uint)npc.MaximumHealth);
+                entry.CurrentHp = checked((uint)npc.CurrentHealth);
+                entry.PositionX = npc.PositionX;
+                entry.PositionY = npc.PositionY;
+                entry.IsAlive = npc.IsAlive;
+            }
+
+            return size;
+        }
+
+        await connection.SendAsync(Write).ConfigureAwait(false);
+    }
+}

--- a/src/GameServer/RemoteView/CastleSiege/CastleSiegeNpcOperationResultPlugIn.cs
+++ b/src/GameServer/RemoteView/CastleSiege/CastleSiegeNpcOperationResultPlugIn.cs
@@ -1,0 +1,91 @@
+// <copyright file="CastleSiegeNpcOperationResultPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.RemoteView.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+using MUnique.OpenMU.Network.Packets.ServerToClient;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// The default implementation of the <see cref="ICastleSiegeNpcOperationResultPlugIn"/>
+/// which forwards defense-structure operation results to the game client.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeNpcOperationResultPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeNpcOperationResultPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("5B2289ED-05A9-49C0-90C0-33554E043E5F")]
+public class CastleSiegeNpcOperationResultPlugIn : ICastleSiegeNpcOperationResultPlugIn
+{
+    private readonly RemotePlayer _player;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeNpcOperationResultPlugIn"/> class.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    public CastleSiegeNpcOperationResultPlugIn(RemotePlayer player) => this._player = player;
+
+    /// <inheritdoc />
+    public ValueTask ShowBuyResultAsync(
+        CastleSiegeNpcOperationResult result,
+        uint npcNumber,
+        uint npcIndex)
+        => this._player.Connection.SendCastleSiegeDefenseBuyResponseAsync(
+            (byte)result,
+            npcNumber,
+            npcIndex);
+
+    /// <inheritdoc />
+    public ValueTask ShowRepairResultAsync(
+        CastleSiegeNpcOperationResult result,
+        uint npcNumber,
+        uint npcIndex,
+        int currentHealth,
+        int maximumHealth)
+        => this._player.Connection.SendCastleSiegeDefenseRepairResponseAsync(
+            (byte)result,
+            npcNumber,
+            npcIndex,
+            checked((uint)currentHealth),
+            checked((uint)maximumHealth));
+
+    /// <inheritdoc />
+    public ValueTask ShowUpgradeResultAsync(
+        CastleSiegeNpcOperationResult result,
+        uint npcNumber,
+        uint npcIndex,
+        CastleSiegeUpgradeType upgradeType,
+        byte upgradeLevel)
+        => this._player.Connection.SendCastleSiegeDefenseUpgradeResponseAsync(
+            (byte)result,
+            npcNumber,
+            npcIndex,
+            (uint)upgradeType,
+            upgradeLevel);
+
+    /// <inheritdoc />
+    public ValueTask ShowGateInterfaceAsync(
+        CastleSiegeNpcOperationResult result,
+        ushort gateIndex)
+        => this._player.Connection.SendCastleSiegeGateInterfaceResponseAsync(
+            (byte)result,
+            gateIndex);
+
+    /// <inheritdoc />
+    public ValueTask ShowGateOperationResultAsync(
+        CastleSiegeNpcOperationResult result,
+        bool isOpen,
+        ushort gateIndex)
+        => this._player.Connection.SendCastleSiegeGateOperateResponseAsync(
+            (byte)result,
+            isOpen,
+            gateIndex);
+
+    /// <inheritdoc />
+    public ValueTask ShowGateStateAsync(bool isOpen, ushort gateIndex)
+        => this._player.Connection.SendCastleSiegeGateStateNotificationAsync(
+            isOpen,
+            gateIndex);
+}

--- a/src/Persistence/EntityFramework/Migrations/20260807142316_ConfigureCastleSiegeRepairCosts.Designer.cs
+++ b/src/Persistence/EntityFramework/Migrations/20260807142316_ConfigureCastleSiegeRepairCosts.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MUnique.OpenMU.Persistence.EntityFramework;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
     [DbContext(typeof(EntityDataContext))]
-    partial class EntityDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260807142316_ConfigureCastleSiegeRepairCosts")]
+    partial class ConfigureCastleSiegeRepairCosts
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Persistence/EntityFramework/Migrations/20260807142316_ConfigureCastleSiegeRepairCosts.cs
+++ b/src/Persistence/EntityFramework/Migrations/20260807142316_ConfigureCastleSiegeRepairCosts.cs
@@ -1,0 +1,61 @@
+// <copyright file="20260807142316_ConfigureCastleSiegeRepairCosts.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+#nullable disable
+
+namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
+{
+    using Microsoft.EntityFrameworkCore.Migrations;
+
+    /// <inheritdoc />
+    public partial class ConfigureCastleSiegeRepairCosts : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "GateRepairCostPerHealthPoint",
+                schema: "config",
+                table: "CastleSiegeConfiguration",
+                type: "integer",
+                nullable: false,
+                defaultValue: 5);
+
+            migrationBuilder.AddColumn<int>(
+                name: "RepairCostPerUpgradeLevel",
+                schema: "config",
+                table: "CastleSiegeConfiguration",
+                type: "integer",
+                nullable: false,
+                defaultValue: 1000000);
+
+            migrationBuilder.AddColumn<int>(
+                name: "StatueRepairCostPerHealthPoint",
+                schema: "config",
+                table: "CastleSiegeConfiguration",
+                type: "integer",
+                nullable: false,
+                defaultValue: 3);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "GateRepairCostPerHealthPoint",
+                schema: "config",
+                table: "CastleSiegeConfiguration");
+
+            migrationBuilder.DropColumn(
+                name: "RepairCostPerUpgradeLevel",
+                schema: "config",
+                table: "CastleSiegeConfiguration");
+
+            migrationBuilder.DropColumn(
+                name: "StatueRepairCostPerHealthPoint",
+                schema: "config",
+                table: "CastleSiegeConfiguration");
+        }
+    }
+}

--- a/src/Persistence/Initialization/VersionSeasonSix/Events/CastleSiegeInitializer.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/Events/CastleSiegeInitializer.cs
@@ -60,6 +60,9 @@ internal sealed class CastleSiegeInitializer : InitializerBase
         configuration.GuildScoreCastleSiegeMembers = 0;
         configuration.GateBuyPrice = 9_500_000;
         configuration.StatueBuyPrice = 4_500_000;
+        configuration.GateRepairCostPerHealthPoint = 5;
+        configuration.StatueRepairCostPerHealthPoint = 3;
+        configuration.RepairCostPerUpgradeLevel = 1_000_000;
         configuration.CastleSiegeMapDefinition = this.GameConfiguration.Maps.Single(map => map.Number == ValleyOfLoren.Number);
         configuration.LandOfTrialsMapDefinition = this.GameConfiguration.Maps.Single(map => map.Number == LandOfTrials.Number);
 

--- a/tests/MUnique.OpenMU.Persistence.Initialization.Tests/TestInitializationWithEfCore.cs
+++ b/tests/MUnique.OpenMU.Persistence.Initialization.Tests/TestInitializationWithEfCore.cs
@@ -204,6 +204,9 @@ internal class TestInitializationWithEfCore
             Assert.That(configuration.MaxAttackingGuilds, Is.EqualTo(3));
             Assert.That(configuration.GateBuyPrice, Is.EqualTo(9_500_000));
             Assert.That(configuration.StatueBuyPrice, Is.EqualTo(4_500_000));
+            Assert.That(configuration.GateRepairCostPerHealthPoint, Is.EqualTo(5));
+            Assert.That(configuration.StatueRepairCostPerHealthPoint, Is.EqualTo(3));
+            Assert.That(configuration.RepairCostPerUpgradeLevel, Is.EqualTo(1_000_000));
             Assert.That(configuration.CastleSiegeMapDefinition?.Number, Is.EqualTo(30));
             Assert.That(configuration.LandOfTrialsMapDefinition?.Number, Is.EqualTo(31));
             Assert.That(configuration.SignOfLordItemDefinition?.Group, Is.EqualTo(14));

--- a/tests/MUnique.OpenMU.Tests/CastleSiegeNpcRemoteViewTests.cs
+++ b/tests/MUnique.OpenMU.Tests/CastleSiegeNpcRemoteViewTests.cs
@@ -1,0 +1,136 @@
+// <copyright file="CastleSiegeNpcRemoteViewTests.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Tests;
+
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+using MUnique.OpenMU.GameServer.RemoteView.CastleSiege;
+using MUnique.OpenMU.Network.Packets.ServerToClient;
+
+/// <summary>
+/// Tests Castle Siege NPC remote-view packet serialization.
+/// </summary>
+[TestFixture]
+public class CastleSiegeNpcRemoteViewTests
+{
+    /// <summary>
+    /// Verifies NPC list and defense-structure operation response packets.
+    /// </summary>
+    [Test]
+    public async ValueTask SerializeNpcListsAndOperationResultsAsync()
+    {
+        var (player, output) = CastleSiegeRemoteViewTestHelper.CreatePlayer();
+        await new CastleSiegeNpcListPlugIn(player)
+            .ShowNpcListAsync(
+                [
+                    new CastleSiegeNpcInfo(
+                        277,
+                        9,
+                        2,
+                        1,
+                        100_000,
+                        75_000,
+                        81,
+                        59,
+                        true),
+                ])
+            .ConfigureAwait(false);
+
+        var operationView = new CastleSiegeNpcOperationResultPlugIn(player);
+        await operationView.ShowBuyResultAsync(CastleSiegeNpcOperationResult.Success, 277, 9)
+            .ConfigureAwait(false);
+        await operationView.ShowRepairResultAsync(
+                CastleSiegeNpcOperationResult.Success,
+                277,
+                9,
+                75_000,
+                100_000)
+            .ConfigureAwait(false);
+        await operationView.ShowUpgradeResultAsync(
+                CastleSiegeNpcOperationResult.Success,
+                277,
+                9,
+                CastleSiegeUpgradeType.Defense,
+                2)
+            .ConfigureAwait(false);
+        await operationView.ShowGateInterfaceAsync(CastleSiegeNpcOperationResult.Success, 9)
+            .ConfigureAwait(false);
+        await operationView.ShowGateOperationResultAsync(CastleSiegeNpcOperationResult.Success, true, 9)
+            .ConfigureAwait(false);
+        await operationView.ShowGateStateAsync(true, 9).ConfigureAwait(false);
+
+        var data = output.ToArray().AsMemory();
+        var npcListLength = CastleSiegeNpcList.GetRequiredSize(1);
+        Assert.That(
+            data.Length,
+            Is.EqualTo(
+                npcListLength
+                + CastleSiegeDefenseBuyResponse.Length
+                + CastleSiegeDefenseRepairResponse.Length
+                + CastleSiegeDefenseUpgradeResponse.Length
+                + CastleSiegeGateInterfaceResponse.Length
+                + CastleSiegeGateOperateResponse.Length
+                + CastleSiegeGateStateNotification.Length));
+
+        var npcPacket = (CastleSiegeNpcList)data[..npcListLength];
+        Assert.That(npcPacket.Result, Is.EqualTo(1));
+        Assert.That(npcPacket.NpcCount, Is.EqualTo(1));
+        Assert.That(npcPacket[0].NpcNumber, Is.EqualTo(277));
+        Assert.That(npcPacket[0].NpcIndex, Is.EqualTo(9));
+        Assert.That(npcPacket[0].DefenseUpgradeLevel, Is.EqualTo(2));
+        Assert.That(npcPacket[0].RegenerationLevel, Is.EqualTo(1));
+        Assert.That(npcPacket[0].MaxHp, Is.EqualTo(100_000));
+        Assert.That(npcPacket[0].CurrentHp, Is.EqualTo(75_000));
+        Assert.That(npcPacket[0].PositionX, Is.EqualTo(81));
+        Assert.That(npcPacket[0].PositionY, Is.EqualTo(59));
+        Assert.That(npcPacket[0].IsAlive, Is.True);
+
+        var offset = npcListLength;
+        var buy = (CastleSiegeDefenseBuyResponse)data.Slice(
+            offset,
+            CastleSiegeDefenseBuyResponse.Length);
+        Assert.That(buy.Result, Is.EqualTo((byte)CastleSiegeNpcOperationResult.Success));
+        Assert.That(buy.NpcNumber, Is.EqualTo(277));
+        Assert.That(buy.NpcIndex, Is.EqualTo(9));
+
+        offset += CastleSiegeDefenseBuyResponse.Length;
+        var repair = (CastleSiegeDefenseRepairResponse)data.Slice(
+            offset,
+            CastleSiegeDefenseRepairResponse.Length);
+        Assert.That(repair.Result, Is.EqualTo((byte)CastleSiegeNpcOperationResult.Success));
+        Assert.That(repair.CurrentHp, Is.EqualTo(75_000));
+        Assert.That(repair.MaxHp, Is.EqualTo(100_000));
+
+        offset += CastleSiegeDefenseRepairResponse.Length;
+        var upgrade = (CastleSiegeDefenseUpgradeResponse)data.Slice(
+            offset,
+            CastleSiegeDefenseUpgradeResponse.Length);
+        Assert.That(upgrade.Result, Is.EqualTo((byte)CastleSiegeNpcOperationResult.Success));
+        Assert.That(upgrade.NpcUpgradeType, Is.EqualTo((uint)CastleSiegeUpgradeType.Defense));
+        Assert.That(upgrade.NpcUpgradeValue, Is.EqualTo(2));
+
+        offset += CastleSiegeDefenseUpgradeResponse.Length;
+        var gateInterface = (CastleSiegeGateInterfaceResponse)data.Slice(
+            offset,
+            CastleSiegeGateInterfaceResponse.Length);
+        Assert.That(gateInterface.Result, Is.EqualTo((byte)CastleSiegeNpcOperationResult.Success));
+        Assert.That(gateInterface.GateIndex, Is.EqualTo(9));
+
+        offset += CastleSiegeGateInterfaceResponse.Length;
+        var gate = (CastleSiegeGateOperateResponse)data.Slice(
+            offset,
+            CastleSiegeGateOperateResponse.Length);
+        Assert.That(gate.Result, Is.EqualTo((byte)CastleSiegeNpcOperationResult.Success));
+        Assert.That(gate.IsOpen, Is.True);
+        Assert.That(gate.GateIndex, Is.EqualTo(9));
+
+        offset += CastleSiegeGateOperateResponse.Length;
+        var gateState = (CastleSiegeGateStateNotification)data.Slice(
+            offset,
+            CastleSiegeGateStateNotification.Length);
+        Assert.That(gateState.IsOpen, Is.True);
+        Assert.That(gateState.GateIndex, Is.EqualTo(9));
+    }
+}

--- a/tests/MUnique.OpenMU.Tests/CastleSiegeNpcTests.cs
+++ b/tests/MUnique.OpenMU.Tests/CastleSiegeNpcTests.cs
@@ -1,0 +1,1054 @@
+// <copyright file="CastleSiegeNpcTests.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Tests;
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.DataModel.Configuration.Items;
+using MUnique.OpenMU.DataModel.Entities;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.Attributes;
+using MUnique.OpenMU.GameLogic.CastleSiege;
+using MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+using MUnique.OpenMU.GameLogic.CastleSiege.Intelligence;
+using MUnique.OpenMU.GameLogic.CastleSiege.NPC;
+using MUnique.OpenMU.GameLogic.MiniGames;
+using MUnique.OpenMU.GameLogic.PlugIns;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+using MUnique.OpenMU.GameLogic.Views.World;
+using MUnique.OpenMU.GameServer;
+using MUnique.OpenMU.GameServer.MessageHandler.CastleSiege;
+using MUnique.OpenMU.Interfaces;
+using MUnique.OpenMU.Pathfinding;
+using MUnique.OpenMU.Persistence.InMemory;
+using MUnique.OpenMU.PlugIns;
+using BasicModel = MUnique.OpenMU.Persistence.BasicModel;
+using RuntimeGuild = MUnique.OpenMU.Interfaces.Guild;
+
+/// <summary>
+/// Tests Castle Siege NPC spawning, lifecycle, actions, terrain, and persistence.
+/// </summary>
+[TestFixture]
+public class CastleSiegeNpcTests
+{
+    private const uint OwnerRuntimeGuildId = 10;
+    private const byte GateInstanceId = 1;
+    private const byte StatueInstanceId = 1;
+    private const byte GateX = 50;
+    private const byte GateY = 50;
+
+    /// <summary>
+    /// Verifies that Castle Senior receives stable management indexes even when structures are not spawned.
+    /// </summary>
+    [Test]
+    public async ValueTask SeniorListsUseConfiguredIndexesBeforeAndAfterSpawnAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        try
+        {
+            await fixture.Context.NpcController.DespawnAllAsync().ConfigureAwait(false);
+            var runtimeCount = fixture.Context.ActiveNpcs.Count;
+            var stateCount = fixture.Context.SiegeData.NpcStates.Count;
+            var unspawnedInfo = (await fixture.Context.NpcController
+                    .GetDefenseStructureSnapshotAsync(CastleSiegeGate.MonsterNumber)
+                    .ConfigureAwait(false))
+                .Single();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(unspawnedInfo.NpcIndex, Is.EqualTo(GateInstanceId));
+                Assert.That(unspawnedInfo.CurrentHealth, Is.EqualTo(1_000));
+                Assert.That(fixture.Context.ActiveNpcs, Has.Count.EqualTo(runtimeCount));
+                Assert.That(fixture.Context.SiegeData.NpcStates, Has.Count.EqualTo(stateCount));
+            });
+
+            await fixture.Context.NpcController.PrepareAsync().ConfigureAwait(false);
+            var spawnedGate = fixture.Context.NpcController.FindDefenseStructure(
+                (uint)CastleSiegeGate.MonsterNumber,
+                GateInstanceId)!;
+            var spawnedInfo = (await fixture.Context.NpcController
+                    .GetDefenseStructureSnapshotAsync(CastleSiegeGate.MonsterNumber)
+                    .ConfigureAwait(false))
+                .Single();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(spawnedInfo.NpcIndex, Is.EqualTo(GateInstanceId));
+                Assert.That(spawnedGate.SpawnedInstance, Is.Not.Null);
+            });
+        }
+        finally
+        {
+            await fixture.Context.NpcController.DespawnAllAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that a castle owner can repair a persistent structure during truce without spawning it.
+    /// </summary>
+    [Test]
+    public async ValueTask SeniorRepairsUnspawnedStructureDuringTruceAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        try
+        {
+            await fixture.Context.NpcController.DespawnAllAsync().ConfigureAwait(false);
+            fixture.Context.CurrentState = CastleSiegeState.RegisterGuild;
+            var gate = fixture.Context.NpcController.FindDefenseStructure(
+                (uint)CastleSiegeGate.MonsterNumber,
+                GateInstanceId)!;
+            gate.PersistedState!.CurrentHp = 900;
+            gate.IsAlive = true;
+            fixture.Player.Money = 500;
+
+            var result = await CastleSiegeNpcRepairAction
+                .RepairAsync(
+                    fixture.Player,
+                    fixture.Context,
+                    (uint)CastleSiegeGate.MonsterNumber,
+                    GateInstanceId)
+                .ConfigureAwait(false);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.EqualTo(CastleSiegeNpcOperationResult.Success));
+                Assert.That(gate.PersistedState.CurrentHp, Is.EqualTo(1_000));
+                Assert.That(gate.SpawnedInstance, Is.Null);
+                Assert.That(fixture.Player.Money, Is.Zero);
+            });
+        }
+        finally
+        {
+            await fixture.Context.NpcController.DespawnAllAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that only attacking participants can damage defense structures during battle.
+    /// </summary>
+    [Test]
+    public async ValueTask DefenseStructuresAcceptOnlyBattleAttackerDamageAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        await AddSiegePlayerAsync(fixture, CastleSiegeJoinSide.Attack1, GateX - 1, GateY).ConfigureAwait(false);
+        try
+        {
+            await fixture.Context.NpcController.PrepareAsync().ConfigureAwait(false);
+            var gate = fixture.Context.ActiveNpcs
+                .Select(runtime => runtime.SpawnedInstance)
+                .OfType<CastleSiegeGate>()
+                .Single();
+
+            Assert.That(
+                await gate.AttackByAsync(fixture.Player, null, false).ConfigureAwait(false),
+                Is.Null,
+                "Structures must be protected outside the battle phase.");
+
+            fixture.Context.CurrentState = CastleSiegeState.Start;
+            SetPlayerJoinSide(fixture, CastleSiegeJoinSide.Defense);
+            Assert.That(
+                await gate.AttackByAsync(fixture.Player, null, false).ConfigureAwait(false),
+                Is.Null,
+                "Defenders must not damage their own structures.");
+
+            SetPlayerJoinSide(fixture, CastleSiegeJoinSide.Attack1);
+            Assert.That(
+                await gate.AttackByAsync(fixture.Player, null, false).ConfigureAwait(false),
+                Is.Not.Null,
+                "An attacking participant must be able to damage a structure during battle.");
+        }
+        finally
+        {
+            await fixture.GameServerContext.RemovePlayerAsync(fixture.Player).ConfigureAwait(false);
+            await fixture.Context.NpcController.DespawnAllAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that a closed gate blocks a crossing route and synchronizes its terrain to an entrant.
+    /// </summary>
+    [Test]
+    public async ValueTask ClosedGateBlocksCrossingRouteAndSynchronizesEntrantAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        await AddSiegePlayerAsync(fixture, CastleSiegeJoinSide.Attack1, GateX - 4, GateY).ConfigureAwait(false);
+        try
+        {
+            await fixture.Context.NpcController.PrepareAsync().ConfigureAwait(false);
+            await fixture.Context.NpcController.CloseGatesAsync().ConfigureAwait(false);
+            var terrainView = Mock.Get(fixture.Player.ViewPlugIns.GetPlugIn<IChangeTerrainAttributesViewPlugin>()!);
+            terrainView.Invocations.Clear();
+
+            await fixture.Context.NpcController.SynchronizePlayerAsync(fixture.Player).ConfigureAwait(false);
+
+            terrainView.Verify(
+                view => view.ChangeAttributesAsync(
+                    TerrainAttributeType.Blocked,
+                    true,
+                    It.IsAny<IReadOnlyCollection<(byte StartX, byte StartY, byte EndX, byte EndY)>>()),
+                Times.Once);
+
+            var start = new Point(GateX - 4, GateY);
+            var target = new Point(GateX + 3, GateY);
+            var steps = Enumerable.Range(start.X, target.X - start.X)
+                .Select(x => new WalkingStep
+                {
+                    From = new Point((byte)x, GateY),
+                    To = new Point((byte)(x + 1), GateY),
+                    Direction = Direction.East,
+                })
+                .ToArray();
+            var movementView = Mock.Get(fixture.Player.ViewPlugIns.GetPlugIn<IObjectMovedPlugIn>()!);
+            movementView.Invocations.Clear();
+
+            await fixture.Player.WalkToAsync(target, steps).ConfigureAwait(false);
+
+            Assert.That(fixture.Player.Position, Is.EqualTo(start));
+            movementView.Verify(view => view.ObjectMovedAsync(fixture.Player, MoveType.Instant), Times.Once);
+        }
+        finally
+        {
+            await fixture.GameServerContext.RemovePlayerAsync(fixture.Player).ConfigureAwait(false);
+            await fixture.Context.NpcController.DespawnAllAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Verifies structure and interaction-NPC creation, upgrade application, gate association, and terrain blocking.
+    /// </summary>
+    [Test]
+    public async ValueTask ReadySpawnsConfiguredNpcsAndGateRestoresOriginalTerrainAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        try
+        {
+            fixture.Map.Terrain.WalkMap[GateX - 3, GateY] = false;
+            await fixture.Context.NpcController.PrepareAsync().ConfigureAwait(false);
+            await fixture.Context.NpcController.CloseGatesAsync().ConfigureAwait(false);
+
+            var gate = fixture.Context.ActiveNpcs
+                .Select(runtime => runtime.SpawnedInstance)
+                .OfType<CastleSiegeGate>()
+                .Single();
+            var lever = fixture.Context.ActiveNpcs
+                .Select(runtime => runtime.SpawnedInstance)
+                .OfType<CastleSiegeLever>()
+                .Single();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(fixture.Context.ActiveNpcs, Has.Count.EqualTo(6));
+                Assert.That(fixture.Context.ActiveNpcs.Select(runtime => runtime.SpawnedInstance), Has.One.InstanceOf<CastleSiegeGate>());
+                Assert.That(fixture.Context.ActiveNpcs.Select(runtime => runtime.SpawnedInstance), Has.One.InstanceOf<CastleSiegeStatue>());
+                Assert.That(fixture.Context.ActiveNpcs.Select(runtime => runtime.SpawnedInstance), Has.One.InstanceOf<CastleSiegeCrown>());
+                Assert.That(fixture.Context.ActiveNpcs.Select(runtime => runtime.SpawnedInstance), Has.Exactly(2).InstanceOf<CastleSiegeSwitch>());
+                Assert.That(fixture.Context.ActiveNpcs.Select(runtime => runtime.SpawnedInstance), Has.One.InstanceOf<CastleSiegeLever>());
+                Assert.That(fixture.Context.ActiveNpcs.Select(runtime => runtime.SpawnedInstance), Has.None.InstanceOf<CastleSiegeMachine>());
+                Assert.That(gate.MaximumHealth, Is.EqualTo(1_000));
+                Assert.That(gate.Attributes[Stats.DefenseBase], Is.EqualTo(100));
+                Assert.That(gate.IsClosed, Is.True);
+                Assert.That(lever.Gate, Is.SameAs(gate));
+            });
+
+            for (var x = GateX - 3; x <= GateX + 2; x++)
+            {
+                for (var y = GateY; y <= GateY + 1; y++)
+                {
+                    Assert.That(fixture.Map.Terrain.WalkMap[x, y], Is.False);
+                }
+            }
+
+            await gate.OpenAsync().ConfigureAwait(false);
+            Assert.Multiple(() =>
+            {
+                Assert.That(gate.IsClosed, Is.False);
+                Assert.That(fixture.Map.Terrain.WalkMap[GateX - 3, GateY], Is.False);
+                Assert.That(fixture.Map.Terrain.WalkMap[GateX - 2, GateY], Is.True);
+                Assert.That(fixture.Map.Terrain.WalkMap[GateX + 2, GateY + 1], Is.True);
+            });
+        }
+        finally
+        {
+            await fixture.Context.NpcController.DespawnAllAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Verifies statue regeneration and battle-only siege-machine lifecycle.
+    /// </summary>
+    [Test]
+    public async ValueTask StatueRegeneratesAndMachinesExistOnlyDuringStartAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        try
+        {
+            await fixture.Context.NpcController.PrepareAsync().ConfigureAwait(false);
+            var statue = fixture.Context.ActiveNpcs
+                .Select(runtime => runtime.SpawnedInstance)
+                .OfType<CastleSiegeStatue>()
+                .Single();
+            statue.Health = 1_000;
+            statue.State.CurrentHp = statue.Health;
+
+            Assert.That(statue.Regenerate(), Is.EqualTo(200));
+            Assert.That(statue.Health, Is.EqualTo(1_200));
+            Assert.That(fixture.Context.ActiveNpcs.Select(runtime => runtime.SpawnedInstance), Has.None.InstanceOf<CastleSiegeMachine>());
+
+            await fixture.Context.NpcController.SpawnMachinesAsync().ConfigureAwait(false);
+            Assert.That(
+                fixture.Context.ActiveNpcs.Select(runtime => runtime.SpawnedInstance).OfType<CastleSiegeMachine>().ToList(),
+                Has.Count.EqualTo(2));
+
+            await fixture.Context.NpcController.DespawnMachinesAsync().ConfigureAwait(false);
+            Assert.Multiple(() =>
+            {
+                Assert.That(fixture.Context.ActiveNpcs, Has.Count.EqualTo(6));
+                Assert.That(fixture.Context.ActiveNpcs.Select(runtime => runtime.SpawnedInstance), Has.None.InstanceOf<CastleSiegeMachine>());
+            });
+        }
+        finally
+        {
+            await fixture.Context.NpcController.DespawnAllAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Verifies the configured upgrade cost, item consumption, stat application, and restart persistence.
+    /// </summary>
+    [Test]
+    public async ValueTask UpgradeConsumesCostAppliesStatsAndSurvivesRestartAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        CastleSiegeContext? restartedContext = null;
+        try
+        {
+            await fixture.Context.NpcController.PrepareAsync().ConfigureAwait(false);
+            fixture.Player.Money = 100;
+            for (byte slot = 20; slot < 22; slot++)
+            {
+                var jewel = fixture.Player.PersistenceContext.CreateNew<Item>();
+                jewel.Definition = fixture.JewelOfGuardian;
+                await fixture.Player.Inventory!.AddItemAsync(slot, jewel).ConfigureAwait(false);
+            }
+
+            var result = await CastleSiegeNpcUpgradeAction
+                .UpgradeAsync(
+                    fixture.Player,
+                    fixture.Context,
+                    (uint)CastleSiegeGate.MonsterNumber,
+                    GateInstanceId,
+                    CastleSiegeUpgradeType.Defense,
+                    1)
+                .ConfigureAwait(false);
+            var gate = fixture.Context.ActiveNpcs
+                .Select(runtime => runtime.SpawnedInstance)
+                .OfType<CastleSiegeGate>()
+                .Single();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.EqualTo(CastleSiegeNpcOperationResult.Success));
+                Assert.That(fixture.Player.Money, Is.Zero);
+                Assert.That(fixture.Player.Inventory!.Items, Is.Empty);
+                Assert.That(gate.DefenseLevel, Is.EqualTo(1));
+                Assert.That(gate.Attributes[Stats.DefenseBase], Is.EqualTo(200));
+            });
+
+            await fixture.Context.NpcController.DespawnAllAsync().ConfigureAwait(false);
+            restartedContext = new CastleSiegeContext(fixture.GameServerContext, fixture.Configuration);
+            await restartedContext.InitializeAsync(fixture.InitializationTimeUtc).ConfigureAwait(false);
+            await restartedContext.NpcController.PrepareAsync().ConfigureAwait(false);
+            var restartedGate = restartedContext.ActiveNpcs
+                .Select(runtime => runtime.SpawnedInstance)
+                .OfType<CastleSiegeGate>()
+                .Single();
+            Assert.Multiple(() =>
+            {
+                Assert.That(restartedGate.DefenseLevel, Is.EqualTo(1));
+                Assert.That(restartedGate.Attributes[Stats.DefenseBase], Is.EqualTo(200));
+                Assert.That(restartedGate.Health, Is.EqualTo(1_000));
+            });
+        }
+        finally
+        {
+            if (restartedContext is not null)
+            {
+                await restartedContext.NpcController.DespawnAllAsync().ConfigureAwait(false);
+            }
+            else
+            {
+                await fixture.Context.NpcController.DespawnAllAsync().ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Verifies that authorization, battle-state, and maximum-level validation happen before charging the player.
+    /// </summary>
+    [Test]
+    public async ValueTask UpgradeRejectsInvalidRequestsWithoutChargingAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        try
+        {
+            await fixture.Context.NpcController.PrepareAsync().ConfigureAwait(false);
+            fixture.Player.Money = 100;
+
+            fixture.Player.GuildStatus = new GuildMemberStatus(999, GuildPosition.GuildMaster);
+            var unauthorized = await CastleSiegeNpcUpgradeAction
+                .UpgradeAsync(
+                    fixture.Player,
+                    fixture.Context,
+                    (uint)CastleSiegeGate.MonsterNumber,
+                    GateInstanceId,
+                    CastleSiegeUpgradeType.Defense,
+                    1)
+                .ConfigureAwait(false);
+
+            fixture.Player.GuildStatus = new GuildMemberStatus(OwnerRuntimeGuildId, GuildPosition.GuildMaster);
+            fixture.Context.CurrentState = CastleSiegeState.Start;
+            var duringBattle = await CastleSiegeNpcUpgradeAction
+                .UpgradeAsync(
+                    fixture.Player,
+                    fixture.Context,
+                    (uint)CastleSiegeGate.MonsterNumber,
+                    GateInstanceId,
+                    CastleSiegeUpgradeType.Defense,
+                    1)
+                .ConfigureAwait(false);
+
+            fixture.Context.CurrentState = CastleSiegeState.Ready;
+            var runtime = fixture.Context.NpcController.FindDefenseStructure(
+                (uint)CastleSiegeGate.MonsterNumber,
+                GateInstanceId)!;
+            runtime.PersistedState!.DefenseLevel = 1;
+            var aboveMaximum = await CastleSiegeNpcUpgradeAction
+                .UpgradeAsync(
+                    fixture.Player,
+                    fixture.Context,
+                    (uint)CastleSiegeGate.MonsterNumber,
+                    GateInstanceId,
+                    CastleSiegeUpgradeType.Defense,
+                    2)
+                .ConfigureAwait(false);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(unauthorized, Is.EqualTo(CastleSiegeNpcOperationResult.NotAuthorized));
+                Assert.That(duringBattle, Is.EqualTo(CastleSiegeNpcOperationResult.Failed));
+                Assert.That(aboveMaximum, Is.EqualTo(CastleSiegeNpcOperationResult.InvalidUpgradeValue));
+                Assert.That(fixture.Player.Money, Is.EqualTo(100));
+            });
+        }
+        finally
+        {
+            await fixture.Context.NpcController.DespawnAllAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that insufficient Zen does not consume Jewels of Guardian.
+    /// </summary>
+    [Test]
+    public async ValueTask UpgradeWithInsufficientZenDoesNotConsumeJewelsAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        try
+        {
+            await fixture.Context.NpcController.PrepareAsync().ConfigureAwait(false);
+            fixture.Player.Money = 99;
+            await AddGuardianJewelsAsync(fixture, 2).ConfigureAwait(false);
+
+            var result = await CastleSiegeNpcUpgradeAction
+                .UpgradeAsync(
+                    fixture.Player,
+                    fixture.Context,
+                    (uint)CastleSiegeGate.MonsterNumber,
+                    GateInstanceId,
+                    CastleSiegeUpgradeType.Defense,
+                    1)
+                .ConfigureAwait(false);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.EqualTo(CastleSiegeNpcOperationResult.InsufficientMoney));
+                Assert.That(fixture.Player.Money, Is.EqualTo(99));
+                Assert.That(fixture.Player.Inventory!.Items.Count(), Is.EqualTo(2));
+            });
+        }
+        finally
+        {
+            await fixture.Context.NpcController.DespawnAllAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that insufficient Jewels of Guardian do not consume Zen.
+    /// </summary>
+    [Test]
+    public async ValueTask UpgradeWithInsufficientJewelsDoesNotConsumeZenAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        try
+        {
+            await fixture.Context.NpcController.PrepareAsync().ConfigureAwait(false);
+            fixture.Player.Money = 100;
+            await AddGuardianJewelsAsync(fixture, 1).ConfigureAwait(false);
+
+            var result = await CastleSiegeNpcUpgradeAction
+                .UpgradeAsync(
+                    fixture.Player,
+                    fixture.Context,
+                    (uint)CastleSiegeGate.MonsterNumber,
+                    GateInstanceId,
+                    CastleSiegeUpgradeType.Defense,
+                    1)
+                .ConfigureAwait(false);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.EqualTo(CastleSiegeNpcOperationResult.RequirementNotMet));
+                Assert.That(fixture.Player.Money, Is.EqualTo(100));
+                Assert.That(fixture.Player.Inventory!.Items.Count(), Is.EqualTo(1));
+            });
+        }
+        finally
+        {
+            await fixture.Context.NpcController.DespawnAllAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that an alive defense structure cannot be bought again and no Zen is charged.
+    /// </summary>
+    [Test]
+    public async ValueTask BuyAliveNpcFailsWithoutChargingAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        try
+        {
+            await fixture.Context.NpcController.PrepareAsync().ConfigureAwait(false);
+            fixture.Player.Money = fixture.Configuration.GateBuyPrice;
+
+            var result = await CastleSiegeNpcBuyAction
+                .BuyAsync(
+                    fixture.Player,
+                    fixture.Context,
+                    (uint)CastleSiegeGate.MonsterNumber,
+                    GateInstanceId)
+                .ConfigureAwait(false);
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(result, Is.EqualTo(CastleSiegeNpcOperationResult.RequirementNotMet));
+                Assert.That(fixture.Player.Money, Is.EqualTo(fixture.Configuration.GateBuyPrice));
+            });
+        }
+        finally
+        {
+            await fixture.Context.NpcController.DespawnAllAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Verifies the repair formula and destroyed-structure purchase behavior.
+    /// </summary>
+    [Test]
+    public async ValueTask RepairChargesFormulaAndBuyRespawnsDestroyedGateAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        try
+        {
+            await fixture.Context.NpcController.PrepareAsync().ConfigureAwait(false);
+            var runtime = fixture.Context.ActiveNpcs.Single(candidate =>
+                candidate.Definition.MonsterDefinition?.Number == CastleSiegeGate.MonsterNumber);
+            var gate = (CastleSiegeGate)runtime.SpawnedInstance!;
+            runtime.PersistedState!.DefenseLevel = 1;
+            gate.ApplyPersistedUpgrades(false);
+            gate.Health = 900;
+            runtime.PersistedState.CurrentHp = gate.Health;
+            fixture.Player.Money = 1_000_500;
+
+            var repairResult = await CastleSiegeNpcRepairAction
+                .RepairAsync(fixture.Player, fixture.Context, (uint)CastleSiegeGate.MonsterNumber, GateInstanceId)
+                .ConfigureAwait(false);
+            Assert.Multiple(() =>
+            {
+                Assert.That(repairResult, Is.EqualTo(CastleSiegeNpcOperationResult.Success));
+                Assert.That(fixture.Player.Money, Is.Zero);
+                Assert.That(gate.Health, Is.EqualTo(gate.MaximumHealth));
+            });
+
+            await gate.OpenAsync().ConfigureAwait(false);
+            await fixture.Map.RemoveAsync(gate).ConfigureAwait(false);
+            gate.Dispose();
+            runtime.SpawnedInstance = null;
+            runtime.IsAlive = false;
+            runtime.PersistedState.CurrentHp = 0;
+            fixture.Player.Money = 500;
+
+            var buyResult = await CastleSiegeNpcBuyAction
+                .BuyAsync(fixture.Player, fixture.Context, (uint)CastleSiegeGate.MonsterNumber, GateInstanceId)
+                .ConfigureAwait(false);
+            var respawnedGate = (CastleSiegeGate)runtime.SpawnedInstance!;
+            Assert.Multiple(() =>
+            {
+                Assert.That(buyResult, Is.EqualTo(CastleSiegeNpcOperationResult.Success));
+                Assert.That(fixture.Player.Money, Is.Zero);
+                Assert.That(runtime.IsAlive, Is.True);
+                Assert.That(runtime.PersistedState.DefenseLevel, Is.Zero);
+                Assert.That(runtime.PersistedState.LifeLevel, Is.Zero);
+                Assert.That(respawnedGate.Health, Is.EqualTo(1_000));
+                Assert.That(respawnedGate.IsClosed, Is.True);
+            });
+        }
+        finally
+        {
+            await fixture.Context.NpcController.DespawnAllAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Verifies Crown and switch proximity tracking without applying the later win-condition mechanics.
+    /// </summary>
+    [Test]
+    public async ValueTask CrownAndSwitchTrackNearbyAlivePlayerAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        try
+        {
+            await fixture.Context.NpcController.PrepareAsync().ConfigureAwait(false);
+            await fixture.GameServerContext.AddPlayerAsync(fixture.Player).ConfigureAwait(false);
+            var crown = fixture.Context.ActiveNpcs
+                .Select(runtime => runtime.SpawnedInstance)
+                .OfType<CastleSiegeCrown>()
+                .Single();
+            var siegeSwitch = fixture.Context.ActiveNpcs
+                .Select(runtime => runtime.SpawnedInstance)
+                .OfType<CastleSiegeSwitch>()
+                .First();
+            fixture.Context.CurrentState = CastleSiegeState.Start;
+            fixture.Context.IsCrownAvailable = true;
+            fixture.Context.CrownAccumulatedTime = TimeSpan.FromSeconds(12);
+            fixture.Player.IsAlive = true;
+            await fixture.Player.WarpToAsync(new ExitGate
+            {
+                Map = fixture.SiegeMap,
+                X1 = crown.Position.X,
+                X2 = crown.Position.X,
+                Y1 = crown.Position.Y,
+                Y2 = crown.Position.Y,
+                Direction = Direction.South,
+            }).ConfigureAwait(false);
+            await fixture.Player.ClientReadyAfterMapChangeAsync().ConfigureAwait(false);
+
+            using var crownIntelligence = new CastleSiegeCrownIntelligence(fixture.Context)
+            {
+                Npc = crown,
+            };
+            await crownIntelligence.TickAsync().ConfigureAwait(false);
+            await crownIntelligence.TickAsync().ConfigureAwait(false);
+            Assert.Multiple(() =>
+            {
+                Assert.That(fixture.Context.CrownUser, Is.SameAs(fixture.Player));
+                Assert.That(fixture.Context.CrownAccumulatedTime, Is.EqualTo(TimeSpan.FromSeconds(12)));
+                Assert.That(crown.State, Is.EqualTo(CastleSiegeCrownState.Idle));
+            });
+
+            fixture.Player.Position = siegeSwitch.Position;
+            using var switchIntelligence = new CastleSiegeSwitchIntelligence(fixture.Context)
+            {
+                Npc = siegeSwitch,
+            };
+            await switchIntelligence.TickAsync().ConfigureAwait(false);
+            Assert.That(fixture.Context.SwitchUsers[siegeSwitch.SwitchIndex], Is.SameAs(fixture.Player));
+
+            fixture.Player.IsAlive = false;
+            await crownIntelligence.TickAsync().ConfigureAwait(false);
+            await switchIntelligence.TickAsync().ConfigureAwait(false);
+            Assert.Multiple(() =>
+            {
+                Assert.That(fixture.Context.CrownUser, Is.Null);
+                Assert.That(fixture.Context.CrownAccumulatedTime, Is.EqualTo(TimeSpan.FromSeconds(12)));
+                Assert.That(fixture.Context.SwitchUsers[siegeSwitch.SwitchIndex], Is.Null);
+            });
+        }
+        finally
+        {
+            await fixture.GameServerContext.RemovePlayerAsync(fixture.Player).ConfigureAwait(false);
+            await fixture.Context.NpcController.DespawnAllAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that a lever opens the gate interface and that a defender can operate its gate.
+    /// </summary>
+    [Test]
+    public async ValueTask LeverInteractionOpensInterfaceAndAllowsDefenderOperationAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        try
+        {
+            await fixture.Context.NpcController.PrepareAsync().ConfigureAwait(false);
+            await fixture.Context.NpcController.CloseGatesAsync().ConfigureAwait(false);
+            var lever = fixture.Context.ActiveNpcs
+                .Select(runtime => runtime.SpawnedInstance)
+                .OfType<CastleSiegeLever>()
+                .Single();
+            var gate = lever.Gate!;
+            var plugIn = new CastleSiegeLeverTalkPlugIn();
+            var eventArgs = new NpcTalkEventArgs();
+
+            await plugIn.PlayerTalksToNpcAsync(fixture.Player, lever, eventArgs).ConfigureAwait(false);
+            Assert.Multiple(() =>
+            {
+                Assert.That(eventArgs.HasBeenHandled, Is.True);
+                Assert.That(eventArgs.LeavesDialogOpen, Is.True);
+                Assert.That(gate.IsClosed, Is.True);
+            });
+            Mock.Get(fixture.Player.ViewPlugIns.GetPlugIn<ICastleSiegeNpcOperationResultPlugIn>()!)
+                .Verify(
+                    view => view.ShowGateInterfaceAsync(CastleSiegeNpcOperationResult.Success, gate.Id),
+                    Times.Once);
+
+            fixture.Context.CurrentState = CastleSiegeState.Start;
+            fixture.Context.FinalGuildList[OwnerRuntimeGuildId] = new CastleSiegeGuildParticipant
+            {
+                GuildId = OwnerRuntimeGuildId,
+                PersistentGuildId = fixture.OwnerPersistentGuildId,
+                GuildName = "Owner",
+                Side = CastleSiegeJoinSide.Defense,
+            };
+            var operationResult = await CastleSiegeGateOperateAction
+                .OperateAsync(fixture.Player, fixture.Context, gate.Id, true)
+                .ConfigureAwait(false);
+            Assert.Multiple(() =>
+            {
+                Assert.That(operationResult, Is.EqualTo(CastleSiegeNpcOperationResult.Success));
+                Assert.That(gate.IsClosed, Is.False);
+            });
+        }
+        finally
+        {
+            await fixture.Context.NpcController.DespawnAllAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Verifies all client request identifiers required by the NPC issue.
+    /// </summary>
+    [Test]
+    public void NpcRequestHandlersUseExpectedSubcodes()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(new CastleSiegeDefenseBuyHandlerPlugIn().Key, Is.EqualTo(0x05));
+            Assert.That(new CastleSiegeDefenseRepairHandlerPlugIn().Key, Is.EqualTo(0x06));
+            Assert.That(new CastleSiegeDefenseUpgradeHandlerPlugIn().Key, Is.EqualTo(0x07));
+            Assert.That(new CastleSiegeGateOperateHandlerPlugIn().Key, Is.EqualTo(0x12));
+            Assert.That(new CastleSiegeGateListHandlerPlugIn().Key, Is.EqualTo(0x01));
+            Assert.That(new CastleSiegeStatueListHandlerPlugIn().Key, Is.EqualTo(0x02));
+        });
+    }
+
+    /// <summary>
+    /// Verifies that field-bearing NPC handlers ignore truncated client packets.
+    /// </summary>
+    [Test]
+    public async ValueTask NpcRequestHandlersIgnoreTruncatedPacketsAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        try
+        {
+            await new CastleSiegeDefenseBuyHandlerPlugIn()
+                .HandlePacketAsync(fixture.Player, Memory<byte>.Empty)
+                .ConfigureAwait(false);
+            await new CastleSiegeDefenseRepairHandlerPlugIn()
+                .HandlePacketAsync(fixture.Player, Memory<byte>.Empty)
+                .ConfigureAwait(false);
+            await new CastleSiegeDefenseUpgradeHandlerPlugIn()
+                .HandlePacketAsync(fixture.Player, Memory<byte>.Empty)
+                .ConfigureAwait(false);
+            await new CastleSiegeGateOperateHandlerPlugIn()
+                .HandlePacketAsync(fixture.Player, Memory<byte>.Empty)
+                .ConfigureAwait(false);
+        }
+        finally
+        {
+            await fixture.Context.NpcController.DespawnAllAsync().ConfigureAwait(false);
+        }
+    }
+
+    private static async ValueTask<TestFixture> CreateFixtureAsync()
+    {
+        var persistenceContextProvider = new InMemoryPersistenceContextProvider();
+        BasicModel.GameConfiguration gameConfiguration;
+        BasicModel.CastleSiegeConfiguration configuration;
+        BasicModel.GameMapDefinition siegeMap;
+        BasicModel.ItemDefinition jewelOfGuardian;
+        Guid ownerPersistentGuildId;
+        using (var persistenceContext = persistenceContextProvider.CreateNewContext())
+        {
+            gameConfiguration = persistenceContext.CreateNew<BasicModel.GameConfiguration>();
+            var normalMap = persistenceContext.CreateNew<BasicModel.GameMapDefinition>();
+            normalMap.Number = 0;
+            normalMap.TerrainData = new byte[65_539];
+            gameConfiguration.Maps.Add(normalMap);
+
+            siegeMap = persistenceContext.CreateNew<BasicModel.GameMapDefinition>();
+            siegeMap.Number = 30;
+            siegeMap.TerrainData = new byte[65_539];
+            gameConfiguration.Maps.Add(siegeMap);
+
+            configuration = persistenceContext.CreateNew<BasicModel.CastleSiegeConfiguration>();
+            configuration.Enabled = true;
+            configuration.CastleSiegeMapDefinition = siegeMap;
+            configuration.GateBuyPrice = 500;
+            configuration.StatueBuyPrice = 400;
+            configuration.CrownHoldTimeSeconds = 2;
+            configuration.StateSchedule.Add(new BasicModel.CastleSiegeStateScheduleEntry
+            {
+                State = CastleSiegeState.Ready,
+                DayOfWeek = DayOfWeek.Monday,
+            });
+            configuration.StateSchedule.Add(new BasicModel.CastleSiegeStateScheduleEntry
+            {
+                State = CastleSiegeState.Start,
+                DayOfWeek = DayOfWeek.Tuesday,
+            });
+            gameConfiguration.CastleSiegeConfiguration = configuration;
+
+            AddUpgrade(configuration.GateDefenseUpgrades, 0, 0, 0, 100);
+            AddUpgrade(configuration.GateDefenseUpgrades, 1, 2, 100, 200);
+            AddUpgrade(configuration.GateLifeUpgrades, 0, 0, 0, 1_000);
+            AddUpgrade(configuration.GateLifeUpgrades, 1, 1, 100, 1_500);
+            AddUpgrade(configuration.StatueDefenseUpgrades, 0, 0, 0, 80);
+            AddUpgrade(configuration.StatueDefenseUpgrades, 1, 1, 100, 160);
+            AddUpgrade(configuration.StatueLifeUpgrades, 0, 0, 0, 2_000);
+            AddUpgrade(configuration.StatueLifeUpgrades, 1, 1, 100, 3_000);
+            AddUpgrade(configuration.StatueRegenUpgrades, 0, 0, 0, 0);
+            AddUpgrade(configuration.StatueRegenUpgrades, 1, 1, 100, 10);
+
+            var crown = AddMonster(216, NpcObjectKind.PassiveNpc);
+            var firstSwitch = AddMonster(217, NpcObjectKind.PassiveNpc);
+            var secondSwitch = AddMonster(218, NpcObjectKind.PassiveNpc);
+            var lever = AddMonster(219, NpcObjectKind.PassiveNpc);
+            var attackMachine = AddMonster(221, NpcObjectKind.PassiveNpc);
+            var defenseMachine = AddMonster(222, NpcObjectKind.PassiveNpc);
+            var gate = AddMonster(CastleSiegeGate.MonsterNumber, NpcObjectKind.Gate);
+            var statue = AddMonster(CastleSiegeStatue.MonsterNumber, NpcObjectKind.Statue);
+            AddAttributes(gate);
+            AddAttributes(statue);
+
+            AddNpc(configuration, crown, 1, false, 60, 60);
+            AddNpc(configuration, firstSwitch, 1, false, 70, 60);
+            AddNpc(configuration, secondSwitch, 1, false, 80, 60);
+            AddNpc(configuration, lever, GateInstanceId, false, GateX, GateY + 4);
+            AddNpc(configuration, attackMachine, 1, false, 20, 20);
+            AddNpc(configuration, defenseMachine, 1, false, 30, 20);
+            AddNpc(configuration, gate, GateInstanceId, true, GateX, GateY);
+            AddNpc(configuration, statue, StatueInstanceId, true, 55, 55);
+
+            var siegeData = persistenceContext.CreateNew<BasicModel.CastleSiegeData>();
+            var gateState = persistenceContext.CreateNew<BasicModel.CastleSiegeNpcState>();
+            gateState.MonsterNumber = CastleSiegeGate.MonsterNumber;
+            gateState.InstanceId = GateInstanceId;
+            gateState.CurrentHp = 1_000;
+            siegeData.NpcStates.Add(gateState);
+            var statueState = persistenceContext.CreateNew<BasicModel.CastleSiegeNpcState>();
+            statueState.MonsterNumber = CastleSiegeStatue.MonsterNumber;
+            statueState.InstanceId = StatueInstanceId;
+            statueState.CurrentHp = 2_000;
+            statueState.RegenLevel = 1;
+            siegeData.NpcStates.Add(statueState);
+
+            var ownerGuild = persistenceContext.CreateNew<BasicModel.Guild>();
+            ownerGuild.Name = "Owner";
+            ownerPersistentGuildId = ownerGuild.Id;
+            siegeData.OwnerGuildId = ownerPersistentGuildId;
+
+            jewelOfGuardian = persistenceContext.CreateNew<BasicModel.ItemDefinition>();
+            jewelOfGuardian.Group = 14;
+            jewelOfGuardian.Number = 31;
+            jewelOfGuardian.Width = 1;
+            jewelOfGuardian.Height = 1;
+            gameConfiguration.Items.Add(jewelOfGuardian);
+            await persistenceContext.SaveChangesAsync().ConfigureAwait(false);
+
+            BasicModel.MonsterDefinition AddMonster(short number, NpcObjectKind objectKind)
+            {
+                var definition = persistenceContext.CreateNew<BasicModel.MonsterDefinition>();
+                definition.Number = number;
+                definition.ObjectKind = objectKind;
+                gameConfiguration.Monsters.Add(definition);
+                return definition;
+            }
+        }
+
+        var guildServer = new Mock<IGuildServer>();
+        guildServer
+            .Setup(server => server.GetGuildAsync(OwnerRuntimeGuildId))
+            .Returns(new ValueTask<RuntimeGuild?>(new RuntimeGuild { Name = "Owner" }));
+        guildServer
+            .Setup(server => server.GetGuildIdByNameAsync("Owner"))
+            .Returns(new ValueTask<uint>(OwnerRuntimeGuildId));
+        guildServer
+            .Setup(server => server.GetPersistentGuildIdAsync(OwnerRuntimeGuildId))
+            .Returns(new ValueTask<Guid?>(ownerPersistentGuildId));
+        guildServer
+            .Setup(server => server.GetPersistentAllianceMasterGuildIdAsync(OwnerRuntimeGuildId))
+            .Returns(new ValueTask<Guid?>(ownerPersistentGuildId));
+
+        var plugInManager = new PlugInManager([], NullLoggerFactory.Instance, null, null);
+        var mapInitializer = new MapInitializer(
+            gameConfiguration,
+            new NullLogger<MapInitializer>(),
+            NullDropGenerator.Instance,
+            null);
+        var gameServerContext = new GameServerContext(
+            new BasicModel.GameServerDefinition
+            {
+                GameConfiguration = gameConfiguration,
+                ServerConfiguration = new BasicModel.GameServerConfiguration(),
+            },
+            guildServer.Object,
+            new Mock<IEventPublisher>().Object,
+            new Mock<ILoginServer>().Object,
+            new Mock<IFriendServer>().Object,
+            persistenceContextProvider,
+            mapInitializer,
+            NullLoggerFactory.Instance,
+            plugInManager,
+            NullDropGenerator.Instance,
+            new ConfigurationChangeMediator());
+        mapInitializer.PlugInManager = gameServerContext.PlugInManager;
+        mapInitializer.PathFinderPool = gameServerContext.PathFinderPool;
+
+        var initializationTimeUtc = new DateTime(2026, 8, 3, 12, 0, 0, DateTimeKind.Utc);
+        var context = new CastleSiegeContext(gameServerContext, configuration);
+        await context.InitializeAsync(initializationTimeUtc).ConfigureAwait(false);
+        context.CurrentState = CastleSiegeState.Ready;
+        var player = await PlayerTestHelper.CreatePlayerAsync(gameServerContext).ConfigureAwait(false);
+        player.GuildStatus = new GuildMemberStatus(OwnerRuntimeGuildId, GuildPosition.GuildMaster);
+        var map = await gameServerContext.GetMapAsync(30).ConfigureAwait(false)
+                  ?? throw new InvalidOperationException("The Castle Siege test map could not be initialized.");
+        return new(
+            persistenceContextProvider,
+            configuration,
+            siegeMap,
+            jewelOfGuardian,
+            gameServerContext,
+            context,
+            map,
+            player,
+            ownerPersistentGuildId,
+            initializationTimeUtc);
+
+        void AddUpgrade(
+            ICollection<CastleSiegeUpgradeDefinition> definitions,
+            byte level,
+            int jewels,
+            int zen,
+            int value)
+        {
+            definitions.Add(new BasicModel.CastleSiegeUpgradeDefinition
+            {
+                Level = level,
+                RequiredJewelOfGuardianCount = jewels,
+                RequiredZen = zen,
+                Value = value,
+            });
+        }
+
+        void AddNpc(
+            CastleSiegeConfiguration castleSiegeConfiguration,
+            MonsterDefinition monster,
+            byte instanceId,
+            bool persisted,
+            byte x,
+            byte y)
+        {
+            castleSiegeConfiguration.NpcDefinitions.Add(new BasicModel.CastleSiegeNpcDefinition
+            {
+                MonsterDefinition = monster,
+                InstanceId = instanceId,
+                IsPersistedToDatabase = persisted,
+                DefaultSide = CastleSiegeJoinSide.Defense,
+                SpawnX = x,
+                SpawnY = y,
+                Direction = Direction.South,
+            });
+        }
+
+        void AddAttributes(BasicModel.MonsterDefinition monster)
+        {
+            monster.Attributes.Add(new BasicModel.MonsterAttribute
+            {
+                AttributeDefinition = Stats.MaximumHealth,
+                Value = 1,
+            });
+            monster.Attributes.Add(new BasicModel.MonsterAttribute
+            {
+                AttributeDefinition = Stats.DefenseBase,
+                Value = 0,
+            });
+        }
+    }
+
+    private static async ValueTask AddSiegePlayerAsync(
+        TestFixture fixture,
+        CastleSiegeJoinSide side,
+        byte x,
+        byte y)
+    {
+        fixture.Player.IsAlive = true;
+        await fixture.GameServerContext.AddPlayerAsync(fixture.Player).ConfigureAwait(false);
+        await fixture.Player.WarpToAsync(new ExitGate
+        {
+            Map = fixture.SiegeMap,
+            X1 = x,
+            X2 = x,
+            Y1 = y,
+            Y2 = y,
+            Direction = Direction.South,
+        }).ConfigureAwait(false);
+        await fixture.Player.ClientReadyAfterMapChangeAsync().ConfigureAwait(false);
+        SetPlayerJoinSide(fixture, side);
+    }
+
+    private static async ValueTask AddGuardianJewelsAsync(TestFixture fixture, int count)
+    {
+        for (byte offset = 0; offset < count; offset++)
+        {
+            var jewel = fixture.Player.PersistenceContext.CreateNew<Item>();
+            jewel.Definition = fixture.JewelOfGuardian;
+            await fixture.Player.Inventory!.AddItemAsync((byte)(20 + offset), jewel).ConfigureAwait(false);
+        }
+    }
+
+    private static void SetPlayerJoinSide(TestFixture fixture, CastleSiegeJoinSide side)
+    {
+        fixture.Context.FinalGuildList[OwnerRuntimeGuildId] = new CastleSiegeGuildParticipant
+        {
+            GuildId = OwnerRuntimeGuildId,
+            PersistentGuildId = fixture.OwnerPersistentGuildId,
+            GuildName = "Owner",
+            Side = side,
+        };
+    }
+
+    private sealed record TestFixture(
+        InMemoryPersistenceContextProvider PersistenceContextProvider,
+        CastleSiegeConfiguration Configuration,
+        GameMapDefinition SiegeMap,
+        ItemDefinition JewelOfGuardian,
+        GameServerContext GameServerContext,
+        CastleSiegeContext Context,
+        GameMap Map,
+        Player Player,
+        Guid OwnerPersistentGuildId,
+        DateTime InitializationTimeUtc);
+}

--- a/tests/MUnique.OpenMU.Tests/CastleSiegeNpcTests.cs
+++ b/tests/MUnique.OpenMU.Tests/CastleSiegeNpcTests.cs
@@ -174,7 +174,7 @@ public class CastleSiegeNpcTests
     public async ValueTask ClosedGateBlocksCrossingRouteAndSynchronizesEntrantAsync()
     {
         var fixture = await CreateFixtureAsync().ConfigureAwait(false);
-        await AddSiegePlayerAsync(fixture, CastleSiegeJoinSide.Attack1, GateX - 4, GateY).ConfigureAwait(false);
+        await AddSiegePlayerAsync(fixture, CastleSiegeJoinSide.Attack1, GateX - 5, GateY).ConfigureAwait(false);
         try
         {
             await fixture.Context.NpcController.PrepareAsync().ConfigureAwait(false);
@@ -191,7 +191,8 @@ public class CastleSiegeNpcTests
                     It.IsAny<IReadOnlyCollection<(byte StartX, byte StartY, byte EndX, byte EndY)>>()),
                 Times.Once);
 
-            var start = new Point(GateX - 4, GateY);
+            var start = new Point(GateX - 5, GateY);
+            var lastReachablePosition = new Point(GateX - 4, GateY);
             var target = new Point(GateX + 3, GateY);
             var steps = Enumerable.Range(start.X, target.X - start.X)
                 .Select(x => new WalkingStep
@@ -205,9 +206,10 @@ public class CastleSiegeNpcTests
             movementView.Invocations.Clear();
 
             await fixture.Player.WalkToAsync(target, steps).ConfigureAwait(false);
+            await Task.Delay(TimeSpan.FromMilliseconds(500)).ConfigureAwait(false);
 
-            Assert.That(fixture.Player.Position, Is.EqualTo(start));
-            movementView.Verify(view => view.ObjectMovedAsync(fixture.Player, MoveType.Instant), Times.Once);
+            Assert.That(fixture.Player.Position, Is.EqualTo(lastReachablePosition));
+            movementView.Verify(view => view.ObjectMovedAsync(fixture.Player, MoveType.Instant), Times.Never);
         }
         finally
         {
@@ -381,6 +383,75 @@ public class CastleSiegeNpcTests
             else
             {
                 await fixture.Context.NpcController.DespawnAllAsync().ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Verifies that overlapping gate terrain remains blocked until every covering gate has opened.
+    /// </summary>
+    [Test]
+    public async ValueTask OverlappingGateTerrainUsesReferenceCountsAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var firstArea = (StartX: (byte)47, StartY: (byte)50, EndX: (byte)52, EndY: (byte)51);
+        var secondArea = (StartX: (byte)52, StartY: (byte)50, EndX: (byte)57, EndY: (byte)51);
+        try
+        {
+            fixture.Context.NpcController.BlockGateTerrain(fixture.Map, firstArea);
+            fixture.Context.NpcController.BlockGateTerrain(fixture.Map, secondArea);
+
+            var stillBlocked = fixture.Context.NpcController.ReleaseGateTerrain(fixture.Map, firstArea);
+            Assert.Multiple(() =>
+            {
+                Assert.That(fixture.Map.Terrain.WalkMap[47, 50], Is.True);
+                Assert.That(fixture.Map.Terrain.WalkMap[52, 50], Is.False);
+                Assert.That(stillBlocked, Does.Contain(((byte)52, (byte)50, (byte)52, (byte)50)));
+            });
+
+            fixture.Context.NpcController.ReleaseGateTerrain(fixture.Map, secondArea);
+            Assert.That(fixture.Map.Terrain.WalkMap[52, 50], Is.True);
+        }
+        finally
+        {
+            await fixture.Context.NpcController.DespawnAllAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that a server which starts during the battle restores closed gates before spawning siege machines.
+    /// </summary>
+    [Test]
+    public async ValueTask ServerStartupDuringBattleClosesGatesAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var battleTimeUtc = new DateTime(2026, 8, 4, 12, 0, 0, DateTimeKind.Utc);
+        var plugIn = new CastleSiegePlugIn(new FixedTimeProvider(battleTimeUtc));
+        CastleSiegeContext? context = null;
+        try
+        {
+            await plugIn.ExecuteTaskAsync(fixture.GameServerContext).ConfigureAwait(false);
+            context = plugIn.GetContext(fixture.GameServerContext);
+            var gate = context!.ActiveNpcs
+                .Select(runtime => runtime.SpawnedInstance)
+                .OfType<CastleSiegeGate>()
+                .Single();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(context.CurrentState, Is.EqualTo(CastleSiegeState.Start));
+                Assert.That(gate.IsClosed, Is.True);
+                Assert.That(fixture.Map.Terrain.WalkMap[GateX, GateY], Is.False);
+                Assert.That(
+                    context.ActiveNpcs.Select(runtime => runtime.SpawnedInstance),
+                    Has.Exactly(2).InstanceOf<CastleSiegeMachine>());
+            });
+        }
+        finally
+        {
+            if (context is not null)
+            {
+                await context.NpcController.DespawnAllAsync().ConfigureAwait(false);
             }
         }
     }
@@ -570,7 +641,9 @@ public class CastleSiegeNpcTests
             gate.ApplyPersistedUpgrades(false);
             gate.Health = 900;
             runtime.PersistedState.CurrentHp = gate.Health;
-            fixture.Player.Money = 1_000_500;
+            fixture.Configuration.GateRepairCostPerHealthPoint = 2;
+            fixture.Configuration.RepairCostPerUpgradeLevel = 100;
+            fixture.Player.Money = 300;
 
             var repairResult = await CastleSiegeNpcRepairAction
                 .RepairAsync(fixture.Player, fixture.Context, (uint)CastleSiegeGate.MonsterNumber, GateInstanceId)
@@ -644,6 +717,12 @@ public class CastleSiegeNpcTests
                 Direction = Direction.South,
             }).ConfigureAwait(false);
             await fixture.Player.ClientReadyAfterMapChangeAsync().ConfigureAwait(false);
+            Assert.Multiple(() =>
+            {
+                Assert.That(fixture.Player.Position, Is.EqualTo(crown.Position));
+                Assert.That(fixture.Player.CurrentMap, Is.SameAs(crown.CurrentMap));
+                Assert.That(crown.CurrentMap.GetAttackablesInRange(crown.Position, 1), Does.Contain(fixture.Player));
+            });
 
             using var crownIntelligence = new CastleSiegeCrownIntelligence(fixture.Context)
             {
@@ -658,7 +737,16 @@ public class CastleSiegeNpcTests
                 Assert.That(crown.State, Is.EqualTo(CastleSiegeCrownState.Idle));
             });
 
-            fixture.Player.Position = siegeSwitch.Position;
+            await fixture.Player.WarpToAsync(new ExitGate
+            {
+                Map = fixture.SiegeMap,
+                X1 = siegeSwitch.Position.X,
+                X2 = siegeSwitch.Position.X,
+                Y1 = siegeSwitch.Position.Y,
+                Y2 = siegeSwitch.Position.Y,
+                Direction = Direction.South,
+            }).ConfigureAwait(false);
+            await fixture.Player.ClientReadyAfterMapChangeAsync().ConfigureAwait(false);
             using var switchIntelligence = new CastleSiegeSwitchIntelligence(fixture.Context)
             {
                 Npc = siegeSwitch,
@@ -1016,6 +1104,7 @@ public class CastleSiegeNpcTests
             Direction = Direction.South,
         }).ConfigureAwait(false);
         await fixture.Player.ClientReadyAfterMapChangeAsync().ConfigureAwait(false);
+        fixture.Context.TrackPlayer(fixture.Player, fixture.Map);
         SetPlayerJoinSide(fixture, side);
     }
 
@@ -1051,4 +1140,12 @@ public class CastleSiegeNpcTests
         Player Player,
         Guid OwnerPersistentGuildId,
         DateTime InitializationTimeUtc);
+
+    private sealed class FixedTimeProvider(DateTime utcNow) : TimeProvider
+    {
+        private readonly DateTimeOffset _utcNow = utcNow;
+
+        /// <inheritdoc />
+        public override DateTimeOffset GetUtcNow() => this._utcNow;
+    }
 }

--- a/tests/MUnique.OpenMU.Tests/CastleSiegeStateMachineTests.cs
+++ b/tests/MUnique.OpenMU.Tests/CastleSiegeStateMachineTests.cs
@@ -173,14 +173,14 @@ public class CastleSiegeStateMachineTests
     }
 
     /// <summary>
-    /// Verifies that only alive database-persisted NPC runtime states are stored.
+    /// Verifies that all database-persisted NPC runtime states are stored, including destroyed and unspawned structures.
     /// </summary>
     [Test]
-    public async ValueTask ContextSavesAlivePersistentNpcStatesAsync()
+    public async ValueTask ContextSavesPersistentNpcStatesIncludingDestroyedAsync()
     {
         var fixture = await CreateFixtureAsync().ConfigureAwait(false);
         var gateStateId = await AddNpcStateAsync(fixture, 277, 0, 250_000).ConfigureAwait(false);
-        await AddNpcStateAsync(fixture, 283, 0, 300_000).ConfigureAwait(false);
+        var statueStateId = await AddNpcStateAsync(fixture, 283, 0, 300_000).ConfigureAwait(false);
         var context = new CastleSiegeContext(fixture.GameContext.Object, fixture.CastleSiegeConfiguration);
         await context.InitializeAsync(new DateTime(2026, 8, 3, 12, 0, 0, DateTimeKind.Utc)).ConfigureAwait(false);
         context.ActiveNpcs.Add(CreateNpcRuntime(277, 0, 125_000, true, true));
@@ -194,10 +194,17 @@ public class CastleSiegeStateMachineTests
             false,
             fixture.GameConfiguration);
         var savedData = (await persistenceContext.GetAsync<CastleSiegeData>().ConfigureAwait(false)).Single();
-        Assert.That(savedData.NpcStates, Has.Count.EqualTo(1));
-        Assert.That(savedData.NpcStates.Single().Id, Is.EqualTo(gateStateId));
-        Assert.That(savedData.NpcStates.Single().MonsterNumber, Is.EqualTo(277));
-        Assert.That(savedData.NpcStates.Single().CurrentHp, Is.EqualTo(125_000));
+        Assert.That(savedData.NpcStates, Has.Count.EqualTo(2));
+        Assert.That(savedData.NpcStates.Select(state => state.MonsterNumber), Is.EquivalentTo(new short[] { 277, 283 }));
+        Assert.Multiple(() =>
+        {
+            var gateState = savedData.NpcStates.Single(state => state.MonsterNumber == 277);
+            var statueState = savedData.NpcStates.Single(state => state.MonsterNumber == 283);
+            Assert.That(gateState.Id, Is.EqualTo(gateStateId));
+            Assert.That(gateState.CurrentHp, Is.EqualTo(125_000));
+            Assert.That(statueState.Id, Is.EqualTo(statueStateId));
+            Assert.That(statueState.CurrentHp, Is.Zero);
+        });
     }
 
     /// <summary>
@@ -323,6 +330,31 @@ public class CastleSiegeStateMachineTests
                 Is.EqualTo(state == CastleSiegeState.Start),
                 $"Unexpected event-running value for state {state}.");
         }
+    }
+
+    /// <summary>
+    /// Verifies that the periodic NPC snapshot is scheduled when the server starts outside the battle phase.
+    /// </summary>
+    [Test]
+    public async ValueTask PeriodicNpcSaveIsScheduledOnStartupAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        await AddNpcStateAsync(fixture, 277, 1, 1_000).ConfigureAwait(false);
+        var timeProvider = new ManualTimeProvider(new DateTimeOffset(2026, 8, 3, 12, 0, 0, TimeSpan.Zero));
+        var plugIn = new CastleSiegePlugIn(timeProvider);
+        await plugIn.ExecuteTaskAsync(fixture.GameContext.Object).ConfigureAwait(false);
+        var context = plugIn.GetContext(fixture.GameContext.Object)!;
+        context.ActiveNpcs.Add(CreateNpcRuntime(277, 1, 500, true, true));
+
+        timeProvider.Advance(TimeSpan.FromMinutes(2));
+        await plugIn.ExecuteTaskAsync(fixture.GameContext.Object).ConfigureAwait(false);
+
+        using var persistenceContext = fixture.PersistenceContextProvider.CreateNewTypedContext(
+            typeof(CastleSiegeData),
+            false,
+            fixture.GameConfiguration);
+        var savedData = (await persistenceContext.GetAsync<CastleSiegeData>().ConfigureAwait(false)).Single();
+        Assert.That(savedData.NpcStates.Single(state => state.MonsterNumber == 277).CurrentHp, Is.EqualTo(500));
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary

Implements the Castle Siege NPC lifecycle and management system described in #725.

- Adds Castle Gates, Guardian Statues, Crown, Crown Switches, Gate Levers, and battle-only Siege Machines.
- Adds the corresponding runtime intelligence and event lifecycle handling.
- Implements defense-structure purchase, repair, and upgrade operations.
- Restores persisted NPC health and upgrade levels after server restarts.
- Synchronizes NPC state periodically outside the active battle.
- Adds the existing B2/B3 packet handlers and RemoteView serializers required by the NPC interfaces.
- Adds localized plug-in metadata for the new handlers and views.

## Gate behavior

- Closed gates apply server-side terrain blocking across their configured area.
- Opening or destroying a gate removes the dynamic terrain restriction.
- Originally blocked terrain remains protected when the dynamic gate restriction is removed.
- Players entering the map receive the current gate state.
- Movement validation checks the complete walking path, preventing players from skipping across a blocked gate area.
- Gate lever operations validate the player’s Castle Siege side or castle ownership before changing the gate state.

## Defense structures

- Gates and Guardian Statues can be purchased, repaired, and upgraded outside the active battle.
- Authorization is limited to the castle owner guild master or assistant master.
- Upgrade requirements, Zen costs, and Jewel of Guardian consumption are validated before applying changes.
- Failed operations do not consume Zen or items.
- Guardian Statues regenerate health according to their configured regeneration level.
- Attack permissions are restricted by the current Castle Siege state and participant side.

## Lifecycle

- Persistent Castle Siege NPCs are restored during the `Ready` state.
- Gates are closed when the event is prepared.
- Siege Machines are spawned only during the `Start` state.
- Machine NPCs are removed and persistent NPC state is saved when the battle ends.
- Destroyed and currently unspawned defense structures remain represented in persistence.

## Crown mechanics boundary

This change tracks Crown and Crown Switch occupants and exposes the runtime state needed by the capture system. Capture-time accumulation, access result packets, ownership changes, and the final win condition remain part of #726.

The Crown uses monster number 216, matching the existing Valley of Loren configuration. Monster number 219 is the Gate Lever; the Crown number in the issue requirements appears to be a typo.

## Testing

- Added lifecycle, authorization, terrain, persistence, purchase, repair, upgrade, regeneration, Crown, switch, lever, and failure-side-effect regression tests.
- Added serialization coverage for NPC lists, operation results, gate interfaces, gate operations, and gate state packets.
- Added startup scheduling and destroyed-state persistence tests.
- CI-style build: 0 warnings and 0 errors.
- Castle Siege focused tests: 42 passed.
- Full `MUnique.OpenMU.Tests` project: 701 passed.
- StyleCop and analyzer checks pass for the changed scope.

Closes #725