### PR TITLE
Refactoring plan for the Player class, and its first step

### DIFF
--- a/docs/PlayerRefactoringPlan.md
+++ b/docs/PlayerRefactoringPlan.md
@@ -59,13 +59,15 @@ Concrete smells worth calling out, because they drive the design below:
    `IsPlayerStoreOpeningAfterEnterSupported`. These four extension points stay.
    (`TryAddMoney` and `RespawnAtAsync` are `virtual` but nobody overrides them —
    they can lose `virtual` when they move.)
-2. **Source compatibility for runtime-compiled plugins.** OpenMU compiles custom
-   plugins from source at server start (see `PlugIns/Readme.md`). Any member we
-   turn into an extension method must live in the **same namespace**
-   (`MUnique.OpenMU.GameLogic`), otherwise third-party plugin sources stop
-   compiling for want of a `using`. With that rule, `player.Foo()` call sites are
-   unaffected — this is why extension methods are the cheapest tool here
-   (`ShowLocalizedBlueMessageAsync` alone has ~208 call sites).
+2. **Source compatibility is a convenience here, not a hard rule.** Breaking
+   changes are acceptable at this stage of the project (§8.3), so this is only
+   about avoiding pointless churn. OpenMU compiles custom plugins from source at
+   server start (see `PlugIns/Readme.md`); keeping every extension class in the
+   **same namespace** (`MUnique.OpenMU.GameLogic`) means `player.Foo()` call
+   sites — inside the repository and in third-party plugin sources — keep
+   compiling without a new `using`. That is free, and it is why extension methods
+   are the cheapest tool here (`ShowLocalizedBlueMessageAsync` alone has ~208
+   call sites).
 3. **The persistence lock contract** documented at `Player.cs:1885-1910` must
    survive verbatim: re-entrancy per async flow, and no cross-player lock
    acquisition ordering cycles. `tests/MUnique.OpenMU.Tests/PersistenceLockTest.cs`
@@ -95,9 +97,14 @@ Concrete smells worth calling out, because they drive the design below:
 | **Feature context object** | groups of properties that only make sense together (`TradeContext`, `GuildRequestContext`) | touches call sites |
 
 Rule of thumb used throughout this plan: **policy → plugin, mechanism → component,
-pure function → extension method.** Do not extract mechanism into plugins just
-because it is possible: everything that becomes a plugin can be deactivated by an
-admin, and deactivating "apply damage to health" is not a feature.
+pure function → extension method.**
+
+Deactivation is explicitly *not* a reason to hold back (decided, see §8.1): an
+admin who switches off `PlayerKillerStatePlugIn` to replace it with their own is
+using the plugin system as intended. So when in doubt between a plugin and a
+component, take the plugin. Mechanism still stays in components — not because
+deactivating it would be dangerous, but because a plugin point that nobody will
+ever implement differently is just indirection.
 
 ### 3.1 Three infrastructure gaps to close first
 
@@ -221,9 +228,32 @@ Existing plugin points that should absorb logic instead of new ones being added:
 | `IPlayerStateChangedPlugIn` | the tail of `OnPlayerEnteredWorldAsync` (2733-2751) → `GameMasterMarkPlugIn`, `MuHelperConfigurationPlugIn`, `RestorePlayerStorePlugIn`, `ResetPetBehaviorPlugIn`; after §4.0 is implemented, also everything reacting to entering/leaving a map |
 | `IPlayerStateChangingPlugIn` | veto hooks for map changes (mini game / castle siege / duel restrictions) once `ChangingMap` is wired up |
 | `IAttackableGotKilledPlugIn` | `AfterKilledPlayerAsync` (1962-2012) → `PlayerKillerStatePlugIn`; the death→respawn flow inside `OnDeathAsync` (2547-2580) → `RespawnAfterDeathPlugIn` (with the CTS in the per-player state bag); `RespawnOfDuelPartnerIfInDuelAsync` (2598) → `DuelPartnerRespawnPlugIn` |
-| `IAttackableGotHitPlugIn` | damage reflection (2484-2524), the defensive durability decrease (2872-2929), `FullyRecoverHealthAfterHitChance`/sleep-clearing (769-783). **Note:** the interface method is currently synchronous (`void AttackableGotHit`), so it needs an async sibling method before these can move |
+| `IAttackableGotHitPlugIn` | damage reflection (2484-2524), the defensive durability decrease (2872-2929), `FullyRecoverHealthAfterHitChance`/sleep-clearing (769-783). The method becomes `ValueTask AttackableGotHitAsync(...)` — see §4.2 |
 | `IObjectAddedToMapPlugIn` / `IObjectRemovedFromMapPlugIn` | the map `CharacterPowerUpDefinitions` handling in `RaisePlayerEnteredMap` (2632-2654). These points already fire for players (`GameContext.cs:219-226`) |
 | `IPeriodicTaskPlugIn` | nothing new — P9 keeps the separate recovery interval |
+
+### 4.2 Making existing plugin points async
+
+Decided (§8.3): existing plugin interfaces may be changed rather than duplicated
+with async siblings. The points on this refactoring's path that are still
+synchronous:
+
+| Point | Current signature | Change |
+|---|---|---|
+| `IAttackableGotHitPlugIn` | `void AttackableGotHit(...)` | → `ValueTask AttackableGotHitAsync(...)`. Required: reflection and durability both await view plugins. Call site `Player.cs:2470` |
+| `ICharacterLevelUpPlugIn` | `void CharacterLeveledUp(Player)` | → `ValueTask CharacterLeveledUpAsync(Player)`, so P7 (master level up) can mirror it and level-up plugins can talk to the view. Call site `Player.cs:2145` |
+| `IItemDestroyedPlugIn` | `void ItemDestroyed(Item)` | → async; the only call site (`Player.cs:1806`) is already async |
+| `ICharacterCreatedPlugIn` | `void CharacterCreated(...)` | → async; call site `Player.cs:2696` is already async |
+
+One exception: **`IAttackableMovedPlugIn.AttackableMoved` stays synchronous.** It
+is invoked from the `Position` and `CurrentMap` property setters
+(`Player.cs:329,413`), which cannot await. Making it async means turning
+`Position` into a method — a much larger change that should be decided on its own
+merits, not as a side effect of this refactoring.
+
+The remaining synchronous points (`IItemConsumedPlugIn`, `IItemMovingPlugIn`,
+`IChatMessageReceivedPlugIn`, …) are outside this refactoring's path. If a
+consistency sweep is wanted, it belongs in its own PR.
 
 ## 5. Extraction plan per cluster
 
@@ -341,10 +371,12 @@ per-hit and per-kill paths add an iteration over the plugin proxy list.
 
 ## 8. Risks and open questions
 
-1. **Deactivatable core behavior.** Every extracted plugin can be switched off in
-   the admin panel. Only *policy* should move; mechanism stays in components.
-   Open question: should there be a "not deactivatable" marker (the mirror image
-   of `IDisabledByDefault`) for plugins like `RespawnAfterDeathPlugIn`?
+1. **Deactivatable core behavior — decided: accepted, no marker.** Every
+   extracted plugin can be switched off in the admin panel, including
+   `RespawnAfterDeathPlugIn`. That is the point of the plugin system: an admin who
+   deactivates one is expected to know what they are doing, possibly because they
+   reimplemented it in a plugin of their own. No "not deactivatable" marker will
+   be introduced. Consequence for this plan: extract generously (§3).
 2. **Ordering.** The enter-world view sequence is client-observable, and
    `IPlayerStateChangedPlugIn` implementations are as unordered as any other
    plugin. If 3.1(a) is rejected, the ordered part of the sequence stays in a
@@ -354,9 +386,12 @@ per-hit and per-kill paths add an iteration over the plugin proxy list.
    makes ~41 `CurrentState == EnteredWorld` guards reject actions during a warp,
    and it makes map changes cancelable by plugins. Both are desirable, both need
    deciding explicitly. Also mind the non-reentrant state machine lock (§4.0).
-3. **`IAttackableGotHitPlugIn` is synchronous.** Adding an async method to the
-   interface is a (source-)breaking change for external plugins — decide between
-   extending the interface and adding a sibling point.
+3. **Synchronous plugin points — decided: change the signatures.** Breaking
+   changes to plugin interfaces are acceptable at this stage of the project, so
+   `IAttackableGotHitPlugIn` and friends get async signatures instead of async
+   sibling points (§4.2). External plugins implementing them need a one-line
+   update. The one point that stays synchronous is
+   `IAttackableMovedPlugIn`, for the property-setter reason given in §4.2.
 4. **Existing installations.** Extracted plugins are active by default when no
    configuration row exists, so behavior is preserved. If they should be
    toggleable in the admin panel for existing databases, add an

--- a/docs/PlayerRefactoringPlan.md
+++ b/docs/PlayerRefactoringPlan.md
@@ -133,14 +133,78 @@ pattern for plugin points that need to produce a value
 
 ## 4. Proposed new plugin points
 
+### 4.0 First: use the state machine we already have
+
+`IPlayerStateChangedPlugIn` and `IPlayerStateChangingPlugIn` already exist and are
+wired in the `Player` constructor (`Player.cs:113-114`). Four plugins already use
+them, with `ShowMessageToAllWhenPlayerEnteredWorldPlugIn` establishing the idiom
+for "the player just entered the world":
+
+```csharp
+if (previousState != PlayerState.CharacterSelection || currentState != PlayerState.EnteredWorld) return;
+```
+
+**Consequence for this plan: no new "entered world" plugin point is needed.**
+The tail of `OnPlayerEnteredWorldAsync` (GM mark, MU Helper configuration, player
+store restore, pet behavior reset) becomes ordinary `IPlayerStateChangedPlugIn`
+implementations. Same for the pre-map view initialization, which can hook
+`IPlayerStateChangingPlugIn` (it fires immediately before `EnteredWorld` is set) —
+though see the caveats below before moving that block at all.
+
+For **map changes** the existing point does not fire today, but it *should*, and
+making it do so is cheaper and better than a new point:
+
+* `PlayerState.ChangingMap` is declared (`PlayerState.cs:181`) and **never used
+  anywhere**. It is also unreachable: no other state lists it in
+  `PossibleTransitions`.
+* `ClientReadyAfterMapChangeAsync` calls `TryAdvanceToAsync(EnteredWorld)` while
+  the player usually *is* already in `EnteredWorld`. Since
+  `EnteredWorld.PossibleTransitions` does not contain `EnteredWorld`,
+  `TryAdvanceToAsync` returns `false` and **no event is raised** — a warp is
+  invisible to the state plugins. (Respawn after death is the exception:
+  `Dead → EnteredWorld` is a legal transition and does fire.)
+* `WarpToAsync` does not touch the state machine at all.
+
+So the task is: set `ChangingMap` in `WarpToAsync`/`RespawnAtAsync`, advance back
+to `EnteredWorld` in `ClientReadyAfterMapChangeAsync`, and add the missing
+transitions (`EnteredWorld → ChangingMap`, `Dead → ChangingMap`,
+`ChangingMap → EnteredWorld`). This gives entered/left map to every plugin for
+free — and, via `IPlayerStateChangingPlugIn`, makes map changes **cancelable**,
+which mini games, castle siege and duels can use.
+
+Four things to keep in mind when leaning on the state machine:
+
+1. **~41 call sites guard on `CurrentState == PlayerState.EnteredWorld`** (item
+   consumption, guild actions, resets, bots, the periodic save). Once
+   `ChangingMap` exists, they all reject actions during a warp. That is almost
+   certainly the correct behavior, but it is a behavior change and belongs in its
+   own commit with its own test, not smuggled into a move.
+2. **The state machine lock is not reentrant.** `TryAdvanceToAsync` holds
+   `StateMachine._asyncLock` while awaiting both events, so a plugin that
+   triggers another transition **on the same player** deadlocks. Anything moved
+   into a state plugin must be checked for this (trade, NPC dialog and store
+   states are the candidates).
+3. **The event fires before `CurrentMap.AddAsync`** in the enter-world flow, so
+   logic that must run once the player is actually on the map either stays in
+   code or needs the call site moved.
+4. **The state does not say which map.** Map-bound power-ups therefore still
+   belong on `IObjectAddedToMapPlugIn`/`IObjectRemovedFromMapPlugIn`, which pass
+   the `GameMap` and already fire for players.
+
+A related pre-existing bug found while checking this: `LogoutAction`
+(`LogoutType.BackToCharacterSelection`) advances to `PlayerState.Authenticated`,
+which is *not* in `EnteredWorld.PossibleTransitions` — the transition silently
+fails and the player stays in `EnteredWorld`. This must be fixed before "leaving
+the game" can be observed via the state machine at all.
+
+### 4.1 Points that are actually new
+
 All of these live in `src/GameLogic/PlugIns/`, need a fresh `Guid` and a
 `[PlugInPoint]` attribute, following `IAttackableGotKilledPlugIn` as the template.
 
 | # | Interface | Signature | Logic that moves there |
 |---|---|---|---|
