### PR TITLE
Add batch operations and merchant cockpit

### DIFF
--- a/src/DataModel/Configuration/GameServerDefinition.cs
+++ b/src/DataModel/Configuration/GameServerDefinition.cs
@@ -31,6 +31,12 @@ public partial class GameServerDefinition
     public float ExperienceRate { get; set; }
 
     /// <summary>
+    /// Gets or sets the Zen/money multiplier for the specific server.
+    /// This is applied in addition to the character/global MoneyAmountRate.
+    /// </summary>
+    public float MoneyRate { get; set; } = 1.0f;
+
+    /// <summary>
     /// Gets or sets a value indicating whether PVP is enabled on this server.
     /// </summary>
     public bool PvpEnabled { get; set; } = true;

--- a/src/GameLogic/GameContext.cs
+++ b/src/GameLogic/GameContext.cs
@@ -114,6 +114,9 @@ public class GameContext : AsyncDisposable, IGameContext
     public virtual float ExperienceRate => this.Configuration.ExperienceRate;
 
     /// <inheritdoc />
+    public virtual float MoneyRate => 1.0f;
+
+    /// <inheritdoc />
     public virtual float MasterExperienceRate => this.Configuration.MasterExperienceRate;
 
     /// <inheritdoc />

--- a/src/GameLogic/IGameContext.cs
+++ b/src/GameLogic/IGameContext.cs
@@ -33,6 +33,11 @@ public interface IGameContext
     float ExperienceRate { get; }
 
     /// <summary>
+    /// Gets the effective Zen/money multiplier of this game server.
+    /// </summary>
+    float MoneyRate { get; }
+
+    /// <summary>
     /// Gets the global master experience rate.
     /// </summary>
     float MasterExperienceRate { get; }

--- a/src/GameLogic/MoneyDistribution.cs
+++ b/src/GameLogic/MoneyDistribution.cs
@@ -139,7 +139,10 @@ internal static class MoneyDistribution
 
         // The rate is applied in double precision: a float multiplication would round money amounts
         // above the ~16.7M the float mantissa can represent exactly, before the cast to long.
-        var scaled = (long)(amount * (double)(player.Attributes?[Stats.MoneyAmountRate] ?? 1.0f));
+        var scaled = (long)(
+            amount
+            * (double)(player.Attributes?[Stats.MoneyAmountRate] ?? 1.0f)
+            * (double)(player.GameContext?.MoneyRate ?? 1.0f));
         if (scaled <= 0)
         {
             return false;

--- a/src/GameServer/GameServerContext.cs
+++ b/src/GameServer/GameServerContext.cs
@@ -106,6 +106,9 @@ public class GameServerContext : GameContext, IGameServerContext
     public override float ExperienceRate => base.ExperienceRate * this._gameServerDefinition.ExperienceRate;
 
     /// <inheritdoc />
+    public override float MoneyRate => base.MoneyRate * this._gameServerDefinition.MoneyRate;
+
+    /// <inheritdoc />
     public override float MasterExperienceRate => base.MasterExperienceRate * this._gameServerDefinition.ExperienceRate;
 
     /// <inheritdoc />

--- a/src/Persistence/EntityFramework/Migrations/20260811103000_AddGameServerMoneyRate.cs
+++ b/src/Persistence/EntityFramework/Migrations/20260811103000_AddGameServerMoneyRate.cs
@@ -1,0 +1,40 @@
+// <copyright file="20260811103000_AddGameServerMoneyRate.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+#nullable disable
+
+namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
+{
+    using Microsoft.EntityFrameworkCore.Infrastructure;
+    using Microsoft.EntityFrameworkCore.Migrations;
+
+    /// <summary>
+    /// Adds a per-game-server Zen multiplier for MU Nueva Era.
+    /// </summary>
+    [DbContext(typeof(EntityDataContext))]
+    [Migration("20260811103000_AddGameServerMoneyRate")]
+    public partial class AddGameServerMoneyRate : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<float>(
+                name: "MoneyRate",
+                schema: "config",
+                table: "GameServerDefinition",
+                type: "real",
+                nullable: false,
+                defaultValue: 1f);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MoneyRate",
+                schema: "config",
+                table: "GameServerDefinition");
+        }
+    }
+}

--- a/src/Web/AdminPanel/Components/Layout/ConfigNavMenu.razor
+++ b/src/Web/AdminPanel/Components/Layout/ConfigNavMenu.razor
@@ -13,10 +13,16 @@
         <NavLink class="dropdown-item" href="@($"edit-config/{typeof(GameConfiguration).FullName}/{this.GameConfigurationId}/hide-collections")" @onclick="() => NavigationHistory.Clear()">@Resources.General</NavLink>
         <NavLink class="dropdown-item" href="@($"edit-config-grid/{typeof(MonsterDefinition).FullName}/")" @onclick="() => NavigationHistory.Clear()">@Resources.Monsters</NavLink>
         <NavLink class="dropdown-item" href="@($"merchants/")" @onclick="() => NavigationHistory.Clear()">@Resources.MerchantStores</NavLink>
+        <NavLink class="dropdown-item" href="merchant-cockpit" @onclick="() => NavigationHistory.Clear()">
+            <span class="oi oi-cart" aria-hidden="true"></span> Merchant Cockpit
+        </NavLink>
         <NavLink class="dropdown-item" href="@($"edit-config-grid/{typeof(CharacterClass).FullName}/")" @onclick="() => NavigationHistory.Clear()">@Resources.CharacterClasses</NavLink>
         <NavLink class="dropdown-item" href="@($"edit-config-grid/{typeof(Skill).FullName}/")" @onclick="() => NavigationHistory.Clear()">@Resources.Skills</NavLink>
         <NavLink class="dropdown-item" href="@($"edit-config-grid/{typeof(ItemDefinition).FullName}/")" @onclick="() => NavigationHistory.Clear()">@Resources.Items</NavLink>
         <NavLink class="dropdown-item" href="@($"edit-config-grid/{typeof(DropItemGroup).FullName}/")" @onclick="() => NavigationHistory.Clear()">@Resources.DropItemGroups</NavLink>
+        <NavLink class="dropdown-item" href="batch-operations" @onclick="() => NavigationHistory.Clear()">
+            <span class="oi oi-cog" aria-hidden="true"></span> Operaciones por lote
+        </NavLink>
         <NavLink class="dropdown-item" href="@($"edit-config-grid/{typeof(GameMapDefinition).FullName}/")" @onclick="() => NavigationHistory.Clear()">@Resources.GameMaps</NavLink>
         <NavLink class="dropdown-item" href="@($"edit-config-grid/{typeof(MiniGameDefinition).FullName}/")" @onclick="() => NavigationHistory.Clear()">@Resources.MiniGames</NavLink>
         <NavLink class="dropdown-item" href="@($"edit-config-grid/{typeof(WarpInfo).FullName}/")" @onclick="() => NavigationHistory.Clear()">@Resources.WarpList</NavLink>

--- a/src/Web/AdminPanel/Pages/BatchOperations.razor
+++ b/src/Web/AdminPanel/Pages/BatchOperations.razor
@@ -8,9 +8,8 @@
 
 <h1>Operaciones por lote</h1>
 <p class="text-muted">
-    Cockpit de MU Nueva Era para modificar configuración nativa de OpenMU por reglas.
-    Todas las operaciones muestran una vista previa antes de guardar y la última operación
-    aplicada puede revertirse mientras permanezcas en esta pantalla.
+    Cockpit de MU Nueva Era para modificar configuración nativa de OpenMU por reglas. Las operaciones por lote muestran una vista previa antes de guardar.
+    El editor directo de cajas aplica al confirmar y permite deshacer la última operación mientras permanezcas en esta pantalla.
 </p>
 
 @if (this._isLoading)
@@ -335,9 +334,97 @@
     </div>
 </div>
 
+<div class="card mb-4 border-primary">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <strong>5. Editor directo de cajas y grupos de drop</strong>
+        <span class="badge text-bg-primary">sin vista previa</span>
+    </div>
+    <div class="card-body">
+        <p class="text-muted">
+            Agrega, quita o reemplaza el contenido de una caja usando filtros por categoria, set, 380,
+            Excellent, Ancient, sockets, alas o armas. La edicion se guarda al pulsar el boton y la ultima
+            operacion se puede deshacer desde el panel superior.
+        </p>
+        <div class="alert alert-warning py-2">
+            Usa <strong>Agregar</strong> para ampliar una caja de forma segura. <strong>Reemplazar</strong>
+            elimina primero todos sus items actuales.
+        </div>
+        <div class="row g-3">
+            <div class="col-lg-5">
+                <label class="form-label">Caja o grupo de drop de items</label>
+                <select class="form-select" @bind="this._contentDropGroupId">
+                    <option value="">Seleccionar caja...</option>
+                    @foreach (var group in this._dropContentGroups)
+                    {
+                        <option value="@group.GetId()">@group.Description (@group.PossibleItems.Count items)</option>
+                    }
+                </select>
+            </div>
+            <div class="col-lg-3">
+                <label class="form-label">Accion</label>
+                <select class="form-select" @bind="this._contentAction">
+                    <option value="add">Agregar coincidencias</option>
+                    <option value="remove">Quitar coincidencias</option>
+                    <option value="replace">Reemplazar todo</option>
+                </select>
+            </div>
+            <div class="col-lg-4">
+                <label class="form-label">Categoria</label>
+                <select class="form-select" @bind="this._contentCategory">
+                    <option value="@DropGroupItemCategory.Any">Nombre / grupo</option>
+                    <option value="@DropGroupItemCategory.Set">Set seleccionado</option>
+                    <option value="@DropGroupItemCategory.Guardian380">Items 380</option>
+                    <option value="@DropGroupItemCategory.Excellent">Excellent posible</option>
+                    <option value="@DropGroupItemCategory.Ancient">Ancient posible</option>
+                    <option value="@DropGroupItemCategory.Socket">Con sockets</option>
+                    <option value="@DropGroupItemCategory.Weapons">Armas</option>
+                    <option value="@DropGroupItemCategory.Armor">Armaduras</option>
+                    <option value="@DropGroupItemCategory.Wings">Alas</option>
+                </select>
+            </div>
+            <div class="col-lg-5">
+                <label class="form-label">Nombre contiene</label>
+                <input class="form-control" @bind="this._contentFilter" @bind:event="oninput" placeholder="Dragon, Kundun, Bone..." />
+            </div>
+            <div class="col-lg-2">
+                <label class="form-label">Grupo (0-15)</label>
+                <input class="form-control" type="number" min="0" max="15" @bind="this._contentGroup" />
+            </div>
+            <div class="col-lg-5">
+                <label class="form-label">Set</label>
+                <select class="form-select" disabled="@(this._contentCategory != DropGroupItemCategory.Set)" @bind="this._contentSetId">
+                    <option value="">Seleccionar set...</option>
+                    @foreach (var set in this._itemSets)
+                    {
+                        <option value="@set.GetId()">@set.Name</option>
+                    }
+                </select>
+            </div>
+        </div>
+        @{ var matchingContentItems = this.GetMatchingContentItems(); }
+        <div class="mt-3 p-3 rounded border bg-body-tertiary">
+            <div class="d-flex justify-content-between align-items-center gap-2 flex-wrap">
+                <strong>@matchingContentItems.Count coincidencias</strong>
+                <span class="text-muted small">Se aplicara directamente sobre la caja elegida.</span>
+            </div>
+            @if (matchingContentItems.Count > 0)
+            {
+                <div class="small text-muted mt-2">@string.Join(" · ", matchingContentItems.Take(18).Select(item => $"{item.Name} G{item.Group}/#{item.Number}"))</div>
+            }
+        </div>
+        <div class="form-check mt-3">
+            <input id="confirmDropContentEdit" class="form-check-input" type="checkbox" @bind="this._contentConfirmed" />
+            <label class="form-check-label" for="confirmDropContentEdit">Confirmo la edicion directa de esta caja</label>
+        </div>
+        <div class="mt-3">
+            <button class="btn btn-primary" disabled="@this._isApplying" @onclick="this.ApplyDropContentBatchAsync">Aplicar edicion directa</button>
+        </div>
+    </div>
+</div>
+
 <div class="card mb-4">
     <div class="card-header d-flex justify-content-between align-items-center">
-        <strong>5. Plantillas de tiendas</strong>
+        <strong>6. Plantillas de tiendas</strong>
         <NavLink class="btn btn-outline-primary btn-sm" href="merchant-cockpit">Abrir Merchant Cockpit</NavLink>
     </div>
     <div class="card-body">

