### PR TITLE
Prevent duplicate map entry on repeated F3 12 packet

### DIFF
--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -949,6 +949,16 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         this.ThrowNotInitializedProperty(this.SelectedCharacter is null, nameof(this.SelectedCharacter));
         this.SelectedCharacter.ThrowNotInitializedProperty(this.SelectedCharacter.CurrentMap is null, nameof(this.SelectedCharacter.CurrentMap));
 
+        if (this.CurrentMap is not null)
+        {
+            // Guard against a repeated F3 12 (client ready after map change) packet:
+            // during a regular map change CurrentMap is set to null and only assigned
+            // here, so a non-null value means this handler already ran for the current
+            // map change. Without this, a duplicate packet would add the player (and its
+            // summon) to the map a second time.
+            return;
+        }
+
         if (this.CurrentMiniGame is { } currentMiniGame)
         {
             this.CurrentMap = currentMiniGame.Map;

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -951,11 +951,14 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
 
         if (this.CurrentMap is not null)
         {
-            // Guard against a repeated F3 12 (client ready after map change) packet:
-            // during a regular map change CurrentMap is set to null and only assigned
-            // here, so a non-null value means this handler already ran for the current
-            // map change. Without this, a duplicate packet would add the player (and its
-            // summon) to the map a second time.
+            // Guard against a repeated F3 12 (client ready after map change) packet.
+            // A map change usually leaves CurrentMap null until this handler assigns it,
+            // so a non-null value means the handler already ran. The exception is the
+            // IRespawnAfterDeathPlugIn branch of RespawnAtAsync, which assigns CurrentMap
+            // and adds the player itself; a trailing packet is redundant there as well.
+            // Without this guard, a duplicate packet adds the player (and its summon) to
+            // the area of interest a second time, which the bucket does not deduplicate.
+            this.Logger.LogWarning("Ignoring client-ready packet: player {0} is already on map {1}.", this, this.CurrentMap);
             return;
         }
 

--- a/tests/MUnique.OpenMU.Tests/ClientReadyAfterMapChangeTests.cs
+++ b/tests/MUnique.OpenMU.Tests/ClientReadyAfterMapChangeTests.cs
@@ -1,0 +1,63 @@
+// <copyright file="ClientReadyAfterMapChangeTests.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Tests;
+
+using System.Linq;
+using System.Threading.Tasks;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.Pathfinding;
+using NUnit.Framework;
+
+/// <summary>
+/// Tests for the handling of the client-ready packet which is sent after a map change.
+/// </summary>
+[TestFixture]
+public class ClientReadyAfterMapChangeTests
+{
+    /// <summary>
+    /// Tests that a repeated client-ready packet does not add the player to the
+    /// area of interest a second time. The bucket does not deduplicate its entries,
+    /// and its removal only strips the first occurrence, so a duplicate entry would
+    /// outlive the player on the map.
+    /// </summary>
+    /// <returns>The task.</returns>
+    [Test]
+    public async Task RepeatedClientReadyDoesNotAddPlayerTwiceAsync()
+    {
+        var player = await PlayerTestHelper.CreatePlayerAsync().ConfigureAwait(false);
+        await player.ClientReadyAfterMapChangeAsync().ConfigureAwait(false);
+
+        var map = player.CurrentMap;
+        Assert.That(map, Is.Not.Null);
+        var occurrencesAfterFirst = map!.GetAttackablesInRange(player.Position, 1).Count(o => o == player);
+        Assert.That(occurrencesAfterFirst, Is.EqualTo(1));
+
+        await player.ClientReadyAfterMapChangeAsync().ConfigureAwait(false);
+
+        var occurrencesAfterSecond = map.GetAttackablesInRange(player.Position, 1).Count(o => o == player);
+        Assert.That(occurrencesAfterSecond, Is.EqualTo(1));
+    }
+
+    /// <summary>
+    /// Tests that the player is fully removed from the area of interest after a
+    /// repeated client-ready packet. A duplicate entry would leave a ghost behind,
+    /// because the removal only takes out the first occurrence.
+    /// </summary>
+    /// <returns>The task.</returns>
+    [Test]
+    public async Task PlayerLeavesNoGhostAfterRepeatedClientReadyAsync()
+    {
+        var player = await PlayerTestHelper.CreatePlayerAsync().ConfigureAwait(false);
+        await player.ClientReadyAfterMapChangeAsync().ConfigureAwait(false);
+        await player.ClientReadyAfterMapChangeAsync().ConfigureAwait(false);
+
+        var map = player.CurrentMap;
+        Assert.That(map, Is.Not.Null);
+        var position = player.Position;
+        await map!.RemoveAsync(player).ConfigureAwait(false);
+
+        Assert.That(map.GetAttackablesInRange(position, 1).Any(o => o == player), Is.False);
+    }
+}


### PR DESCRIPTION
Hi @sven-n — first, thank you for the detailed review on #867. The time you took
to explain the *why*, not just the *what*, is what let me step back and split the
useful parts out cleanly instead of pushing one big lump. This is the first of the
two pieces you said you'd take, on its own on top of current master.

## Problem

A repeated `F3 12` ("client ready after map change") packet re-runs
`ClientReadyAfterMapChangeAsync`, which unconditionally re-adds the player — and,
if present, its summon (`CurrentMap.AddAsync(summon)` + `summon.OnSpawn()`) — to
the current map. You suspected this in the review; I've confirmed it on master.

## Fix

Return early when `CurrentMap` is already set on entry. During a regular map
change `CurrentMap` is set to `null` (see the `// Will be set again, when the
client acknowledged the map change by F3 12 packet.` spots) and only reassigned
inside this handler, so a non-null value on entry is a reliable "this handler
already ran for the current map change" signal.

## Notes

- One file, +10 lines. No behaviour change for the normal single-packet path.
- Independent of the large-map work — nothing else from #867 rides along.
- Rebased on current `master`.