-| P1 | `IPlayerEnteringWorldPlugIn` | `ValueTask PlayerEnteringWorldAsync(Player player)` | the view-initialization block of `OnPlayerEnteredWorldAsync` (2717-2722): stats, inventory list, skill list, key config, quest state |
-| P2 | `IPlayerEnteredWorldPlugIn` | `ValueTask PlayerEnteredWorldAsync(Player player)` | the tail of `OnPlayerEnteredWorldAsync` (2733-2751): rotation update, pet behavior reset, MU Helper config, GM mark effect, player store restore |
-| P3 | `IPlayerLeavingGamePlugIn` | `ValueTask PlayerLeavingGameAsync(Player player)` | `RemoveFromGameAsync` steps (1840-1856): party leave-temporarily, safezone move, temporary storage restore, `OpenedNpc` reset |
+| P3 | `IPlayerLeavingGamePlugIn` | `ValueTask PlayerLeavingGameAsync(Player player)` | `RemoveFromGameAsync` steps (1840-1856): party leave-temporarily, safezone move, temporary storage restore, `OpenedNpc` reset. **Only if** the `LogoutAction` state bug above is not fixed — with it fixed, `IPlayerStateChangedPlugIn` covers this too, and P3 is dropped |
 | P4 | `IPlayerSpawnGateSelectionPlugIn` | `ValueTask SelectSpawnGateAsync(Player player, SpawnGateSelectionArgs args)` | the duel and guild-war-soccer branches of `GetSpawnGateOfCurrentMapAsync` (2409-2428); later also mini games and castle siege |
 | P5 | `IExperienceCalculationPlugIn` | `ValueTask CalculateExperienceAsync(Player player, ExperienceCalculationArgs args)` | the multiplier chain in `CalculateExpAfterKill` (1271-1288): map multiplier, bonus rate, random min/max multipliers |
 | P6 | `IPlayerGainedExperiencePlugIn` | `ValueTask PlayerGainedExperienceAsync(Player player, int experience, IAttackable? killedObject, ExperienceType type)` | `AddPetExperienceAsync` (2953-3020) becomes `PetExperiencePlugIn`; also the natural hook for statistics/events |
@@ -154,6 +218,8 @@ Existing plugin points that should absorb logic instead of new ones being added:
 
 | Existing point | Logic that moves there |
 |---|---|
+| `IPlayerStateChangedPlugIn` | the tail of `OnPlayerEnteredWorldAsync` (2733-2751) → `GameMasterMarkPlugIn`, `MuHelperConfigurationPlugIn`, `RestorePlayerStorePlugIn`, `ResetPetBehaviorPlugIn`; after §4.0 is implemented, also everything reacting to entering/leaving a map |
+| `IPlayerStateChangingPlugIn` | veto hooks for map changes (mini game / castle siege / duel restrictions) once `ChangingMap` is wired up |
 | `IAttackableGotKilledPlugIn` | `AfterKilledPlayerAsync` (1962-2012) → `PlayerKillerStatePlugIn`; the death→respawn flow inside `OnDeathAsync` (2547-2580) → `RespawnAfterDeathPlugIn` (with the CTS in the per-player state bag); `RespawnOfDuelPartnerIfInDuelAsync` (2598) → `DuelPartnerRespawnPlugIn` |
 | `IAttackableGotHitPlugIn` | damage reflection (2484-2524), the defensive durability decrease (2872-2929), `FullyRecoverHealthAfterHitChance`/sleep-clearing (769-783). **Note:** the interface method is currently synchronous (`void AttackableGotHit`), so it needs an async sibling method before these can move |
 | `IObjectAddedToMapPlugIn` / `IObjectRemovedFromMapPlugIn` | the map `CharacterPowerUpDefinitions` handling in `RaisePlayerEnteredMap` (2632-2654). These points already fire for players (`GameContext.cs:219-226`) |
