### PR TITLE
Bounds-check client-supplied walk steps against the terrain grid

### DIFF
--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -1668,8 +1668,14 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         for (var index = 0; index < steps.Length; index++)
         {
             var target = steps[index].To;
-            if (!terrain.WalkMap[target.X, target.Y])
+            if (target.X >= terrain.WalkMap.GetLength(0)
+                || target.Y >= terrain.WalkMap.GetLength(1)
+                || !terrain.WalkMap[target.X, target.Y])
             {
+                // Treat an out-of-bounds step as non-walkable instead of indexing past
+                // the terrain grid. With today's byte-sized coordinates on a 256x256 grid
+                // this is unreachable, but it keeps the client-supplied path from indexing
+                // the map out of range once coordinate widths change.
                 return index;
             }
         }


### PR DESCRIPTION
Second of the two pieces from the #867 review, standalone on top of current
master and independent of the re-entrancy guard PR.

## Change

`GetWalkableStepCount` (used by `WalkToAsync`) indexes `terrain.WalkMap` with
coordinates taken directly from the client's walk request. This guards the access
with the grid dimensions and treats an out-of-bounds step as non-walkable,
truncating the path at that step rather than indexing past the terrain grid.

## Honest scope note

On master `Point` is `record struct Point(byte X, byte Y)` and `WalkMap` is
`[256, 256]`, so the index cannot currently exceed the bounds — this is defensive
hardening, not a live bug fix. I'm sending it as its own PR (per your review)
rather than folding it into the large-map proposal. Completely fine to close it if
you'd rather not carry a guard that's unreachable today; it becomes load-bearing
the moment coordinate widths change.
