### PR TITLE
Add configurable server time zone for periodic event schedules

### DIFF
--- a/src/DataModel/Configuration/SystemConfiguration.cs
+++ b/src/DataModel/Configuration/SystemConfiguration.cs
@@ -76,6 +76,18 @@ public partial class SystemConfiguration
         ResourceType = typeof(Resources))]
     public bool ReadConsoleInput { get; set; }
 
+    /// <summary>
+    /// Gets or sets the time zone id used to interpret the time-of-day entries of the periodic
+    /// event schedules (e.g. invasions, Blood Castle, Devil Square). IANA ids are recommended
+    /// (for example "Europe/Warsaw"); when empty or unresolvable, UTC is used.
+    /// </summary>
+    [Display(
+        Order = 6,
+        Name = nameof(Resources.SystemConfiguration_TimeZoneId_Name),
+        Description = nameof(Resources.SystemConfiguration_TimeZoneId_Description),
+        ResourceType = typeof(Resources))]
+    public string? TimeZoneId { get; set; }
+
     /// <inheritdoc />
     public override string ToString()
     {

--- a/src/DataModel/Properties/Resources.Designer.cs
+++ b/src/DataModel/Properties/Resources.Designer.cs
@@ -217,5 +217,23 @@ namespace MUnique.OpenMU.DataModel.Properties {
                 return ResourceManager.GetString("SystemConfiguration_ReadConsoleInput_Name", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Server time zone.
+        /// </summary>
+        public static string SystemConfiguration_TimeZoneId_Name {
+            get {
+                return ResourceManager.GetString("SystemConfiguration_TimeZoneId_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The time zone id used to interpret the times of periodic event schedules (e.g. invasions, Blood Castle, Devil Square). IANA ids are recommended, for example &apos;Europe/Warsaw&apos;. When empty, UTC is used..
+        /// </summary>
+        public static string SystemConfiguration_TimeZoneId_Description {
+            get {
+                return ResourceManager.GetString("SystemConfiguration_TimeZoneId_Description", resourceCulture);
+            }
+        }
     }
 }

--- a/src/DataModel/Properties/Resources.resx
+++ b/src/DataModel/Properties/Resources.resx
@@ -127,6 +127,12 @@ or behind a firewall) and you want to use it within your computer or private net
 	<data name="SystemConfiguration_ReadConsoleInput_Name" xml:space="preserve">
 		<value>Read console input</value>
 	</data>
+	<data name="SystemConfiguration_TimeZoneId_Name" xml:space="preserve">
+		<value>Server time zone</value>
+	</data>
+	<data name="SystemConfiguration_TimeZoneId_Description" xml:space="preserve">
+		<value>The time zone id used to interpret the times of periodic event schedules (e.g. invasions, Blood Castle, Devil Square). IANA ids are recommended, for example 'Europe/Warsaw'. When empty, UTC is used.</value>
+	</data>
 	<data name="SystemConfiguration_Name" xml:space="preserve">
 		<value>System Configuration</value>
 	</data>

--- a/src/GameLogic/GameContext.cs
+++ b/src/GameLogic/GameContext.cs
@@ -123,6 +123,9 @@ public class GameContext : AsyncDisposable, IGameContext
     public GameConfiguration Configuration { get; }
 
     /// <inheritdoc/>
+    public TimeZoneInfo ServerTimeZone { get; set; } = TimeZoneInfo.Utc;
+
+    /// <inheritdoc/>
     public long[] ExperienceTable { get; private set; }
 
     /// <inheritdoc/>

--- a/src/GameLogic/IGameContext.cs
+++ b/src/GameLogic/IGameContext.cs
@@ -58,6 +58,12 @@ public interface IGameContext
     GameConfiguration Configuration { get; }
 
     /// <summary>
+    /// Gets or sets the server time zone used to interpret the time-of-day entries of periodic
+    /// event schedules (e.g. invasions, Blood Castle, Devil Square). Defaults to <see cref="TimeZoneInfo.Utc"/>.
+    /// </summary>
+    TimeZoneInfo ServerTimeZone { get; set; }
+
+    /// <summary>
     /// Gets the experience table. Index is the player level, value the needed experience to reach that level.
     /// </summary>
     long[] ExperienceTable { get; }

--- a/src/GameLogic/PlugIns/PeriodicTasks/PeriodicTaskBasePlugIn.cs
+++ b/src/GameLogic/PlugIns/PeriodicTasks/PeriodicTaskBasePlugIn.cs
@@ -135,7 +135,7 @@ public abstract class PeriodicTaskBasePlugIn<TConfiguration, TState> : IPeriodic
     /// </returns>
     protected virtual bool IsItTimeToStart(IGameContext gameContext)
     {
-        return this._isStartForced || (this.Configuration?.IsItTimeToStart() ?? false);
+        return this._isStartForced || (this.Configuration?.IsItTimeToStart(gameContext.ServerTimeZone) ?? false);
     }
 
     /// <summary>

--- a/src/GameLogic/PlugIns/PeriodicTasks/PeriodicTaskConfiguration.cs
+++ b/src/GameLogic/PlugIns/PeriodicTasks/PeriodicTaskConfiguration.cs
@@ -62,15 +62,20 @@ public class PeriodicTaskConfiguration
     /// <summary>
     /// Check if current time is OK for starting an invasion.
     /// </summary>
+    /// <param name="serverTimeZone">
+    /// The server time zone used to interpret the <see cref="Timetable"/> times of day.
+    /// Pass <see cref="TimeZoneInfo.Utc"/> to keep the previous UTC-based behavior.
+    /// </param>
     /// <returns>Returns true if the invasion can be started.</returns>
-    public virtual bool IsItTimeToStart()
+    public virtual bool IsItTimeToStart(TimeZoneInfo serverTimeZone)
     {
         if (this.Timetable.Count == 0)
         {
             return false;
         }
 
-        var nowTime = TimeOnly.FromDateTime(DateTime.UtcNow);
+        var nowLocal = TimeZoneInfo.ConvertTimeFromUtc(DateTime.UtcNow, serverTimeZone);
+        var nowTime = TimeOnly.FromDateTime(nowLocal);
         var earlier = nowTime.Add(TimeSpan.FromSeconds(-5));
 
         // For example, p = 00:00. Check that time between 00:00:00 and 00:00:05

--- a/src/Persistence/EntityFramework/Migrations/20260813000114_AddSystemConfigurationTimeZoneId.Designer.cs
+++ b/src/Persistence/EntityFramework/Migrations/20260813000114_AddSystemConfigurationTimeZoneId.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MUnique.OpenMU.Persistence.EntityFramework;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
     [DbContext(typeof(EntityDataContext))]
-    partial class EntityDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260813000114_AddSystemConfigurationTimeZoneId")]
+    partial class AddSystemConfigurationTimeZoneId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Persistence/EntityFramework/Migrations/20260813000114_AddSystemConfigurationTimeZoneId.cs
+++ b/src/Persistence/EntityFramework/Migrations/20260813000114_AddSystemConfigurationTimeZoneId.cs
@@ -1,0 +1,30 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSystemConfigurationTimeZoneId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "TimeZoneId",
+                schema: "config",
+                table: "SystemConfiguration",
+                type: "text",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "TimeZoneId",
+                schema: "config",
+                table: "SystemConfiguration");
+        }
+    }
+}