@@ -205,9 +271,11 @@ New plugin implementations created by the moves above (all in
 * `MapCharacterPowerUpPlugIn` — map-bound power-ups via the map plugin points.
 * `IntervalRegenerationPlugIn`, `HeroStateRecoveryPlugIn`.
 * `GameMasterMarkPlugIn`, `MuHelperConfigurationPlugIn`, `RestorePlayerStorePlugIn`,
-  `InitialViewUpdatePlugIn` — the enter-world steps (P1/P2).
+  `ResetPetBehaviorPlugIn` — the enter-world steps, on the **existing**
+  `IPlayerStateChangedPlugIn` (§4.0).
 * `PartyLeaveTemporarilyPlugIn`, `MoveToSafezoneOnLeavePlugIn`,
-  `RestoreTemporaryStorageItemsPlugIn` — the leave-game steps (P3).
+  `RestoreTemporaryStorageItemsPlugIn` — the leave-game steps (P3, or
+  `IPlayerStateChangedPlugIn` once the `LogoutAction` transition is fixed).
 * `DuelSpawnGatePlugIn`, `SoccerSpawnGatePlugIn` — spawn gate selection (P4).
 * `RavenCommandManagerFactoryPlugIn` — the pet factory TODO (P10).
 
@@ -231,12 +299,13 @@ Each phase is independently mergeable and leaves the build green.
 | Phase | Content | Risk | Player.cs after |
 |---|---|---|---|
 | **0** | Characterization tests (see §7); plugin ordering (3.1a); per-player state bag (3.1b); args-object convention (3.1c) | low | 3,098 |
+| **0b** | State machine repair (§4.0): wire `ChangingMap` into warp/respawn, add the missing transitions, fix the `LogoutAction` transition. Own commit, own tests — this is a behavior change, not a move | medium | 3,098 |
 | **1** | §5.1 extension-method moves + nested class files | very low | ~2,600 |
 | **2** | `PlayerMovement`, `PlayerPersistence`, `PlayerSummon`, `PlayerStorages` components | low | ~2,150 |
 | **3** | `PlayerExperience` + P5/P6/P7 + `PetExperiencePlugIn` | medium | ~1,850 |
 | **4** | `PlayerMapTransitions` + P4 spawn gate plugins | medium | ~1,550 |
 | **5** | `PlayerCombat` + `AttackableNpcBase` dedup + P8 and the `IAttackableGotHit`/`GotKilled` plugins (PK state, respawn, reflection, durability) | **high** | ~1,150 |
-| **6** | Enter-world / leave-game: P1, P2, P3 + `PlayerAttributeHost` + P9 regeneration | medium-high | ~900 |
+| **6** | Enter-world / leave-game moved onto `IPlayerStateChangedPlugIn` (+ P3 if needed) + `PlayerAttributeHost` + P9 regeneration | medium-high | ~900 |
 | **7** | §5.4 property consolidation, final cleanup of `virtual` members nobody overrides | low | ~700-800 |
 
 Phase 5 is the one to schedule carefully: combat touches PvP, duels, mini games
@@ -276,8 +345,15 @@ per-hit and per-kill paths add an iteration over the plugin proxy list.
    the admin panel. Only *policy* should move; mechanism stays in components.
    Open question: should there be a "not deactivatable" marker (the mirror image
    of `IDisabledByDefault`) for plugins like `RespawnAfterDeathPlugIn`?
-2. **Ordering.** The enter-world view sequence is client-observable. If 3.1(a) is
-   rejected, phase 6 must use several narrow plugin points instead of one.
+2. **Ordering.** The enter-world view sequence is client-observable, and
+   `IPlayerStateChangedPlugIn` implementations are as unordered as any other
+   plugin. If 3.1(a) is rejected, the ordered part of the sequence stays in a
+   component and only the order-independent steps (GM mark, MU Helper config,
+   store restore) become plugins.
+2b. **State machine repair is a behavior change.** Introducing `ChangingMap`
+   makes ~41 `CurrentState == EnteredWorld` guards reject actions during a warp,
+   and it makes map changes cancelable by plugins. Both are desirable, both need
+   deciding explicitly. Also mind the non-reentrant state machine lock (§4.0).
 3. **`IAttackableGotHitPlugIn` is synchronous.** Adding an async method to the
    interface is a (source-)breaking change for external plugins — decide between
    extending the interface and adding a sibling point.

--- a/docs/PlayerRefactoringPlan.md
+++ b/docs/PlayerRefactoringPlan.md
@@ -1,0 +1,296 @@
+# Refactoring plan: breaking up the `Player` class
+
+**Status:** proposal / not implemented yet
+**Subject:** `src/GameLogic/Player.cs` (3,098 lines, ~150 members)
+
+## 1. Diagnosis
+
+`Player` is currently ten classes in a trench coat. It implements 11 interfaces
+(`IBucketMapObserver`, `IAttackable`, `IAttacker`, `ITrader`, `IPartyMember`,
+`IRotatable`, `IHasBucketInformation`, `ISupportWalk`, `IMovable`,
+`ILoggerOwner<Player>`, plus `AsyncDisposable`) and additionally hosts:
+
+| Responsibility | Approx. lines | Where |
+|---|---|---|
+| Map transitions (warp, teleport, respawn, spawn gate selection) | ~370 | 832-930, 1104-1210, 2160-2244, 2402-2435, 2593-2660 |
+| Combat (attack, hit application, death, PK state) | ~325 | 732-832, 932-943, 1956-2012, 2437-2609 |
+| Experience & leveling (incl. master & pet experience) | ~255 | 1212-1311, 2071-2158, 2953-3020 |
+| Enter-world / leave-game orchestration | ~215 | 575-625, 1836-1866, 1477-1499, 2662-2752 |
+| Movement / walking / speed calculation | ~190 | 160-171, 1313-1428, 2057-2069, 2357-2400 |
+| Magic effect power-up factory | ~145 | 1588-1730 |
+| Storage handling (temp storage restore, item logging, destroy) | ~140 | 504-523, 1796-1807, 2246-2324, 2754-2780 |
+| Attribute glue & regeneration | ~115 | 1430-1475, 2326-2355, 2782-2844 |
+| Item durability accounting | ~105 | 2846-2951 |
+| Money & vault money | ~105 | 192-211, 970-1055 |
+| Persistence gateway | ~90 | 1868-1955 |
+| Observers / bucket map adapter | ~55 | 1501-1556 |
+| Summon | ~55 | 376-379, 1732-1786 |
+| Invisibility effects | ~46 | 1057-1102 |
+| Pet command manager | ~40 | 525-543, 1788-1794, 1826-1835 |
+| Messages / localization | ~45 | 686-730 |
+| Self defense queries | ~30 | 654-683 |
+| Nested helper classes | ~65 | 3032-3097 |
+
+Concrete smells worth calling out, because they drive the design below:
+
+* **Player knows about optional game features.** `GetSpawnGateOfCurrentMapAsync`
+  (2402) hardcodes duel rooms *and* guild war soccer maps.
+  `HandleMoveToNextSafezoneAsync` (2163) hardcodes mini-games and duels.
+  `OnDeathAsync` (2527) hardcodes the duel-partner respawn and guild war scores.
+* **Player reaches into a concrete plugin implementation.**
+  `WalkToAsync` (1362) does
+  `GameContext.FeaturePlugIns.GetPlugIn<SpeedHackDetectPlugIn>()?.Configuration`
+  to read `MaxAllowedWalkStartOffset` and then implements the rubberband policy
+  itself, although an `ISpeedHackCheatCheckPlugIn` point already exists.
+* **An explicit TODO asks for a strategy plugin.** `PetCommandManager` (528-542)
+  says "in the future we might use a factory as a strategy plugin here".
+* **An explicit TODO asks for a context object.** Line 296: `// TODO: TradeContext-object?`
+* **Rules that servers legitimately want to change are baked in**: PK state
+  transitions, the fixed 3 second respawn delay, the 20 % pet experience share,
+  the random-experience multipliers, shield-recovery-only-in-safezone.
+* **Duplication with NPCs**: `AttackByAsync`/`HitAsync` largely mirror
+  `AttackableNpcBase` (`src/GameLogic/NPC/AttackableNpcBase.cs:108,136`).
+
+## 2. Constraints and invariants (what must not break)
+
+1. **Two subclasses exist**: `RemotePlayer` (`src/GameServer/RemoteView/RemotePlayer.cs`)
+   and `OfflinePlayer` (`src/GameLogic/Offline/OfflinePlayer.cs`). They override
+   `InternalDisconnectAsync`, `DisposeAsyncCore`, `CreateViewPlugInContainer` and
+   `IsPlayerStoreOpeningAfterEnterSupported`. These four extension points stay.
+   (`TryAddMoney` and `RespawnAtAsync` are `virtual` but nobody overrides them —
+   they can lose `virtual` when they move.)
+2. **Source compatibility for runtime-compiled plugins.** OpenMU compiles custom
+   plugins from source at server start (see `PlugIns/Readme.md`). Any member we
+   turn into an extension method must live in the **same namespace**
+   (`MUnique.OpenMU.GameLogic`), otherwise third-party plugin sources stop
+   compiling for want of a `using`. With that rule, `player.Foo()` call sites are
+   unaffected — this is why extension methods are the cheapest tool here
+   (`ShowLocalizedBlueMessageAsync` alone has ~208 call sites).
+3. **The persistence lock contract** documented at `Player.cs:1885-1910` must
+   survive verbatim: re-entrancy per async flow, and no cross-player lock
+   acquisition ordering cycles. `tests/MUnique.OpenMU.Tests/PersistenceLockTest.cs`
+   guards this.
+4. **Plugin point method signatures may only return `void`, `Task` or `ValueTask`.**
+   `PlugInProxyTypeGenerator` (lines 132-138) only generates aggregation code for
+   those. Anything that needs a result uses a mutable args object — the existing
+   precedent is `SpeedHackCheckEventArgs`.
+5. **Plugins are unordered.** `PlugInContainerBase.ActivePlugIns` is a plain list
+   in discovery order. Any extraction whose order is observable by the client
+   (the enter-world view sequence) needs either explicit ordering support or
+   separate plugin points (see 3.1).
+6. **Extracted plugins are active by default** for existing databases (a missing
+   `PlugInConfiguration` means active; `DataInitializationBase:136` only marks
+   `IDisabledByDefault` types inactive). New configurations for existing installs
+   can be added via `IConfigurationUpdatePlugIn` if admins should be able to
+   toggle them.
+
+## 3. Toolbox — which mechanism for which kind of code
+
+| Mechanism | Use for | Cost |
+|---|---|---|
+| **Plugin point** (`[PlugInPoint]`) | game *rules/policy* that a server operator may want to change, add to, or turn off; anything optional (PK penalty, pet exp, respawn delay, map power-ups) | new interface + config entry; unordered; no return values |
+| **Strategy plugin** (`IStrategyPlugIn<TKey>`) | exactly one implementation must be picked by a key (pet command manager per pet item, spawn gate per context) | same, plus key design |
+| **Component object owned by `Player`** | cohesive stateful subsystems that are not configurable (movement, storages, persistence gate) — this is the pattern already used by `Walker`, `MagicEffectsList`, `ObserverToWorldViewAdapter` | cheap, no config surface |
+| **Extension methods** (same namespace) | pure or nearly-pure helpers (messages, money, requirement checks, power-up factories) | ~zero risk, call sites unchanged |
+| **Feature context object** | groups of properties that only make sense together (`TradeContext`, `GuildRequestContext`) | touches call sites |
+
+Rule of thumb used throughout this plan: **policy → plugin, mechanism → component,
+pure function → extension method.** Do not extract mechanism into plugins just
+because it is possible: everything that becomes a plugin can be deactivated by an
+admin, and deactivating "apply damage to health" is not a feature.
+
+### 3.1 Three infrastructure gaps to close first
+
+These are small, self-contained, and unblock the rest.
+
+**(a) Plugin ordering.** Add an optional order to plugin registration, e.g. an
+`[PlugInOrder(int)]` attribute (default 0) honored when
+`PlugInContainerBase` builds `ActivePlugIns`. Needed for the enter-world sequence
+where the client expects stats → inventory → skills → key config → quests.
+Alternative if ordering is unwanted: keep the ordered core in code and expose only
+"before"/"after" hooks. `tests/MUnique.OpenMU.PlugIns.Tests` covers this project
+well, so the change is cheap to verify.
+
+**(b) Per-player state for plugins.** Extracted plugins need per-player state
+(respawn cancellation token, map power-up disposables, potion cooldown) without
+adding fields to `Player`. Add a small typed bag:
+
+```csharp
+// Player.cs
+public T GetOrCreateState<T>() where T : new();
+public T? GetState<T>() where T : class;
+```
+
+backed by a `ConcurrentDictionary<Type, object>` that is cleared on character
+deselect and on dispose. This is the enabler that makes "as much logic as
+possible" extractable — without it, every new plugin wants a new `Player`
+property. (The existing `GameContext.SelfDefenseState` dictionary keyed by player
+tuples is the pattern to *avoid*: it needs manual cleanup.)
+
+**(c) Args-object convention.** Document and reuse the `SpeedHackCheckEventArgs`
+pattern for plugin points that need to produce a value
+(`SpawnGateSelectionArgs`, `ExperienceCalculationArgs`, `WalkRequestArgs`).
+
+## 4. Proposed new plugin points
+
+All of these live in `src/GameLogic/PlugIns/`, need a fresh `Guid` and a
+`[PlugInPoint]` attribute, following `IAttackableGotKilledPlugIn` as the template.
+
+| # | Interface | Signature | Logic that moves there |
+|---|---|---|---|
+| P1 | `IPlayerEnteringWorldPlugIn` | `ValueTask PlayerEnteringWorldAsync(Player player)` | the view-initialization block of `OnPlayerEnteredWorldAsync` (2717-2722): stats, inventory list, skill list, key config, quest state |
+| P2 | `IPlayerEnteredWorldPlugIn` | `ValueTask PlayerEnteredWorldAsync(Player player)` | the tail of `OnPlayerEnteredWorldAsync` (2733-2751): rotation update, pet behavior reset, MU Helper config, GM mark effect, player store restore |
+| P3 | `IPlayerLeavingGamePlugIn` | `ValueTask PlayerLeavingGameAsync(Player player)` | `RemoveFromGameAsync` steps (1840-1856): party leave-temporarily, safezone move, temporary storage restore, `OpenedNpc` reset |
+| P4 | `IPlayerSpawnGateSelectionPlugIn` | `ValueTask SelectSpawnGateAsync(Player player, SpawnGateSelectionArgs args)` | the duel and guild-war-soccer branches of `GetSpawnGateOfCurrentMapAsync` (2409-2428); later also mini games and castle siege |
+| P5 | `IExperienceCalculationPlugIn` | `ValueTask CalculateExperienceAsync(Player player, ExperienceCalculationArgs args)` | the multiplier chain in `CalculateExpAfterKill` (1271-1288): map multiplier, bonus rate, random min/max multipliers |
+| P6 | `IPlayerGainedExperiencePlugIn` | `ValueTask PlayerGainedExperienceAsync(Player player, int experience, IAttackable? killedObject, ExperienceType type)` | `AddPetExperienceAsync` (2953-3020) becomes `PetExperiencePlugIn`; also the natural hook for statistics/events |
+| P7 | `ICharacterMasterLevelUpPlugIn` | `void CharacterMasterLeveledUp(Player player)` | mirrors the existing `ICharacterLevelUpPlugIn` for the master level branch (2099-2107) |
+| P8 | `IAttackerHitTargetPlugIn` | `ValueTask AttackerHitTargetAsync(IAttacker attacker, IAttackable target, HitInfo hitInfo, SkillEntry? skill)` | `AfterHitTargetAsync` (809-814): weapon durability, `HealthLossAfterHit`; plus mace mastery stun (797-800) |
+| P9 | `IPlayerRegenerationPlugIn` | `ValueTask RegenerateAsync(Player player)` | `RegenerateAsync` (1433) and `RegenerateHeroStateAsync` (2326) split into `IntervalRegenerationPlugIn` and `HeroStateRecoveryPlugIn`; invoked from the existing recover timer in `GameContext.RecoverTimerElapsed` so the `RecoveryInterval` semantics stay intact |
+| P10 | `IPetCommandManagerFactoryPlugIn : IStrategyPlugIn<ItemIdentifier>` | `IPetCommandManager Create(Player player, Item pet)` | the `PetCommandManager` getter (528-542) — this is the TODO in the source |
+| P11 | `IWalkRequestValidationPlugIn` *(or a new method on `ISpeedHackCheatCheckPlugIn`)* | `ValueTask ValidateAsync(Player player, Memory<WalkingStep> steps, WalkRequestArgs args)` | the start-offset/rubberband check in `WalkToAsync` (1362-1389), removing the concrete `SpeedHackDetectPlugIn` reference from `Player` |
+
+Existing plugin points that should absorb logic instead of new ones being added:
+
+| Existing point | Logic that moves there |
+|---|---|
+| `IAttackableGotKilledPlugIn` | `AfterKilledPlayerAsync` (1962-2012) → `PlayerKillerStatePlugIn`; the death→respawn flow inside `OnDeathAsync` (2547-2580) → `RespawnAfterDeathPlugIn` (with the CTS in the per-player state bag); `RespawnOfDuelPartnerIfInDuelAsync` (2598) → `DuelPartnerRespawnPlugIn` |
+| `IAttackableGotHitPlugIn` | damage reflection (2484-2524), the defensive durability decrease (2872-2929), `FullyRecoverHealthAfterHitChance`/sleep-clearing (769-783). **Note:** the interface method is currently synchronous (`void AttackableGotHit`), so it needs an async sibling method before these can move |
+| `IObjectAddedToMapPlugIn` / `IObjectRemovedFromMapPlugIn` | the map `CharacterPowerUpDefinitions` handling in `RaisePlayerEnteredMap` (2632-2654). These points already fire for players (`GameContext.cs:219-226`) |
+| `IPeriodicTaskPlugIn` | nothing new — P9 keeps the separate recovery interval |
+
+## 5. Extraction plan per cluster
+
+### 5.1 Pure moves — extension methods, same namespace (no behavior change)
+
+| New file (`src/GameLogic/`) | Members moved | LOC |
+|---|---|---|
+| `PlayerMessageExtensions.cs` | `GetLocalizedMessage`, `ShowLocalizedBlueMessageAsync`, `ShowLocalizedGoldenMessageAsync`, `ShowBlueMessageAsync` | ~45 |
+| `PlayerMoneyExtensions.cs` | `TryAddMoney`, `TryRemoveMoney`, `TryDepositVaultMoney`, `TryTakeVaultMoney` (the `Money` property stays — it raises the view update) | ~85 |
+| `PlayerItemExtensions.cs` | `CompliesRequirements`, `DestroyInventoryItemAsync`, `InventorySize`, `LogInvalidInventoryItems`, `LogInvalidVaultItems` | ~80 |
+| `SelfDefenseExtensions.cs` (next to `SelfDefensePlugIn`) | `IsSelfDefenseActive`, `IsAnySelfDefenseActive` | ~30 |
+| `MagicEffectPowerUpFactory.cs` | both `CreateMagicEffectPowerUp` overloads; register as a service on `IGameContext` next to `IItemPowerUpFactory` so it becomes replaceable | ~145 |
+| `PlayerInvisibilityExtensions.cs` | `AddInvisibleEffectAsync`, `RemoveInvisibleEffectAsync` | ~46 |
+| `PlayerAppearanceData.cs`, `GMMagicEffectDefinition.cs`, `TemporaryItemStorage.cs` | the three nested classes | ~65 |
+
+**~500 lines out, zero behavioral risk, one PR.**
+
+### 5.2 Component extraction (owned by `Player`, delegating members kept)
+
+| Component | Members absorbed | LOC | Notes |
+|---|---|---|---|
+| `PlayerMovement` | `MoveAsync`, `WalkToAsync`, `GetDirectionsAsync`, `GetStepsAsync`, `StopWalkingAsync`, `GetStepDelay`, `GetClientMovementSpeed`, `ApplyMovementSpeedFactor`, `IsInClientSafezone`, `GetWalkableStepCount`, `_walker`, `_moveLock` | ~190 | `ISupportWalk`/`IMovable` members on `Player` become one-liners. Anti-cheat policy leaves via P11 |
+| `PlayerExperience` | `AddExpAfterKillAsync`, `CalculateExpAfterKill`, `AddExperienceAsync`, `AddMasterExperienceAsync` + cores, `_experienceLock` | ~190 | pet exp leaves via P6, multipliers via P5, master level-up notification via P7 |
+| `PlayerMapTransitions` | `TeleportAsync`, `TeleportToMapAsync`, `WarpToAsync`, `WarpToSafezoneAsync`, `RespawnAtAsync`, `ClientReadyAfterMapChangeAsync`, `PlaceAtGateAsync`, `TryRemoveFromCurrentMapAsync`, `RemoveFromCurrentMapAsync`, `GetSpawnGateOfCurrentMapAsync` | ~290 | feature-specific gates leave via P4 |
+| `PlayerStorages` | `RestoreTemporaryStorageItemsAsync`, backup inventory handling, storage creation from `OnPlayerEnteredWorldAsync` | ~120 | restore is triggered by P3 |
+| `PlayerPersistence` | `SaveProgressAsync`, both `RunPersistenceExclusiveAsync` overloads, `_persistenceLock`, `_persistenceLockHeld` | ~90 | keep `Player` delegates — 14 call sites and a documented invariant |
+| `PlayerSummon` | `Summon`, `CreateSummonedMonsterAsync`, `SummonDied`, `RemoveSummonAsync` + the summon branches in respawn/teleport code | ~70 | |
+| `PlayerAttributeHost` | `Attributes` creation, `OnAttributeValueChanged`, `OnTransformationSkinChanged`, `OnAmmunitionAmountChanged`, `SetReclaimableAttributes*`, `AddMissingStatAttributes` | ~130 | regeneration leaves via P9 |
+| `PlayerCombat` | `AttackByAsync`, `HitAsync`, `KillInstantlyAsync`, `ReflectDamageAsync`, `ApplyPoisonDamageAsync`, `ApplyBleedingDamageAsync`, `OnDeathAsync`, `AfterKilledMonsterAsync` | ~250 | **and** deduplicate against `AttackableNpcBase` — the shared parts belong in `AttackableExtensions` so NPC and player hit handling stop drifting |
+
+**~1,300 lines out.** `Player` keeps the interface members as thin delegates, so
+`IAttackable`/`IAttacker`/`ISupportWalk` implementations remain intact.
+
+### 5.3 Policy → plugins
+
+New plugin implementations created by the moves above (all in
+`src/GameLogic/PlugIns/`, all active by default):
+
+* `PlayerKillerStatePlugIn` — PK state increase, self-defense/rival-guild/duel exemptions.
+* `RespawnAfterDeathPlugIn` — 3 s delay, effect clearing, attribute restore, respawn at gate.
+* `DuelPartnerRespawnPlugIn` — the duel-specific half of the above.
+* `DamageReflectionPlugIn` — `DamageReflection` and `FullyReflectDamageAfterHitChance`.
+* `DefensiveItemDurabilityPlugIn` / `WeaponDurabilityPlugIn` / `PetDurabilityPlugIn`.
+* `PetExperiencePlugIn` — the 20 % share and pet level-ups.
+* `MapCharacterPowerUpPlugIn` — map-bound power-ups via the map plugin points.
+* `IntervalRegenerationPlugIn`, `HeroStateRecoveryPlugIn`.
+* `GameMasterMarkPlugIn`, `MuHelperConfigurationPlugIn`, `RestorePlayerStorePlugIn`,
+  `InitialViewUpdatePlugIn` — the enter-world steps (P1/P2).
+* `PartyLeaveTemporarilyPlugIn`, `MoveToSafezoneOnLeavePlugIn`,
+  `RestoreTemporaryStorageItemsPlugIn` — the leave-game steps (P3).
+* `DuelSpawnGatePlugIn`, `SoccerSpawnGatePlugIn` — spawn gate selection (P4).
+* `RavenCommandManagerFactoryPlugIn` — the pet factory TODO (P10).
+
+**~500 more lines out of `Player`**, and — more importantly — duels, guild wars,
+mini games and pets stop being referenced from `Player`.
+
+### 5.4 Property consolidation (optional, last)
+
+* `TradeContext` (the TODO at line 296): `TradingPartner`, `TradingMoney`,
+  `BackupInventory`, `TemporaryStorage`.
+* `GuildRequestContext`: `LastGuildRequester`, `PendingAllianceRequest`, `GuildStatus`.
+* Move to the state bag from 3.1(b): `PotionCooldownUntil`,
+  `LastRequestedPlayerStore`, `LoginResultOverride`, `MuHelperSettings`.
+* Keep as typed properties: `DuelRoom`, `CurrentMiniGame`, `Party`, `CurrentMap`,
+  `Attributes`, `Inventory` — hot paths and/or used nearly everywhere.
+
+## 6. Sequencing
+
+Each phase is independently mergeable and leaves the build green.
+
+| Phase | Content | Risk | Player.cs after |
+|---|---|---|---|
+| **0** | Characterization tests (see §7); plugin ordering (3.1a); per-player state bag (3.1b); args-object convention (3.1c) | low | 3,098 |
+| **1** | §5.1 extension-method moves + nested class files | very low | ~2,600 |
+| **2** | `PlayerMovement`, `PlayerPersistence`, `PlayerSummon`, `PlayerStorages` components | low | ~2,150 |
+| **3** | `PlayerExperience` + P5/P6/P7 + `PetExperiencePlugIn` | medium | ~1,850 |
+| **4** | `PlayerMapTransitions` + P4 spawn gate plugins | medium | ~1,550 |
+| **5** | `PlayerCombat` + `AttackableNpcBase` dedup + P8 and the `IAttackableGotHit`/`GotKilled` plugins (PK state, respawn, reflection, durability) | **high** | ~1,150 |
+| **6** | Enter-world / leave-game: P1, P2, P3 + `PlayerAttributeHost` + P9 regeneration | medium-high | ~900 |
+| **7** | §5.4 property consolidation, final cleanup of `virtual` members nobody overrides | low | ~700-800 |
+
+Phase 5 is the one to schedule carefully: combat touches PvP, duels, mini games
+and the offline bots, and it is where behavior differences would be noticed last.
+
+## 7. Verification
+
+Existing tests to lean on (and to extend *before* each phase touches its area):
+
+* `MasterSystemTest.cs`, `ExperienceRateSplitTest.cs` — phase 3.
+* `CharacterMoveTest.cs`, `SpeedHackAntiCheatTests.cs` — phases 2 and 4.
+* `PersistenceLockTest.cs` — phase 2.
+* `SelfDefensePlugInTest.cs`, `PKClearChatCommandPlugInTest.cs` — phase 5.
+* `Offline/CombatHandlerTests.cs`, `Offline/PetHandlerTests.cs`,
+  `BotSelfHealingTest.cs` — phases 3 and 5 (the offline bots exercise `Player`
+  end to end and are the most sensitive consumers).
+* `ObserverToWorldAdapterTest.cs`, `MoveItemActionTests.cs`, `ItemConsumptionTest.cs`.
+
+Gaps to fill in phase 0 (characterization tests, written against current behavior):
+
+1. Experience: normal/master/max-level/overflow paths and the level-up point grant.
+2. PK state machine: warning → 1st → 2nd stage, self-defense and rival-guild exemptions.
+3. Spawn gate selection: normal map, safezone map, duel, soccer.
+4. Walk request validation: accepted walk, too-large start offset (rubberband),
+   blocked path truncation.
+5. Temporary storage restore with and without a backup inventory.
+6. Durability: defensive item, weapon, pet, ammunition consumption to zero.
+
+Per phase: `dotnet build src/MUnique.OpenMU.sln` and
+`dotnet test tests/MUnique.OpenMU.Tests`. For phases 3 and 5, also run
+`tests/MUnique.OpenMU.GameLogic.Benchmarks` before/after — plugin points on the
+per-hit and per-kill paths add an iteration over the plugin proxy list.
+
+## 8. Risks and open questions
+
+1. **Deactivatable core behavior.** Every extracted plugin can be switched off in
+   the admin panel. Only *policy* should move; mechanism stays in components.
+   Open question: should there be a "not deactivatable" marker (the mirror image
+   of `IDisabledByDefault`) for plugins like `RespawnAfterDeathPlugIn`?
+2. **Ordering.** The enter-world view sequence is client-observable. If 3.1(a) is
+   rejected, phase 6 must use several narrow plugin points instead of one.
+3. **`IAttackableGotHitPlugIn` is synchronous.** Adding an async method to the
+   interface is a (source-)breaking change for external plugins — decide between
+   extending the interface and adding a sibling point.
+4. **Existing installations.** Extracted plugins are active by default when no
+   configuration row exists, so behavior is preserved. If they should be
+   toggleable in the admin panel for existing databases, add an
+   `IConfigurationUpdatePlugIn` in the same PR.
+5. **Extension method namespace.** All extension classes must stay in
+   `MUnique.OpenMU.GameLogic` (constraint §2.2).
+6. **Per-hit plugin overhead.** `GetPlugInPoint<T>()` returns a proxy iterating
+   all active plugins; on `HitAsync` this runs for every hit of every attacker.
+   Benchmark before committing to P8.
+7. **`Player` will still be ~800 lines** and that is fine: state, ~45 properties,
+   events, the interface implementations and the dispose logic are irreducible
+   without turning `Player` into an anemic bag and churning thousands of call
+   sites.

--- a/src/GameLogic/GameMasterMagicEffectDefinition.cs
+++ b/src/GameLogic/GameMasterMagicEffectDefinition.cs
@@ -1,0 +1,23 @@
+// <copyright file="GameMasterMagicEffectDefinition.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic;
+
+using MUnique.OpenMU.DataModel.Attributes;
+
+/// <summary>
+/// A <see cref="MagicEffectDefinition"/> used to apply the GM mark
+/// to a <see cref="Player"/> with <see cref="CharacterStatus.GameMaster"/> status.
+/// </summary>
+internal sealed class GameMasterMagicEffectDefinition : MagicEffectDefinition
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="GameMasterMagicEffectDefinition"/> class
+    /// with an empty power-up definitions list.
+    /// </summary>
+    public GameMasterMagicEffectDefinition()
+    {
+        this.PowerUpDefinitions = new List<PowerUpDefinition>(0);
+    }
+}

