### PR TITLE
Give bots their own log category and quiet their per-tick logging

### DIFF
--- a/src/GameLogic/Bots/BotEquipmentHandler.cs
+++ b/src/GameLogic/Bots/BotEquipmentHandler.cs
@@ -114,7 +114,7 @@ internal static class BotEquipmentHandler
             return false;
         }
 
-        player.Logger.LogInformation(
+        player.Logger.LogDebug(
             "Bot '{Name}' equipped '{New}'{Replaced}.",
             player.Name,
             item,

--- a/src/GameLogic/Bots/BotFeaturePlugIn.cs
+++ b/src/GameLogic/Bots/BotFeaturePlugIn.cs
@@ -603,7 +603,7 @@ public class BotFeaturePlugIn : IFeaturePlugIn, IPeriodicTaskPlugIn, ISupportCus
             if (offline.SelectRandom() is { Login: not null } candidate
                 && await state.Manager.SpawnBotAsync(gameContext, candidate.Login, candidate.Slot).ConfigureAwait(false))
             {
-                logger.LogInformation("Bot presence rotation: +1 (online {Online}/{Target} of {Total}).", online + 1, targetOnline, totalPopulation);
+                logger.LogDebug("Bot presence rotation: +1 (online {Online}/{Target} of {Total}).", online + 1, targetOnline, totalPopulation);
             }
         }
         else if (online > targetOnline)
@@ -611,7 +611,7 @@ public class BotFeaturePlugIn : IFeaturePlugIn, IPeriodicTaskPlugIn, ISupportCus
             var stopped = await state.Manager.StopRandomBotAsync().ConfigureAwait(false);
             if (stopped is not null)
             {
-                logger.LogInformation("Bot presence rotation: -1 '{Name}' (online {Online}/{Target} of {Total}).", stopped, online - 1, targetOnline, totalPopulation);
+                logger.LogDebug("Bot presence rotation: -1 '{Name}' (online {Online}/{Target} of {Total}).", stopped, online - 1, targetOnline, totalPopulation);
             }
         }
     }

--- a/src/GameLogic/Bots/BotJewelHandler.cs
+++ b/src/GameLogic/Bots/BotJewelHandler.cs
@@ -358,7 +358,7 @@ internal static class BotJewelHandler
         var consumed = inventory.GetItem(jewelSlot) != jewel;
         if (consumed)
         {
-            player.Logger.LogInformation(
+            player.Logger.LogDebug(
                 "Bot '{Name}' used '{Jewel}' on '{Item}': level {Before} -> {After}.",
                 player.Name,
                 jewel.Definition?.Name,

--- a/src/GameLogic/Bots/BotManager.cs
+++ b/src/GameLogic/Bots/BotManager.cs
@@ -87,7 +87,7 @@ public sealed class BotManager
 
             BotSkillProgressionPlugIn.CatchUpPendingProgress(bot);
 
-            bot.Logger.LogInformation("Bot started for account '{LoginName}', character '{Character}'.", loginName, character.Name);
+            bot.Logger.LogDebug("Bot started for account '{LoginName}', character '{Character}'.", loginName, character.Name);
             return true;
         }
         catch (Exception ex)
@@ -272,7 +272,7 @@ public sealed class BotManager
                     }
                 }
 