--- a/src/Startup/GameServerContainer.cs
+++ b/src/Startup/GameServerContainer.cs
@@ -167,6 +167,7 @@ public sealed class GameServerContainer : ServerContainerBase, IGameServerInstan
     {
         using var loggerScope = this._logger.BeginScope("GameServer: {0}", gameServerDefinition.ServerID);
         var gameServer = new GameServer(gameServerDefinition, this._guildServer, this._eventPublisher, this._loginServer, this._persistenceContextProvider, this._friendServer, this._loggerFactory, this._plugInManager, this._changeMediator);
+        gameServer.Context.ServerTimeZone = Program.ServerTimeZone;
         foreach (var endpoint in gameServerDefinition.Endpoints)
         {
             gameServer.AddListener(new DefaultTcpGameServerListener(endpoint, gameServer.CreateServerInfo(), gameServer.Context, this._connectServerContainer.GetObserver(endpoint.Client!), this._ipResolver, this._loggerFactory));

--- a/src/Startup/Program.cs
+++ b/src/Startup/Program.cs
@@ -48,6 +48,12 @@ internal sealed class Program : IDisposable
     private static bool _confirmExit;
     private static SystemConfiguration? _systemConfiguration;
 
+    /// <summary>
+    /// Gets the resolved server time zone (from <see cref="SystemConfiguration.TimeZoneId"/>),
+    /// used to interpret the times of periodic event schedules. Defaults to <see cref="TimeZoneInfo.Utc"/>.
+    /// </summary>
+    internal static TimeZoneInfo ServerTimeZone { get; private set; } = TimeZoneInfo.Utc;
+
     private readonly IDictionary<int, IGameServer> _gameServers = new Dictionary<int, IGameServer>();
     private readonly IList<IManageableServer> _servers = new List<IManageableServer>();
     private readonly Serilog.ILogger _logger;
@@ -533,6 +539,27 @@ internal sealed class Program : IDisposable
         if (config != null)
         {
             _systemConfiguration = config;
+        }
+
+        ServerTimeZone = this.ResolveServerTimeZone(_systemConfiguration?.TimeZoneId);
+    }
+
+    private TimeZoneInfo ResolveServerTimeZone(string? timeZoneId)
+    {
+        if (string.IsNullOrWhiteSpace(timeZoneId))
+        {
+            return TimeZoneInfo.Utc;
+        }
+
+        try
+        {
+            // FindSystemTimeZoneById accepts both IANA and Windows ids on all platforms since .NET 6 (ICU).
+            return TimeZoneInfo.FindSystemTimeZoneById(timeZoneId);
+        }
+        catch (Exception ex) when (ex is TimeZoneNotFoundException or InvalidTimeZoneException)
+        {
+            this._logger.Warning(ex, "Could not resolve configured server time zone '{TimeZoneId}'. Falling back to UTC.", timeZoneId);
+            return TimeZoneInfo.Utc;
         }
     }
 

--- a/src/Web/Shared/ComponentBuilders/TimeZoneIdFieldBuilder.cs
+++ b/src/Web/Shared/ComponentBuilders/TimeZoneIdFieldBuilder.cs
@@ -1,0 +1,27 @@
+// <copyright file="TimeZoneIdFieldBuilder.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Web.Shared.ComponentBuilders;
+
+using System.Reflection;
+using Microsoft.AspNetCore.Components.Rendering;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.Web.Shared.Components.Form;
+using MUnique.OpenMU.Web.Shared.Services;
+
+/// <summary>
+/// A <see cref="IComponentBuilder"/> for the <see cref="SystemConfiguration.TimeZoneId"/>, which offers the
+/// available system time zones as suggestions while still allowing a free-text value.
+/// </summary>
+public class TimeZoneIdFieldBuilder : BaseComponentBuilder, IComponentBuilder
+{
+    /// <inheritdoc/>
+    public int BuildComponent(object model, PropertyInfo propertyInfo, RenderTreeBuilder builder, int currentIndex, IChangeNotificationService notificationService)
+    {
+        return this.BuildField<string, TimeZoneIdField>(model, propertyInfo, builder, currentIndex, notificationService);
+    }
+
+    /// <inheritdoc/>
+    public bool CanBuildComponent(PropertyInfo propertyInfo) => propertyInfo.PropertyType == typeof(string) && propertyInfo.Name == nameof(SystemConfiguration.TimeZoneId);
+}

--- a/src/Web/Shared/Components/Form/AutoFields.cs
+++ b/src/Web/Shared/Components/Form/AutoFields.cs
@@ -31,6 +31,7 @@ public class AutoFields : ComponentBase
     static AutoFields()
     {
         Builders.Add(new PasswordHashFieldBuilder());
+        Builders.Add(new TimeZoneIdFieldBuilder());
         Builders.Add(new TextFieldBuilder());
         Builders.Add(new LocalizedStringFieldBuilder());
         Builders.Add(new NumberFieldBuilder<long>());

--- a/src/Web/Shared/Components/Form/TimeZoneIdField.razor
+++ b/src/Web/Shared/Components/Form/TimeZoneIdField.razor
@@ -1,0 +1,80 @@
+@using System.ComponentModel.DataAnnotations
+@using System.Diagnostics.CodeAnalysis
+@inherits NotifyableInputBase<string>
+
+    <div class="mb-3">
+        <FieldLabel Text="@Label" ValueExpression="@this.ValueExpression" />
+        <input @bind="CurrentValueAsString" id="@this.FieldIdentifier.FieldName" class="form-control @CssClass" list="server-time-zone-ids" autocomplete="off" placeholder="UTC" />
+        @if (TimeZoneIds.Count > 0)
+        {
+            <datalist id="server-time-zone-ids">
+                @foreach (var id in TimeZoneIds)
+                {
+                    <option value="@id"></option>
+                }
+            </datalist>
+        }
+        <ValidationMessage For=@this.ValueExpression />
+    </div>
+
+@code {
+
+    /// <summary>
+    /// The suggested time zone ids, normalized to IANA so they look the same regardless of the host operating system.
+    /// </summary>
+    private static readonly IReadOnlyList<string> TimeZoneIds = GetSuggestibleTimeZoneIds();
+
+    /// <summary>
+    /// Gets or sets the label which should be displayed. If it's not explicitly provided, the component shows the
+    /// Name defined in the <see cref="DisplayAttribute"/>. If there is no Name in a <see cref="DisplayAttribute"/>, it shows the property name instead.
+    /// </summary>
+    [Parameter]
+    public string? Label { get; set; }
+
+    /// <inheritdoc />
+    protected override bool TryParseValueFromString(string? value, [MaybeNullWhen(false)] out string result, [NotNullWhen(false)] out string? validationErrorMessage)
+    {
+        if (string.IsNullOrWhiteSpace(value))
+        {
+            // An empty value means UTC. This keeps the previous behavior for servers which never configured a time zone.
+            result = string.Empty;
+            validationErrorMessage = null;
+            return true;
+        }
+
+        var trimmed = value.Trim();
+        try
+        {
+            // Accepts IANA ids on every platform and Windows ids as well, because .NET maps them via ICU.
+            _ = TimeZoneInfo.FindSystemTimeZoneById(trimmed);
+            result = trimmed;
+            validationErrorMessage = null;
+            return true;
+        }
+        catch (Exception ex) when (ex is TimeZoneNotFoundException or InvalidTimeZoneException)
+        {
+            result = value;
+            validationErrorMessage = $"Unknown time zone id '{trimmed}'. Leave empty for UTC or pick a suggestion, e.g. Europe/Warsaw.";
+            return false;
+        }
+    }
+
+    private static IReadOnlyList<string> GetSuggestibleTimeZoneIds()
+    {
+        try
+        {
+            return TimeZoneInfo.GetSystemTimeZones()
+                .Select(tz => tz.HasIanaId
+                    ? tz.Id
+                    : TimeZoneInfo.TryConvertWindowsIdToIanaId(tz.Id, out var ianaId) ? ianaId! : tz.Id)
+                .Distinct()
+                .OrderBy(id => id, StringComparer.OrdinalIgnoreCase)
+                .ToList();
+        }
+        catch
+        {
+            // Without time zone data the field simply degrades to a plain text input; resolution still falls back to UTC.
+            return Array.Empty<string>();
+        }
+    }
+}


### PR DESCRIPTION
## Problem

Periodic events (Golden/Red Dragon invasions, White Wizard Invasion, Blood Castle,
Devil Square, Chaos Castle, Happy Hour) decide when to start in
`PeriodicTaskConfiguration.IsItTimeToStart()`, which compares the configured
`Timetable` (a list of `TimeOnly`) against `DateTime.UtcNow`. The times of day are
therefore effectively interpreted as **UTC**, but nothing in the model or the Admin
Panel says so. Consequences:

- Admins enter what they think are local times; the server treats them as UTC.
- Anything presenting these times (e.g. a website) has to re-apply an offset, which
  is a second, separate source of truth.
- The local wall-clock time of an event drifts by an hour across daylight saving time.

## Solution

Introduce a single, optional `SystemConfiguration.TimeZoneId`. The scheduler
interprets the timetable in that zone; a website or any other consumer can read the
same value. Empty/unresolvable ⇒ UTC, i.e. exactly today's behavior.

## Changes

- **DataModel** — `SystemConfiguration.TimeZoneId` (nullable string) with a `[Display]`
  name/description, plus resources and an EF migration adding the nullable `text`
  column in the `config` schema.
- **GameLogic** — `IGameContext.ServerTimeZone` (defaults to `TimeZoneInfo.Utc`).
  `PeriodicTaskConfiguration.IsItTimeToStart(TimeZoneInfo)` converts `DateTime.UtcNow`
  into that zone before matching the timetable. The single caller in
  `PeriodicTaskBasePlugIn` passes `gameContext.ServerTimeZone`.
- **Startup** — `TimeZoneId` is resolved once (`Program.ResolveServerTimeZone`) and
  flowed into each game server context in `GameServerContainer`. Resolution accepts
  IANA and Windows ids (ICU maps them on both platforms since .NET 6) and falls back
  to UTC with a warning when the id is empty or unresolvable.
- **Admin Panel** — the generic editor for the **System** section shows a new
  *Server time zone* field. A dedicated component builder (same pattern as the
  existing `PasswordHashFieldBuilder`) renders a text input backed by a `<datalist>`
  of the available system time zones, normalized to IANA (`HasIanaId` /
  `TryConvertWindowsIdToIanaId`) so the suggestions look the same regardless of the
  host OS. The field validates the entered id (`FindSystemTimeZoneById`) and rejects
  garbage with a message, while still allowing any free-text value and an empty value
  (= UTC).

## Backward compatibility

`TimeZoneId` null/empty ⇒ everything is interpreted in UTC ⇒ **identical to current
behavior**. Existing databases are untouched until an admin sets a value.

## One-time step for admins who set a zone

After setting e.g. `Europe/Warsaw`, the existing timetable entries (which were UTC)
should be shifted once to the natural local time, because they are now interpreted in
the configured zone. New entries are entered directly as local time.

## Cross-platform

- `FindSystemTimeZoneById` accepts IANA ids on Windows too (no `tzdata` package
  needed there — Windows ships its own time zone data, and ICU maps IANA⇄Windows).
- Requires ICU (globalization not invariant), which OpenMU already enables
  (`DOTNET_SYSTEM_GLOBALIZATION_INVARIANT=false`).
- Without any time zone data at all, the field degrades to a plain text input and
  resolution falls back to UTC — nothing throws.

## Testing

- Fresh seed: migration applies, column present.
- Invalid id (`Bogus/DoesNotExist`) ⇒ `[Warning] Could not resolve configured server
  time zone ... Falling back to UTC`, events run in UTC.
- End-to-end: `TimeZoneId=Europe/Warsaw` + a non-whole-hour local slot ⇒ the event
  fired at the configured **local** time (e.g. Chaos Castle at 03:14 local = 01:14
  UTC), which UTC-based scheduling could not produce.
- Admin Panel field renders, suggests zones, validates garbage, accepts empty (= UTC).
- Build clean (0 warnings introduced; the earlier CS1574 from a stray doc cref was
  fixed during review).

## Companion

A separate, optional website PR (`openmu-simple-web`, branch
`events-timezone-from-config`) makes the events page read the same `TimeZoneId` from
the database instead of the container time zone. Deploy the server change first.