--- a/src/GameLogic/MagicEffectPowerUpExtensions.cs
+++ b/src/GameLogic/MagicEffectPowerUpExtensions.cs
@@ -1,0 +1,162 @@
+// <copyright file="MagicEffectPowerUpExtensions.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic;
+
+using MUnique.OpenMU.AttributeSystem;
+using MUnique.OpenMU.DataModel.Attributes;
+using MUnique.OpenMU.GameLogic.Attributes;
+
+/// <summary>
+/// Extensions which create the power-ups of magic effects for a <see cref="Player"/>,
+/// based on its current attribute values.
+/// </summary>
+public static class MagicEffectPowerUpExtensions
+{
+    /// <summary>
+    /// Creates the magic effect power up for the given skill entry.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="skillEntry">The skill entry.</param>
+    public static void CreateMagicEffectPowerUp(this Player player, SkillEntry skillEntry)
+    {
+        skillEntry.ThrowNotInitializedProperty(skillEntry.Skill is null, nameof(skillEntry.Skill));
+
+        var skill = skillEntry.Skill;
+
+        if (skill.MagicEffectDef?.PowerUpDefinitions.Any(d => d.Boost is null) ?? true)
+        {
+            throw new InvalidOperationException($"Skill {skill.Name} ({skill.Number}) has no magic effect definition or is without a PowerUpDefinition.");
+        }
+
+        if (skill.MagicEffectDef.Duration is null)
+        {
+            throw new InvalidOperationException($"Skill {skill.Name} ({skill.Number}) has no duration in MagicEffectDef.");
+        }
+
+        var result = new (AttributeDefinition Target, IElement BuffPowerUp)[skill.MagicEffectDef.PowerUpDefinitions.Count];
+        var resultPvp = new (AttributeDefinition Target, IElement BuffPowerUp)[skill.MagicEffectDef.PowerUpDefinitionsPvp.Count];
+        var durationElement = player.Attributes!.CreateDurationElement(skill.MagicEffectDef.Duration);
+        var durationElementPvp = skill.MagicEffectDef.DurationPvp is { } durationPvp ? player.Attributes!.CreateDurationElement(durationPvp) : durationElement;
+        var chanceElement = skill.MagicEffectDef.Chance is { } chance ? player.Attributes!.CreateChanceElement(chance) : new ConstantElement(1.0f);
+        var chanceElementPvp = skill.MagicEffectDef.ChancePvp is { } chancePvp ? player.Attributes!.CreateChanceElement(chancePvp) : chanceElement;
+        AddSkillPowersToResult(skill.MagicEffectDef.PowerUpDefinitions, ref result);
+        AddSkillPowersToResult(skill.MagicEffectDef.PowerUpDefinitionsPvp, ref resultPvp);
+        skillEntry.PowerUpDuration = durationElement;
+        skillEntry.PowerUpDurationPvp = durationElementPvp;
+        skillEntry.PowerUpChance = chanceElement;
+        skillEntry.PowerUpChancePvp = chanceElementPvp;
+        skillEntry.PowerUps = result;
+        skillEntry.PowerUpsPvp = resultPvp.Count() > 0 ? resultPvp : result;
+
+        if (skillEntry.EnsureSkillAttributes(player.Attributes!) is { } skillAttributes
+            && skillAttributes[Stats.SleepStrBonusChance] is float bonusChance
+            && bonusChance > 0)
+        {
+            skillEntry.PowerUpChance = new CombinedElement(skillEntry.PowerUpChance, new ConstantElement(bonusChance));
+            skillEntry.PowerUpChancePvp = new CombinedElement(skillEntry.PowerUpChancePvp, new ConstantElement(bonusChance));
+        }
+
+        void AddSkillPowersToResult(ICollection<PowerUpDefinition> powerUps, ref (AttributeDefinition Target, IElement BuffPowerUp)[] result)
+        {
+            if (powerUps.Count() == 0)
+            {
+                return;
+            }
+
+            int i = 0;
+            var durationExtended = false;
+            foreach (var powerUpDef in powerUps)
+            {
+                IElement powerUp = player.Attributes!.CreateElement(powerUpDef);
+                if (skillEntry.Level > 0)
+                {
+                    foreach (var masterSkillEntry in GetMasterSkillEntries(skillEntry))
+                    {
+                        var extendsDuration = masterSkillEntry.Skill?.MasterDefinition?.ExtendsDuration ?? false;
+                        if (extendsDuration && !durationExtended)
+                        {
+                            var value = masterSkillEntry.CalculateValue();
+                            if (value < 1)
+                            {
+                                value *= 100;
+                            }
+
+                            durationElement = new CombinedElement(durationElement, new ConstantElement(value));
+                            durationElementPvp = new CombinedElement(durationElementPvp, new ConstantElement(value));
+                        }
+
+                        if (masterSkillEntry.Skill?.MasterDefinition?.TargetAttribute is not null)
+                        {
+                            powerUp = AppedMasterSkillPowerUp(masterSkillEntry, powerUpDef, powerUp);
+                        }
+                    }
+
+                    // After the first iteration all possible duration extensions have been applied
+                    durationExtended = true;
+                }
+
+                result[i] = (powerUpDef.TargetAttribute!, powerUp);
+                i++;
+            }
+        }
+
+        IEnumerable<SkillEntry> GetMasterSkillEntries(SkillEntry masterSkillEntry)
+        {
+            yield return masterSkillEntry;
+
+            foreach (var masterSkill in skillEntry.Skill.GetBaseSkills(true))
+            {
+                yield return player.SkillList!.GetSkill((ushort)masterSkill.Number)!;
+            }
+        }
+
+        IElement AppedMasterSkillPowerUp(SkillEntry masterSkillEntry, PowerUpDefinition powerUpDef, IElement powerUp)
+        {
+            var masterSkillDefinition = masterSkillEntry.Skill!.MasterDefinition!;
+
+            if (masterSkillDefinition.TargetAttribute == powerUpDef.TargetAttribute
+                && masterSkillDefinition.Aggregation == powerUp.AggregateType)
+            {
+                var additionalValue = new SimpleElement(masterSkillEntry.CalculateValue(), masterSkillDefinition.Aggregation);
+                powerUp = new CombinedElement(powerUp, additionalValue);
+            }
+
+            return powerUp;
+        }
+    }
+
+    /// <summary>
+    /// Creates the magic effect power up for the given definition.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="magicEffectDefinition">The definition for a magic effect.</param>
+    /// <returns>A tuple containing the duration element and the power-up elements.</returns>
+    public static (IElement DurationInSeconds, (AttributeDefinition Target, IElement BuffPowerUp)[] PowerUps) CreateMagicEffectPowerUp(this Player player, MagicEffectDefinition magicEffectDefinition)
+    {
+        ArgumentNullException.ThrowIfNull(magicEffectDefinition);
+
+        if (magicEffectDefinition.PowerUpDefinitions.Any(d => d.Boost is null))
+        {
+            throw new InvalidOperationException($"Magic effect definition {magicEffectDefinition.Name} ({magicEffectDefinition.Number}) is without a PowerUpDefinition.");
+        }
+
+        if (magicEffectDefinition.Duration is null)
+        {
+            throw new InvalidOperationException($"Magic effect definition {magicEffectDefinition.Name} ({magicEffectDefinition.Number}) has no duration.");
+        }
+
+        int i = 0;
+        var result = new (AttributeDefinition Target, IElement BuffPowerUp)[magicEffectDefinition.PowerUpDefinitions.Count];
+        foreach (var powerUpDef in magicEffectDefinition.PowerUpDefinitions)
+        {
+            IElement powerUp = player.Attributes!.CreateElement(powerUpDef);
+
+            result[i] = (powerUpDef.TargetAttribute!, powerUp);
+            i++;
+        }
+
+        return (player.Attributes!.CreateDurationElement(magicEffectDefinition.Duration), result);
+    }
+}

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -8,8 +8,6 @@ using System;
 using System.Globalization;
 using System.Threading;
 using MUnique.OpenMU.AttributeSystem;