-                leader.Logger.LogInformation(
+                leader.Logger.LogDebug(
                     "Formed bot party of {Count} around '{Leader}' (level {Level}).",
                     members.Count,
                     leader.Name,

--- a/src/GameLogic/Bots/BotMasterHandler.cs
+++ b/src/GameLogic/Bots/BotMasterHandler.cs
@@ -98,7 +98,7 @@ internal static class BotMasterHandler
 
         var masterClass = BotProgression.GetMasterEvolutionTarget(character.CharacterClass!)!;
         character.CharacterClass = masterClass;
-        player.Logger.LogInformation(
+        player.Logger.LogDebug(
             "Bot '{Name}' evolved into master class {Class} at level {Level}.",
             player.Name,
             masterClass.Name,
@@ -153,7 +153,7 @@ internal static class BotMasterHandler
                 break;
             }
 
-            player.Logger.LogInformation(
+            player.Logger.LogDebug(
                 "Bot '{Name}' invested {Points} master point(s) into '{Skill}'.",
                 player.Name,
                 pointsBefore - character.MasterLevelUpPoints,

--- a/src/GameLogic/Bots/BotMiniGameHandler.cs
+++ b/src/GameLogic/Bots/BotMiniGameHandler.cs
@@ -126,7 +126,7 @@ internal static class BotMiniGameHandler
         {
             // Like a player who cannot join the run: the bot says goodbye and goes back to its
             // own hunting life instead of waiting at the gate.
-            bot.Logger.LogInformation(
+            bot.Logger.LogDebug(
                 "Bot '{Name}' cannot follow '{Leader}' into {Event} ({Reason}) and leaves the party.",
                 bot.Name,
                 leader.Name,
@@ -150,7 +150,7 @@ internal static class BotMiniGameHandler
         {
             // Full or already closed - not the bot's fault; it stays in the party and waits for
             // the leader outside, hunting normally.
-            bot.Logger.LogInformation(
+            bot.Logger.LogDebug(
                 "Bot '{Name}' could not follow '{Leader}' into {Event}: {Result}.",
                 bot.Name,
                 leader.Name,
@@ -168,7 +168,7 @@ internal static class BotMiniGameHandler
         await bot.MagicEffectList.ClearEffectsAfterDeathAsync().ConfigureAwait(false);
         await bot.RemoveSummonAsync().ConfigureAwait(false);
         await bot.WarpToAsync(entrance).ConfigureAwait(false);
-        bot.Logger.LogInformation(
+        bot.Logger.LogDebug(
             "Bot '{Name}' follows '{Leader}' into {Event}.",
             bot.Name,
             leader.Name,

--- a/src/GameLogic/Bots/BotNavigator.cs
+++ b/src/GameLogic/Bots/BotNavigator.cs
@@ -650,7 +650,7 @@ internal sealed class BotNavigator : AsyncDisposable
                     // No way to the merchant from here - give up this trip and don't retry every
                     // check interval (an unreachable merchant stays unreachable for a while; a bot
                     // retrying twice a minute wastes its hunting time on futile marches).
-                    this._player.Logger.LogInformation("Bot '{Name}' gives up its shopping trip: no route to the merchant at {Target}.", this._player.Name, target);
+                    this._player.Logger.LogDebug("Bot '{Name}' gives up its shopping trip: no route to the merchant at {Target}.", this._player.Name, target);
                     this._shoppingTarget = null;
                     this._player.IsOnShoppingTrip = false;
                     this._nextShoppingCheckUtc = NextShoppingCheckUtc();
@@ -696,7 +696,7 @@ internal sealed class BotNavigator : AsyncDisposable
                 this._hasDestination = false;
                 this._lastWarpUtc = DateTime.UtcNow;
                 this._nextShoppingCheckUtc = DateTime.UtcNow; // start the trip on the new map right away
-                this._player.Logger.LogInformation("Bot '{Name}' warps home to {Map} for a shopping trip - no merchant on its map.", this._player.Name, homeMap.Name);
+                this._player.Logger.LogDebug("Bot '{Name}' warps home to {Map} for a shopping trip - no merchant on its map.", this._player.Name, homeMap.Name);
                 await this._player.WarpToAsync(homeGate).ConfigureAwait(false);
                 return true;
             }
@@ -716,7 +716,7 @@ internal sealed class BotNavigator : AsyncDisposable
 
         this._shoppingTarget = merchantPosition;
         this._player.IsOnShoppingTrip = true;
-        this._player.Logger.LogInformation("Bot '{Name}' heads to the merchant for a shopping trip.", this._player.Name);
+        this._player.Logger.LogDebug("Bot '{Name}' heads to the merchant for a shopping trip.", this._player.Name);
         return true;
     }
 
@@ -913,7 +913,7 @@ internal sealed class BotNavigator : AsyncDisposable
                 // behind unreachable or sneak in through a back door, the bot leaves the group.
                 if (this._player.Party is { } party)
                 {
-                    this._player.Logger.LogInformation(
+                    this._player.Logger.LogDebug(
                         "Bot {Character} leaves its party: it cannot legally follow '{Leader}' to map {Map}.",
                         this._player.Name,
                         leader.Name,
@@ -944,7 +944,7 @@ internal sealed class BotNavigator : AsyncDisposable
                 this._lastWarpUtc = DateTime.UtcNow;
                 this._hasDestination = false;
                 this._travelPath = null;
-                this._player.Logger.LogInformation(
+                this._player.Logger.LogDebug(
                     "Bot {Character} following party leader {Leader} to map {Map}.",
                     this._player.Name,
                     leader.Name,
@@ -1119,7 +1119,7 @@ internal sealed class BotNavigator : AsyncDisposable
         this._lastWarpUtc = DateTime.UtcNow;
         this._hasDestination = false;
         this._travelPath = null;
-        this._player.Logger.LogInformation(
+        this._player.Logger.LogDebug(
             "Bot {Character} (level {Level}) warping to map {Map} (monsters ~{MonsterLevel}, fare {Fare} zen).",
             this._player.Name,
             botLevel,
@@ -1245,7 +1245,7 @@ internal sealed class BotNavigator : AsyncDisposable
 
         this._destination = ground;
         this._hasDestination = true;
-        this._player.Logger.LogInformation(
+        this._player.Logger.LogDebug(
             "Bot {Character} (level {Level}) heading to hunting ground {Ground} (monster level ~{MonsterLevel}).",
             this._player.Name,
             this.GetBotLevel(),

--- a/src/GameLogic/Bots/BotPartyHandler.cs
+++ b/src/GameLogic/Bots/BotPartyHandler.cs
@@ -73,7 +73,7 @@ internal static class BotPartyHandler
 
         // The same feedback a human invitee's request flow gives, so the inviter knows it went out.
         await requester.ShowLocalizedBlueMessageAsync(nameof(PlayerMessage.RequestedPlayerForParty), bot.Name).ConfigureAwait(false);
-        bot.Logger.LogInformation("Bot '{Name}' accepts the party invitation of '{Requester}' in {Delay}.", bot.Name, requester.Name, delay);
+        bot.Logger.LogDebug("Bot '{Name}' accepts the party invitation of '{Requester}' in {Delay}.", bot.Name, requester.Name, delay);
         return true;
     }
 
@@ -106,7 +106,7 @@ internal static class BotPartyHandler
             if (DateTime.UtcNow >= bot.PartyBoredomAtUtc)
             {
                 bot.PartyBoredomAtUtc = null;
-                bot.Logger.LogInformation("Bot '{Name}' got bored and leaves its party.", bot.Name);
+                bot.Logger.LogDebug("Bot '{Name}' got bored and leaves its party.", bot.Name);
                 await party.KickMySelfAsync(bot).ConfigureAwait(false);
             }
         }
@@ -134,14 +134,14 @@ internal static class BotPartyHandler
         // and the inviter may have died, left the game or joined another party.
         if (HasHumanCompanion(bot) || !IsRequesterEligible(requester))
         {
-            bot.Logger.LogInformation("Bot '{Name}' dropped the party invitation of '{Requester}' - the situation changed.", bot.Name, requester.Name);
+            bot.Logger.LogDebug("Bot '{Name}' dropped the party invitation of '{Requester}' - the situation changed.", bot.Name, requester.Name);
             return;
         }
 
         await LeaveBotPartyAsync(bot).ConfigureAwait(false);
         if (bot.Party is not null)
         {
-            bot.Logger.LogInformation("Bot '{Name}' could not leave its bot party for '{Requester}'.", bot.Name, requester.Name);
+            bot.Logger.LogDebug("Bot '{Name}' could not leave its bot party for '{Requester}'.", bot.Name, requester.Name);
             return;
         }
 
@@ -167,7 +167,7 @@ internal static class BotPartyHandler
 
         if (success)
         {
-            bot.Logger.LogInformation("Bot '{Name}' joined the party of '{Requester}'.", bot.Name, requester.Name);
+            bot.Logger.LogDebug("Bot '{Name}' joined the party of '{Requester}'.", bot.Name, requester.Name);
         }
     }
 
@@ -188,7 +188,7 @@ internal static class BotPartyHandler
 
         if (Equals(party.PartyMaster, bot))
         {
-            bot.Logger.LogInformation("Bot '{Name}' breaks up its bot party to join a player.", bot.Name);
+            bot.Logger.LogDebug("Bot '{Name}' breaks up its bot party to join a player.", bot.Name);
             foreach (var member in party.PartyList.ToList())
             {
                 await party.KickMySelfAsync(member).ConfigureAwait(false);

--- a/src/GameLogic/Bots/BotPlayer.cs
+++ b/src/GameLogic/Bots/BotPlayer.cs
@@ -35,6 +35,10 @@ public sealed class BotPlayer : OfflinePlayer
     public BotPlayer(IGameContext gameContext)
         : base(gameContext)
     {
+        // File the bot's log entries under its own runtime category
+        // (MUnique.OpenMU.GameLogic.Bots.BotPlayer), so a single Serilog MinimumLevel.Override can
+        // silence or surface bot logging without touching real players, who keep the base Player category.
+        this.Logger = new RuntimeCategoryLogger<Player>(gameContext.LoggerFactory, this);
     }
 
     /// <inheritdoc />

--- a/src/GameLogic/Bots/BotResetHandler.cs
+++ b/src/GameLogic/Bots/BotResetHandler.cs
@@ -133,7 +133,7 @@ internal static class BotResetHandler
             character.LevelUpPoints += resetProgression.PointsForReset;
         }
 
-        player.Logger.LogInformation(
+        player.Logger.LogDebug(
             "Bot '{Name}' performed reset {ResetCount} and got {Points} points to invest.",
             player.Name,
             resetProgression.NextResetCount,

--- a/src/GameLogic/Bots/BotShoppingHandler.cs
+++ b/src/GameLogic/Bots/BotShoppingHandler.cs
@@ -138,16 +138,17 @@ internal static class BotShoppingHandler
             .FirstOrDefault(n => n.Definition is { ObjectKind: NpcObjectKind.PassiveNpc, MerchantStore.Items.Count: > 0 });
         if (merchant is null || player.Inventory is not { } inventory)
         {
-            // Not silent: exactly this case hid the wandering-merchant bug (a configured but
-            // unspawned merchant) for a long time.
-            player.Logger.LogInformation("Bot '{Name}' found no merchant near {Position} and gives up the trip.", player.Name, merchantPosition);
+            // Kept as a diagnostic: this exact case (a configured but unspawned merchant) hid the
+            // wandering-merchant bug for a long time. At Debug it stays out of the default log but
+            // surfaces the moment bot logging is turned up.
+            player.Logger.LogDebug("Bot '{Name}' found no merchant near {Position} and gives up the trip.", player.Name, merchantPosition);
             return false;
         }
 
         await TalkAction.TalkToNpcAsync(player, merchant).ConfigureAwait(false);
         if (player.OpenedNpc is null)
         {
-            player.Logger.LogInformation("Bot '{Name}' could not open the dialog of '{Merchant}'.", player.Name, merchant.Definition.Designation);
+            player.Logger.LogDebug("Bot '{Name}' could not open the dialog of '{Merchant}'.", player.Name, merchant.Definition.Designation);
             return false;
         }
 
@@ -170,10 +171,10 @@ internal static class BotShoppingHandler
             var (soldLate, discarded) = await ClearUnsoldAsync(player, inventory, unsold).ConfigureAwait(false);
             sold += soldLate;
 
-            // Logged even for a 0/0 visit: an audit must be able to tell "went and had nothing to
-            // do" from a silently failed trip. Every counter reports what REALLY happened - a sale
-            // which the money limit refused is not a sale.
-            player.Logger.LogInformation(
+            // Logged even for a 0/0 visit: at Debug this is the bot's per-trip audit trail, telling
+            // "went and had nothing to do" apart from a silently failed trip. Every counter reports
+            // what REALLY happened - a sale which the money limit refused is not a sale.
+            player.Logger.LogDebug(
                 "Bot '{Name}' traded with '{Merchant}': sold {Sold} item(s), discarded {Discarded}, repaired {Repaired}, bought {Potions} potion stack(s) and {Jewels} jewel(s), {Money} zen left.",
                 player.Name,
                 merchant.Definition.Designation,
@@ -314,7 +315,7 @@ internal static class BotShoppingHandler
 
         if (discarded > 0)
         {
-            player.Logger.LogInformation(
+            player.Logger.LogDebug(
                 "Bot '{Name}' destroyed {Count} item(s) it could not sell: its money is at the maximum of {Maximum}.",
                 player.Name,
                 discarded,

--- a/src/GameLogic/Bots/BotSkillProgressionPlugIn.cs
+++ b/src/GameLogic/Bots/BotSkillProgressionPlugIn.cs
@@ -98,7 +98,7 @@ public class BotSkillProgressionPlugIn : ICharacterLevelUpPlugIn
         }
 
         character.CharacterClass = evolvedClass;
-        player.Logger.LogInformation(
+        player.Logger.LogDebug(
             "Bot '{Name}' evolved into {Class} at level {Level}.",
             player.Name,
             evolvedClass.Name,
@@ -168,7 +168,7 @@ public class BotSkillProgressionPlugIn : ICharacterLevelUpPlugIn
             }
 
             await skillList.AddLearnedSkillAsync(skill).ConfigureAwait(false);
-            player.Logger.LogInformation("Bot '{Name}' learned '{Skill}' at level {Level}.", player.Name, skill.Name, player.Level);
+            player.Logger.LogDebug("Bot '{Name}' learned '{Skill}' at level {Level}.", player.Name, skill.Name, player.Level);
         }
     }
 }

--- a/src/GameLogic/Bots/BotWingHandler.cs
+++ b/src/GameLogic/Bots/BotWingHandler.cs
@@ -72,7 +72,7 @@ internal static class BotWingHandler
         if (inventory.GetItem(InventoryConstants.WingsSlot) is { } outgrown)
         {
             await player.DestroyInventoryItemAsync(outgrown).ConfigureAwait(false);
-            player.Logger.LogInformation("Bot '{Name}' discarded its outgrown wings '{Wings}'.", player.Name, outgrown);
+            player.Logger.LogDebug("Bot '{Name}' discarded its outgrown wings '{Wings}'.", player.Name, outgrown);
         }
 
         // Directly into the wing slot: the planner already guarantees the class qualification and
@@ -87,7 +87,7 @@ internal static class BotWingHandler
             return;
         }
 
-        player.Logger.LogInformation("Bot '{Name}' earned its tier {Tier} wings: '{Wings}'.", player.Name, plan.Tier, wings);
+        player.Logger.LogDebug("Bot '{Name}' earned its tier {Tier} wings: '{Wings}'.", player.Name, plan.Tier, wings);
 
         try
         {

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -153,7 +153,7 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
     ILogger ILoggerOwner.Logger => this.Logger;
 
     /// <inheritdoc />
-    public ILogger<Player> Logger { get; }
+    public ILogger<Player> Logger { get; protected set; }
 
     /// <inheritdoc />
     public bool CanWalkOnSafezone => true;

--- a/src/GameLogic/RuntimeCategoryLogger.cs
+++ b/src/GameLogic/RuntimeCategoryLogger.cs
@@ -1,0 +1,48 @@
+// <copyright file="RuntimeCategoryLogger.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic;
+
+/// <summary>
+/// An <see cref="ILogger{T}"/> which files its entries under the category of the owner's actual
+/// runtime type, while still satisfying an <see cref="ILoggerOwner{T}"/> contract declared for a
+/// base type.
+/// </summary>
+/// <remarks>
+/// <see cref="Player"/> is subclassed and a logger built with <c>CreateLogger&lt;Player&gt;()</c> puts
+/// every subclass under the same <c>...GameLogic.Player</c> category, so their output cannot be told
+/// apart by log configuration. This adapter resolves the category from the runtime type instead
+/// (e.g. <c>...GameLogic.Bots.BotPlayer</c>), which Serilog's prefix-based <c>MinimumLevel.Override</c>
+/// can then address individually. The wrapper is needed because the <see cref="ILoggerOwner{T}"/>
+/// contract requires an <see cref="ILogger{T}"/>, while <c>CreateLogger(Type)</c> only returns a
+/// non-generic <see cref="ILogger"/>.
+/// It is currently used to give bots their own log category, leaving real players on the
+/// <see cref="Player"/> category untouched.
+/// </remarks>
+/// <typeparam name="T">The type whose <see cref="ILogger{T}"/> contract is being satisfied.</typeparam>
+internal sealed class RuntimeCategoryLogger<T> : ILogger<T>
+{
+    private readonly ILogger _inner;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RuntimeCategoryLogger{T}"/> class.
+    /// </summary>
+    /// <param name="loggerFactory">The logger factory.</param>
+    /// <param name="owner">The instance whose runtime type provides the log category.</param>
+    public RuntimeCategoryLogger(ILoggerFactory loggerFactory, object owner)
+    {
+        this._inner = loggerFactory.CreateLogger(owner.GetType());
+    }
+
+    /// <inheritdoc />
+    public IDisposable? BeginScope<TState>(TState state)
+        where TState : notnull => this._inner.BeginScope(state);
+
+    /// <inheritdoc />
+    public bool IsEnabled(LogLevel logLevel) => this._inner.IsEnabled(logLevel);
+
+    /// <inheritdoc />
+    public void Log<TState>(LogLevel logLevel, EventId eventId, TState state, Exception? exception, Func<TState, Exception?, string> formatter)
+        => this._inner.Log(logLevel, eventId, state, exception, formatter);
+}


### PR DESCRIPTION
## Summary

Server-side bots now log under their own category
(`MUnique.OpenMU.GameLogic.Bots.BotPlayer`) instead of sharing
`MUnique.OpenMU.GameLogic.Player` with real players, and their recurring per-bot
log entries drop from Information to Debug. A single Serilog
`MinimumLevel.Override` can now silence bots — or turn them up for inspection —
without touching real players, whose logging stays byte-for-byte unchanged.

## Background

Every `Player` created its logger with `CreateLogger<Player>()`, so all
subclasses — the connected `RemotePlayer`, the offline MU Helper `OfflinePlayer`
and `BotPlayer` — logged under the single `...GameLogic.Player` category. On a
server running bots this made bot output indistinguishable from a real player's.

## The problem

Measured on a Season Six server with 500 bots (100 accounts × 5 characters, 3
game servers): 592 log lines per minute just after startup, 293 in the steady
state, every single one under `...GameLogic.Player`. `BotNavigator` alone was
74.6% of the volume, its "heading to hunting ground" line 58.7%. No log
configuration could quiet the bots without also quieting real players.

## The fix

Two independent parts.

**1. Own category.** A new `RuntimeCategoryLogger<T>` — an `ILogger<T>` adapter
that resolves its category from the owner's *runtime* type. `BotPlayer` installs
it for itself in its constructor, so bots log under `...GameLogic.Bots.BotPlayer`.
`Player`'s constructor is untouched (`CreateLogger<Player>()`), so connected and
offline real players keep the exact `...GameLogic.Player` category as before. The
base class has no knowledge of the bot subclass; `Player.Logger` merely gains a
`protected set` so a subclass can supply its own logger. The adapter is needed
because the `ILoggerOwner<Player>` contract requires an `ILogger<Player>` while
`CreateLogger(Type)` returns a non-generic `ILogger`.

**2. Quiet by default.** The 33 bot log entries that fire on a recurring per-bot
basis (hunting-ground walks, shopping trips, party churn, equipment and
progression milestones) move from Information to Debug. The eight operator-facing
events keep Information (start, stop, purge, reset, account generation, population
summary); all warnings and errors are unchanged.

The same 500 bots now produce about one log line per five minutes at the default
level.

## Configuration

- Default (`appsettings.json`: `Default=Information`, `MUnique=Information`): bots
  are effectively silent; real players are unaffected.
- Silence bots entirely:
  `Serilog__MinimumLevel__Override__MUnique.OpenMU.GameLogic.Bots=Warning`.
- Inspect bot behaviour: `...GameLogic.Bots=Debug` (verbose — dominated by the
  per-step `Player.WalkToAsync` trace; `| grep -v WalkToAsync` to skim).

`BotFeaturePlugIn`'s own operator lines use the periodic-plugin house-style
category (`BotFeaturePlugIn`, from `CreateLogger(GetType().Name)`, like the other
periodic plugins), so they are addressed by the `BotFeaturePlugIn` key, not the
`...Bots` prefix — deliberately left consistent with the sibling plugins.

## Verified live

Rebuilt and run with 200 generated bots (~65 concurrently animated). At the
default Information level: 0 lines under `...GameLogic.Player` and no per-tick bot
spam. Flipping only `...GameLogic.Bots=Debug` brought back 2600+ Debug lines, all
under `...Bots.BotPlayer`, still 0 under `...GameLogic.Player`.

## Changes

- `src/GameLogic/RuntimeCategoryLogger.cs` (new) — the `ILogger<T>` adapter that
  categorises by runtime type.
- `src/GameLogic/Bots/BotPlayer.cs` — the constructor installs the
  runtime-category logger.
- `src/GameLogic/Player.cs` — `Logger` gains a `protected set`; the constructor is
  otherwise unchanged.
- `src/GameLogic/Bots/*` — 33 recurring `LogInformation` → `LogDebug` across
  `BotNavigator`, `BotPartyHandler`, `BotShoppingHandler`, `BotMiniGameHandler`,
  `BotMasterHandler`, `BotSkillProgressionPlugIn`, `BotWingHandler`,
  `BotJewelHandler`, `BotEquipmentHandler`, `BotResetHandler`, `BotManager`,
  `BotFeaturePlugIn`. Two comments in `BotShoppingHandler` were reworded so they no
  longer imply the line is visible at the default level.

## No client impact

Server-side only; no packet or client change.