--- a/src/Web/AdminPanel/Pages/BatchOperations.razor
+++ b/src/Web/AdminPanel/Pages/BatchOperations.razor
@@ -1,0 +1,385 @@
+@page "/batch-operations"
+
+@using MUnique.OpenMU.DataModel.Configuration
+@using MUnique.OpenMU.Persistence
+
+<PageTitle>OpenMU: Operaciones por lote</PageTitle>
+<Breadcrumb Caption="Operaciones por lote" />
+
+<h1>Operaciones por lote</h1>
+<p class="text-muted">
+    Cockpit de MU Nueva Era para modificar configuración nativa de OpenMU por reglas.
+    Todas las operaciones muestran una vista previa antes de guardar y la última operación
+    aplicada puede revertirse mientras permanezcas en esta pantalla.
+</p>
+
+@if (this._isLoading)
+{
+    <div class="alert alert-info">Cargando configuración de OpenMU…</div>
+    return;
+}
+
+<div class="alert alert-warning">
+    <strong>Seguridad:</strong> haz un respaldo de PostgreSQL antes de una sesión de balance.
+    Las operaciones trabajan sobre la configuración real del servidor, no sobre una copia paralela.
+</div>
+
+<div class="card mb-4">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <strong>@this._previewTitle</strong>
+        @if (this._undoAction is not null)
+        {
+            <button class="btn btn-outline-warning btn-sm"
+                    disabled="@this._isApplying"
+                    @onclick="this.UndoLastAsync">
+                Deshacer última operación
+            </button>
+        }
+    </div>
+    <div class="card-body">
+        <p class="mb-2">@this._previewSummary</p>
+        @if (this._previewLines.Count > 0)
+        {
+            <div class="border rounded p-2 bg-body-tertiary" style="max-height: 280px; overflow:auto;">
+                <ul class="mb-0 small">
+                    @foreach (var line in this._previewLines)
+                    {
+                        <li>@line</li>
+                    }
+                </ul>
+            </div>
+        }
+    </div>
+</div>
+
+<div class="card mb-4">
+    <div class="card-header">
+        <strong>1. Economía global y canales</strong>
+    </div>
+    <div class="card-body">
+        <div class="row g-3">
+            <div class="col-md-4">
+                <label class="form-label">EXP global</label>
+                <input class="form-control" type="number" min="0" step="0.1" @bind="this._economy.ExperienceRate" />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Master EXP global</label>
+                <input class="form-control" type="number" min="0" step="0.1" @bind="this._economy.MasterExperienceRate" />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Duración del drop en suelo (seg.)</label>
+                <input class="form-control" type="number" min="0" step="1" @bind="this._economy.ItemDropDurationSeconds" />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Zen máximo inventario</label>
+                <input class="form-control" type="number" min="0" @bind="this._economy.MaximumInventoryMoney" />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Zen máximo baúl</label>
+                <input class="form-control" type="number" min="0" @bind="this._economy.MaximumVaultMoney" />
+            </div>
+            <div class="col-md-4 d-flex align-items-end">
+                <div class="form-check mb-2">
+                    <input id="shouldDropMoney" class="form-check-input" type="checkbox" @bind="this._economy.ShouldDropMoney" />
+                    <label class="form-check-label" for="shouldDropMoney">El Zen cae al suelo</label>
+                </div>
+            </div>
+        </div>
+
+        <hr />
+        <h5>Canales / realms</h5>
+        <div class="table-responsive">
+            <table class="table table-sm align-middle">
+                <thead>
+                    <tr>
+                        <th>Canal</th>
+                        <th style="min-width:130px;">EXP</th>
+                        <th style="min-width:130px;">Zen</th>
+                        <th>PvP</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var server in this._serverEdits)
+                    {
+                        <tr>
+                            <td>
+                                <strong>#@server.ServerId</strong>
+                                <span>@server.Description</span>
+                            </td>
+                            <td><input class="form-control form-control-sm" type="number" min="0" step="0.1" @bind="server.ExperienceRate" /></td>
+                            <td><input class="form-control form-control-sm" type="number" min="0" step="0.05" @bind="server.MoneyRate" /></td>
+                            <td><input class="form-check-input" type="checkbox" @bind="server.PvpEnabled" /></td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+
+        <h5 class="mt-3">Drops comunes</h5>
+        <div class="row g-3">
+            @foreach (var drop in this._dropChanceEdits)
+            {
+                <div class="col-md-6 col-xl-3">
+                    <label class="form-label">@drop.Type · @drop.Description</label>
+                    <div class="input-group">
+                        <input class="form-control" type="number" min="0" max="100" step="0.001" @bind="drop.Percent" />
+                        <span class="input-group-text">%</span>
+                    </div>
+                </div>
+            }
+        </div>
+
+        <div class="form-check mt-3">
+            <input id="restartAfterEconomy" class="form-check-input" type="checkbox" @bind="this._restartAllAfterEconomyApply" />
+            <label class="form-check-label" for="restartAfterEconomy">
+                Reiniciar todos los Game Servers después de guardar
+                <span class="text-muted">(recomendado para que EXP/Zen por canal entren en vigor inmediatamente)</span>
+            </label>
+        </div>
+
+        <div class="mt-3 d-flex gap-2">
+            <button class="btn btn-outline-primary" disabled="@this._isApplying" @onclick="this.PreviewEconomy">Vista previa</button>
+            <button class="btn btn-primary" disabled="@this._isApplying" @onclick="this.ApplyEconomyAsync">Aplicar economía</button>
+        </div>
+    </div>
+</div>
+
+<div class="card mb-4">
+    <div class="card-header">
+        <strong>2. Drops masivos</strong>
+    </div>
+    <div class="card-body">
+        <p class="text-muted">
+            Asigna o quita un Drop Item Group completo a mapas o a un conjunto de monstruos filtrados.
+            Esto evita configurar cientos de criaturas una por una.
+        </p>
+
+        <div class="row g-3">
+            <div class="col-md-5">
+                <label class="form-label">Grupo de drop</label>
+                <select class="form-select" @bind="this._selectedDropGroupId">
+                    <option value="">Seleccionar…</option>
+                    @foreach (var group in this._dropGroups)
+                    {
+                        <option value="@group.GetId()">@group.ItemType · @group.Description</option>
+                    }
+                </select>
+            </div>
+            <div class="col-md-3">
+                <label class="form-label">Acción</label>
+                <select class="form-select" @bind="this._dropAction">
+                    <option value="add">Agregar</option>
+                    <option value="remove">Quitar</option>
+                </select>
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Aplicar a</label>
+                <select class="form-select" @bind="this._dropScope">
+                    <option value="maps">Mapas seleccionados</option>
+                    <option value="monsters">Monstruos filtrados</option>
+                </select>
+            </div>
+        </div>
+
+        <hr />
+        <div class="row g-4">
+            <div class="col-lg-6">
+                <div class="d-flex justify-content-between align-items-center">
+                    <h6 class="mb-2">Mapas</h6>
+                    <div class="btn-group btn-group-sm">
+                        <button class="btn btn-outline-secondary" @onclick="() => this.SelectAllMaps(true)">Todos</button>
+                        <button class="btn btn-outline-secondary" @onclick="() => this.SelectAllMaps(false)">Ninguno</button>
+                    </div>
+                </div>
+                <div class="border rounded p-2" style="height:260px; overflow:auto;">
+                    @foreach (var map in this._maps)
+                    {
+                        var id = map.GetId();
+                        <div class="form-check">
+                            <input class="form-check-input"
+                                   type="checkbox"
+                                   checked="@this._selectedMapIds.Contains(id)"
+                                   @onchange="e => this.ToggleMap(id, (bool)(e.Value ?? false))" />
+                            <label class="form-check-label">@map.Number - @map.Name</label>
+                        </div>
+                    }
+                </div>
+            </div>
+
+            <div class="col-lg-6">
+                <h6>Filtro de monstruos</h6>
+                <div class="row g-2">
+                    <div class="col-12">
+                        <label class="form-label">Nombre contiene</label>
+                        <input class="form-control" @bind="this._monsterFilter" placeholder="Ej.: Golden, Orc, Kundun…" />
+                    </div>
+                    <div class="col-6">
+                        <label class="form-label">Nivel mínimo</label>
+                        <input class="form-control" type="number" min="0" max="255" @bind="this._monsterMinLevel" />
+                    </div>
+                    <div class="col-6">
+                        <label class="form-label">Nivel máximo</label>
+                        <input class="form-control" type="number" min="0" max="255" @bind="this._monsterMaxLevel" />
+                    </div>
+                    <div class="col-12">
+                        <div class="form-check">
+                            <input id="onlyMaps" class="form-check-input" type="checkbox" @bind="this._monsterOnlySelectedMaps" />
+                            <label class="form-check-label" for="onlyMaps">Solo monstruos que aparecen en los mapas seleccionados</label>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="mt-3 d-flex gap-2">
+            <button class="btn btn-outline-primary" disabled="@this._isApplying" @onclick="this.PreviewDropAssignment">Vista previa</button>
+            <button class="btn btn-primary" disabled="@this._isApplying" @onclick="this.ApplyDropAssignmentAsync">Aplicar drops</button>
+        </div>
+    </div>
+</div>
+
+<div class="card mb-4">
+    <div class="card-header">
+        <strong>3. Monstruos masivos</strong>
+    </div>
+    <div class="card-body">
+        <p class="text-muted">
+            Usa el mismo filtro de monstruos de la sección anterior. Deja un campo vacío para no modificarlo.
+        </p>
+        <div class="row g-3">
+            <div class="col-md-4">
+                <label class="form-label">Máximo de drops por muerte</label>
+                <input class="form-control" type="number" min="0" @bind="this._batchMaximumItemDrops" />
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Respawn (segundos)</label>
+                <input class="form-control" type="number" min="0" step="0.1" @bind="this._batchRespawnSeconds" />
+            </div>
+            <div class="col-md-4 d-flex align-items-end">
+                <span class="text-muted small mb-2">Filtro actual: @this.GetMatchingMonsters().Count() monstruos</span>
+            </div>
+        </div>
+
+        <div class="mt-3 d-flex gap-2">
+            <button class="btn btn-outline-primary" disabled="@this._isApplying" @onclick="this.PreviewMonsterBatch">Vista previa</button>
+            <button class="btn btn-primary" disabled="@this._isApplying" @onclick="this.ApplyMonsterBatchAsync">Aplicar a monstruos</button>
+        </div>
+    </div>
+</div>
+
+<div class="card mb-4">
+    <div class="card-header">
+        <strong>4. Items masivos</strong>
+    </div>
+    <div class="card-body">
+        <p class="text-muted">
+            Filtra el catálogo y modifica niveles de drop o habilitación de drop desde monstruos en una sola operación.
+        </p>
+        <div class="row g-3">
+            <div class="col-md-4">
+                <label class="form-label">Nombre contiene</label>
+                <input class="form-control" @bind="this._itemFilter" placeholder="Ej.: Dragon, Jewel, Helm…" />
+            </div>
+            <div class="col-md-2">
+                <label class="form-label">Grupo (0–15)</label>
+                <input class="form-control" type="number" min="0" max="15" @bind="this._itemGroup" />
+            </div>
+            <div class="col-md-3">
+                <label class="form-label">Drop level actual ≥</label>
+                <input class="form-control" type="number" min="0" max="255" @bind="this._itemCurrentMinDropLevel" />
+            </div>
+            <div class="col-md-3">
+                <label class="form-label">Drop level actual ≤</label>
+                <input class="form-control" type="number" min="0" max="255" @bind="this._itemCurrentMaxDropLevel" />
+            </div>
+        </div>
+
+        <hr />
+        <div class="row g-3">
+            <div class="col-md-3">
+                <label class="form-label">Nuevo DropLevel</label>
+                <input class="form-control" type="number" min="0" max="255" @bind="this._newItemDropLevel" />
+                <div class="form-text">Vacío = no cambiar.</div>
+            </div>
+            <div class="col-md-4">
+                <div class="form-check mb-2">
+                    <input id="setMaxDrop" class="form-check-input" type="checkbox" @bind="this._setItemMaximumDropLevel" />
+                    <label class="form-check-label" for="setMaxDrop">Modificar MaximumDropLevel</label>
+                </div>
+                <input class="form-control"
+                       type="number"
+                       min="0"
+                       max="255"
+                       disabled="@(!this._setItemMaximumDropLevel)"
+                       @bind="this._newItemMaximumDropLevel" />
+                <div class="form-text">Vacío + casilla activa = sin límite superior.</div>
+            </div>
+            <div class="col-md-5">
+                <div class="form-check mb-2">
+                    <input id="setMonsterDrop" class="form-check-input" type="checkbox" @bind="this._setDropsFromMonsters" />
+                    <label class="form-check-label" for="setMonsterDrop">Modificar “DropsFromMonsters”</label>
+                </div>
+                <select class="form-select" disabled="@(!this._setDropsFromMonsters)" @bind="this._newDropsFromMonsters">
+                    <option value="true">Sí, puede caer de monstruos</option>
+                    <option value="false">No, excluir del pool normal</option>
+                </select>
+            </div>
+        </div>
+
+        <div class="mt-2 text-muted small">Filtro actual: @this.GetMatchingItems().Count() items.</div>
+
+        <div class="mt-3 d-flex gap-2">
+            <button class="btn btn-outline-primary" disabled="@this._isApplying" @onclick="this.PreviewItemBatch">Vista previa</button>
+            <button class="btn btn-primary" disabled="@this._isApplying" @onclick="this.ApplyItemBatchAsync">Aplicar a items</button>
+        </div>
+    </div>
+</div>
+
+<div class="card mb-4">
+    <div class="card-header d-flex justify-content-between align-items-center">
+        <strong>5. Plantillas de tiendas</strong>
+        <NavLink class="btn btn-outline-primary btn-sm" href="merchant-cockpit">Abrir Merchant Cockpit</NavLink>
+    </div>
+    <div class="card-body">
+        <div class="alert alert-secondary">
+            Aquí puedes clonar tiendas completas por lote. Para editar merchants cómodamente —buscar items,
+            agregar/quitar, configurar nivel, skill, sockets, Luck/opciones, ordenar slots y copiar en modo
+            reemplazar o agregar— usa el <strong>Merchant Cockpit</strong>.
+        </div>
+
+        <div class="row g-3">
+            <div class="col-lg-5">
+                <label class="form-label">Tienda origen</label>
+                <select class="form-select" @bind="this._sourceMerchantId">
+                    <option value="">Seleccionar…</option>
+                    @foreach (var merchant in this._merchants)
+                    {
+                        <option value="@merchant.GetId()">@merchant.Designation (@merchant.MerchantStore!.Items.Count items)</option>
+                    }
+                </select>
+            </div>
+            <div class="col-lg-7">
+                <label class="form-label">Tiendas destino</label>
+                <div class="border rounded p-2" style="height:240px; overflow:auto;">
+                    @foreach (var merchant in this._merchants)
+                    {
+                        var id = merchant.GetId();
+                        <div class="form-check">
+                            <input class="form-check-input"
+                                   type="checkbox"
+                                   disabled="@(this._sourceMerchantId == id)"
+                                   checked="@this._targetMerchantIds.Contains(id)"
+                                   @onchange="e => this.ToggleMerchant(id, (bool)(e.Value ?? false))" />
+                            <label class="form-check-label">@merchant.Designation (@merchant.MerchantStore!.Items.Count items)</label>
+                        </div>
+                    }
+                </div>
+            </div>
+        </div>
+
+        <div class="mt-3 d-flex gap-2">
+            <button class="btn btn-outline-primary" disabled="@this._isApplying" @onclick="this.PreviewMerchantClone">Vista previa</button>
+            <button class="btn btn-primary" disabled="@this._isApplying" @onclick="this.ApplyMerchantCloneAsync">Clonar tienda</button>
+        </div>
+    </div>
+</div>

--- a/src/Web/AdminPanel/Pages/BatchOperations.razor.cs
+++ b/src/Web/AdminPanel/Pages/BatchOperations.razor.cs
@@ -1,0 +1,1040 @@
+// <copyright file="BatchOperations.razor.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Web.AdminPanel.Pages;
+
+using System.Globalization;
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.DataModel.Configuration.Items;
+using MUnique.OpenMU.DataModel.Entities;
+using MUnique.OpenMU.GameLogic.Attributes;
+using MUnique.OpenMU.Interfaces;
+using MUnique.OpenMU.Persistence;
+using MUnique.OpenMU.Web.Shared.Components.Toast;
+using MUnique.OpenMU.Web.Shared.Services;
+
+/// <summary>
+/// MU Nueva Era batch configuration cockpit.
+/// Provides preview-first bulk operations over the native OpenMU configuration graph.
+/// </summary>
+public partial class BatchOperations : ComponentBase, IAsyncDisposable
+{
+    private readonly HashSet<Guid> _selectedMapIds = [];
+    private readonly HashSet<Guid> _targetMerchantIds = [];
+
+    private GameConfiguration? _gameConfiguration;
+    private IContext? _gameContext;
+    private IContext? _serverContext;
+
+    private List<GameServerDefinition> _servers = [];
+    private List<ServerRateEdit> _serverEdits = [];
+    private List<GameMapDefinition> _maps = [];
+    private List<MonsterDefinition> _monsters = [];
+    private List<ItemDefinition> _items = [];
+    private List<DropItemGroup> _dropGroups = [];
+    private List<DropChanceEdit> _dropChanceEdits = [];
+    private List<MonsterDefinition> _merchants = [];
+
+    private EconomyEdit _economy = new();
+
+    private string _dropScope = "maps";
+    private string _dropAction = "add";
+    private Guid? _selectedDropGroupId;
+    private string _monsterFilter = string.Empty;
+    private int? _monsterMinLevel;
+    private int? _monsterMaxLevel;
+    private bool _monsterOnlySelectedMaps;
+
+    private int? _batchMaximumItemDrops;
+    private double? _batchRespawnSeconds;
+
+    private string _itemFilter = string.Empty;
+    private int? _itemGroup;
+    private int? _itemCurrentMinDropLevel;
+    private int? _itemCurrentMaxDropLevel;
+    private int? _newItemDropLevel;
+    private bool _setItemMaximumDropLevel;
+    private int? _newItemMaximumDropLevel;
+    private bool _setDropsFromMonsters;
+    private bool _newDropsFromMonsters = true;
+
+    private Guid? _sourceMerchantId;
+
+    private bool _restartAllAfterEconomyApply = true;
+    private bool _isLoading = true;
+    private bool _isApplying;
+
+    private string _previewTitle = "Sin vista previa";
+    private string _previewSummary = "Configura una operación y pulsa Vista previa.";
+    private List<string> _previewLines = [];
+    private Func<Task>? _undoAction;
+
+    /// <summary>
+    /// Gets or sets the game configuration data source.
+    /// </summary>
+    [Inject]
+    public IDataSource<GameConfiguration> DataSource { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the persistence context provider.
+    /// </summary>
+    [Inject]
+    public IPersistenceContextProvider ContextProvider { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the game server instance manager.
+    /// </summary>
+    [Inject]
+    public IGameServerInstanceManager ServerInstanceManager { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the toast service.
+    /// </summary>
+    [Inject]
+    public IToastService ToastService { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the loading overlay service.
+    /// </summary>
+    [Inject]
+    public LoadingOverlayService LoadingService { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the logger.
+    /// </summary>
+    [Inject]
+    public ILogger<BatchOperations> Logger { get; set; } = null!;
+
+    /// <inheritdoc/>
+    protected override async Task OnInitializedAsync()
+    {
+        using var loading = this.LoadingService.ShowLoadingIndicator();
+        try
+        {
+            this._gameContext = await this.DataSource.GetContextAsync().ConfigureAwait(true);
+            this._gameConfiguration = await this.DataSource.GetOwnerAsync().ConfigureAwait(true);
+
+            this._maps = this.DataSource.GetAll<GameMapDefinition>()
+                .OrderBy(m => m.Number)
+                .ThenBy(m => m.Name.ToString())
+                .ToList();
+
+            this._monsters = this.DataSource.GetAll<MonsterDefinition>()
+                .Where(m => m.ObjectKind == NpcObjectKind.Monster)
+                .OrderBy(GetMonsterLevel)
+                .ThenBy(m => m.Designation.ToString())
+                .ToList();
+
+            this._items = this.DataSource.GetAll<ItemDefinition>()
+                .OrderBy(i => i.Group)
+                .ThenBy(i => i.Number)
+                .ToList();
+
+            this._dropGroups = this.DataSource.GetAll<DropItemGroup>()
+                .OrderBy(g => g.ItemType)
+                .ThenBy(g => g.Description.ToString())
+                .ToList();
+
+            this._merchants = this.DataSource.GetAll<MonsterDefinition>()
+                .Where(m => m is { ObjectKind: NpcObjectKind.PassiveNpc, MerchantStore: not null })
+                .OrderBy(m => m.Designation.ToString())
+                .ToList();
+
+            this._economy = new EconomyEdit
+            {
+                ExperienceRate = this._gameConfiguration.ExperienceRate,
+                MasterExperienceRate = this._gameConfiguration.MasterExperienceRate,
+                MaximumInventoryMoney = this._gameConfiguration.MaximumInventoryMoney,
+                MaximumVaultMoney = this._gameConfiguration.MaximumVaultMoney,
+                ShouldDropMoney = this._gameConfiguration.ShouldDropMoney,
+                ItemDropDurationSeconds = this._gameConfiguration.ItemDropDuration.TotalSeconds,
+            };
+
+            this._dropChanceEdits = this._dropGroups
+                .Where(IsCommonEconomyDropGroup)
+                .Select(group => new DropChanceEdit(group))
+                .ToList();
+
+            this._serverContext = this.ContextProvider.CreateNewTypedContext(
+                typeof(GameServerDefinition),
+                true,
+                this._gameConfiguration);
+
+            this._servers = (await this._serverContext.GetAsync<GameServerDefinition>().ConfigureAwait(true))
+                .OrderBy(s => s.ServerID)
+                .ToList();
+
+            this._serverEdits = this._servers.Select(server => new ServerRateEdit(server)).ToList();
+        }
+        catch (Exception ex)
+        {
+            this.Logger.LogError(ex, "Failed to load batch cockpit.");
+            this.ToastService.ShowError($"No se pudo cargar Operaciones por lote: {ex.Message}");
+        }
+        finally
+        {
+            this._isLoading = false;
+        }
+    }
+
+    /// <inheritdoc/>
+    public ValueTask DisposeAsync()
+    {
+        this._serverContext?.Dispose();
+        this._serverContext = null;
+        return ValueTask.CompletedTask;
+    }
+
+    private void SelectAllMaps(bool selected)
+    {
+        this._selectedMapIds.Clear();
+        if (selected)
+        {
+            foreach (var map in this._maps)
+            {
+                this._selectedMapIds.Add(map.GetId());
+            }
+        }
+    }
+
+    private void ToggleMap(Guid id, bool selected)
+    {
+        if (selected)
+        {
+            this._selectedMapIds.Add(id);
+        }
+        else
+        {
+            this._selectedMapIds.Remove(id);
+        }
+    }
+
+    private void ToggleMerchant(Guid id, bool selected)
+    {
+        if (selected)
+        {
+            this._targetMerchantIds.Add(id);
+        }
+        else
+        {
+            this._targetMerchantIds.Remove(id);
+        }
+    }
+
+    private void PreviewEconomy()
+    {
+        if (this._gameConfiguration is null)
+        {
+            return;
+        }
+
+        var lines = new List<string>();
+        AddDiff(lines, "EXP global", this._gameConfiguration.ExperienceRate, this._economy.ExperienceRate);
+        AddDiff(lines, "Master EXP global", this._gameConfiguration.MasterExperienceRate, this._economy.MasterExperienceRate);
+        AddDiff(lines, "Zen máximo inventario", this._gameConfiguration.MaximumInventoryMoney, this._economy.MaximumInventoryMoney);
+        AddDiff(lines, "Zen máximo baúl", this._gameConfiguration.MaximumVaultMoney, this._economy.MaximumVaultMoney);
+        AddDiff(lines, "Zen cae al suelo", this._gameConfiguration.ShouldDropMoney, this._economy.ShouldDropMoney);
+        AddDiff(lines, "Duración drops (s)", this._gameConfiguration.ItemDropDuration.TotalSeconds, this._economy.ItemDropDurationSeconds);
+
+        foreach (var edit in this._serverEdits)
+        {
+            var server = this._servers.First(s => s.GetId() == edit.Id);
+            AddDiff(lines, $"Canal #{server.ServerID} {server.Description} · EXP", server.ExperienceRate, edit.ExperienceRate);
+            AddDiff(lines, $"Canal #{server.ServerID} {server.Description} · Zen", server.MoneyRate, edit.MoneyRate);
+            AddDiff(lines, $"Canal #{server.ServerID} {server.Description} · PvP", server.PvpEnabled, edit.PvpEnabled);
+        }
+
+        foreach (var edit in this._dropChanceEdits)
+        {
+            var group = this._dropGroups.First(g => g.GetId() == edit.Id);
+            AddDiff(lines, $"Drop {group.Description}", group.Chance * 100.0, edit.Percent, "%");
+        }
+
+        this.SetPreview(
+            "Economía y canales",
+            lines,
+            lines.Count == 0 ? "No hay cambios pendientes." : $"{lines.Count} cambios listos para aplicar.");
+    }
+
+    private async Task ApplyEconomyAsync()
+    {
+        if (this._gameConfiguration is null || this._gameContext is null || this._serverContext is null)
+        {
+            return;
+        }
+
+        this.PreviewEconomy();
+        if (this._previewLines.Count == 0)
+        {
+            this.ToastService.ShowSuccess("No hay cambios de economía para guardar.");
+            return;
+        }
+
+        if (this._economy.ExperienceRate < 0
+            || this._economy.MasterExperienceRate < 0
+            || this._economy.ItemDropDurationSeconds < 0
+            || this._serverEdits.Any(e => e.ExperienceRate < 0 || e.MoneyRate < 0)
+            || this._dropChanceEdits.Any(e => e.Percent is < 0 or > 100))
+        {
+            this.ToastService.ShowError("Hay valores fuera de rango. EXP/Zen no pueden ser negativos y los drops deben estar entre 0% y 100%.");
+            return;
+        }
+
+        var gameSnapshot = new EconomyEdit
+        {
+            ExperienceRate = this._gameConfiguration.ExperienceRate,
+            MasterExperienceRate = this._gameConfiguration.MasterExperienceRate,
+            MaximumInventoryMoney = this._gameConfiguration.MaximumInventoryMoney,
+            MaximumVaultMoney = this._gameConfiguration.MaximumVaultMoney,
+            ShouldDropMoney = this._gameConfiguration.ShouldDropMoney,
+            ItemDropDurationSeconds = this._gameConfiguration.ItemDropDuration.TotalSeconds,
+        };
+
+        var serverSnapshot = this._servers.ToDictionary(
+            s => s.GetId(),
+            s => new ServerSnapshot(s.ExperienceRate, s.MoneyRate, s.PvpEnabled));
+
+        var dropSnapshot = this._dropChanceEdits.ToDictionary(
+            e => e.Id,
+            e => this._dropGroups.First(g => g.GetId() == e.Id).Chance);
+
+        await this.RunApplyAsync(async () =>
+        {
+            this._gameConfiguration.ExperienceRate = this._economy.ExperienceRate;
+            this._gameConfiguration.MasterExperienceRate = this._economy.MasterExperienceRate;
+            this._gameConfiguration.MaximumInventoryMoney = this._economy.MaximumInventoryMoney;
+            this._gameConfiguration.MaximumVaultMoney = this._economy.MaximumVaultMoney;
+            this._gameConfiguration.ShouldDropMoney = this._economy.ShouldDropMoney;
+            this._gameConfiguration.ItemDropDuration = TimeSpan.FromSeconds(this._economy.ItemDropDurationSeconds);
+
+            foreach (var edit in this._serverEdits)
+            {
+                var server = this._servers.First(s => s.GetId() == edit.Id);
+                server.ExperienceRate = edit.ExperienceRate;
+                server.MoneyRate = edit.MoneyRate;
+                server.PvpEnabled = edit.PvpEnabled;
+            }
+
+            foreach (var edit in this._dropChanceEdits)
+            {
+                var group = this._dropGroups.First(g => g.GetId() == edit.Id);
+                group.Chance = edit.Percent / 100.0;
+            }
+
+            await this.SaveContextsAsync().ConfigureAwait(true);
+
+            this._undoAction = async () =>
+            {
+                this._gameConfiguration.ExperienceRate = gameSnapshot.ExperienceRate;
+                this._gameConfiguration.MasterExperienceRate = gameSnapshot.MasterExperienceRate;
+                this._gameConfiguration.MaximumInventoryMoney = gameSnapshot.MaximumInventoryMoney;
+                this._gameConfiguration.MaximumVaultMoney = gameSnapshot.MaximumVaultMoney;
+                this._gameConfiguration.ShouldDropMoney = gameSnapshot.ShouldDropMoney;
+                this._gameConfiguration.ItemDropDuration = TimeSpan.FromSeconds(gameSnapshot.ItemDropDurationSeconds);
+
+                foreach (var server in this._servers)
+                {
+                    var snapshot = serverSnapshot[server.GetId()];
+                    server.ExperienceRate = snapshot.ExperienceRate;
+                    server.MoneyRate = snapshot.MoneyRate;
+                    server.PvpEnabled = snapshot.PvpEnabled;
+                }
+
+                foreach (var pair in dropSnapshot)
+                {
+                    this._dropGroups.First(g => g.GetId() == pair.Key).Chance = pair.Value;
+                }
+
+                await this.SaveContextsAsync().ConfigureAwait(true);
+            };
+
+            if (this._restartAllAfterEconomyApply)
+            {
+                await this.ServerInstanceManager.RestartAllAsync(false).ConfigureAwait(true);
+            }
+        }, "Economía y canales guardados.").ConfigureAwait(true);
+    }
+
+    private void PreviewDropAssignment()
+    {
+        var group = this.GetSelectedDropGroup();
+        if (group is null)
+        {
+            this.SetPreview("Drops masivos", [], "Selecciona un grupo de drop.");
+            return;
+        }
+
+        var lines = new List<string>();
+        if (this._dropScope == "maps")
+        {
+            foreach (var map in this.GetSelectedMaps())
+            {
+                var contains = map.DropItemGroups.Contains(group);
+                if ((this._dropAction == "add" && !contains) || (this._dropAction == "remove" && contains))
+                {
+                    lines.Add($"{(this._dropAction == "add" ? "Agregar" : "Quitar")} '{group.Description}' {(this._dropAction == "add" ? "a" : "de")} mapa {map.Number} - {map.Name}");
+                }
+            }
+        }
+        else
+        {
+            foreach (var monster in this.GetMatchingMonsters())
+            {
+                var contains = monster.DropItemGroups.Contains(group);
+                if ((this._dropAction == "add" && !contains) || (this._dropAction == "remove" && contains))
+                {
+                    lines.Add($"{(this._dropAction == "add" ? "Agregar" : "Quitar")} '{group.Description}' {(this._dropAction == "add" ? "a" : "de")} {monster.Designation} (lvl {GetMonsterLevel(monster)})");
+                }
+            }
+        }
+
+        this.SetPreview("Drops masivos", lines, $"{lines.Count} relaciones cambiarán.");
+    }
+
+    private async Task ApplyDropAssignmentAsync()
+    {
+        if (this._gameContext is null)
+        {
+            return;
+        }
+
+        var group = this.GetSelectedDropGroup();
+        if (group is null)
+        {
+            this.ToastService.ShowError("Selecciona un grupo de drop.");
+            return;
+        }
+
+        var snapshots = new List<DropMembershipSnapshot>();
+        if (this._dropScope == "maps")
+        {
+            foreach (var map in this.GetSelectedMaps())
+            {
+                var had = map.DropItemGroups.Contains(group);
+                if ((this._dropAction == "add" && !had) || (this._dropAction == "remove" && had))
+                {
+                    snapshots.Add(new DropMembershipSnapshot(map, null, group, had));
+                }
+            }
+        }
+        else
+        {
+            foreach (var monster in this.GetMatchingMonsters())
+            {
+                var had = monster.DropItemGroups.Contains(group);
+                if ((this._dropAction == "add" && !had) || (this._dropAction == "remove" && had))
+                {
+                    snapshots.Add(new DropMembershipSnapshot(null, monster, group, had));
+                }
+            }
+        }
+
+        if (snapshots.Count == 0)
+        {
+            this.ToastService.ShowSuccess("No hay relaciones de drop para modificar.");
+            return;
+        }
+
+        await this.RunApplyAsync(async () =>
+        {
+            foreach (var snapshot in snapshots)
+            {
+                SetDropMembership(snapshot.Map, snapshot.Monster, group, this._dropAction == "add");
+            }
+
+            await this.SaveGameContextAsync().ConfigureAwait(true);
+
+            this._undoAction = async () =>
+            {
+                foreach (var snapshot in snapshots)
+                {
+                    SetDropMembership(snapshot.Map, snapshot.Monster, snapshot.Group, snapshot.HadGroup);
+                }
+
+                await this.SaveGameContextAsync().ConfigureAwait(true);
+            };
+        }, $"{snapshots.Count} relaciones de drop actualizadas.").ConfigureAwait(true);
+    }
+
+    private void PreviewMonsterBatch()
+    {
+        var targets = this.GetMatchingMonsters().ToList();
+        var lines = new List<string>();
+
+        foreach (var monster in targets)
+        {
+            var changes = new List<string>();
+            if (this._batchMaximumItemDrops.HasValue && monster.NumberOfMaximumItemDrops != this._batchMaximumItemDrops.Value)
+            {
+                changes.Add($"max drops {monster.NumberOfMaximumItemDrops} → {this._batchMaximumItemDrops.Value}");
+            }
+
+            if (this._batchRespawnSeconds.HasValue
+                && Math.Abs(monster.RespawnDelay.TotalSeconds - this._batchRespawnSeconds.Value) > 0.001)
+            {
+                changes.Add($"respawn {monster.RespawnDelay.TotalSeconds:0.##}s → {this._batchRespawnSeconds.Value:0.##}s");
+            }
+
+            if (changes.Count > 0)
+            {
+                lines.Add($"{monster.Designation} (lvl {GetMonsterLevel(monster)}): {string.Join(", ", changes)}");
+            }
+        }
+
+        this.SetPreview("Monstruos por lote", lines, $"{lines.Count} monstruos cambiarán.");
+    }
+
+    private async Task ApplyMonsterBatchAsync()
+    {
+        if (this._gameContext is null)
+        {
+            return;
+        }
+
+        if (!this._batchMaximumItemDrops.HasValue && !this._batchRespawnSeconds.HasValue)
+        {
+            this.ToastService.ShowError("Define al menos un valor a modificar.");
+            return;
+        }
+
+        if (this._batchMaximumItemDrops is < 0 || this._batchRespawnSeconds is < 0)
+        {
+            this.ToastService.ShowError("Max drops y respawn no pueden ser negativos.");
+            return;
+        }
+
+        var targets = this.GetMatchingMonsters().ToList();
+        var snapshots = targets.ToDictionary(
+            m => m.GetId(),
+            m => new MonsterBatchSnapshot(m.NumberOfMaximumItemDrops, m.RespawnDelay));
+
+        await this.RunApplyAsync(async () =>
+        {
+            foreach (var monster in targets)
+            {
+                if (this._batchMaximumItemDrops.HasValue)
+                {
+                    monster.NumberOfMaximumItemDrops = this._batchMaximumItemDrops.Value;
+                }
+
+                if (this._batchRespawnSeconds.HasValue)
+                {
+                    monster.RespawnDelay = TimeSpan.FromSeconds(this._batchRespawnSeconds.Value);
+                }
+            }
+
+            await this.SaveGameContextAsync().ConfigureAwait(true);
+
+            this._undoAction = async () =>
+            {
+                foreach (var monster in targets)
+                {
+                    var snapshot = snapshots[monster.GetId()];
+                    monster.NumberOfMaximumItemDrops = snapshot.MaximumItemDrops;
+                    monster.RespawnDelay = snapshot.RespawnDelay;
+                }
+
+                await this.SaveGameContextAsync().ConfigureAwait(true);
+            };
+        }, $"{targets.Count} monstruos procesados.").ConfigureAwait(true);
+    }
+
+    private void PreviewItemBatch()
+    {
+        var targets = this.GetMatchingItems().ToList();
+        var lines = new List<string>();
+        foreach (var item in targets)
+        {
+            var changes = new List<string>();
+            if (this._newItemDropLevel.HasValue && item.DropLevel != this._newItemDropLevel.Value)
+            {
+                changes.Add($"drop lvl {item.DropLevel} → {this._newItemDropLevel.Value}");
+            }
+
+            if (this._setItemMaximumDropLevel)
+            {
+                var newMax = this._newItemMaximumDropLevel.HasValue ? this._newItemMaximumDropLevel.Value.ToString(CultureInfo.InvariantCulture) : "sin límite";
+                var oldMax = item.MaximumDropLevel?.ToString(CultureInfo.InvariantCulture) ?? "sin límite";
+                if (oldMax != newMax)
+                {
+                    changes.Add($"max drop lvl {oldMax} → {newMax}");
+                }
+            }
+
+            if (this._setDropsFromMonsters && item.DropsFromMonsters != this._newDropsFromMonsters)
+            {
+                changes.Add($"drop monstruos {item.DropsFromMonsters} → {this._newDropsFromMonsters}");
+            }
+
+            if (changes.Count > 0)
+            {
+                lines.Add($"[{item.Group},{item.Number}] {item.Name}: {string.Join(", ", changes)}");
+            }
+        }
+
+        this.SetPreview("Items por lote", lines, $"{lines.Count} items cambiarán.");
+    }
+
+    private async Task ApplyItemBatchAsync()
+    {
+        if (this._gameContext is null)
+        {
+            return;
+        }
+
+        if (!this._newItemDropLevel.HasValue && !this._setItemMaximumDropLevel && !this._setDropsFromMonsters)
+        {
+            this.ToastService.ShowError("Define al menos un campo de item a modificar.");
+            return;
+        }
+
+        if (!IsByteOrNull(this._newItemDropLevel) || !IsByteOrNull(this._newItemMaximumDropLevel))
+        {
+            this.ToastService.ShowError("Los niveles de drop deben estar entre 0 y 255.");
+            return;
+        }
+
+        var targets = this.GetMatchingItems().ToList();
+        var snapshots = targets.ToDictionary(
+            i => i.GetId(),
+            i => new ItemBatchSnapshot(i.DropLevel, i.MaximumDropLevel, i.DropsFromMonsters));
+
+        await this.RunApplyAsync(async () =>
+        {
+            foreach (var item in targets)
+            {
+                if (this._newItemDropLevel.HasValue)
+                {
+                    item.DropLevel = (byte)this._newItemDropLevel.Value;
+                }
+
+                if (this._setItemMaximumDropLevel)
+                {
+                    item.MaximumDropLevel = this._newItemMaximumDropLevel.HasValue
+                        ? (byte)this._newItemMaximumDropLevel.Value
+                        : null;
+                }
+
+                if (this._setDropsFromMonsters)
+                {
+                    item.DropsFromMonsters = this._newDropsFromMonsters;
+                }
+            }
+
+            await this.SaveGameContextAsync().ConfigureAwait(true);
+
+            this._undoAction = async () =>
+            {
+                foreach (var item in targets)
+                {
+                    var snapshot = snapshots[item.GetId()];
+                    item.DropLevel = snapshot.DropLevel;
+                    item.MaximumDropLevel = snapshot.MaximumDropLevel;
+                    item.DropsFromMonsters = snapshot.DropsFromMonsters;
+                }
+
+                await this.SaveGameContextAsync().ConfigureAwait(true);
+            };
+        }, $"{targets.Count} items procesados.").ConfigureAwait(true);
+    }
+
+    private void PreviewMerchantClone()
+    {
+        var source = this.GetSourceMerchant();
+        if (source?.MerchantStore is null)
+        {
+            this.SetPreview("Plantilla de tienda", [], "Selecciona una tienda origen.");
+            return;
+        }
+
+        var targets = this.GetTargetMerchants(source.GetId()).ToList();
+        var lines = targets
+            .Select(target => $"{target.Designation}: {target.MerchantStore!.Items.Count} items → {source.MerchantStore.Items.Count} items")
+            .ToList();
+
+        this.SetPreview("Plantilla de tienda", lines, $"{lines.Count} tiendas serán reemplazadas por una copia de {source.Designation}.");
+    }
+
+    private async Task ApplyMerchantCloneAsync()
+    {
+        if (this._gameContext is null)
+        {
+            return;
+        }
+
+        var source = this.GetSourceMerchant();
+        if (source?.MerchantStore is null)
+        {
+            this.ToastService.ShowError("Selecciona una tienda origen.");
+            return;
+        }
+
+        var targets = this.GetTargetMerchants(source.GetId()).ToList();
+        if (targets.Count == 0)
+        {
+            this.ToastService.ShowError("Selecciona al menos una tienda destino.");
+            return;
+        }
+
+        var snapshots = targets.ToDictionary(
+            m => m.GetId(),
+            m => m.MerchantStore!.Items.Select(CreateShopItemSnapshot).ToList());
+
+        var sourceSnapshots = source.MerchantStore.Items.Select(CreateShopItemSnapshot).ToList();
+
+        await this.RunApplyAsync(async () =>
+        {
+            foreach (var target in targets)
+            {
+                await this.ReplaceMerchantItemsAsync(target, sourceSnapshots).ConfigureAwait(true);
+            }
+
+            await this.SaveGameContextAsync().ConfigureAwait(true);
+
+            this._undoAction = async () =>
+            {
+                foreach (var target in targets)
+                {
+                    await this.ReplaceMerchantItemsAsync(target, snapshots[target.GetId()]).ConfigureAwait(true);
+                }
+
+                await this.SaveGameContextAsync().ConfigureAwait(true);
+            };
+        }, $"{targets.Count} tiendas clonadas. Puedes deshacer la última operación mientras permanezcas en esta pantalla.").ConfigureAwait(true);
+    }
+
+    private async Task UndoLastAsync()
+    {
+        if (this._undoAction is null)
+        {
+            return;
+        }
+
+        await this.RunApplyAsync(async () =>
+        {
+            var undo = this._undoAction;
+            this._undoAction = null;
+            await undo().ConfigureAwait(true);
+        }, "Última operación revertida.").ConfigureAwait(true);
+    }
+
+    private async Task ReplaceMerchantItemsAsync(MonsterDefinition merchant, IReadOnlyList<ShopItemSnapshot> snapshots)
+    {
+        if (this._gameContext is null || merchant.MerchantStore is null)
+        {
+            return;
+        }
+
+        foreach (var oldItem in merchant.MerchantStore.Items.ToList())
+        {
+            merchant.MerchantStore.Items.Remove(oldItem);
+            await this._gameContext.DeleteAsync(oldItem).ConfigureAwait(true);
+        }
+
+        foreach (var snapshot in snapshots)
+        {
+            merchant.MerchantStore.Items.Add(CreateItemFromSnapshot(this._gameContext, snapshot));
+        }
+    }
+
+    private async Task RunApplyAsync(Func<Task> action, string successMessage)
+    {
+        if (this._isApplying)
+        {
+            return;
+        }
+
+        this._isApplying = true;
+        using var loading = this.LoadingService.ShowLoadingIndicator();
+        try
+        {
+            await action().ConfigureAwait(true);
+            this.ToastService.ShowSuccess(successMessage);
+            this._previewTitle = "Aplicado";
+            this._previewSummary = successMessage;
+        }
+        catch (Exception ex)
+        {
+            this.Logger.LogError(ex, "Batch operation failed.");
+            this.ToastService.ShowError($"La operación falló: {ex.Message}");
+        }
+        finally
+        {
+            this._isApplying = false;
+        }
+    }
+
+    private async Task SaveContextsAsync()
+    {
+        await this.SaveGameContextAsync().ConfigureAwait(true);
+        if (this._serverContext?.HasChanges is true)
+        {
+            await this._serverContext.SaveChangesAsync().ConfigureAwait(true);
+        }
+    }
+
+    private async Task SaveGameContextAsync()
+    {
+        if (this._gameContext?.HasChanges is true)
+        {
+            await this._gameContext.SaveChangesAsync().ConfigureAwait(true);
+        }
+    }
+
+    private DropItemGroup? GetSelectedDropGroup()
+        => this._selectedDropGroupId.HasValue
+            ? this._dropGroups.FirstOrDefault(g => g.GetId() == this._selectedDropGroupId.Value)
+            : null;
+
+    private IEnumerable<GameMapDefinition> GetSelectedMaps()
+        => this._maps.Where(m => this._selectedMapIds.Contains(m.GetId()));
+
+    private IEnumerable<MonsterDefinition> GetMatchingMonsters()
+    {
+        IEnumerable<MonsterDefinition> result = this._monsters;
+
+        if (!string.IsNullOrWhiteSpace(this._monsterFilter))
+        {
+            result = result.Where(m => (m.Designation.ToString() ?? string.Empty).Contains(this._monsterFilter, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (this._monsterMinLevel.HasValue)
+        {
+            result = result.Where(m => GetMonsterLevel(m) >= this._monsterMinLevel.Value);
+        }
+
+        if (this._monsterMaxLevel.HasValue)
+        {
+            result = result.Where(m => GetMonsterLevel(m) <= this._monsterMaxLevel.Value);
+        }
+
+        if (this._monsterOnlySelectedMaps && this._selectedMapIds.Count > 0)
+        {
+            var ids = this.GetSelectedMaps()
+                .SelectMany(m => m.MonsterSpawns)
+                .Where(s => s.MonsterDefinition is not null)
+                .Select(s => s.MonsterDefinition!.GetId())
+                .ToHashSet();
+
+            result = result.Where(m => ids.Contains(m.GetId()));
+        }
+
+        return result;
+    }
+
+    private IEnumerable<ItemDefinition> GetMatchingItems()
+    {
+        IEnumerable<ItemDefinition> result = this._items;
+
+        if (!string.IsNullOrWhiteSpace(this._itemFilter))
+        {
+            result = result.Where(i => (i.Name.ToString() ?? string.Empty).Contains(this._itemFilter, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (this._itemGroup.HasValue)
+        {
+            result = result.Where(i => i.Group == this._itemGroup.Value);
+        }
+
+        if (this._itemCurrentMinDropLevel.HasValue)
+        {
+            result = result.Where(i => i.DropLevel >= this._itemCurrentMinDropLevel.Value);
+        }
+
+        if (this._itemCurrentMaxDropLevel.HasValue)
+        {
+            result = result.Where(i => i.DropLevel <= this._itemCurrentMaxDropLevel.Value);
+        }
+
+        return result;
+    }
+
+    private MonsterDefinition? GetSourceMerchant()
+        => this._sourceMerchantId.HasValue
+            ? this._merchants.FirstOrDefault(m => m.GetId() == this._sourceMerchantId.Value)
+            : null;
+
+    private IEnumerable<MonsterDefinition> GetTargetMerchants(Guid sourceId)
+        => this._merchants.Where(m => m.GetId() != sourceId && this._targetMerchantIds.Contains(m.GetId()));
+
+    private void SetPreview(string title, IReadOnlyList<string> lines, string summary)
+    {
+        this._previewTitle = title;
+        this._previewSummary = summary;
+        this._previewLines = lines.Take(250).ToList();
+        if (lines.Count > 250)
+        {
+            this._previewLines.Add($"… y {lines.Count - 250} cambios adicionales.");
+        }
+    }
+
+    private static void SetDropMembership(GameMapDefinition? map, MonsterDefinition? monster, DropItemGroup group, bool shouldContain)
+    {
+        var collection = map?.DropItemGroups ?? monster?.DropItemGroups;
+        if (collection is null)
+        {
+            return;
+        }
+
+        var contains = collection.Contains(group);
+        if (shouldContain && !contains)
+        {
+            collection.Add(group);
+        }
+        else if (!shouldContain && contains)
+        {
+            collection.Remove(group);
+        }
+    }
+
+    private static bool IsCommonEconomyDropGroup(DropItemGroup group)
+        => group.Monster is null
+           && !group.MinimumMonsterLevel.HasValue
+           && !group.MaximumMonsterLevel.HasValue
+           && group.ItemType is SpecialItemType.Money
+               or SpecialItemType.RandomItem
+               or SpecialItemType.Excellent
+               or SpecialItemType.Jewel;
+
+    private static int GetMonsterLevel(MonsterDefinition monster)
+        => (int)(monster.Attributes.FirstOrDefault(a => a.AttributeDefinition == Stats.Level)?.Value ?? 0);
+
+    private static bool IsByteOrNull(int? value)
+        => !value.HasValue || value is >= byte.MinValue and <= byte.MaxValue;
+
+    private static void AddDiff<T>(ICollection<string> lines, string label, T oldValue, T newValue, string suffix = "")
+    {
+        if (EqualityComparer<T>.Default.Equals(oldValue, newValue))
+        {
+            return;
+        }
+
+        lines.Add($"{label}: {oldValue}{suffix} → {newValue}{suffix}");
+    }
+
+    private static ShopItemSnapshot CreateShopItemSnapshot(Item item)
+        => new(
+            item.ItemSlot,
+            item.Definition,
+            item.Durability,
+            item.Level,
+            item.HasSkill,
+            item.SocketCount,
+            item.StorePrice,
+            item.PetExperience,
+            item.ItemOptions.Select(option => new ShopOptionSnapshot(option.ItemOption, option.Level, option.Index)).ToList(),
+            item.ItemSetGroups.ToList());
+
+    private static Item CreateItemFromSnapshot(IContext context, ShopItemSnapshot snapshot)
+    {
+        var item = context.CreateNew<Item>();
+        item.ItemSlot = snapshot.ItemSlot;
+        item.Definition = snapshot.Definition;
+        item.Durability = snapshot.Durability;
+        item.Level = snapshot.Level;
+        item.HasSkill = snapshot.HasSkill;
+        item.SocketCount = snapshot.SocketCount;
+        item.StorePrice = snapshot.StorePrice;
+        item.PetExperience = snapshot.PetExperience;
+
+        foreach (var optionSnapshot in snapshot.Options)
+        {
+            var option = context.CreateNew<ItemOptionLink>();
+            option.ItemOption = optionSnapshot.ItemOption;
+            option.Level = optionSnapshot.Level;
+            option.Index = optionSnapshot.Index;
+            item.ItemOptions.Add(option);
+        }
+
+        foreach (var setGroup in snapshot.ItemSetGroups)
+        {
+            item.ItemSetGroups.Add(setGroup);
+        }
+
+        return item;
+    }
+
+    private sealed class EconomyEdit
+    {
+        public float ExperienceRate { get; set; }
+
+        public float MasterExperienceRate { get; set; }
+
+        public int MaximumInventoryMoney { get; set; }
+
+        public int MaximumVaultMoney { get; set; }
+
+        public bool ShouldDropMoney { get; set; }
+
+        public double ItemDropDurationSeconds { get; set; }
+    }
+
+    private sealed class ServerRateEdit
+    {
+        public ServerRateEdit(GameServerDefinition server)
+        {
+            this.Id = server.GetId();
+            this.ServerId = server.ServerID;
+            this.Description = server.Description;
+            this.ExperienceRate = server.ExperienceRate;
+            this.MoneyRate = server.MoneyRate;
+            this.PvpEnabled = server.PvpEnabled;
+        }
+
+        public Guid Id { get; }
+
+        public byte ServerId { get; }
+
+        public string Description { get; }
+
+        public float ExperienceRate { get; set; }
+
+        public float MoneyRate { get; set; }
+
+        public bool PvpEnabled { get; set; }
+    }
+
+    private sealed class DropChanceEdit
+    {
+        public DropChanceEdit(DropItemGroup group)
+        {
+            this.Id = group.GetId();
+            this.Description = group.Description.ToString() ?? string.Empty;
+            this.Type = group.ItemType;
+            this.Percent = group.Chance * 100.0;
+        }
+
+        public Guid Id { get; }
+
+        public string Description { get; }
+
+        public SpecialItemType Type { get; }
+
+        public double Percent { get; set; }
+    }
+
+    private sealed record ServerSnapshot(float ExperienceRate, float MoneyRate, bool PvpEnabled);
+
+    private sealed record DropMembershipSnapshot(GameMapDefinition? Map, MonsterDefinition? Monster, DropItemGroup Group, bool HadGroup);
+
+    private sealed record MonsterBatchSnapshot(int MaximumItemDrops, TimeSpan RespawnDelay);
+
+    private sealed record ItemBatchSnapshot(byte DropLevel, byte? MaximumDropLevel, bool DropsFromMonsters);
+
+    private sealed record ShopOptionSnapshot(IncreasableItemOption? ItemOption, int Level, int Index);
+
+    private sealed record ShopItemSnapshot(
+        byte ItemSlot,
+        ItemDefinition? Definition,
+        double Durability,
+        byte Level,
+        bool HasSkill,
+        int SocketCount,
+        int? StorePrice,
+        int PetExperience,
+        IReadOnlyList<ShopOptionSnapshot> Options,
+        IReadOnlyList<ItemOfItemSet> ItemSetGroups);
+}

--- a/src/Web/AdminPanel/Pages/BatchOperations.razor.cs
+++ b/src/Web/AdminPanel/Pages/BatchOperations.razor.cs
@@ -35,6 +35,8 @@ public partial class BatchOperations : ComponentBase, IAsyncDisposable
     private List<MonsterDefinition> _monsters = [];
     private List<ItemDefinition> _items = [];
     private List<DropItemGroup> _dropGroups = [];
+    private List<ItemDropItemGroup> _dropContentGroups = [];
+    private List<ItemSetGroup> _itemSets = [];
     private List<DropChanceEdit> _dropChanceEdits = [];
     private List<MonsterDefinition> _merchants = [];
 
@@ -60,6 +62,14 @@ public partial class BatchOperations : ComponentBase, IAsyncDisposable
     private int? _newItemMaximumDropLevel;
     private bool _setDropsFromMonsters;
     private bool _newDropsFromMonsters = true;
+
+    private Guid? _contentDropGroupId;
+    private string _contentAction = "add";
+    private string _contentFilter = string.Empty;
+    private int? _contentGroup;
+    private Guid? _contentSetId;
+    private DropGroupItemCategory _contentCategory = DropGroupItemCategory.Any;
+    private bool _contentConfirmed;
 
     private Guid? _sourceMerchantId;
 
@@ -136,6 +146,14 @@ public partial class BatchOperations : ComponentBase, IAsyncDisposable
             this._dropGroups = this.DataSource.GetAll<DropItemGroup>()
                 .OrderBy(g => g.ItemType)
                 .ThenBy(g => g.Description.ToString())
+                .ToList();
+
+            this._dropContentGroups = this.DataSource.GetAll<ItemDropItemGroup>()
+                .OrderBy(g => g.Description.ToString())
+                .ToList();
+
+            this._itemSets = this.DataSource.GetAll<ItemSetGroup>()
+                .OrderBy(set => set.Name.ToString())
                 .ToList();
 
             this._merchants = this.DataSource.GetAll<MonsterDefinition>()
@@ -641,6 +659,106 @@ public partial class BatchOperations : ComponentBase, IAsyncDisposable
         }, $"{targets.Count} items procesados.").ConfigureAwait(true);
     }
 
+    private ItemDropItemGroup? GetSelectedContentDropGroup()
+        => this._contentDropGroupId.HasValue
+            ? this._dropContentGroups.FirstOrDefault(group => group.GetId() == this._contentDropGroupId.Value)
+            : null;
+
+    private IReadOnlyList<ItemDefinition> GetMatchingContentItems()
+        => DropGroupItemSelector.Filter(
+            this._items,
+            this._contentFilter,
+            this._contentGroup,
+            this._contentSetId,
+            this._contentCategory);
+
+    private async Task ApplyDropContentBatchAsync()
+    {
+        if (this._gameContext is null)
+        {
+            return;
+        }
+
+        var group = this.GetSelectedContentDropGroup();
+        if (group is null)
+        {
+            this.ToastService.ShowError("Selecciona una caja o grupo de drop de items.");
+            return;
+        }
+
+        if (!this._contentConfirmed)
+        {
+            this.ToastService.ShowError("Marca la confirmación para aplicar la edición directa.");
+            return;
+        }
+
+        var targets = this.GetMatchingContentItems();
+        if (targets.Count == 0)
+        {
+            this.ToastService.ShowError("Los filtros no encontraron items.");
+            return;
+        }
+
+        if (this._contentAction is not ("add" or "remove" or "replace"))
+        {
+            this.ToastService.ShowError("La acción seleccionada no es válida.");
+            return;
+        }
+
+        var original = group.PossibleItems.ToList();
+        await this.RunApplyAsync(async () =>
+        {
+            if (this._contentAction == "replace")
+            {
+                foreach (var item in group.PossibleItems.ToList())
+                {
+                    group.PossibleItems.Remove(item);
+                }
+            }
+
+            var targetIds = targets.Select(item => item.GetId()).ToHashSet();
+            if (this._contentAction is "add" or "replace")
+            {
+                var existingIds = group.PossibleItems.Select(item => item.GetId()).ToHashSet();
+                foreach (var item in targets.Where(item => !existingIds.Contains(item.GetId())))
+                {
+                    group.PossibleItems.Add(item);
+                }
+            }
+            else
+            {
+                foreach (var item in group.PossibleItems.Where(item => targetIds.Contains(item.GetId())).ToList())
+                {
+                    group.PossibleItems.Remove(item);
+                }
+            }
+
+            await this.SaveGameContextAsync().ConfigureAwait(true);
+            this._contentConfirmed = false;
+            var action = this._contentAction switch
+            {
+                "add" => "agregados",
+                "remove" => "quitados",
+                _ => "reemplazados",
+            };
+            var message = $"{targets.Count} items {action} en {group.Description}.";
+            this.SetPreview("Edición directa aplicada", [], message);
+            this._undoAction = async () =>
+            {
+                foreach (var item in group.PossibleItems.ToList())
+                {
+                    group.PossibleItems.Remove(item);
+                }
+
+                foreach (var item in original)
+                {
+                    group.PossibleItems.Add(item);
+                }
+
+                await this.SaveGameContextAsync().ConfigureAwait(true);
+            };
+        }, $"{targets.Count} items modificados en {group.Description}. Puedes deshacer la última operación.").ConfigureAwait(true);
+    }
     private void PreviewMerchantClone()
     {
         var source = this.GetSourceMerchant();

--- a/src/Web/AdminPanel/Pages/CreateGameServerConfig.razor.cs
+++ b/src/Web/AdminPanel/Pages/CreateGameServerConfig.razor.cs
@@ -123,6 +123,7 @@ public partial class CreateGameServerConfig : ComponentBase, IAsyncDisposable
             ServerConfiguration = serverConfigs.FirstOrDefault(),
             ServerId = (byte)nextServerId,
             ExperienceRate = 1.0f,
+            MoneyRate = 1.0f,
             PvpEnabled = true,
             NetworkPort = networkPort,
             Client = clients.FirstOrDefault(),
@@ -143,6 +144,7 @@ public partial class CreateGameServerConfig : ComponentBase, IAsyncDisposable
         result.Description = this._viewModel.Description;
         result.PvpEnabled = this._viewModel.PvpEnabled;
         result.ExperienceRate = this._viewModel.ExperienceRate;
+        result.MoneyRate = this._viewModel.MoneyRate;
         result.GameConfiguration = await this.DataSource.GetOwnerAsync().ConfigureAwait(false);
         result.ServerConfiguration = this._viewModel.ServerConfiguration!;
 
@@ -221,6 +223,12 @@ public partial class CreateGameServerConfig : ComponentBase, IAsyncDisposable
         /// </value>
         [Range(0, float.MaxValue)]
         public float ExperienceRate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Zen/money multiplier of the server.
+        /// </summary>
+        [Range(0, float.MaxValue)]
+        public float MoneyRate { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether PVP is enabled on this server.

--- a/src/Web/AdminPanel/Pages/DropGroupItemSelector.cs
+++ b/src/Web/AdminPanel/Pages/DropGroupItemSelector.cs
@@ -1,0 +1,129 @@
+// <copyright file="DropGroupItemSelector.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Web.AdminPanel.Pages;
+
+using MUnique.OpenMU.DataModel;
+using MUnique.OpenMU.DataModel.Configuration.Items;
+using MUnique.OpenMU.Persistence;
+
+/// <summary>
+/// Categories understood by the drop-group editor.
+/// </summary>
+public enum DropGroupItemCategory
+{
+    /// <summary>Every item matching the text/group filters.</summary>
+    Any,
+
+    /// <summary>Items belonging to the selected set group.</summary>
+    Set,
+
+    /// <summary>Items which can receive the level 380 Guardian option.</summary>
+    Guardian380,
+
+    /// <summary>Items which can receive Excellent options.</summary>
+    Excellent,
+
+    /// <summary>Items which belong to an ancient set.</summary>
+    Ancient,
+
+    /// <summary>Items with socket support.</summary>
+    Socket,
+
+    /// <summary>Items equipped in either hand.</summary>
+    Weapons,
+
+    /// <summary>Items equipped in an armor slot.</summary>
+    Armor,
+
+    /// <summary>Wing definitions.</summary>
+    Wings,
+}
+
+/// <summary>
+/// Pure item selection rules shared by the Batch Operations page and tests.
+/// </summary>
+public static class DropGroupItemSelector
+{
+    /// <summary>
+    /// Filters item definitions using the same rules displayed by the drop-group editor.
+    /// </summary>
+    public static IReadOnlyList<ItemDefinition> Filter(
+        IEnumerable<ItemDefinition> items,
+        string? nameFilter,
+        int? group,
+        Guid? setId,
+        DropGroupItemCategory category)
+    {
+        ArgumentNullException.ThrowIfNull(items);
+
+        IEnumerable<ItemDefinition> result = items;
+        if (!string.IsNullOrWhiteSpace(nameFilter))
+        {
+            result = result.Where(item => (item.Name.ToString() ?? string.Empty).Contains(nameFilter, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (group.HasValue)
+        {
+            result = result.Where(item => item.Group == group.Value);
+        }
+
+        if (category == DropGroupItemCategory.Set)
+        {
+            result = setId.HasValue
+                ? result.Where(item => item.PossibleItemSetGroups.Any(set => set.GetId() == setId.Value))
+                : [];
+        }
+
+        result = category switch
+        {
+            DropGroupItemCategory.Guardian380 => result.Where(HasOptionType(ItemOptionTypes.GuardianOption)),
+            DropGroupItemCategory.Excellent => result.Where(HasOptionType(ItemOptionTypes.Excellent)),
+            DropGroupItemCategory.Ancient => result.Where(IsAncientItem),
+            DropGroupItemCategory.Socket => result.Where(item => item.MaximumSockets > 0),
+            DropGroupItemCategory.Weapons => result.Where(IsWeapon),
+            DropGroupItemCategory.Armor => result.Where(IsArmor),
+            DropGroupItemCategory.Wings => result.Where(item => item.IsWing()),
+            _ => result,
+        };
+
+        return result
+            .OrderBy(item => item.Group)
+            .ThenBy(item => item.Number)
+            .ToList();
+    }
+
+    /// <summary>
+    /// Determines whether a definition can receive a specific option type.
+    /// </summary>
+    public static bool HasOptionType(ItemDefinition item, ItemOptionType optionType)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        ArgumentNullException.ThrowIfNull(optionType);
+        return item.PossibleItemOptions
+            .SelectMany(option => option.PossibleOptions)
+            .Any(option => option.OptionType == optionType);
+    }
+
+    /// <summary>
+    /// Determines whether a definition is linked to an ancient set entry.
+    /// </summary>
+    public static bool IsAncientItem(ItemDefinition item)
+    {
+        ArgumentNullException.ThrowIfNull(item);
+        var id = item.GetId();
+        return item.PossibleItemSetGroups
+            .SelectMany(set => set.Items)
+            .Any(entry => entry.AncientSetDiscriminator > 0 && entry.ItemDefinition?.GetId() == id);
+    }
+
+    private static bool IsWeapon(ItemDefinition item)
+        => item.ItemSlot?.ItemSlots.Any(slot => slot is 0 or 1) is true;
+
+    private static bool IsArmor(ItemDefinition item)
+        => item.ItemSlot?.ItemSlots.Any(slot => slot is >= 2 and <= 6) is true;
+
+    private static Func<ItemDefinition, bool> HasOptionType(ItemOptionType optionType)
+        => item => HasOptionType(item, optionType);
+}

--- a/src/Web/AdminPanel/Pages/MerchantCockpit.razor
+++ b/src/Web/AdminPanel/Pages/MerchantCockpit.razor
@@ -1,0 +1,346 @@
+@page "/merchant-cockpit"
+
+@using MUnique.OpenMU.DataModel.Configuration
+@using MUnique.OpenMU.DataModel.Configuration.Items
+@using MUnique.OpenMU.DataModel.Entities
+@using MUnique.OpenMU.Persistence
+
+<PageTitle>OpenMU: Merchant Cockpit</PageTitle>
+<Breadcrumb Caption="Merchant Cockpit" />
+
+<h1>Merchant Cockpit</h1>
+<p class="text-muted">
+    Editor rápido de NPC vendedores para MU Nueva Era. Los cambios se preparan en memoria:
+    revisa la tienda y pulsa <strong>Guardar cambios</strong> cuando estés conforme.
+</p>
+
+@if (this._isLoading)
+{
+    <div class="alert alert-info">Cargando merchants e items…</div>
+    return;
+}
+
+<div class="d-flex flex-wrap gap-2 mb-3">
+    <button class="btn btn-success" disabled="@(!this.HasPendingChanges || this._isSaving)" @onclick="this.SaveAsync">
+        Guardar cambios
+    </button>
+    <button class="btn btn-outline-secondary" disabled="@(!this.HasPendingChanges || this._isSaving)" @onclick="this.DiscardAsync">
+        Descartar cambios
+    </button>
+    <button class="btn btn-outline-primary" disabled="@(this.SelectedMerchant is null)" @onclick="this.AutoArrangeCurrentMerchant">
+        Autoordenar slots
+    </button>
+    <NavLink class="btn btn-outline-dark" href="batch-operations">Operaciones por lote</NavLink>
+
+    @if (this.HasPendingChanges)
+    {
+        <span class="badge text-bg-warning align-self-center">Cambios sin guardar</span>
+    }
+</div>
+
+@if (!string.IsNullOrWhiteSpace(this._message))
+{
+    <div class="alert @this._messageCss">@this._message</div>
+}
+
+<div class="row g-3">
+    <div class="col-xl-3">
+        <div class="card h-100">
+            <div class="card-header">
+                <strong>1. Merchant</strong>
+            </div>
+            <div class="card-body">
+                <label class="form-label">Buscar NPC</label>
+                <input class="form-control mb-2" @bind="this._merchantFilter" @bind:event="oninput" placeholder="Hanzo, Pasi, potion…" />
+
+                <div class="list-group" style="max-height: 650px; overflow:auto;">
+                    @foreach (var merchant in this.FilteredMerchants)
+                    {
+                        var id = merchant.GetId();
+                        var active = this._selectedMerchantId == id;
+                        <button class="list-group-item list-group-item-action @(active ? "active" : "")"
+                                @onclick="() => this.SelectMerchant(id)">
+                            <div class="d-flex justify-content-between">
+                                <strong>@merchant.Designation</strong>
+                                <span class="badge @(active ? "text-bg-light" : "text-bg-secondary")">@merchant.MerchantStore!.Items.Count</span>
+                            </div>
+                            <div class="small opacity-75">#@merchant.Number · @this.GetMerchantMapsText(merchant)</div>
+                        </button>
+                    }
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="col-xl-5">
+        <div class="card h-100">
+            <div class="card-header d-flex justify-content-between align-items-center">
+                <strong>2. Tienda actual</strong>
+                @if (this.SelectedMerchant is { } selectedMerchant)
+                {
+                    <span>@selectedMerchant.Designation · @selectedMerchant.MerchantStore!.Items.Count items</span>
+                }
+            </div>
+            <div class="card-body">
+                @if (this.SelectedMerchant is null)
+                {
+                    <div class="alert alert-secondary">Selecciona un merchant a la izquierda.</div>
+                }
+                else
+                {
+                    <div class="row g-2 mb-3">
+                        <div class="col-md-8">
+                            <input class="form-control" @bind="this._shopFilter" @bind:event="oninput" placeholder="Filtrar la tienda actual…" />
+                        </div>
+                        <div class="col-md-4 d-grid">
+                            <button class="btn btn-outline-danger" @onclick="this.ClearCurrentMerchantAsync">
+                                Vaciar tienda
+                            </button>
+                        </div>
+                    </div>
+
+                    <div class="table-responsive" style="max-height: 430px; overflow:auto;">
+                        <table class="table table-sm table-hover align-middle">
+                            <thead class="sticky-top bg-body">
+                                <tr>
+                                    <th>Slot</th>
+                                    <th>Item</th>
+                                    <th>Nivel</th>
+                                    <th>Precio compra</th>
+                                    <th></th>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                @foreach (var item in this.FilteredShopItems)
+                                {
+                                    var id = item.GetId();
+                                    var selected = this._selectedShopItemId == id;
+                                    <tr class="@(selected ? "table-primary" : "")">
+                                        <td>@item.ItemSlot</td>
+                                        <td>
+                                            <button class="btn btn-link btn-sm text-start p-0" @onclick="() => this.SelectShopItem(id)">
+                                                @item.Definition?.Name
+                                            </button>
+                                            <div class="small text-muted">
+                                                G@(item.Definition?.Group)/#@(item.Definition?.Number)
+                                                · @item.Definition?.Width×@item.Definition?.Height
+                                            </div>
+                                        </td>
+                                        <td>+@item.Level</td>
+                                        <td>@this.FormatZen(this.GetBuyingPrice(item))</td>
+                                        <td class="text-end">
+                                            <button class="btn btn-outline-danger btn-sm" @onclick="() => this.RemoveShopItemAsync(item)">
+                                                Quitar
+                                            </button>
+                                        </td>
+                                    </tr>
+                                }
+                            </tbody>
+                        </table>
+                    </div>
+
+                    @if (this.SelectedShopItem is { } editItem)
+                    {
+                        <hr />
+                        <h6>Edición rápida · @editItem.Definition?.Name</h6>
+                        <div class="row g-2">
+                            <div class="col-6 col-md-3">
+                                <label class="form-label">Nivel</label>
+                                <input class="form-control form-control-sm" type="number" min="0" max="15" @bind="this._editLevel" />
+                            </div>
+                            <div class="col-6 col-md-3">
+                                <label class="form-label">Durabilidad</label>
+                                <input class="form-control form-control-sm" type="number" min="0" step="1" @bind="this._editDurability" />
+                            </div>
+                            <div class="col-6 col-md-3">
+                                <label class="form-label">Sockets</label>
+                                <input class="form-control form-control-sm" type="number" min="0" max="5" @bind="this._editSocketCount" />
+                            </div>
+                            <div class="col-6 col-md-3 d-flex align-items-end">
+                                <div class="form-check mb-2">
+                                    <input id="editSkill" class="form-check-input" type="checkbox" @bind="this._editHasSkill" />
+                                    <label class="form-check-label" for="editSkill">Skill</label>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div class="d-flex flex-wrap gap-2 mt-2">
+                            <button class="btn btn-primary btn-sm" @onclick="this.ApplyQuickItemEdit">Aplicar edición</button>
+                            <button class="btn btn-outline-primary btn-sm" @onclick="this.ToggleLuckAsync">
+                                @(this.SelectedItemHasLuck ? "Quitar Luck" : "Agregar Luck")
+                            </button>
+                        </div>
+
+                        <div class="mt-3">
+                            <label class="form-label">Opciones actuales</label>
+                            @if (!editItem.ItemOptions.Any())
+                            {
+                                <div class="text-muted small">Sin opciones adicionales.</div>
+                            }
+                            else
+                            {
+                                <div class="d-flex flex-wrap gap-1">
+                                    @foreach (var option in editItem.ItemOptions.ToList())
+                                    {
+                                        <button class="btn btn-outline-secondary btn-sm" title="Clic para quitar" @onclick="() => this.RemoveOptionAsync(option)">
+                                            @option
+                                            <span aria-hidden="true">×</span>
+                                        </button>
+                                    }
+                                </div>
+                            }
+                        </div>
+
+                        @if (this.AvailableOptionsForSelectedItem.Any())
+                        {
+                            <div class="row g-2 mt-2">
+                                <div class="col-md-7">
+                                    <select class="form-select form-select-sm" @bind="this._optionToAddId">
+                                        <option value="">Agregar otra opción…</option>
+                                        @foreach (var option in this.AvailableOptionsForSelectedItem)
+                                        {
+                                            <option value="@option.GetId()">@option.OptionType · @option</option>
+                                        }
+                                    </select>
+                                </div>
+                                <div class="col-md-2">
+                                    <input class="form-control form-control-sm" type="number" min="0" @bind="this._optionLevel" title="Nivel de opción" />
+                                </div>
+                                <div class="col-md-3 d-grid">
+                                    <button class="btn btn-outline-primary btn-sm" @onclick="this.AddSelectedOption">Agregar opción</button>
+                                </div>
+                            </div>
+                        }
+
+                        <div class="small text-muted mt-2">
+                            Precio mostrado: cálculo nativo de OpenMU para compra desde NPC.
+                            No es un precio exclusivo de este merchant.
+                        </div>
+                    }
+                }
+            </div>
+        </div>
+    </div>
+
+    <div class="col-xl-4">
+        <div class="card mb-3">
+            <div class="card-header">
+                <strong>3. Catálogo de items</strong>
+            </div>
+            <div class="card-body">
+                <div class="row g-2">
+                    <div class="col-8">
+                        <input class="form-control" @bind="this._catalogFilter" @bind:event="oninput" placeholder="Buscar item…" />
+                    </div>
+                    <div class="col-4">
+                        <select class="form-select" @bind="this._catalogGroup">
+                            <option value="">Todos</option>
+                            @for (var group = 0; group <= 15; group++)
+                            {
+                                <option value="@group">Grupo @group</option>
+                            }
+                        </select>
+                    </div>
+                </div>
+
+                <div class="row g-2 mt-1">
+                    <div class="col-4">
+                        <label class="form-label small">Nivel</label>
+                        <input class="form-control form-control-sm" type="number" min="0" max="15" @bind="this._newItemLevel" />
+                    </div>
+                    <div class="col-4">
+                        <label class="form-label small">Sockets</label>
+                        <input class="form-control form-control-sm" type="number" min="0" max="5" @bind="this._newItemSocketCount" />
+                    </div>
+                    <div class="col-4 d-flex align-items-end">
+                        <div class="form-check mb-1">
+                            <input id="newItemSkill" class="form-check-input" type="checkbox" @bind="this._newItemHasSkill" />
+                            <label class="form-check-label small" for="newItemSkill">Skill</label>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="d-flex gap-2 my-2">
+                    <button class="btn btn-outline-secondary btn-sm" @onclick="() => this.SelectAllVisibleCatalog(true)">Seleccionar visibles</button>
+                    <button class="btn btn-outline-secondary btn-sm" @onclick="() => this.SelectAllVisibleCatalog(false)">Limpiar</button>
+                    <button class="btn btn-primary btn-sm" disabled="@(this._selectedCatalogIds.Count == 0 || this.SelectedMerchant is null)" @onclick="this.AddSelectedCatalogItems">
+                        Agregar @this._selectedCatalogIds.Count
+                    </button>
+                </div>
+
+                <div class="border rounded p-2" style="height: 390px; overflow:auto;">
+                    @foreach (var definition in this.FilteredCatalog)
+                    {
+                        var id = definition.GetId();
+                        <div class="form-check border-bottom py-1">
+                            <input class="form-check-input"
+                                   type="checkbox"
+                                   checked="@this._selectedCatalogIds.Contains(id)"
+                                   @onchange="e => this.ToggleCatalog(id, (bool)(e.Value ?? false))" />
+                            <label class="form-check-label">
+                                <strong>@definition.Name</strong>
+                                <span class="text-muted small">G@(definition.Group)/#@definition.Number · @definition.Width×@definition.Height</span>
+                            </label>
+                        </div>
+                    }
+                </div>
+            </div>
+        </div>
+
+        <div class="card">
+            <div class="card-header">
+                <strong>4. Copiar tienda a otros NPC</strong>
+            </div>
+            <div class="card-body">
+                <div class="row g-2 mb-2">
+                    <div class="col-6">
+                        <label class="form-label">Modo</label>
+                        <select class="form-select form-select-sm" @bind="this._cloneMode">
+                            <option value="replace">Reemplazar</option>
+                            <option value="append">Agregar</option>
+                        </select>
+                    </div>
+                    <div class="col-6 d-flex align-items-end">
+                        <div class="form-check mb-1">
+                            <input id="skipDuplicates" class="form-check-input" type="checkbox" @bind="this._skipCloneDuplicates" />
+                            <label class="form-check-label small" for="skipDuplicates">Omitir duplicados</label>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="border rounded p-2 mb-2" style="height: 210px; overflow:auto;">
+                    @foreach (var merchant in this.FilteredCloneTargets)
+                    {
+                        var id = merchant.GetId();
+                        <div class="form-check">
+                            <input class="form-check-input"
+                                   type="checkbox"
+                                   checked="@this._cloneTargetIds.Contains(id)"
+                                   @onchange="e => this.ToggleCloneTarget(id, (bool)(e.Value ?? false))" />
+                            <label class="form-check-label">@merchant.Designation (@merchant.MerchantStore!.Items.Count)</label>
+                        </div>
+                    }
+                </div>
+
+                <div class="d-flex gap-2">
+                    <button class="btn btn-outline-primary btn-sm" disabled="@(this.SelectedMerchant is null || this._cloneTargetIds.Count == 0)" @onclick="this.PreviewClone">
+                        Vista previa
+                    </button>
+                    <button class="btn btn-primary btn-sm" disabled="@(this.SelectedMerchant is null || this._cloneTargetIds.Count == 0)" @onclick="this.StageCloneAsync">
+                        Preparar copia
+                    </button>
+                </div>
+
+                @if (this._clonePreviewLines.Count > 0)
+                {
+                    <div class="alert alert-info mt-2 mb-0 small">
+                        @foreach (var line in this._clonePreviewLines)
+                        {
+                            <div>@line</div>
+                        }
+                    </div>
+                }
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/Web/AdminPanel/Pages/MerchantCockpit.razor.cs
+++ b/src/Web/AdminPanel/Pages/MerchantCockpit.razor.cs
@@ -1,0 +1,890 @@
+// <copyright file="MerchantCockpit.razor.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Web.AdminPanel.Pages;
+
+using Microsoft.AspNetCore.Components;
+using Microsoft.Extensions.Logging;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.DataModel.Configuration.Items;
+using MUnique.OpenMU.DataModel.Entities;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.Persistence;
+using MUnique.OpenMU.Web.Shared.Components.Toast;
+using MUnique.OpenMU.Web.Shared.Services;
+
+/// <summary>
+/// Practical merchant editor for MU Nueva Era.
+/// </summary>
+public partial class MerchantCockpit : ComponentBase
+{
+    private const int MerchantGridWidth = 8;
+    private const int MerchantGridHeight = 15;
+    private const int MerchantGridSize = MerchantGridWidth * MerchantGridHeight;
+
+    private readonly ItemPriceCalculator _priceCalculator = new();
+    private readonly HashSet<Guid> _selectedCatalogIds = [];
+    private readonly HashSet<Guid> _cloneTargetIds = [];
+
+    private IContext? _context;
+    private GameConfiguration? _gameConfiguration;
+    private List<MonsterDefinition> _merchants = [];
+    private List<ItemDefinition> _items = [];
+    private List<GameMapDefinition> _maps = [];
+
+    private Guid? _selectedMerchantId;
+    private Guid? _selectedShopItemId;
+    private string _merchantFilter = string.Empty;
+    private string _shopFilter = string.Empty;
+    private string _catalogFilter = string.Empty;
+    private int? _catalogGroup;
+
+    private int _newItemLevel;
+    private int _newItemSocketCount;
+    private bool _newItemHasSkill;
+
+    private int _editLevel;
+    private double _editDurability;
+    private int _editSocketCount;
+    private bool _editHasSkill;
+
+    private Guid? _optionToAddId;
+    private int _optionLevel;
+
+    private string _cloneMode = "replace";
+    private bool _skipCloneDuplicates = true;
+    private List<string> _clonePreviewLines = [];
+
+    private bool _isLoading = true;
+    private bool _isSaving;
+    private string _message = string.Empty;
+    private string _messageCss = "alert-info";
+
+    /// <summary>
+    /// Gets or sets the game configuration data source.
+    /// </summary>
+    [Inject]
+    public IDataSource<GameConfiguration> DataSource { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the toast service.
+    /// </summary>
+    [Inject]
+    public IToastService ToastService { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the loading overlay.
+    /// </summary>
+    [Inject]
+    public LoadingOverlayService LoadingService { get; set; } = null!;
+
+    /// <summary>
+    /// Gets or sets the logger.
+    /// </summary>
+    [Inject]
+    public ILogger<MerchantCockpit> Logger { get; set; } = null!;
+
+    private bool HasPendingChanges => this._context?.HasChanges is true;
+
+    private MonsterDefinition? SelectedMerchant
+        => this._selectedMerchantId.HasValue
+            ? this._merchants.FirstOrDefault(m => m.GetId() == this._selectedMerchantId.Value)
+            : null;
+
+    private Item? SelectedShopItem
+        => this.SelectedMerchant?.MerchantStore?.Items.FirstOrDefault(i => i.GetId() == this._selectedShopItemId);
+
+    private IEnumerable<MonsterDefinition> FilteredMerchants
+        => this._merchants
+            .Where(m => string.IsNullOrWhiteSpace(this._merchantFilter)
+                        || (m.Designation.ToString() ?? string.Empty).Contains(this._merchantFilter, StringComparison.OrdinalIgnoreCase));
+
+    private IEnumerable<Item> FilteredShopItems
+        => (this.SelectedMerchant?.MerchantStore?.Items ?? [])
+            .Where(i => string.IsNullOrWhiteSpace(this._shopFilter)
+                        || (i.Definition?.Name.ToString() ?? string.Empty).Contains(this._shopFilter, StringComparison.OrdinalIgnoreCase))
+            .OrderBy(i => i.ItemSlot)
+            .ThenBy(i => i.Definition?.Group)
+            .ThenBy(i => i.Definition?.Number);
+
+    private IEnumerable<ItemDefinition> FilteredCatalog
+        => this._items
+            .Where(i => string.IsNullOrWhiteSpace(this._catalogFilter)
+                        || (i.Name.ToString() ?? string.Empty).Contains(this._catalogFilter, StringComparison.OrdinalIgnoreCase))
+            .Where(i => !this._catalogGroup.HasValue || i.Group == this._catalogGroup.Value)
+            .Take(300);
+
+    private IEnumerable<MonsterDefinition> FilteredCloneTargets
+        => this._merchants.Where(m => m.GetId() != this._selectedMerchantId);
+
+    private IEnumerable<IncreasableItemOption> AvailableOptionsForSelectedItem
+    {
+        get
+        {
+            var item = this.SelectedShopItem;
+            if (item?.Definition is null)
+            {
+                return [];
+            }
+
+            var existing = item.ItemOptions
+                .Where(o => o.ItemOption is not null)
+                .Select(o => o.ItemOption!.GetId())
+                .ToHashSet();
+
+            return item.Definition.PossibleItemOptions
+                .SelectMany(o => o.PossibleOptions)
+                .Where(o => !existing.Contains(o.GetId()))
+                .OrderBy(o => o.OptionType?.ToString())
+                .ThenBy(o => o.ToString());
+        }
+    }
+
+    private bool SelectedItemHasLuck
+        => this.SelectedShopItem?.ItemOptions.Any(o => o.ItemOption?.OptionType == ItemOptionTypes.Luck) is true;
+
+    /// <inheritdoc/>
+    protected override async Task OnInitializedAsync()
+    {
+        await this.LoadAsync().ConfigureAwait(true);
+    }
+
+    private async Task LoadAsync()
+    {
+        using var loading = this.LoadingService.ShowLoadingIndicator();
+        this._isLoading = true;
+
+        try
+        {
+            this._context = await this.DataSource.GetContextAsync().ConfigureAwait(true);
+            this._gameConfiguration = await this.DataSource.GetOwnerAsync().ConfigureAwait(true);
+
+            this._merchants = this.DataSource.GetAll<MonsterDefinition>()
+                .Where(m => m is { ObjectKind: NpcObjectKind.PassiveNpc, MerchantStore: not null })
+                .OrderBy(m => m.Designation.ToString())
+                .ToList();
+
+            this._items = this.DataSource.GetAll<ItemDefinition>()
+                .OrderBy(i => i.Group)
+                .ThenBy(i => i.Number)
+                .ToList();
+
+            this._maps = this.DataSource.GetAll<GameMapDefinition>()
+                .OrderBy(m => m.Number)
+                .ToList();
+
+            if (!this._selectedMerchantId.HasValue
+                || this._merchants.All(m => m.GetId() != this._selectedMerchantId.Value))
+            {
+                this._selectedMerchantId = this._merchants.FirstOrDefault()?.GetId();
+            }
+
+            this._selectedShopItemId = null;
+            this._selectedCatalogIds.Clear();
+            this._cloneTargetIds.Clear();
+            this._clonePreviewLines.Clear();
+            this.ClearMessage();
+        }
+        catch (Exception ex)
+        {
+            this.Logger.LogError(ex, "Failed to load Merchant Cockpit.");
+            this.SetMessage($"No se pudo cargar Merchant Cockpit: {ex.Message}", "alert-danger");
+        }
+        finally
+        {
+            this._isLoading = false;
+        }
+    }
+
+    private void SelectMerchant(Guid id)
+    {
+        this._selectedMerchantId = id;
+        this._selectedShopItemId = null;
+        this._cloneTargetIds.Remove(id);
+        this._clonePreviewLines.Clear();
+        this.ClearMessage();
+    }
+
+    private void SelectShopItem(Guid id)
+    {
+        this._selectedShopItemId = id;
+        if (this.SelectedShopItem is { } item)
+        {
+            this._editLevel = item.Level;
+            this._editDurability = item.Durability;
+            this._editSocketCount = item.SocketCount;
+            this._editHasSkill = item.HasSkill;
+            this._optionToAddId = null;
+            this._optionLevel = 0;
+        }
+    }
+
+    private void ToggleCatalog(Guid id, bool selected)
+    {
+        if (selected)
+        {
+            this._selectedCatalogIds.Add(id);
+        }
+        else
+        {
+            this._selectedCatalogIds.Remove(id);
+        }
+    }
+
+    private void SelectAllVisibleCatalog(bool selected)
+    {
+        if (!selected)
+        {
+            this._selectedCatalogIds.Clear();
+            return;
+        }
+
+        foreach (var definition in this.FilteredCatalog)
+        {
+            this._selectedCatalogIds.Add(definition.GetId());
+        }
+    }
+
+    private void ToggleCloneTarget(Guid id, bool selected)
+    {
+        if (selected)
+        {
+            this._cloneTargetIds.Add(id);
+        }
+        else
+        {
+            this._cloneTargetIds.Remove(id);
+        }
+    }
+
+    private void AddSelectedCatalogItems()
+    {
+        var merchant = this.SelectedMerchant;
+        if (merchant?.MerchantStore is null || this._context is null)
+        {
+            return;
+        }
+
+        var definitions = this._items
+            .Where(i => this._selectedCatalogIds.Contains(i.GetId()))
+            .ToList();
+
+        if (definitions.Count == 0)
+        {
+            return;
+        }
+
+        var added = 0;
+        foreach (var definition in definitions)
+        {
+            var freeSlot = FindFirstFreeSlot(merchant.MerchantStore.Items, definition);
+            if (!freeSlot.HasValue)
+            {
+                this.SetMessage(
+                    $"La tienda se quedó sin espacio después de agregar {added} item(s). "
+                    + $"{definition.Name} y los siguientes no fueron agregados.",
+                    "alert-warning");
+                break;
+            }
+
+            var item = this.CreateMerchantItem(definition, freeSlot.Value);
+            merchant.MerchantStore.Items.Add(item);
+            added++;
+        }
+
+        if (added > 0)
+        {
+            this.SetMessage(
+                $"{added} item(s) agregados a {merchant.Designation}. Revisa la tienda y guarda cuando estés conforme.",
+                "alert-success");
+        }
+
+        this._selectedCatalogIds.Clear();
+    }
+
+    private Item CreateMerchantItem(ItemDefinition definition, byte slot)
+    {
+        if (this._context is null)
+        {
+            throw new InvalidOperationException("Persistence context not initialized.");
+        }
+
+        var item = this._context.CreateNew<Item>();
+        item.Definition = definition;
+        item.ItemSlot = slot;
+        item.Level = (byte)Math.Clamp(this._newItemLevel, 0, definition.MaximumItemLevel);
+        item.Durability = definition.Durability;
+        item.HasSkill = this._newItemHasSkill && definition.Skill is not null;
+        item.SocketCount = Math.Clamp(this._newItemSocketCount, 0, definition.MaximumSockets);
+        return item;
+    }
+
+    private async Task RemoveShopItemAsync(Item item)
+    {
+        var merchant = this.SelectedMerchant;
+        if (merchant?.MerchantStore is null || this._context is null)
+        {
+            return;
+        }
+
+        merchant.MerchantStore.Items.Remove(item);
+        await this._context.DeleteAsync(item).ConfigureAwait(true);
+
+        if (this._selectedShopItemId == item.GetId())
+        {
+            this._selectedShopItemId = null;
+        }
+
+        this.SetMessage($"{item.Definition?.Name} quitado de {merchant.Designation}. Cambio aún sin guardar.", "alert-warning");
+    }
+
+    private async Task ClearCurrentMerchantAsync()
+    {
+        var merchant = this.SelectedMerchant;
+        if (merchant?.MerchantStore is null || this._context is null)
+        {
+            return;
+        }
+
+        var count = merchant.MerchantStore.Items.Count;
+        foreach (var item in merchant.MerchantStore.Items.ToList())
+        {
+            merchant.MerchantStore.Items.Remove(item);
+            await this._context.DeleteAsync(item).ConfigureAwait(true);
+        }
+
+        this._selectedShopItemId = null;
+        this.SetMessage($"{merchant.Designation}: {count} item(s) preparados para eliminación. Pulsa Guardar para confirmar.", "alert-warning");
+    }
+
+    private void ApplyQuickItemEdit()
+    {
+        var item = this.SelectedShopItem;
+        if (item?.Definition is null)
+        {
+            return;
+        }
+
+        item.Level = (byte)Math.Clamp(this._editLevel, 0, item.Definition.MaximumItemLevel);
+        item.Durability = Math.Max(0, this._editDurability);
+        item.SocketCount = Math.Clamp(this._editSocketCount, 0, item.Definition.MaximumSockets);
+        item.HasSkill = this._editHasSkill && item.Definition.Skill is not null;
+
+        this._editLevel = item.Level;
+        this._editDurability = item.Durability;
+        this._editSocketCount = item.SocketCount;
+        this._editHasSkill = item.HasSkill;
+
+        this.SetMessage(
+            $"{item.Definition.Name} actualizado. Precio calculado actual: {this.FormatZen(this.GetBuyingPrice(item))}.",
+            "alert-success");
+    }
+
+    private async Task ToggleLuckAsync()
+    {
+        var item = this.SelectedShopItem;
+        if (item?.Definition is null || this._context is null)
+        {
+            return;
+        }
+
+        var existing = item.ItemOptions.FirstOrDefault(o => o.ItemOption?.OptionType == ItemOptionTypes.Luck);
+        if (existing is not null)
+        {
+            item.ItemOptions.Remove(existing);
+            await this._context.DeleteAsync(existing).ConfigureAwait(true);
+            this.SetMessage($"Luck quitado de {item.Definition.Name}.", "alert-warning");
+            return;
+        }
+
+        var luck = item.Definition.PossibleItemOptions
+            .SelectMany(o => o.PossibleOptions)
+            .FirstOrDefault(o => o.OptionType == ItemOptionTypes.Luck);
+
+        if (luck is null)
+        {
+            this.SetMessage($"{item.Definition.Name} no tiene una opción Luck válida en su definición.", "alert-warning");
+            return;
+        }
+
+        var link = this._context.CreateNew<ItemOptionLink>();
+        link.ItemOption = luck;
+        link.Level = 0;
+        link.Index = this.GetNextOptionIndex(item);
+        item.ItemOptions.Add(link);
+        this.SetMessage($"Luck agregado a {item.Definition.Name}.", "alert-success");
+    }
+
+    private async Task RemoveOptionAsync(ItemOptionLink option)
+    {
+        var item = this.SelectedShopItem;
+        if (item is null || this._context is null)
+        {
+            return;
+        }
+
+        item.ItemOptions.Remove(option);
+        await this._context.DeleteAsync(option).ConfigureAwait(true);
+        this.SetMessage("Opción quitada. Cambio aún sin guardar.", "alert-warning");
+    }
+
+    private void AddSelectedOption()
+    {
+        var item = this.SelectedShopItem;
+        if (item?.Definition is null || this._context is null || !this._optionToAddId.HasValue)
+        {
+            return;
+        }
+
+        var option = item.Definition.PossibleItemOptions
+            .SelectMany(o => o.PossibleOptions)
+            .FirstOrDefault(o => o.GetId() == this._optionToAddId.Value);
+
+        if (option is null)
+        {
+            this.SetMessage("La opción seleccionada ya no está disponible para este item.", "alert-warning");
+            return;
+        }
+
+        if (item.ItemOptions.Any(o => o.ItemOption?.GetId() == option.GetId()))
+        {
+            this.SetMessage("Ese tipo de opción ya está aplicado al item.", "alert-warning");
+            return;
+        }
+
+        var link = this._context.CreateNew<ItemOptionLink>();
+        link.ItemOption = option;
+        link.Level = Math.Max(0, this._optionLevel);
+        link.Index = this.GetNextOptionIndex(item);
+        item.ItemOptions.Add(link);
+
+        this._optionToAddId = null;
+        this._optionLevel = 0;
+        this.SetMessage($"Opción agregada a {item.Definition.Name}.", "alert-success");
+    }
+
+    private int GetNextOptionIndex(Item item)
+        => item.ItemOptions.Count == 0 ? 0 : item.ItemOptions.Max(o => o.Index) + 1;
+
+    private void AutoArrangeCurrentMerchant()
+    {
+        var merchant = this.SelectedMerchant;
+        if (merchant?.MerchantStore is null)
+        {
+            return;
+        }
+
+        var items = merchant.MerchantStore.Items
+            .OrderBy(i => i.Definition?.Group)
+            .ThenBy(i => i.Definition?.Number)
+            .ThenBy(i => i.Level)
+            .ToList();
+
+        if (!TryPack(items, out var placements))
+        {
+            this.SetMessage(
+                $"No es posible ordenar {merchant.Designation}: los items no caben en la grilla {MerchantGridWidth}×{MerchantGridHeight}.",
+                "alert-danger");
+            return;
+        }
+
+        foreach (var pair in placements)
+        {
+            pair.Key.ItemSlot = pair.Value;
+        }
+
+        this.SetMessage($"{merchant.Designation}: slots reordenados automáticamente.", "alert-success");
+    }
+
+    private void PreviewClone()
+    {
+        var source = this.SelectedMerchant;
+        if (source?.MerchantStore is null)
+        {
+            this._clonePreviewLines = [];
+            return;
+        }
+
+        var sourceSnapshots = source.MerchantStore.Items.Select(CreateSnapshot).ToList();
+        var lines = new List<string>
+        {
+            $"Origen: {source.Designation} · {sourceSnapshots.Count} items · modo {this._cloneMode}.",
+        };
+
+        foreach (var target in this.GetCloneTargets())
+        {
+            if (this._cloneMode == "replace")
+            {
+                lines.Add($"{target.Designation}: {target.MerchantStore!.Items.Count} → {sourceSnapshots.Count} items.");
+                continue;
+            }
+
+            var append = this.GetSnapshotsToAppend(target, sourceSnapshots).ToList();
+            var canFit = CanAppend(target.MerchantStore!.Items, append);
+            lines.Add(
+                $"{target.Designation}: {target.MerchantStore.Items.Count} + {append.Count} "
+                + $"→ {(canFit ? target.MerchantStore.Items.Count + append.Count : "SIN ESPACIO")}.");
+        }
+
+        this._clonePreviewLines = lines;
+    }
+
+    private async Task StageCloneAsync()
+    {
+        var source = this.SelectedMerchant;
+        if (source?.MerchantStore is null || this._context is null)
+        {
+            return;
+        }
+
+        var targets = this.GetCloneTargets().ToList();
+        if (targets.Count == 0)
+        {
+            return;
+        }
+
+        var sourceSnapshots = source.MerchantStore.Items.Select(CreateSnapshot).ToList();
+
+        if (this._cloneMode == "append")
+        {
+            foreach (var target in targets)
+            {
+                var append = this.GetSnapshotsToAppend(target, sourceSnapshots).ToList();
+                if (!CanAppend(target.MerchantStore!.Items, append))
+                {
+                    this.SetMessage(
+                        $"No se preparó la copia: {target.Designation} no tiene espacio suficiente. "
+                        + "Usa Reemplazar, reduce la plantilla o quita items.",
+                        "alert-danger");
+                    return;
+                }
+            }
+        }
+
+        foreach (var target in targets)
+        {
+            if (this._cloneMode == "replace")
+            {
+                foreach (var oldItem in target.MerchantStore!.Items.ToList())
+                {
+                    target.MerchantStore.Items.Remove(oldItem);
+                    await this._context.DeleteAsync(oldItem).ConfigureAwait(true);
+                }
+
+                foreach (var snapshot in sourceSnapshots)
+                {
+                    target.MerchantStore.Items.Add(this.CreateFromSnapshot(snapshot, snapshot.ItemSlot));
+                }
+
+                continue;
+            }
+
+            foreach (var snapshot in this.GetSnapshotsToAppend(target, sourceSnapshots))
+            {
+                var slot = FindFirstFreeSlot(target.MerchantStore!.Items, snapshot.Definition);
+                if (!slot.HasValue)
+                {
+                    throw new InvalidOperationException($"Unexpected shop capacity failure on {target.Designation}.");
+                }
+
+                target.MerchantStore.Items.Add(this.CreateFromSnapshot(snapshot, slot.Value));
+            }
+        }
+
+        this.SetMessage(
+            $"Copia preparada para {targets.Count} merchant(s). Revisa los destinos y pulsa Guardar cambios para persistir.",
+            "alert-success");
+        this.PreviewClone();
+    }
+
+    private IEnumerable<MonsterDefinition> GetCloneTargets()
+        => this._merchants
+            .Where(m => m.GetId() != this._selectedMerchantId && this._cloneTargetIds.Contains(m.GetId()));
+
+    private IEnumerable<ShopItemSnapshot> GetSnapshotsToAppend(
+        MonsterDefinition target,
+        IReadOnlyList<ShopItemSnapshot> sourceSnapshots)
+    {
+        if (!this._skipCloneDuplicates)
+        {
+            return sourceSnapshots;
+        }
+
+        return sourceSnapshots.Where(snapshot =>
+            !target.MerchantStore!.Items.Any(item =>
+                item.Definition?.GetId() == snapshot.Definition.GetId()
+                && item.Level == snapshot.Level));
+    }
+
+    private async Task SaveAsync()
+    {
+        if (this._context is null || !this.HasPendingChanges)
+        {
+            return;
+        }
+
+        this._isSaving = true;
+        try
+        {
+            var saved = await this._context.SaveChangesAsync().ConfigureAwait(true);
+            if (!saved)
+            {
+                this.ToastService.ShowError("OpenMU no informó cambios guardados.");
+                return;
+            }
+
+            this.ToastService.ShowSuccess("Merchant configuration guardada.");
+            var selectedMerchantId = this._selectedMerchantId;
+            await this.DataSource.ForceDiscardChangesAsync().ConfigureAwait(true);
+            this._selectedMerchantId = selectedMerchantId;
+            await this.LoadAsync().ConfigureAwait(true);
+        }
+        catch (Exception ex)
+        {
+            this.Logger.LogError(ex, "Failed to save Merchant Cockpit changes.");
+            this.SetMessage($"Error al guardar merchants: {ex.Message}", "alert-danger");
+        }
+        finally
+        {
+            this._isSaving = false;
+        }
+    }
+
+    private async Task DiscardAsync()
+    {
+        var selectedMerchantId = this._selectedMerchantId;
+        await this.DataSource.DiscardChangesAsync().ConfigureAwait(true);
+        this._selectedMerchantId = selectedMerchantId;
+        await this.LoadAsync().ConfigureAwait(true);
+        this.ToastService.ShowSuccess("Cambios de merchants descartados.");
+    }
+
+    private string GetMerchantMapsText(MonsterDefinition merchant)
+    {
+        var names = this._maps
+            .Where(map => map.MonsterSpawns.Any(spawn => spawn.MonsterDefinition?.GetId() == merchant.GetId()))
+            .Select(map => map.Name.ToString())
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Take(3)
+            .ToList();
+
+        return names.Count == 0 ? "sin mapa detectado" : string.Join(", ", names);
+    }
+
+    private long GetBuyingPrice(Item item)
+    {
+        try
+        {
+            return this._priceCalculator.CalculateFinalBuyingPrice(item);
+        }
+        catch
+        {
+            return 0;
+        }
+    }
+
+    private string FormatZen(long amount)
+        => $"{amount:N0} Zen";
+
+    private static byte? FindFirstFreeSlot(IEnumerable<Item> existingItems, ItemDefinition definition)
+    {
+        var occupied = BuildOccupancy(existingItems);
+        return FindFirstFreeSlot(occupied, definition);
+    }
+
+    private static bool[] BuildOccupancy(IEnumerable<Item> items)
+    {
+        var occupied = new bool[MerchantGridSize];
+        foreach (var item in items)
+        {
+            if (item.Definition is null)
+            {
+                continue;
+            }
+
+            MarkOccupied(occupied, item.ItemSlot, item.Definition, true);
+        }
+
+        return occupied;
+    }
+
+    private static byte? FindFirstFreeSlot(bool[] occupied, ItemDefinition definition)
+    {
+        var width = Math.Max(1, (int)definition.Width);
+        var height = Math.Max(1, (int)definition.Height);
+
+        if (width > MerchantGridWidth || height > MerchantGridHeight)
+        {
+            return null;
+        }
+
+        for (var row = 0; row <= MerchantGridHeight - height; row++)
+        {
+            for (var col = 0; col <= MerchantGridWidth - width; col++)
+            {
+                var fits = true;
+                for (var y = 0; y < height && fits; y++)
+                {
+                    for (var x = 0; x < width; x++)
+                    {
+                        var slot = ((row + y) * MerchantGridWidth) + col + x;
+                        if (occupied[slot])
+                        {
+                            fits = false;
+                            break;
+                        }
+                    }
+                }
+
+                if (!fits)
+                {
+                    continue;
+                }
+
+                var firstSlot = (row * MerchantGridWidth) + col;
+                MarkOccupied(occupied, (byte)firstSlot, definition, true);
+                return (byte)firstSlot;
+            }
+        }
+
+        return null;
+    }
+
+    private static void MarkOccupied(bool[] occupied, byte itemSlot, ItemDefinition definition, bool value)
+    {
+        var startRow = itemSlot / MerchantGridWidth;
+        var startCol = itemSlot % MerchantGridWidth;
+        var width = Math.Max(1, (int)definition.Width);
+        var height = Math.Max(1, (int)definition.Height);
+
+        for (var y = 0; y < height; y++)
+        {
+            for (var x = 0; x < width; x++)
+            {
+                var row = startRow + y;
+                var col = startCol + x;
+                if (row >= MerchantGridHeight || col >= MerchantGridWidth)
+                {
+                    continue;
+                }
+
+                occupied[(row * MerchantGridWidth) + col] = value;
+            }
+        }
+    }
+
+    private static bool TryPack(IReadOnlyList<Item> items, out Dictionary<Item, byte> placements)
+    {
+        placements = [];
+        var occupied = new bool[MerchantGridSize];
+
+        foreach (var item in items)
+        {
+            if (item.Definition is null)
+            {
+                return false;
+            }
+
+            var slot = FindFirstFreeSlot(occupied, item.Definition);
+            if (!slot.HasValue)
+            {
+                return false;
+            }
+
+            placements[item] = slot.Value;
+        }
+
+        return true;
+    }
+
+    private static bool CanAppend(IEnumerable<Item> currentItems, IReadOnlyList<ShopItemSnapshot> snapshots)
+    {
+        var occupied = BuildOccupancy(currentItems);
+        foreach (var snapshot in snapshots)
+        {
+            if (!FindFirstFreeSlot(occupied, snapshot.Definition).HasValue)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static ShopItemSnapshot CreateSnapshot(Item item)
+        => new(
+            item.ItemSlot,
+            item.Definition ?? throw new InvalidOperationException("Shop item without definition."),
+            item.Durability,
+            item.Level,
+            item.HasSkill,
+            item.SocketCount,
+            item.StorePrice,
+            item.PetExperience,
+            item.ItemOptions
+                .Where(o => o.ItemOption is not null)
+                .Select(o => new ShopOptionSnapshot(o.ItemOption!, o.Level, o.Index))
+                .ToList(),
+            item.ItemSetGroups.ToList());
+
+    private Item CreateFromSnapshot(ShopItemSnapshot snapshot, byte slot)
+    {
+        if (this._context is null)
+        {
+            throw new InvalidOperationException("Persistence context not initialized.");
+        }
+
+        var item = this._context.CreateNew<Item>();
+        item.ItemSlot = slot;
+        item.Definition = snapshot.Definition;
+        item.Durability = snapshot.Durability;
+        item.Level = snapshot.Level;
+        item.HasSkill = snapshot.HasSkill;
+        item.SocketCount = snapshot.SocketCount;
+        item.StorePrice = snapshot.StorePrice;
+        item.PetExperience = snapshot.PetExperience;
+
+        foreach (var optionSnapshot in snapshot.Options)
+        {
+            var link = this._context.CreateNew<ItemOptionLink>();
+            link.ItemOption = optionSnapshot.ItemOption;
+            link.Level = optionSnapshot.Level;
+            link.Index = optionSnapshot.Index;
+            item.ItemOptions.Add(link);
+        }
+
+        foreach (var setGroup in snapshot.ItemSetGroups)
+        {
+            item.ItemSetGroups.Add(setGroup);
+        }
+
+        return item;
+    }
+
+    private void SetMessage(string text, string css)
+    {
+        this._message = text;
+        this._messageCss = css;
+    }
+
+    private void ClearMessage()
+    {
+        this._message = string.Empty;
+        this._messageCss = "alert-info";
+    }
+
+    private sealed record ShopOptionSnapshot(IncreasableItemOption ItemOption, int Level, int Index);
+
+    private sealed record ShopItemSnapshot(
+        byte ItemSlot,
+        ItemDefinition Definition,
+        double Durability,
+        byte Level,
+        bool HasSkill,
+        int SocketCount,
+        int? StorePrice,
+        int PetExperience,
+        IReadOnlyList<ShopOptionSnapshot> Options,
+        IReadOnlyList<ItemOfItemSet> ItemSetGroups);
+}

--- a/tests/MUnique.OpenMU.Web.Tests/DropGroupItemSelectorTests.cs
+++ b/tests/MUnique.OpenMU.Web.Tests/DropGroupItemSelectorTests.cs
@@ -1,0 +1,47 @@
+// <copyright file="DropGroupItemSelectorTests.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Web.Tests;
+
+using MUnique.OpenMU.DataModel.Configuration.Items;
+using MUnique.OpenMU.Interfaces;
+using Moq;
+using MUnique.OpenMU.Web.AdminPanel.Pages;
+
+/// <summary>
+/// Tests the category selectors used by the direct drop-group editor.
+/// </summary>
+[TestFixture]
+public class DropGroupItemSelectorTests
+{
+    /// <summary>
+    /// A 380-capable item is selected by its Guardian option and the normal group filter.
+    /// </summary>
+    [Test]
+    public void FindsGuardian380ItemsWithinAGroup()
+    {
+        var guardianOption = new IncreasableItemOption { OptionType = ItemOptionTypes.GuardianOption };
+        var guardianDefinition = new Mock<ItemOptionDefinition>();
+        guardianDefinition.SetupGet(definition => definition.PossibleOptions).Returns([guardianOption]);
+
+        var guardianItem = new Mock<ItemDefinition> { CallBase = true };
+        guardianItem.Object.Name = new LocalizedString("Dragon Armor");
+        guardianItem.Object.Group = 14;
+        guardianItem.SetupGet(item => item.PossibleItemOptions).Returns([guardianDefinition.Object]);
+
+        var otherItem = new Mock<ItemDefinition> { CallBase = true };
+        otherItem.Object.Name = new LocalizedString("Dragon Helm");
+        otherItem.Object.Group = 14;
+        otherItem.SetupGet(item => item.PossibleItemOptions).Returns([]);
+
+        var result = DropGroupItemSelector.Filter(
+            [guardianItem.Object, otherItem.Object],
+            "Dragon",
+            14,
+            null,
+            DropGroupItemCategory.Guardian380);
+
+        Assert.That(result, Is.EqualTo(new[] { guardianItem.Object }));
+    }
+}


### PR DESCRIPTION
## Summary
- add a per-game-server `MoneyRate`, propagated through the game context and money distribution
- add a guarded Batch Operations admin page for economy, realm, drop, monster, item, and merchant operations with preview-first workflows
- add a Merchant Cockpit for item search, shop editing, slot ordering, and replace/append shop cloning
- add the EF migration and Admin Panel navigation entries

`MoneyRate` defaults to `1`, including existing database rows, so the feature does not change the current server balance by itself.

## Validation
- `MUnique.OpenMU.Web.AdminPanel.csproj`: builds with 0 errors
- `MUnique.OpenMU.Startup.csproj`: builds with 0 errors
- package validator: 11/11 checks passed
- Docker deployment and automatic schema update completed; OpenMU and PostgreSQL healthy
- verified all three existing realms retain `MoneyRate = 1`
- browser-tested Merchant Cockpit search, slot placement, auto-order, copy preview/staging/discard, and a real save/reload/native-editor round trip followed by restoration
- browser-tested Batch Operations against the live configuration without applying a mass operation
- verified existing account and character counts remained unchanged