-using MUnique.OpenMU.DataModel.Attributes;
-using MUnique.OpenMU.DataModel.Configuration.Items;
 using MUnique.OpenMU.GameLogic.Attributes;
 using MUnique.OpenMU.GameLogic.GuildWar;
 using MUnique.OpenMU.GameLogic.MiniGames;
@@ -21,7 +19,6 @@ using MUnique.OpenMU.GameLogic.PlayerActions.Items;
 using MUnique.OpenMU.GameLogic.PlayerActions.Skills;
 using MUnique.OpenMU.GameLogic.PlayerActions.Trade;
 using MUnique.OpenMU.GameLogic.PlugIns;
-using MUnique.OpenMU.GameLogic.Properties;
 using MUnique.OpenMU.GameLogic.Views;
 using MUnique.OpenMU.GameLogic.Views.Character;
 using MUnique.OpenMU.GameLogic.Views.Guild;
@@ -43,7 +40,7 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
 {
     private const double WalkMovementSpeed = 12.0;
 
-    private static readonly MagicEffectDefinition GMEffect = new GMMagicEffectDefinition
+    private static readonly MagicEffectDefinition GMEffect = new GameMasterMagicEffectDefinition
     {
         InformObservers = true,
         Name = "GM MARK",
@@ -71,7 +68,7 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
 
     private readonly Walker _walker;
 
-    private readonly AppearanceDataAdapter _appearanceData;
+    private readonly PlayerAppearanceData _appearanceData;
 
     private readonly ObserverToWorldViewAdapter _observerToWorldViewAdapter;
 
@@ -109,7 +106,7 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         this._walker = new Walker(this, this.GetStepDelay);
 
         this.MagicEffectList = new MagicEffectsList(this);
-        this._appearanceData = new AppearanceDataAdapter(this);
+        this._appearanceData = new PlayerAppearanceData(this);
         this.PlayerState.StateChanged += async args => await (this.GameContext.PlugInManager.GetPlugInPoint<IPlayerStateChangedPlugIn>()?.PlayerStateChangedAsync(this, args.PreviousState, args.CurrentStateState) ?? ValueTask.CompletedTask).ConfigureAwait(false);
         this.PlayerState.StateChanges += async args => await (this.GameContext.PlugInManager.GetPlugInPoint<IPlayerStateChangingPlugIn>()?.PlayerStateChangingAsync(this, args) ?? ValueTask.CompletedTask).ConfigureAwait(false);
         this._observerToWorldViewAdapter = new ObserverToWorldViewAdapter(this, this.InfoRange);
@@ -651,84 +648,6 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         await this.OnDeathAsync(null).ConfigureAwait(false);
     }
 
-    /// <summary>
-    /// Determines whether the self defense is active for the specified attacker.
-    /// </summary>
-    /// <param name="attacker">The attacker.</param>
-    /// <returns>
-    ///   <c>true</c> if the self defense is active for the specified attacker; otherwise, <c>false</c>.
-    /// </returns>
-    public bool IsSelfDefenseActive(Player attacker)
-    {
-        if (this.GameContext.SelfDefenseState.TryGetValue((attacker, this), out var timeout))
-        {
-            return timeout > DateTime.UtcNow;
-        }
-
-        return false;
-    }
-
-    /// <summary>
-    /// Determines whether the self-defense is active for any attacker.
-    /// </summary>
-    /// <returns>
-    ///   <c>true</c> if any self-defense is active; otherwise, <c>false</c>.
-    /// </returns>
-    public bool IsAnySelfDefenseActive()
-    {
-        var selfDefenses = this.GameContext.SelfDefenseState.Keys.Where(c => c.Attacker == this).ToList();
-        return selfDefenses.Any(sd =>
-            this.GameContext.SelfDefenseState.TryGetValue(sd, out var timeout)
-            && timeout >= DateTime.UtcNow);
-    }
-
-    /// <summary>
-    /// Gets the localized message.
-    /// </summary>
-    /// <param name="resourceName">Name of the resource.</param>
-    /// <param name="formatArguments">The format arguments.</param>
-    /// <returns>The localized message.</returns>
-    public string GetLocalizedMessage(string resourceName, params ReadOnlySpan<object?> formatArguments)
-    {
-        if (formatArguments.Length > 0)
-        {
-            return string.Format(PlayerMessage.ResourceManager.GetString(resourceName, this.Culture) ?? string.Empty, formatArguments);
-        }
-
-        return PlayerMessage.ResourceManager.GetString(resourceName, this.Culture) ?? string.Empty;
-    }
-
-    /// <summary>
-    /// Easier way to show a localized blue message to the player.
-    /// </summary>
-    /// <param name="messageKey">The message resource key.</param>
-    /// <param name="arguments">The parameters for the message.</param>
-    public ValueTask ShowLocalizedBlueMessageAsync(string messageKey, params ReadOnlySpan<object?> arguments)
-    {
-        var message = this.GetLocalizedMessage(messageKey, arguments);
-        return this.InvokeViewPlugInAsync<IShowMessagePlugIn>(p => p.ShowMessageAsync(message, MessageType.BlueNormal));
-    }
-
-    /// <summary>
-    /// Easier way to show a localized golden message to the player.
-    /// </summary>
-    /// <param name="messageKey">The message resource key.</param>
-    /// <param name="arguments">The parameters for the message.</param>
-    public ValueTask ShowLocalizedGoldenMessageAsync(string messageKey, params ReadOnlySpan<object?> arguments)
-    {
-        var message = this.GetLocalizedMessage(messageKey, arguments);
-        return this.InvokeViewPlugInAsync<IShowMessagePlugIn>(p => p.ShowMessageAsync(message, MessageType.GoldenCenter));
-    }
-
-    /// <summary>
-    /// Easier way to show a blue message to the player.
-    /// </summary>
-    /// <param name="message">The message resource key.</param>
-    public ValueTask ShowBlueMessageAsync(string message)
-    {
-        return this.InvokeViewPlugInAsync<IShowMessagePlugIn>(p => p.ShowMessageAsync(message, MessageType.BlueNormal));
-    }
-
     /// <inheritdoc/>
     public async ValueTask<HitInfo?> AttackByAsync(IAttacker attacker, SkillEntry? skill, bool isCombo, double damageFactor = 1.0, bool? isFinalStreakHit = null)
     {
@@ -946,160 +865,6 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
     /// Resets the appearance cache.
     /// </summary>
     public void OnAppearanceChanged() => this._appearanceData.RaiseAppearanceChanged();
-
-    /// <summary>
-    /// Determines whether the player complies with the requirements of the specified item.
-    /// </summary>
-    /// <param name="item">The item.</param>
-    /// <returns><c>True</c>, if the player complies with the requirements of the specified item; Otherwise, <c>false</c>.</returns>
-    public bool CompliesRequirements(Item item)
-    {
-        item.ThrowNotInitializedProperty(item.Definition is null, nameof(item.Definition));
-
-        foreach (var requirement in item.Definition.Requirements.Select(item.GetRequirement))
-        {
-            if (this.Attributes![requirement.Attr] < requirement.Value)
-            {
-                return false;
-            }
-        }
-
-        return item.Definition.QualifiedCharacters.Contains(this.SelectedCharacter!.CharacterClass!);
-    }
-
-    /// <summary>
-    /// Tries to remove the money from the player inventory.
-    /// </summary>
-    /// <param name="value">The value that should be removed.</param>
-    /// <returns><c>True</c>, if the player inventory had enough money to remove; Otherwise, <c>false</c>.</returns>
-    public bool TryRemoveMoney(int value)
-    {
-        if (this.Money < value)
-        {
-            return false;
-        }
-
-        this.Money = checked(this.Money - value);
-        return true;
-    }
-
-    /// <summary>
-    /// Tries to deposit the money from the player inventory.
-    /// </summary>
-    /// <param name="value">The value that should be retrieved from the vault.</param>
-    /// <returns><c>True</c>, if the player inventory had enough money to move; Otherwise, <c>false</c>.</returns>
-    public bool TryDepositVaultMoney(int value)
-    {
-        if (this.Vault is null)
-        {
-            return false;
-        }
-
-        if (this.Vault.ItemStorage.Money + value > this.GameContext?.Configuration?.MaximumVaultMoney)
-        {
-            return false;
-        }
-
-        if (this.TryRemoveMoney(value))
-        {
-            return this.Vault.TryAddMoney(value);
-        }
-
-        return false;
-    }
-
-    /// <summary>
-    /// Tries to take the money from the vault.
-    /// </summary>
-    /// <param name="value">The value that should be retrieved from the vault.</param>
-    /// <returns><c>True</c>, if the vault had enough money to move and player inventory isn't maximum; Otherwise, <c>false</c>.</returns>
-    public bool TryTakeVaultMoney(int value)
-    {
-        if (this.Vault is null)
-        {
-            return false;
-        }
-
-        if (this.Money + value > this.GameContext?.Configuration?.MaximumInventoryMoney)
-        {
-            return false;
-        }
-
-        if (this.Vault.TryRemoveMoney(value))
-        {
-            return this.TryAddMoney(value);
-        }
-
-        return false;
-    }
-
-    /// <summary>
-    /// Tries to add the money from the player inventory.
-    /// </summary>
-    /// <param name="value">The value that should be added.</param>
-    /// <returns><c>True</c>, if the player inventory had space to add money; Otherwise, <c>false</c>.</returns>
-    public virtual bool TryAddMoney(int value)
-    {
-        if (this.Money + value > this.GameContext?.Configuration?.MaximumInventoryMoney)
-        {
-            return false;
-        }
-
-        if (this.Money + value < 0)
-        {
-            return false;
-        }
-
-        this.Money = checked(this.Money + value);
-        return true;
-    }
-
-    /// <summary>
-    /// Adds the invisible effect.
-    /// </summary>
-    public async ValueTask AddInvisibleEffectAsync()
-    {
-        var invisibleEffect = this.GameContext.Configuration.MagicEffects.FirstOrDefault(e => e.PowerUpDefinitions.Any(e => e.TargetAttribute == Stats.IsInvisible));
-        if (invisibleEffect is null)
-        {
-            this.Logger.LogError("Invisible effect not found!");
-        }
-        else
-        {
-            var (duration, powerUps) = this.CreateMagicEffectPowerUp(invisibleEffect);
-            var magicEffect = new MagicEffect(TimeSpan.FromSeconds(duration.Value), invisibleEffect, powerUps.Select(p => new MagicEffect.ElementWithTarget(p.BuffPowerUp, p.Target)).ToArray());
-            await this.MagicEffectList.AddEffectAsync(magicEffect).ConfigureAwait(false);
-
-            if (this._currentMap is { } currentMap)
-            {
-                await currentMap.RespawnAsync(this).ConfigureAwait(false);
-            }
-        }
-    }
-
-    /// <summary>
-    /// Removes the invisible effect.
-    /// </summary>
-    public async ValueTask RemoveInvisibleEffectAsync()
-    {
-        var invisibleEffect = this.GameContext.Configuration.MagicEffects.FirstOrDefault(e => e.PowerUpDefinitions.Any(e => e.TargetAttribute == Stats.IsInvisible));
-        if (invisibleEffect is null)
-        {
-            return;
-        }
-
-        var activeEffect = this.MagicEffectList.ActiveEffects.Values.FirstOrDefault(e => e.Definition == invisibleEffect);
-        if (activeEffect is null)
-        {
-            return;
-        }
-
-        await activeEffect.DisposeAsync().ConfigureAwait(false);
-        if (this._currentMap is { } currentMap)
-        {
-            await currentMap.RespawnAsync(this).ConfigureAwait(false);
-        }
-    }
 
     /// <summary>
     /// Moves the player to the specified gate.
@@ -1586,150 +1351,6 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
     }
 
     /// <summary>
-    /// Creates the magic effect power up for the given skill entry.
-    /// </summary>
-    /// <param name="skillEntry">The skill entry.</param>
-    public void CreateMagicEffectPowerUp(SkillEntry skillEntry)
-    {
-        skillEntry.ThrowNotInitializedProperty(skillEntry.Skill is null, nameof(skillEntry.Skill));
-
-        var skill = skillEntry.Skill;
-
-        if (skill.MagicEffectDef?.PowerUpDefinitions.Any(d => d.Boost is null) ?? true)
-        {
-            throw new InvalidOperationException($"Skill {skill.Name} ({skill.Number}) has no magic effect definition or is without a PowerUpDefinition.");
-        }
-
-        if (skill.MagicEffectDef.Duration is null)
-        {
-            throw new InvalidOperationException($"Skill {skill.Name} ({skill.Number}) has no duration in MagicEffectDef.");
-        }
-
-        var result = new (AttributeDefinition Target, IElement BuffPowerUp)[skill.MagicEffectDef.PowerUpDefinitions.Count];
-        var resultPvp = new (AttributeDefinition Target, IElement BuffPowerUp)[skill.MagicEffectDef.PowerUpDefinitionsPvp.Count];
-        var durationElement = this.Attributes!.CreateDurationElement(skill.MagicEffectDef.Duration);
-        var durationElementPvp = skill.MagicEffectDef.DurationPvp is { } durationPvp ? this.Attributes!.CreateDurationElement(durationPvp) : durationElement;
-        var chanceElement = skill.MagicEffectDef.Chance is { } chance ? this.Attributes!.CreateChanceElement(chance) : new ConstantElement(1.0f);
-        var chanceElementPvp = skill.MagicEffectDef.ChancePvp is { } chancePvp ? this.Attributes!.CreateChanceElement(chancePvp) : chanceElement;
-        AddSkillPowersToResult(skill.MagicEffectDef.PowerUpDefinitions, ref result);
-        AddSkillPowersToResult(skill.MagicEffectDef.PowerUpDefinitionsPvp, ref resultPvp);
-        skillEntry.PowerUpDuration = durationElement;
-        skillEntry.PowerUpDurationPvp = durationElementPvp;
-        skillEntry.PowerUpChance = chanceElement;
-        skillEntry.PowerUpChancePvp = chanceElementPvp;
-        skillEntry.PowerUps = result;
-        skillEntry.PowerUpsPvp = resultPvp.Count() > 0 ? resultPvp : result;
-
-        if (skillEntry.EnsureSkillAttributes(this.Attributes!) is { } skillAttributes
-            && skillAttributes[Stats.SleepStrBonusChance] is float bonusChance
-            && bonusChance > 0)
-        {
-            skillEntry.PowerUpChance = new CombinedElement(skillEntry.PowerUpChance, new ConstantElement(bonusChance));
-            skillEntry.PowerUpChancePvp = new CombinedElement(skillEntry.PowerUpChancePvp, new ConstantElement(bonusChance));
-        }
-
-        void AddSkillPowersToResult(ICollection<PowerUpDefinition> powerUps, ref (AttributeDefinition Target, IElement BuffPowerUp)[] result)
-        {
-            if (powerUps.Count() == 0)
-            {
-                return;
-            }
-
-            int i = 0;
-            var durationExtended = false;
-            foreach (var powerUpDef in powerUps)
-            {
-                IElement powerUp = this.Attributes!.CreateElement(powerUpDef);
-                if (skillEntry.Level > 0)
-                {
-                    foreach (var masterSkillEntry in GetMasterSkillEntries(skillEntry))
-                    {
-                        var extendsDuration = masterSkillEntry.Skill?.MasterDefinition?.ExtendsDuration ?? false;
-                        if (extendsDuration && !durationExtended)
-                        {
-                            var value = masterSkillEntry.CalculateValue();
-                            if (value < 1)
-                            {
-                                value *= 100;
-                            }
-
-                            durationElement = new CombinedElement(durationElement, new ConstantElement(value));
-                            durationElementPvp = new CombinedElement(durationElementPvp, new ConstantElement(value));
-                        }
-
-                        if (masterSkillEntry.Skill?.MasterDefinition?.TargetAttribute is not null)
-                        {
-                            powerUp = AppedMasterSkillPowerUp(masterSkillEntry, powerUpDef, powerUp);
-                        }
-                    }
-
-                    // After the first iteration all possible duration extensions have been applied
-                    durationExtended = true;
-                }
-
-                result[i] = (powerUpDef.TargetAttribute!, powerUp);
-                i++;
-            }
-        }
-
-        IEnumerable<SkillEntry> GetMasterSkillEntries(SkillEntry masterSkillEntry)
-        {
-            yield return masterSkillEntry;
-
-            foreach (var masterSkill in skillEntry.Skill.GetBaseSkills(true))
-            {
-                yield return this.SkillList!.GetSkill((ushort)masterSkill.Number)!;
-            }
-        }
-
-        IElement AppedMasterSkillPowerUp(SkillEntry masterSkillEntry, PowerUpDefinition powerUpDef, IElement powerUp)
-        {
-            var masterSkillDefinition = masterSkillEntry.Skill!.MasterDefinition!;
-
-            if (masterSkillDefinition.TargetAttribute == powerUpDef.TargetAttribute
-                && masterSkillDefinition.Aggregation == powerUp.AggregateType)
-            {
-                var additionalValue = new SimpleElement(masterSkillEntry.CalculateValue(), masterSkillDefinition.Aggregation);
-                powerUp = new CombinedElement(powerUp, additionalValue);
-            }
-
-            return powerUp;
-        }
-    }
-
-    /// <summary>
-    /// Creates the magic effect power up for the given definition.
-    /// </summary>
-    /// <param name="magicEffectDefinition">The definition for a magic effect.</param>
-    /// <returns>A tuple containing the duration element and the power-up elements.</returns>
-    public (IElement DurationInSeconds, (AttributeDefinition Target, IElement BuffPowerUp)[] PowerUps) CreateMagicEffectPowerUp(MagicEffectDefinition magicEffectDefinition)
-    {
-        ArgumentNullException.ThrowIfNull(magicEffectDefinition);
-
-        if (magicEffectDefinition.PowerUpDefinitions.Any(d => d.Boost is null))
-        {
-            throw new InvalidOperationException($"Magic effect definition {magicEffectDefinition.Name} ({magicEffectDefinition.Number}) is without a PowerUpDefinition.");
-        }
-
-        if (magicEffectDefinition.Duration is null)
-        {
-            throw new InvalidOperationException($"Magic effect definition {magicEffectDefinition.Name} ({magicEffectDefinition.Number}) has no duration.");
-        }
-
-        int i = 0;
-        var result = new (AttributeDefinition Target, IElement BuffPowerUp)[magicEffectDefinition.PowerUpDefinitions.Count];
-        foreach (var powerUpDef in magicEffectDefinition.PowerUpDefinitions)
-        {
-            IElement powerUp = this.Attributes!.CreateElement(powerUpDef);
-
-            result[i] = (powerUpDef.TargetAttribute!, powerUp);
-            i++;
-        }
-
-        return (this.Attributes!.CreateDurationElement(magicEffectDefinition.Duration), result);
-    }
-
-    /// <summary>
     /// Creates a summoned monster for the player.
     /// </summary>
     /// <param name="definition">The definition.</param>
@@ -1792,18 +1413,6 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
     {
         this._petCommandManager?.Dispose();
         this._petCommandManager = null;
-    }
-
-    /// <summary>
-    /// Destroys an item of the <see cref="Inventory"/>.
-    /// </summary>
-    /// <param name="item">The item.</param>
-    public async ValueTask DestroyInventoryItemAsync(Item item)
-    {
-        await this.Inventory!.RemoveItemAsync(item).ConfigureAwait(false);
-        await this.PersistenceContext.DeleteAsync(item).ConfigureAwait(false);
-        await this.InvokeViewPlugInAsync<IItemRemovedPlugIn>(p => p.RemoveItemAsync(item.ItemSlot)).ConfigureAwait(false);
-        this.GameContext.PlugInManager.GetPlugInPoint<IItemDestroyedPlugIn>()?.ItemDestroyed(item);
     }
 
     /// <inheritdoc/>
@@ -2751,34 +2360,6 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         await openStoreAction.RestoreAfterEnterWorldAsync(this, this.IsPlayerStoreOpeningAfterEnterSupported).ConfigureAwait(false);
     }
 
-    private void LogInvalidVaultItems()
-    {
-        var invalidItems = this.Account?.Vault?.Items.Where(i => i.Definition is null);
-        if (invalidItems is null)
-        {
-            return;
-        }
-
-        foreach (var item in invalidItems)
-        {
-            this.Logger.LogWarning("Account {name} has item without definition in vault, Slot: {slot}, ID: {id}", this.Account?.LoginName, item.ItemSlot, item.GetId());
-        }
-    }
-
-    private void LogInvalidInventoryItems()
-    {
-        var invalidItems = this.SelectedCharacter?.Inventory?.Items.Where(i => i.Definition is null);
-        if (invalidItems is null)
-        {
-            return;
-        }
-
-        foreach (var item in invalidItems)
-        {
-            this.Logger.LogWarning("Character {name} has item without definition in inventory, Slot: {slot}, ID: {id}", this.SelectedCharacter?.Name, item.ItemSlot, item.GetId());
-        }
-    }
-
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Usage", "VSTHRD100:Avoid async void methods", Justification = "Catching all Exceptions.")]
     private async void OnTransformationSkinChanged(object? sender, EventArgs args)
     {
@@ -3026,73 +2607,6 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         {
             var cancelAction = new TradeCancelAction();
             await cancelAction.CancelTradeAsync(this).ConfigureAwait(false);
-        }
-    }
-
-    /// <summary>
-    /// A <see cref="MagicEffectDefinition"/> used to apply the GM mark
-    /// to a <see cref="Player"/> with <see cref="CharacterStatus.GameMaster"/> status.
-    /// </summary>
-    private protected sealed class GMMagicEffectDefinition : MagicEffectDefinition
-    {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="GMMagicEffectDefinition"/> class
-        /// with an empty power-up definitions list.
-        /// </summary>
-        public GMMagicEffectDefinition()
-        {
-            this.PowerUpDefinitions = new List<PowerUpDefinition>(0);
-        }
-    }
-
-    private sealed class TemporaryItemStorage : ItemStorage
-    {
-        public TemporaryItemStorage()
-        {
-            this.Items = new List<Item>();
-        }
-    }
-
-    private class AppearanceDataAdapter : IAppearanceData
-    {
-        private readonly Player _player;
-        private bool? _fullAncientSetEquipped;
-
-        public AppearanceDataAdapter(Player player)
-        {
-            this._player = player;
-        }
-
-        public event EventHandler? AppearanceChanged;
-
-        public CharacterClass? CharacterClass => this._player.SelectedCharacter?.CharacterClass;
-
-        public CharacterStatus CharacterStatus => this._player.SelectedCharacter?.CharacterStatus ?? default;
-
-        public CharacterPose Pose => this._player.SelectedCharacter?.Pose ?? default;
-
-        public bool FullAncientSetEquipped => (this._fullAncientSetEquipped ??= this._player.SelectedCharacter?.HasFullAncientSetEquipped()) ?? false;
-
-        public IEnumerable<ItemAppearance> EquippedItems
-        {
-            get
-            {
-                if (this._player.Inventory != null)
-                {
-                    return this._player.Inventory.EquippedItems.Select(item => item.GetAppearance());
-                }
-
-                return Enumerable.Empty<ItemAppearance>();
-            }
-        }
-
-        /// <summary>
-        /// Raises the <see cref="AppearanceChanged"/> event.
-        /// </summary>
-        public void RaiseAppearanceChanged()
-        {
-            this._fullAncientSetEquipped = null;
-            this.AppearanceChanged?.Invoke(this, EventArgs.Empty);
         }
     }
 }

--- a/src/GameLogic/PlayerAppearanceData.cs
+++ b/src/GameLogic/PlayerAppearanceData.cs
@@ -1,0 +1,62 @@
+// <copyright file="PlayerAppearanceData.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic;
+
+/// <summary>
+/// The appearance data of a <see cref="Player"/>, which is based on the
+/// currently selected character and its equipped items.
+/// </summary>
+internal sealed class PlayerAppearanceData : IAppearanceData
+{
+    private readonly Player _player;
+    private bool? _fullAncientSetEquipped;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PlayerAppearanceData"/> class.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    public PlayerAppearanceData(Player player)
+    {
+        this._player = player;
+    }
+
+    /// <inheritdoc />
+    public event EventHandler? AppearanceChanged;
+
+    /// <inheritdoc />
+    public CharacterClass? CharacterClass => this._player.SelectedCharacter?.CharacterClass;
+
+    /// <inheritdoc />
+    public CharacterStatus CharacterStatus => this._player.SelectedCharacter?.CharacterStatus ?? default;
+
+    /// <inheritdoc />
+    public CharacterPose Pose => this._player.SelectedCharacter?.Pose ?? default;
+
+    /// <inheritdoc />
+    public bool FullAncientSetEquipped => (this._fullAncientSetEquipped ??= this._player.SelectedCharacter?.HasFullAncientSetEquipped()) ?? false;
+
+    /// <inheritdoc />
+    public IEnumerable<ItemAppearance> EquippedItems
+    {
+        get
+        {
+            if (this._player.Inventory != null)
+            {
+                return this._player.Inventory.EquippedItems.Select(item => item.GetAppearance());
+            }
+
+            return Enumerable.Empty<ItemAppearance>();
+        }
+    }
+
+    /// <summary>
+    /// Raises the <see cref="AppearanceChanged"/> event.
+    /// </summary>
+    public void RaiseAppearanceChanged()
+    {
+        this._fullAncientSetEquipped = null;
+        this.AppearanceChanged?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/GameLogic/PlayerInvisibilityExtensions.cs
+++ b/src/GameLogic/PlayerInvisibilityExtensions.cs
@@ -1,0 +1,62 @@
+// <copyright file="PlayerInvisibilityExtensions.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic;
+
+using MUnique.OpenMU.GameLogic.Attributes;
+
+/// <summary>
+/// Extensions to add and remove the invisibility effect of a <see cref="Player"/>.
+/// </summary>
+public static class PlayerInvisibilityExtensions
+{
+    /// <summary>
+    /// Adds the invisible effect.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    public static async ValueTask AddInvisibleEffectAsync(this Player player)
+    {
+        var invisibleEffect = player.GameContext.Configuration.MagicEffects.FirstOrDefault(e => e.PowerUpDefinitions.Any(e => e.TargetAttribute == Stats.IsInvisible));
+        if (invisibleEffect is null)
+        {
+            player.Logger.LogError("Invisible effect not found!");
+        }
+        else
+        {
+            var (duration, powerUps) = player.CreateMagicEffectPowerUp(invisibleEffect);
+            var magicEffect = new MagicEffect(TimeSpan.FromSeconds(duration.Value), invisibleEffect, powerUps.Select(p => new MagicEffect.ElementWithTarget(p.BuffPowerUp, p.Target)).ToArray());
+            await player.MagicEffectList.AddEffectAsync(magicEffect).ConfigureAwait(false);
+
+            if (player.CurrentMap is { } currentMap)
+            {
+                await currentMap.RespawnAsync(player).ConfigureAwait(false);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Removes the invisible effect.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    public static async ValueTask RemoveInvisibleEffectAsync(this Player player)
+    {
+        var invisibleEffect = player.GameContext.Configuration.MagicEffects.FirstOrDefault(e => e.PowerUpDefinitions.Any(e => e.TargetAttribute == Stats.IsInvisible));
+        if (invisibleEffect is null)
+        {
+            return;
+        }
+
+        var activeEffect = player.MagicEffectList.ActiveEffects.Values.FirstOrDefault(e => e.Definition == invisibleEffect);
+        if (activeEffect is null)
+        {
+            return;
+        }
+
+        await activeEffect.DisposeAsync().ConfigureAwait(false);
+        if (player.CurrentMap is { } currentMap)
+        {
+            await currentMap.RespawnAsync(player).ConfigureAwait(false);
+        }
+    }
+}

--- a/src/GameLogic/PlayerItemExtensions.cs
+++ b/src/GameLogic/PlayerItemExtensions.cs
@@ -1,0 +1,85 @@
+// <copyright file="PlayerItemExtensions.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic;
+
+using MUnique.OpenMU.GameLogic.PlugIns;
+using MUnique.OpenMU.GameLogic.Views.Inventory;
+using MUnique.OpenMU.Persistence;
+
+/// <summary>
+/// Extensions for the items of a <see cref="Player"/>.
+/// </summary>
+public static class PlayerItemExtensions
+{
+    /// <summary>
+    /// Determines whether the player complies with the requirements of the specified item.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="item">The item.</param>
+    /// <returns><c>True</c>, if the player complies with the requirements of the specified item; Otherwise, <c>false</c>.</returns>
+    public static bool CompliesRequirements(this Player player, Item item)
+    {
+        item.ThrowNotInitializedProperty(item.Definition is null, nameof(item.Definition));
+
+        foreach (var requirement in item.Definition.Requirements.Select(item.GetRequirement))
+        {
+            if (player.Attributes![requirement.Attr] < requirement.Value)
+            {
+                return false;
+            }
+        }
+
+        return item.Definition.QualifiedCharacters.Contains(player.SelectedCharacter!.CharacterClass!);
+    }
+
+    /// <summary>
+    /// Destroys an item of the <see cref="Player.Inventory"/>.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="item">The item.</param>
+    public static async ValueTask DestroyInventoryItemAsync(this Player player, Item item)
+    {
+        await player.Inventory!.RemoveItemAsync(item).ConfigureAwait(false);
+        await player.PersistenceContext.DeleteAsync(item).ConfigureAwait(false);
+        await player.InvokeViewPlugInAsync<IItemRemovedPlugIn>(p => p.RemoveItemAsync(item.ItemSlot)).ConfigureAwait(false);
+        player.GameContext.PlugInManager.GetPlugInPoint<IItemDestroyedPlugIn>()?.ItemDestroyed(item);
+    }
+
+    /// <summary>
+    /// Logs the items of the vault of the account which have no item definition.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    internal static void LogInvalidVaultItems(this Player player)
+    {
+        var invalidItems = player.Account?.Vault?.Items.Where(i => i.Definition is null);
+        if (invalidItems is null)
+        {
+            return;
+        }
+
+        foreach (var item in invalidItems)
+        {
+            player.Logger.LogWarning("Account {name} has item without definition in vault, Slot: {slot}, ID: {id}", player.Account?.LoginName, item.ItemSlot, item.GetId());
+        }
+    }
+
+    /// <summary>
+    /// Logs the items of the inventory of the selected character which have no item definition.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    internal static void LogInvalidInventoryItems(this Player player)
+    {
+        var invalidItems = player.SelectedCharacter?.Inventory?.Items.Where(i => i.Definition is null);
+        if (invalidItems is null)
+        {
+            return;
+        }
+
+        foreach (var item in invalidItems)
+        {
+            player.Logger.LogWarning("Character {name} has item without definition in inventory, Slot: {slot}, ID: {id}", player.SelectedCharacter?.Name, item.ItemSlot, item.GetId());
+        }
+    }
+}

--- a/src/GameLogic/PlayerMessageExtensions.cs
+++ b/src/GameLogic/PlayerMessageExtensions.cs
@@ -1,0 +1,66 @@
+// <copyright file="PlayerMessageExtensions.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic;
+
+using MUnique.OpenMU.GameLogic.Properties;
+using MUnique.OpenMU.GameLogic.Views;
+using MUnique.OpenMU.Interfaces;
+
+/// <summary>
+/// Extensions to show (localized) messages to a <see cref="Player"/>.
+/// </summary>
+public static class PlayerMessageExtensions
+{
+    /// <summary>
+    /// Gets the localized message.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="resourceName">Name of the resource.</param>
+    /// <param name="formatArguments">The format arguments.</param>
+    /// <returns>The localized message.</returns>
+    public static string GetLocalizedMessage(this Player player, string resourceName, params ReadOnlySpan<object?> formatArguments)
+    {
+        if (formatArguments.Length > 0)
+        {
+            return string.Format(PlayerMessage.ResourceManager.GetString(resourceName, player.Culture) ?? string.Empty, formatArguments);
+        }
+
+        return PlayerMessage.ResourceManager.GetString(resourceName, player.Culture) ?? string.Empty;
+    }
+
+    /// <summary>
+    /// Easier way to show a localized blue message to the player.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="messageKey">The message resource key.</param>
+    /// <param name="arguments">The parameters for the message.</param>
+    public static ValueTask ShowLocalizedBlueMessageAsync(this Player player, string messageKey, params ReadOnlySpan<object?> arguments)
+    {
+        var message = player.GetLocalizedMessage(messageKey, arguments);
+        return player.InvokeViewPlugInAsync<IShowMessagePlugIn>(p => p.ShowMessageAsync(message, MessageType.BlueNormal));
+    }
+
+    /// <summary>
+    /// Easier way to show a localized golden message to the player.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="messageKey">The message resource key.</param>
+    /// <param name="arguments">The parameters for the message.</param>
+    public static ValueTask ShowLocalizedGoldenMessageAsync(this Player player, string messageKey, params ReadOnlySpan<object?> arguments)
+    {
+        var message = player.GetLocalizedMessage(messageKey, arguments);
+        return player.InvokeViewPlugInAsync<IShowMessagePlugIn>(p => p.ShowMessageAsync(message, MessageType.GoldenCenter));
+    }
+
+    /// <summary>
+    /// Easier way to show a blue message to the player.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="message">The message.</param>
+    public static ValueTask ShowBlueMessageAsync(this Player player, string message)
+    {
+        return player.InvokeViewPlugInAsync<IShowMessagePlugIn>(p => p.ShowMessageAsync(message, MessageType.BlueNormal));
+    }
+}

--- a/src/GameLogic/PlayerMoneyExtensions.cs
+++ b/src/GameLogic/PlayerMoneyExtensions.cs
@@ -1,0 +1,102 @@
+// <copyright file="PlayerMoneyExtensions.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic;
+
+/// <summary>
+/// Extensions to move money between the inventory and the vault of a <see cref="Player"/>.
+/// </summary>
+public static class PlayerMoneyExtensions
+{
+    /// <summary>
+    /// Tries to remove the money from the player inventory.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="value">The value that should be removed.</param>
+    /// <returns><c>True</c>, if the player inventory had enough money to remove; Otherwise, <c>false</c>.</returns>
+    public static bool TryRemoveMoney(this Player player, int value)
+    {
+        if (player.Money < value)
+        {
+            return false;
+        }
+
+        player.Money = checked(player.Money - value);
+        return true;
+    }
+
+    /// <summary>
+    /// Tries to add the money to the player inventory.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="value">The value that should be added.</param>
+    /// <returns><c>True</c>, if the player inventory had space to add money; Otherwise, <c>false</c>.</returns>
+    public static bool TryAddMoney(this Player player, int value)
+    {
+        if (player.Money + value > player.GameContext?.Configuration?.MaximumInventoryMoney)
+        {
+            return false;
+        }
+
+        if (player.Money + value < 0)
+        {
+            return false;
+        }
+
+        player.Money = checked(player.Money + value);
+        return true;
+    }
+
+    /// <summary>
+    /// Tries to deposit the money from the player inventory.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="value">The value that should be moved to the vault.</param>
+    /// <returns><c>True</c>, if the player inventory had enough money to move; Otherwise, <c>false</c>.</returns>
+    public static bool TryDepositVaultMoney(this Player player, int value)
+    {
+        if (player.Vault is null)
+        {
+            return false;
+        }
+
+        if (player.Vault.ItemStorage.Money + value > player.GameContext?.Configuration?.MaximumVaultMoney)
+        {
+            return false;
+        }
+
+        if (player.TryRemoveMoney(value))
+        {
+            return player.Vault.TryAddMoney(value);
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Tries to take the money from the vault.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="value">The value that should be retrieved from the vault.</param>
+    /// <returns><c>True</c>, if the vault had enough money to move and player inventory isn't maximum; Otherwise, <c>false</c>.</returns>
+    public static bool TryTakeVaultMoney(this Player player, int value)
+    {
+        if (player.Vault is null)
+        {
+            return false;
+        }
+
+        if (player.Money + value > player.GameContext?.Configuration?.MaximumInventoryMoney)
+        {
+            return false;
+        }
+
+        if (player.Vault.TryRemoveMoney(value))
+        {
+            return player.TryAddMoney(value);
+        }
+
+        return false;
+    }
+}

--- a/src/GameLogic/SelfDefenseExtensions.cs
+++ b/src/GameLogic/SelfDefenseExtensions.cs
@@ -1,0 +1,45 @@
+// <copyright file="SelfDefenseExtensions.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic;
+
+/// <summary>
+/// Extensions to query the self defense state which is maintained by the
+/// <see cref="PlugIns.SelfDefensePlugIn"/>.
+/// </summary>
+public static class SelfDefenseExtensions
+{
+    /// <summary>
+    /// Determines whether the self defense is active for the specified attacker.
+    /// </summary>
+    /// <param name="player">The player which defends itself.</param>
+    /// <param name="attacker">The attacker.</param>
+    /// <returns>
+    ///   <c>true</c> if the self defense is active for the specified attacker; otherwise, <c>false</c>.
+    /// </returns>
+    public static bool IsSelfDefenseActive(this Player player, Player attacker)
+    {
+        if (player.GameContext.SelfDefenseState.TryGetValue((attacker, player), out var timeout))
+        {
+            return timeout > DateTime.UtcNow;
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether the self-defense is active for any attacker.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <returns>
+    ///   <c>true</c> if any self-defense is active; otherwise, <c>false</c>.
+    /// </returns>
+    public static bool IsAnySelfDefenseActive(this Player player)
+    {
+        var selfDefenses = player.GameContext.SelfDefenseState.Keys.Where(c => c.Attacker == player).ToList();
+        return selfDefenses.Any(sd =>
+            player.GameContext.SelfDefenseState.TryGetValue(sd, out var timeout)
+            && timeout >= DateTime.UtcNow);
+    }
+}

--- a/src/GameLogic/TemporaryItemStorage.cs
+++ b/src/GameLogic/TemporaryItemStorage.cs
@@ -1,0 +1,20 @@
+// <copyright file="TemporaryItemStorage.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic;
+
+/// <summary>
+/// An <see cref="ItemStorage"/> which is not persisted, used for the temporary
+/// storage of a <see cref="Player"/>, e.g. while an NPC or trade dialog is open.
+/// </summary>
+internal sealed class TemporaryItemStorage : ItemStorage
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="TemporaryItemStorage"/> class.
+    /// </summary>
+    public TemporaryItemStorage()
+    {
+        this.Items = new List<Item>();
+    }
+}


### PR DESCRIPTION
## What this is

`Player` is 3,098 lines and ~150 members. This PR adds a plan for breaking it up (`docs/PlayerRefactoringPlan.md`) and implements the first, risk-free phase of it.

## The plan

`docs/PlayerRefactoringPlan.md` inventories what is in the class today and proposes how each cluster leaves it, following **policy → plugin, mechanism → component, pure function → extension method**.

Highlights:

* **Reuse the existing state plugin points.** `IPlayerStateChangedPlugIn` already fires when a character enters the world, and four plugins already use it — so no new "entered world" point is needed. For map changes it does *not* fire today: `PlayerState.ChangingMap` is declared but used nowhere and is unreachable (no state lists it in `PossibleTransitions`), and `ClientReadyAfterMapChangeAsync` calls `TryAdvanceToAsync(EnteredWorld)` while the player already is in `EnteredWorld`, which returns `false` silently. Wiring `ChangingMap` up gives entered/left map to all plugins and makes map changes cancelable via `IPlayerStateChangingPlugIn`.
* **9 new plugin points** where no existing one fits: spawn gate selection (removes the hardcoded duel and guild-war-soccer branches from `Player`), experience calculation, experience gained (pet experience becomes a plugin), master level up, attacker-hit-target, player regeneration, the pet command manager factory (the TODO at `Player.cs:528`), walk request validation (removes the concrete `SpeedHackDetectPlugIn` reference from `Player`), and leaving the game.
* **Existing points absorb the rest**: PK state and the respawn-after-death flow fit `IAttackableGotKilledPlugIn`, reflection and durability fit `IAttackableGotHitPlugIn`, map power-ups fit the map points that already fire for players.
* **Eight phases**, each independently mergeable, ending at roughly 700-800 lines.

Two decisions are recorded in the plan: extracted plugins may be deactivated by admins (no "not deactivatable" marker), and existing plugin interfaces get async signatures rather than async sibling points — `IAttackableMovedPlugIn` being the exception, since it is raised from property setters that cannot await.

Also noted while writing it: `LogoutAction` with `LogoutType.BackToCharacterSelection` advances to `PlayerState.Authenticated`, which is not in `EnteredWorld.PossibleTransitions` — the transition silently fails and the player stays in `EnteredWorld`. Not fixed here, it belongs to the state machine phase.

## The first step

Everything that does not need private state of the player moves into extension classes **in the same namespace**, so every call site stays as it is (`ShowLocalizedBlueMessageAsync` alone has ~208 of them):

| New file | Contents |
|---|---|
| `PlayerMessageExtensions` | `GetLocalizedMessage`, `ShowLocalizedBlueMessageAsync`, `ShowLocalizedGoldenMessageAsync`, `ShowBlueMessageAsync` |
| `PlayerMoneyExtensions` | `TryAddMoney`, `TryRemoveMoney`, `TryDepositVaultMoney`, `TryTakeVaultMoney` |
| `PlayerItemExtensions` | `CompliesRequirements`, `DestroyInventoryItemAsync`, the invalid-item logging |
| `SelfDefenseExtensions` | `IsSelfDefenseActive`, `IsAnySelfDefenseActive`, next to the state they read |
| `MagicEffectPowerUpExtensions` | both `CreateMagicEffectPowerUp` overloads |
| `PlayerInvisibilityExtensions` | `AddInvisibleEffectAsync`, `RemoveInvisibleEffectAsync` |

The three nested classes move into their own files as well: `PlayerAppearanceData` (formerly `AppearanceDataAdapter`), `GameMasterMagicEffectDefinition` and `TemporaryItemStorage`.

`TryAddMoney` loses its `virtual` modifier — no type overrides it.

**Player.cs: 3,098 → 2,612 lines.** The diff on it is 489 deletions and 3 insertions, and those three are the two renamed type references. No behavior change is intended.

## Verification

`dotnet build src/MUnique.OpenMU.sln` succeeds with no errors, and `dotnet test tests/MUnique.OpenMU.Tests` passes 703 of 703 — same as before the change.


---
_Generated by [Claude Code](https://claude.ai/code/session_01V5grV5oveZNhhjK1mazM2B)_