### PR TITLE
Extract the experience of the player and make it extensible

### DIFF
--- a/docs/PlayerRefactoringPlan.md
+++ b/docs/PlayerRefactoringPlan.md
@@ -1,6 +1,6 @@
 # Refactoring plan: breaking up the `Player` class
 
-**Status:** in progress — phases 0b and 1 are done, see §6
+**Status:** in progress — phases 0b, 1, 2 and 3 are done, see §6
 **Subject:** `src/GameLogic/Player.cs` (3,098 lines and ~150 members when this
 plan was written; 2,614 after phase 1)
 
@@ -221,7 +221,7 @@ All of these live in `src/GameLogic/PlugIns/`, need a fresh `Guid` and a
 |---|---|---|---|
 | P3 | `IPlayerLeavingGamePlugIn` | `ValueTask PlayerLeavingGameAsync(Player player)` | `RemoveFromGameAsync` steps (1840-1856): party leave-temporarily, safezone move, temporary storage restore, `OpenedNpc` reset. **Only if** the `LogoutAction` state bug above is not fixed — with it fixed, `IPlayerStateChangedPlugIn` covers this too, and P3 is dropped |
 | P4 | `IPlayerSpawnGateSelectionPlugIn` | `ValueTask SelectSpawnGateAsync(Player player, SpawnGateSelectionArgs args)` | the duel and guild-war-soccer branches of `GetSpawnGateOfCurrentMapAsync` (2409-2428); later also mini games and castle siege |
-| P5 | `IExperienceCalculationPlugIn` | `ValueTask CalculateExperienceAsync(Player player, ExperienceCalculationArgs args)` | the multiplier chain in `CalculateExpAfterKill` (1271-1288): map multiplier, bonus rate, random min/max multipliers |
+| P5 | `IExperienceCalculationPlugIn` | `ValueTask CalculateExperienceAsync(Player player, ExperienceCalculationArgs args)` | ✔ implemented, but *not* by splitting the multiplier chain of `CalculateExpAfterKill` into competing plugins: without plugin ordering (3.1a) their result would depend on the discovery order, and the random multiplier truncates to `int`, so it has to stay last. The rates and the map multiplier stay in the component, the plugin point runs after them and before the randomization, where factors compose order-independently |
 | P6 | `IPlayerGainedExperiencePlugIn` | `ValueTask PlayerGainedExperienceAsync(Player player, int experience, IAttackable? killedObject, ExperienceType type)` | `AddPetExperienceAsync` (2953-3020) becomes `PetExperiencePlugIn`; also the natural hook for statistics/events |
 | P7 | `ICharacterMasterLevelUpPlugIn` | `void CharacterMasterLeveledUp(Player player)` | mirrors the existing `ICharacterLevelUpPlugIn` for the master level branch (2099-2107) |
 | P8 | `IAttackerHitTargetPlugIn` | `ValueTask AttackerHitTargetAsync(IAttacker attacker, IAttackable target, HitInfo hitInfo, SkillEntry? skill)` | `AfterHitTargetAsync` (809-814): weapon durability, `HealthLossAfterHit`; plus mace mastery stun (797-800) |
@@ -339,8 +339,8 @@ Each phase is independently mergeable and leaves the build green.
 | **0** | Characterization tests (see §7); plugin ordering (3.1a); per-player state bag (3.1b); args-object convention (3.1c) | low | 3,098 |
 | **0b** | ✔ done — State machine repair (§4.0): `ChangingMap` wired into warp/respawn, missing transitions added, `LogoutAction` transition fixed. Behavior change, own tests | medium | 2,614 |
 | **1** | ✔ done — §5.1 extension-method moves + nested class files | very low | 2,612 |
-| **2** | `PlayerMovement`, `PlayerPersistence`, `PlayerSummon`, `PlayerStorages` components | low | ~2,150 |
-| **3** | `PlayerExperience` + P5/P6/P7 + `PetExperiencePlugIn` | medium | ~1,850 |
+| **2** | ✔ done — `PlayerMovement`, `PlayerPersistence`, `PlayerSummon`, `PlayerStorages` components | low | 2,269 |
+| **3** | ✔ done — `PlayerExperience` + P5/P6/P7 + `PetExperiencePlugIn` | medium | 2,058 |
 | **4** | `PlayerMapTransitions` + P4 spawn gate plugins | medium | ~1,550 |
 | **5** | `PlayerCombat` + `AttackableNpcBase` dedup + P8 and the `IAttackableGotHit`/`GotKilled` plugins (PK state, respawn, reflection, durability) | **high** | ~1,150 |
 | **6** | Enter-world / leave-game moved onto `IPlayerStateChangedPlugIn` (+ P3 if needed) + `PlayerAttributeHost` + P9 regeneration | medium-high | ~900 |

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -46,7 +46,7 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         StopByDeath = false,
     };
 
-    private readonly AsyncLock _experienceLock = new();
+    private readonly PlayerExperience _experience;
 
     /// <summary>
     /// Serializes context mutations done by this player's action handlers against the periodic and
@@ -97,6 +97,7 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         this.Logger = gameContext.LoggerFactory.CreateLogger<Player>();
         this.PersistenceContext = this.GameContext.PersistenceContextProvider.CreateNewPlayerContext(gameContext.Configuration);
         this._persistence = new PlayerPersistence(this);
+        this._experience = new PlayerExperience(this);
         this._movement = new PlayerMovement(this);
         this._summon = new PlayerSummon(this);
         this._storages = new PlayerStorages(this);
@@ -996,101 +997,28 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
     /// </summary>
     /// <param name="killedObject">The killed object.</param>
     /// <returns>The gained experience.</returns>
-    public async ValueTask<int> AddExpAfterKillAsync(IAttackable killedObject)
-    {
-        if (this.SelectedCharacter?.CharacterClass is not { } characterClass)
-        {
-            return 0;
-        }
-
-        var experience = this.CalculateExpAfterKill(killedObject);
-        if (experience == 0)
-        {
-            return 0;
-        }
-
-        var currentLevel = (short)this.Attributes![Stats.Level];
-        var isMaxLevel = currentLevel == this.GameContext.Configuration.MaximumLevel;
-        var isAddMasterExperience = characterClass.IsMasterClass && isMaxLevel;
-
-        if (isAddMasterExperience)
-        {
-            await this.AddMasterExperienceAsync(experience, killedObject).ConfigureAwait(false);
-        }
-        else
-        {
-            await this.AddExperienceAsync(experience, killedObject).ConfigureAwait(false);
-        }
-
-        await this.AddPetExperienceAsync(experience).ConfigureAwait(false);
-
-        return experience;
-    }
+    public ValueTask<int> AddExpAfterKillAsync(IAttackable killedObject) => this._experience.AddAfterKillAsync(killedObject);
 
     /// <summary>
     /// Calculates the amount of experience gained after a kill, without applying it to the character.
     /// </summary>
     /// <param name="killedObject">The killed monster.</param>
     /// <returns>The calculated experience amount.</returns>
-    public int CalculateExpAfterKill(IAttackable killedObject)
-    {
-        if (this.SelectedCharacter?.CharacterClass is not { } characterClass)
-        {
-            return 0;
-        }
-
-        if (this.Attributes is not { } attributes)
-        {
-            return 0;
-        }
-
-        var currentLevel = (short)attributes[Stats.Level];
-        var isMaxLevel = currentLevel == this.GameContext.Configuration.MaximumLevel;
-        var isAddMasterExperience = characterClass.IsMasterClass && isMaxLevel;
-        var expRateAttribute = isAddMasterExperience ? Stats.MasterExperienceRate : Stats.ExperienceRate;
-        var gameRate = isAddMasterExperience ? this.GameContext.MasterExperienceRate : this.GameContext.ExperienceRate;
-
-        var experience = killedObject.CalculateBaseExperience(attributes[Stats.TotalLevel]);
-        experience *= gameRate;
-        experience *= attributes[expRateAttribute] + attributes[Stats.BonusExperienceRate];
-        experience *= this.CurrentMap?.Definition.ExpMultiplier ?? 1;
-
-        var minMultiplier = attributes[Stats.RandomExperienceMinMultiplier];
-        var maxMultiplier = attributes[Stats.RandomExperienceMaxMultiplier];
-        if (minMultiplier > 0 && maxMultiplier > 0)
-        {
-            var minimumExperience = (int)(experience * minMultiplier);
-            var maximumExperience = (int)(experience * maxMultiplier);
-            if (minimumExperience < maximumExperience)
-            {
-                return Rand.NextInt(minimumExperience, maximumExperience);
-            }
-        }
-
-        return (int)experience;
-    }
+    public ValueTask<int> CalculateExpAfterKillAsync(IAttackable killedObject) => this._experience.CalculateAfterKillAsync(killedObject);
 
     /// <summary>
     /// Adds the master experience to the current character.
     /// </summary>
     /// <param name="experience">The experience that should be added.</param>
     /// <param name="killedObject">The killed object that caused the experience gain.</param>
-    public async ValueTask AddMasterExperienceAsync(int experience, IAttackable? killedObject)
-    {
-        using var d = await this._experienceLock.LockAsync().ConfigureAwait(false);
-        await this.AddMasterExperienceCoreAsync(experience, killedObject).ConfigureAwait(false);
-    }
+    public ValueTask AddMasterExperienceAsync(int experience, IAttackable? killedObject) => this._experience.AddMasterExperienceAsync(experience, killedObject);
 
     /// <summary>
     /// Adds the experience to the current character.
     /// </summary>
     /// <param name="experience">The experience that should be added.</param>
     /// <param name="killedObject">The killed object that caused the experience gain.</param>
-    public async ValueTask AddExperienceAsync(int experience, IAttackable? killedObject)
-    {
-        using var d = await this._experienceLock.LockAsync().ConfigureAwait(false);
-        await this.AddExperienceCoreAsync(experience, killedObject).ConfigureAwait(false);
-    }
+    public ValueTask AddExperienceAsync(int experience, IAttackable? killedObject) => this._experience.AddExperienceAsync(experience, killedObject);
 
     /// <summary>
     /// Moves the player to the specified coordinate.
@@ -1488,95 +1416,6 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
     protected virtual ICustomPlugInContainer<IViewPlugIn> CreateViewPlugInContainer()
     {
         throw new NotImplementedException("CreateViewPlugInContainer must be overwritten in derived classes.");
-    }
-
-    private async ValueTask AddMasterExperienceCoreAsync(int experience, IAttackable? killedObject)
-    {
-        if (this.Attributes![Stats.MasterLevel] >= this.GameContext.Configuration.MaximumMasterLevel)
-        {
-            await this.InvokeViewPlugInAsync<IAddExperiencePlugIn>(p => p.AddExperienceAsync(0, killedObject, ExperienceType.MaxMasterLevelReached)).ConfigureAwait(false);
-            return;
-        }
-
-        if (killedObject is not null && killedObject.Attributes[Stats.Level] < this.GameContext.Configuration.MinimumMonsterLevelForMasterExperience)
-        {
-            await this.InvokeViewPlugInAsync<IAddExperiencePlugIn>(p => p.AddExperienceAsync(0, killedObject, ExperienceType.MonsterLevelTooLowForMasterExperience)).ConfigureAwait(false);
-            return;
-        }
-
-        long exp = experience;
-
-        bool lvlup = false;
-        var expTable = this.GameContext.MasterExperienceTable;
-        if (expTable[(int)this.Attributes[Stats.MasterLevel] + 1] - this.SelectedCharacter!.MasterExperience < exp)
-        {
-            exp = expTable[(int)this.Attributes[Stats.MasterLevel] + 1] - this.SelectedCharacter.MasterExperience;
-            lvlup = true;
-        }
-
-        this.SelectedCharacter.MasterExperience += exp;
-
-        await this.InvokeViewPlugInAsync<IAddExperiencePlugIn>(p => p.AddExperienceAsync((int)exp, killedObject, ExperienceType.Master)).ConfigureAwait(false);
-
-        if (lvlup)
-        {
-            this.Attributes[Stats.MasterLevel]++;
-            this.SelectedCharacter.MasterLevelUpPoints += (int)this.Attributes[Stats.MasterPointsPerLevelUp];
-            this.SetReclaimableAttributesToMaximum();
-            this.Logger.LogDebug("Character {0} leveled up to master level {1}", this.SelectedCharacter.Name, this.Attributes[Stats.MasterLevel]);
-            await this.InvokeViewPlugInAsync<IUpdateLevelPlugIn>(p => p.UpdateMasterLevelAsync()).ConfigureAwait(false);
-            await this.ForEachWorldObserverAsync<IShowEffectPlugIn>(p => p.ShowEffectAsync(this, IShowEffectPlugIn.EffectType.LevelUp), true).ConfigureAwait(false);
-        }
-    }
-
-    private async ValueTask AddExperienceCoreAsync(int experience, IAttackable? killedObject)
-    {
-        var remainingExperience = experience;
-        while (remainingExperience > 0)
-        {
-            if (this.Attributes![Stats.Level] >= this.GameContext.Configuration.MaximumLevel)
-            {
-                await this.InvokeViewPlugInAsync<IAddExperiencePlugIn>(p => p.AddExperienceAsync(0, killedObject, ExperienceType.MaxLevelReached)).ConfigureAwait(false);
-                return;
-            }
-
-            long gainedExperience = remainingExperience;
-            bool isLevelUp = false;
-            var expTable = this.GameContext.ExperienceTable;
-            var expForNextLevel = expTable[(int)this.Attributes[Stats.Level] + 1];
-            if (expForNextLevel - this.SelectedCharacter!.Experience < gainedExperience)
-            {
-                gainedExperience = expForNextLevel - this.SelectedCharacter.Experience;
-                isLevelUp = true;
-            }
-
-            this.SelectedCharacter.Experience += gainedExperience;
-
-            await this.InvokeViewPlugInAsync<IAddExperiencePlugIn>(p => p.AddExperienceAsync((int)gainedExperience, killedObject, ExperienceType.Normal)).ConfigureAwait(false);
-
-            if (!isLevelUp)
-            {
-                return;
-            }
-
-            this.Attributes[Stats.Level]++;
-            this.SelectedCharacter.LevelUpPoints += (int)this.Attributes[Stats.PointsPerLevelUp];
-            this.SetReclaimableAttributesToMaximum();
-            this.Logger.LogDebug("Character {0} leveled up to {1}", this.SelectedCharacter.Name, this.Attributes[Stats.Level]);
-
-            this.GameContext.PlugInManager.GetPlugInPoint<ICharacterLevelUpPlugIn>()?.CharacterLeveledUp(this);
-
-            await this.InvokeViewPlugInAsync<IUpdateLevelPlugIn>(p => p.UpdateLevelAsync()).ConfigureAwait(false);
-            await this.ForEachWorldObserverAsync<IShowEffectPlugIn>(p => p.ShowEffectAsync(this, IShowEffectPlugIn.EffectType.LevelUp), true).ConfigureAwait(false);
-
-            remainingExperience -= (int)gainedExperience;
-            if (remainingExperience <= 0
-                || this.Attributes[Stats.Level] >= this.GameContext.Configuration.MaximumLevel
-                || this.GameContext.Configuration.PreventExperienceOverflow)
-            {
-                return;
-            }
-        }
     }
 
     /// <summary>
@@ -2060,7 +1899,10 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         this.Attributes[Stats.CurrentHealth] = Math.Min(this.Attributes[Stats.CurrentHealth], this.Attributes[Stats.MaximumHealth]);
     }
 
-    private void SetReclaimableAttributesToMaximum()
+    /// <summary>
+    /// Sets the current values of the regeneration attributes to their maximum values.
+    /// </summary>
+    internal void SetReclaimableAttributesToMaximum()
     {
         foreach (var regeneration in Stats.IntervalRegenerationAttributes)
         {
@@ -2201,75 +2043,6 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
                 pet.PetExperience = (int)Math.Max((int)(pet.PetExperience * 0.9), minimumExp);
                 await this.ResetPetBehaviorAsync().ConfigureAwait(false);
             }
-        }
-    }
-
-    private async ValueTask AddPetExperienceAsync(double gainedExperience)
-    {
-        async ValueTask AddExpToPetAsync(Item pet, double experience)
-        {
-            pet.PetExperience += (int)experience;
-
-            while (pet.PetExperience >= pet.Definition!.GetExperienceOfPetLevel((byte)(pet.Level + 1), pet.Definition!.MaximumItemLevel)
-                   && (!pet.IsDarkRaven() || pet.GetDarkRavenLeadershipRequirement(pet.Level + 1) <= this.Attributes![Stats.TotalLeadership]))
-            {
-                pet.Level++;
-                this.Attributes!.ItemPowerUps[pet] = this.Attributes.ItemPowerUps[pet]
-                    .Append(new PowerUpWrapper(
-                        new SimpleElement(1, AggregateType.AddRaw),
-                        pet.IsDarkRaven() ? Stats.RavenLevel : Stats.HorseLevel,
-                        this.Attributes)).ToList();
-
-                await this.InvokeViewPlugInAsync<IPetInfoViewPlugIn>(p => p.ShowPetInfoAsync(pet, pet.ItemSlot, PetStorageLocation.InventoryPetSlot)).ConfigureAwait(false);
-            }
-        }
-
-        Item? GetTrainablePet(byte inventorySlot)
-        {
-            var pet = this.Inventory?.GetItem(inventorySlot);
-            if (pet is not null
-                && pet.Definition is not null
-                && pet.Definition.PetExperienceFormula is not null
-                && pet.Definition.MaximumItemLevel > 0
-                && pet.Durability > 0
-                && pet.Level < pet.Definition.MaximumItemLevel)
-            {
-                return pet;
-            }
-
-            return null;
-        }
-
-        const double petShare = 0.2;
-        Item? movePet = GetTrainablePet(InventoryConstants.PetSlot);
-        Item? attackPet = GetTrainablePet(InventoryConstants.RightHandSlot);
-
-        if (movePet is null && attackPet is null)
-        {
-            return;
-        }
-
-        var petExperience = (int)(gainedExperience * petShare);
-
-        if (movePet is not null && attackPet is not null)
-        {
-            // Both are there, so each gains just the half.
-            petExperience /= 2;
-        }
-
-        if (petExperience < 1)
-        {
-            return;
-        }
-
-        if (movePet is { })
-        {
-            await AddExpToPetAsync(movePet, petExperience).ConfigureAwait(false);
-        }
-
-        if (attackPet is { })
-        {
-            await AddExpToPetAsync(attackPet, petExperience).ConfigureAwait(false);
         }
     }
 

--- a/src/GameLogic/PlayerExperience.cs
+++ b/src/GameLogic/PlayerExperience.cs
@@ -1,0 +1,247 @@
+// <copyright file="PlayerExperience.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic;
+
+using MUnique.OpenMU.GameLogic.Attributes;
+using MUnique.OpenMU.GameLogic.PlugIns;
+using MUnique.OpenMU.GameLogic.Views.Character;
+using MUnique.OpenMU.GameLogic.Views.World;
+using Nito.AsyncEx;
+
+/// <summary>
+/// The experience and the leveling of a <see cref="Player"/>.
+/// </summary>
+internal sealed class PlayerExperience
+{
+    private readonly Player _player;
+
+    private readonly AsyncLock _lock = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PlayerExperience"/> class.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    public PlayerExperience(Player player)
+    {
+        this._player = player;
+    }
+
+    /// <summary>
+    /// Adds experience points after killing the target object.
+    /// </summary>
+    /// <param name="killedObject">The killed object.</param>
+    /// <returns>The gained experience.</returns>
+    public async ValueTask<int> AddAfterKillAsync(IAttackable killedObject)
+    {
+        if (!this.TryGetExperienceKind(out var isMasterExperience))
+        {
+            return 0;
+        }
+
+        var experience = await this.CalculateAfterKillAsync(killedObject).ConfigureAwait(false);
+        if (experience == 0)
+        {
+            return 0;
+        }
+
+        if (isMasterExperience)
+        {
+            await this.AddMasterExperienceAsync(experience, killedObject).ConfigureAwait(false);
+        }
+        else
+        {
+            await this.AddExperienceAsync(experience, killedObject).ConfigureAwait(false);
+        }
+
+        if (this._player.GameContext.PlugInManager.GetPlugInPoint<IPlayerGainedExperiencePlugIn>() is { } plugInPoint)
+        {
+            await plugInPoint.PlayerGainedExperienceAsync(this._player, experience, killedObject, isMasterExperience).ConfigureAwait(false);
+        }
+
+        return experience;
+    }
+
+    /// <summary>
+    /// Calculates the amount of experience gained after a kill, without applying it to the character.
+    /// </summary>
+    /// <param name="killedObject">The killed monster.</param>
+    /// <returns>The calculated experience amount.</returns>
+    public async ValueTask<int> CalculateAfterKillAsync(IAttackable killedObject)
+    {
+        if (!this.TryGetExperienceKind(out var isMasterExperience)
+            || this._player.Attributes is not { } attributes)
+        {
+            return 0;
+        }
+
+        var expRateAttribute = isMasterExperience ? Stats.MasterExperienceRate : Stats.ExperienceRate;
+        var gameRate = isMasterExperience ? this._player.GameContext.MasterExperienceRate : this._player.GameContext.ExperienceRate;
+
+        var experience = killedObject.CalculateBaseExperience(attributes[Stats.TotalLevel]);
+        experience *= gameRate;
+        experience *= attributes[expRateAttribute] + attributes[Stats.BonusExperienceRate];
+        experience *= this._player.CurrentMap?.Definition.ExpMultiplier ?? 1;
+
+        if (this._player.GameContext.PlugInManager.GetPlugInPoint<IExperienceCalculationPlugIn>() is { } plugInPoint)
+        {
+            var args = new ExperienceCalculationArgs(killedObject, isMasterExperience, experience);
+            await plugInPoint.CalculateExperienceAsync(this._player, args).ConfigureAwait(false);
+            experience = args.Experience;
+        }
+
+        var minMultiplier = attributes[Stats.RandomExperienceMinMultiplier];
+        var maxMultiplier = attributes[Stats.RandomExperienceMaxMultiplier];
+        if (minMultiplier > 0 && maxMultiplier > 0)
+        {
+            var minimumExperience = (int)(experience * minMultiplier);
+            var maximumExperience = (int)(experience * maxMultiplier);
+            if (minimumExperience < maximumExperience)
+            {
+                return Rand.NextInt(minimumExperience, maximumExperience);
+            }
+        }
+
+        return (int)experience;
+    }
+
+    /// <summary>
+    /// Adds the master experience to the current character.
+    /// </summary>
+    /// <param name="experience">The experience that should be added.</param>
+    /// <param name="killedObject">The killed object that caused the experience gain.</param>
+    public async ValueTask AddMasterExperienceAsync(int experience, IAttackable? killedObject)
+    {
+        using var d = await this._lock.LockAsync().ConfigureAwait(false);
+        await this.AddMasterExperienceCoreAsync(experience, killedObject).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Adds the experience to the current character.
+    /// </summary>
+    /// <param name="experience">The experience that should be added.</param>
+    /// <param name="killedObject">The killed object that caused the experience gain.</param>
+    public async ValueTask AddExperienceAsync(int experience, IAttackable? killedObject)
+    {
+        using var d = await this._lock.LockAsync().ConfigureAwait(false);
+        await this.AddExperienceCoreAsync(experience, killedObject).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Determines whether the player gains master experience instead of normal experience.
+    /// </summary>
+    /// <param name="isMasterExperience">If set to <c>true</c>, master experience is gained.</param>
+    /// <returns><c>True</c>, if the player can gain experience at all; Otherwise, <c>false</c>.</returns>
+    private bool TryGetExperienceKind(out bool isMasterExperience)
+    {
+        isMasterExperience = false;
+        if (this._player.SelectedCharacter?.CharacterClass is not { } characterClass
+            || this._player.Attributes is not { } attributes)
+        {
+            return false;
+        }
+
+        var currentLevel = (short)attributes[Stats.Level];
+        var isMaxLevel = currentLevel == this._player.GameContext.Configuration.MaximumLevel;
+        isMasterExperience = characterClass.IsMasterClass && isMaxLevel;
+        return true;
+    }
+
+    private async ValueTask AddMasterExperienceCoreAsync(int experience, IAttackable? killedObject)
+    {
+        var player = this._player;
+        if (player.Attributes![Stats.MasterLevel] >= player.GameContext.Configuration.MaximumMasterLevel)
+        {
+            await player.InvokeViewPlugInAsync<IAddExperiencePlugIn>(p => p.AddExperienceAsync(0, killedObject, ExperienceType.MaxMasterLevelReached)).ConfigureAwait(false);
+            return;
+        }
+
+        if (killedObject is not null && killedObject.Attributes[Stats.Level] < player.GameContext.Configuration.MinimumMonsterLevelForMasterExperience)
+        {
+            await player.InvokeViewPlugInAsync<IAddExperiencePlugIn>(p => p.AddExperienceAsync(0, killedObject, ExperienceType.MonsterLevelTooLowForMasterExperience)).ConfigureAwait(false);
+            return;
+        }
+
+        long exp = experience;
+
+        bool lvlup = false;
+        var expTable = player.GameContext.MasterExperienceTable;
+        if (expTable[(int)player.Attributes[Stats.MasterLevel] + 1] - player.SelectedCharacter!.MasterExperience < exp)
+        {
+            exp = expTable[(int)player.Attributes[Stats.MasterLevel] + 1] - player.SelectedCharacter.MasterExperience;
+            lvlup = true;
+        }
+
+        player.SelectedCharacter.MasterExperience += exp;
+
+        await player.InvokeViewPlugInAsync<IAddExperiencePlugIn>(p => p.AddExperienceAsync((int)exp, killedObject, ExperienceType.Master)).ConfigureAwait(false);
+
+        if (lvlup)
+        {
+            player.Attributes[Stats.MasterLevel]++;
+            player.SelectedCharacter.MasterLevelUpPoints += (int)player.Attributes[Stats.MasterPointsPerLevelUp];
+            player.SetReclaimableAttributesToMaximum();
+            player.Logger.LogDebug("Character {0} leveled up to master level {1}", player.SelectedCharacter.Name, player.Attributes[Stats.MasterLevel]);
+
+            if (player.GameContext.PlugInManager.GetPlugInPoint<ICharacterMasterLevelUpPlugIn>() is { } plugInPoint)
+            {
+                await plugInPoint.CharacterMasterLeveledUpAsync(player).ConfigureAwait(false);
+            }
+
+            await player.InvokeViewPlugInAsync<IUpdateLevelPlugIn>(p => p.UpdateMasterLevelAsync()).ConfigureAwait(false);
+            await player.ForEachWorldObserverAsync<IShowEffectPlugIn>(p => p.ShowEffectAsync(player, IShowEffectPlugIn.EffectType.LevelUp), true).ConfigureAwait(false);
+        }
+    }
+
+    private async ValueTask AddExperienceCoreAsync(int experience, IAttackable? killedObject)
+    {
+        var player = this._player;
+        var remainingExperience = experience;
+        while (remainingExperience > 0)
+        {
+            if (player.Attributes![Stats.Level] >= player.GameContext.Configuration.MaximumLevel)
+            {
+                await player.InvokeViewPlugInAsync<IAddExperiencePlugIn>(p => p.AddExperienceAsync(0, killedObject, ExperienceType.MaxLevelReached)).ConfigureAwait(false);
+                return;
+            }
+
+            long gainedExperience = remainingExperience;
+            bool isLevelUp = false;
+            var expTable = player.GameContext.ExperienceTable;
+            var expForNextLevel = expTable[(int)player.Attributes[Stats.Level] + 1];
+            if (expForNextLevel - player.SelectedCharacter!.Experience < gainedExperience)
+            {
+                gainedExperience = expForNextLevel - player.SelectedCharacter.Experience;
+                isLevelUp = true;
+            }
+
+            player.SelectedCharacter.Experience += gainedExperience;
+
+            await player.InvokeViewPlugInAsync<IAddExperiencePlugIn>(p => p.AddExperienceAsync((int)gainedExperience, killedObject, ExperienceType.Normal)).ConfigureAwait(false);
+
+            if (!isLevelUp)
+            {
+                return;
+            }
+
+            player.Attributes[Stats.Level]++;
+            player.SelectedCharacter.LevelUpPoints += (int)player.Attributes[Stats.PointsPerLevelUp];
+            player.SetReclaimableAttributesToMaximum();
+            player.Logger.LogDebug("Character {0} leveled up to {1}", player.SelectedCharacter.Name, player.Attributes[Stats.Level]);
+
+            player.GameContext.PlugInManager.GetPlugInPoint<ICharacterLevelUpPlugIn>()?.CharacterLeveledUp(player);
+
+            await player.InvokeViewPlugInAsync<IUpdateLevelPlugIn>(p => p.UpdateLevelAsync()).ConfigureAwait(false);
+            await player.ForEachWorldObserverAsync<IShowEffectPlugIn>(p => p.ShowEffectAsync(player, IShowEffectPlugIn.EffectType.LevelUp), true).ConfigureAwait(false);
+
+            remainingExperience -= (int)gainedExperience;
+            if (remainingExperience <= 0
+                || player.Attributes[Stats.Level] >= player.GameContext.Configuration.MaximumLevel
+                || player.GameContext.Configuration.PreventExperienceOverflow)
+            {
+                return;
+            }
+        }
+    }
+}

--- a/src/GameLogic/PlugIns/ExperienceCalculationArgs.cs
+++ b/src/GameLogic/PlugIns/ExperienceCalculationArgs.cs
@@ -1,0 +1,40 @@
+// <copyright file="ExperienceCalculationArgs.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.PlugIns;
+
+/// <summary>
+/// The arguments of the <see cref="IExperienceCalculationPlugIn"/>. Plugin points can't return
+/// values, so the calculated experience is passed in and out through this object.
+/// </summary>
+public sealed class ExperienceCalculationArgs
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ExperienceCalculationArgs"/> class.
+    /// </summary>
+    /// <param name="killedObject">The killed object which caused the experience gain.</param>
+    /// <param name="isMasterExperience">If set to <c>true</c>, master experience is gained.</param>
+    /// <param name="experience">The calculated experience.</param>
+    public ExperienceCalculationArgs(IAttackable killedObject, bool isMasterExperience, double experience)
+    {
+        this.KilledObject = killedObject;
+        this.IsMasterExperience = isMasterExperience;
+        this.Experience = experience;
+    }
+
+    /// <summary>
+    /// Gets the killed object which caused the experience gain.
+    /// </summary>
+    public IAttackable KilledObject { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether master experience is gained instead of normal experience.
+    /// </summary>
+    public bool IsMasterExperience { get; }
+
+    /// <summary>
+    /// Gets or sets the calculated experience. It can be modified by the plugins.
+    /// </summary>
+    public double Experience { get; set; }
+}

--- a/src/GameLogic/PlugIns/ICharacterMasterLevelUpPlugIn.cs
+++ b/src/GameLogic/PlugIns/ICharacterMasterLevelUpPlugIn.cs
@@ -1,0 +1,25 @@
+// <copyright file="ICharacterMasterLevelUpPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.PlugIns;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// A plugin interface which is called when a <see cref="Player"/> gained a master level.
+/// </summary>
+/// <remarks>
+/// It's the counterpart of <see cref="ICharacterLevelUpPlugIn"/> for the master level.
+/// </remarks>
+[Guid("4F63B5A9-2E4E-4F0F-8A6B-19B7A9E1D4C3")]
+[PlugInPoint("Player gained master level", "Plugins which will be executed when a player gained a master level.")]
+public interface ICharacterMasterLevelUpPlugIn
+{
+    /// <summary>
+    /// This method is called when a <see cref="Player"/> gained a master level.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    ValueTask CharacterMasterLeveledUpAsync(Player player);
+}

--- a/src/GameLogic/PlugIns/IExperienceCalculationPlugIn.cs
+++ b/src/GameLogic/PlugIns/IExperienceCalculationPlugIn.cs
@@ -1,0 +1,31 @@
+// <copyright file="IExperienceCalculationPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.PlugIns;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// A plugin interface which is called when the experience for a kill is calculated, so that the
+/// amount can be modified, e.g. by an event or a party bonus.
+/// </summary>
+/// <remarks>
+/// The plugins are called after the configured experience rates and the map multiplier have been
+/// applied, and before the random multiplier of <see cref="Attributes.Stats.RandomExperienceMinMultiplier"/>
+/// and <see cref="Attributes.Stats.RandomExperienceMaxMultiplier"/> is applied.
+/// Because the plugins are not called in a defined order, they should only apply factors or
+/// summands which are independent of each other.
+/// </remarks>
+[Guid("35B0F1F6-EE79-4C0E-9C5C-6A9E0F8DCB70")]
+[PlugInPoint("Experience calculation", "Plugins which modify the amount of experience which a player gains for a kill.")]
+public interface IExperienceCalculationPlugIn
+{
+    /// <summary>
+    /// Is called when the experience for a kill has been calculated.
+    /// </summary>
+    /// <param name="player">The player which gains the experience.</param>
+    /// <param name="args">The arguments, which hold the calculated experience.</param>
+    ValueTask CalculateExperienceAsync(Player player, ExperienceCalculationArgs args);
+}

--- a/src/GameLogic/PlugIns/IPlayerGainedExperiencePlugIn.cs
+++ b/src/GameLogic/PlugIns/IPlayerGainedExperiencePlugIn.cs
@@ -1,0 +1,25 @@
+// <copyright file="IPlayerGainedExperiencePlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.PlugIns;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// A plugin interface which is called after a player gained experience for a kill.
+/// </summary>
+[Guid("D5A0F2F1-3C1E-4E60-9E8B-59A6EF8A0C21")]
+[PlugInPoint("Player gained experience", "Plugins which are executed after a player gained experience for a kill.")]
+public interface IPlayerGainedExperiencePlugIn
+{
+    /// <summary>
+    /// Is called after the player gained experience for a kill.
+    /// </summary>
+    /// <param name="player">The player which gained the experience.</param>
+    /// <param name="experience">The gained experience.</param>
+    /// <param name="killedObject">The killed object which caused the experience gain.</param>
+    /// <param name="isMasterExperience">If set to <c>true</c>, master experience was gained.</param>
+    ValueTask PlayerGainedExperienceAsync(Player player, int experience, IAttackable killedObject, bool isMasterExperience);
+}

--- a/src/GameLogic/PlugIns/PetExperiencePlugIn.cs
+++ b/src/GameLogic/PlugIns/PetExperiencePlugIn.cs
@@ -1,0 +1,98 @@
+// <copyright file="PetExperiencePlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.PlugIns;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.AttributeSystem;
+using MUnique.OpenMU.GameLogic.Attributes;
+using MUnique.OpenMU.GameLogic.Pet;
+using MUnique.OpenMU.GameLogic.PlayerActions.Items;
+using MUnique.OpenMU.GameLogic.Views.Pet;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// A plugin which gives the trainable pets of a player a share of the experience which the
+/// player gained for a kill, and levels them up.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PetExperiencePlugIn), Description = "Gives the trainable pets of a player a share of the experience which the player gained for a kill.")]
+[Guid("6B9A0A0E-5C6A-4E8F-A4E1-3C7B8B9A2D51")]
+public class PetExperiencePlugIn : IPlayerGainedExperiencePlugIn
+{
+    /// <summary>
+    /// The share of the player's experience which a pet gains. If both, a riding pet and an
+    /// attacking pet are equipped, each of them gains the half of it.
+    /// </summary>
+    private const double PetShare = 0.2;
+
+    /// <inheritdoc />
+    public async ValueTask PlayerGainedExperienceAsync(Player player, int experience, IAttackable killedObject, bool isMasterExperience)
+    {
+        var movePet = GetTrainablePet(player, InventoryConstants.PetSlot);
+        var attackPet = GetTrainablePet(player, InventoryConstants.RightHandSlot);
+
+        if (movePet is null && attackPet is null)
+        {
+            return;
+        }
+
+        var petExperience = (int)(experience * PetShare);
+
+        if (movePet is not null && attackPet is not null)
+        {
+            // Both are there, so each gains just the half.
+            petExperience /= 2;
+        }
+
+        if (petExperience < 1)
+        {
+            return;
+        }
+
+        if (movePet is { })
+        {
+            await AddExpToPetAsync(player, movePet, petExperience).ConfigureAwait(false);
+        }
+
+        if (attackPet is { })
+        {
+            await AddExpToPetAsync(player, attackPet, petExperience).ConfigureAwait(false);
+        }
+    }
+
+    private static Item? GetTrainablePet(Player player, byte inventorySlot)
+    {
+        var pet = player.Inventory?.GetItem(inventorySlot);
+        if (pet is not null
+            && pet.Definition is not null
+            && pet.Definition.PetExperienceFormula is not null
+            && pet.Definition.MaximumItemLevel > 0
+            && pet.Durability > 0
+            && pet.Level < pet.Definition.MaximumItemLevel)
+        {
+            return pet;
+        }
+
+        return null;
+    }
+
+    private static async ValueTask AddExpToPetAsync(Player player, Item pet, double experience)
+    {
+        pet.PetExperience += (int)experience;
+
+        while (pet.PetExperience >= pet.Definition!.GetExperienceOfPetLevel((byte)(pet.Level + 1), pet.Definition!.MaximumItemLevel)
+               && (!pet.IsDarkRaven() || pet.GetDarkRavenLeadershipRequirement(pet.Level + 1) <= player.Attributes![Stats.TotalLeadership]))
+        {
+            pet.Level++;
+            player.Attributes!.ItemPowerUps[pet] = player.Attributes.ItemPowerUps[pet]
+                .Append(new PowerUpWrapper(
+                    new SimpleElement(1, AggregateType.AddRaw),
+                    pet.IsDarkRaven() ? Stats.RavenLevel : Stats.HorseLevel,
+                    player.Attributes)).ToList();
+
+            await player.InvokeViewPlugInAsync<IPetInfoViewPlugIn>(p => p.ShowPetInfoAsync(pet, pet.ItemSlot, PetStorageLocation.InventoryPetSlot)).ConfigureAwait(false);
+        }
+    }
+}

--- a/tests/MUnique.OpenMU.Tests/ExperiencePlugInTests.cs
+++ b/tests/MUnique.OpenMU.Tests/ExperiencePlugInTests.cs
@@ -1,0 +1,197 @@
+// <copyright file="ExperiencePlugInTests.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Tests;
+
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using MUnique.OpenMU.AttributeSystem;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.Attributes;
+using MUnique.OpenMU.GameLogic.PlugIns;
+using MUnique.OpenMU.Persistence.InMemory;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Tests for the plugin points around the experience gain of a player.
+/// </summary>
+[TestFixture]
+public class ExperiencePlugInTests
+{
+    /// <summary>
+    /// Tests that a plugin can modify the experience which is gained for a kill.
+    /// </summary>
+    [Test]
+    public async ValueTask CalculationPlugInModifiesGainedExperienceAsync()
+    {
+        var player = await this.CreatePlayerAsync().ConfigureAwait(false);
+        var killedObject = CreateKilledObject(level: 100);
+
+        var withoutPlugIn = await player.CalculateExpAfterKillAsync(killedObject).ConfigureAwait(false);
+        Assert.That(withoutPlugIn, Is.GreaterThan(0));
+
+        player.GameContext.PlugInManager.RegisterPlugInAtPlugInPoint<IExperienceCalculationPlugIn>(new DoubleExperiencePlugIn());
+        var withPlugIn = await player.CalculateExpAfterKillAsync(killedObject).ConfigureAwait(false);
+
+        Assert.That(withPlugIn, Is.EqualTo(withoutPlugIn * 2));
+    }
+
+    /// <summary>
+    /// Tests that the calculation plugin also affects the experience which is actually granted.
+    /// </summary>
+    [Test]
+    public async ValueTask CalculationPlugInAffectsGrantedExperienceAsync()
+    {
+        var player = await this.CreatePlayerAsync().ConfigureAwait(false);
+        var killedObject = CreateKilledObject(level: 100);
+        player.GameContext.PlugInManager.RegisterPlugInAtPlugInPoint<IExperienceCalculationPlugIn>(new DoubleExperiencePlugIn());
+
+        var gained = await player.AddExpAfterKillAsync(killedObject).ConfigureAwait(false);
+
+        Assert.That(gained, Is.GreaterThan(0));
+        Assert.That(player.SelectedCharacter!.Experience, Is.EqualTo(gained));
+    }
+
+    /// <summary>
+    /// Tests that a plugin is informed about the gained experience, which is how the pets get
+    /// their share of it.
+    /// </summary>
+    [Test]
+    public async ValueTask GainedExperienceIsReportedToPlugInAsync()
+    {
+        var player = await this.CreatePlayerAsync().ConfigureAwait(false);
+        var plugIn = new ExperienceRecordingPlugIn();
+        player.GameContext.PlugInManager.RegisterPlugInAtPlugInPoint<IPlayerGainedExperiencePlugIn>(plugIn);
+        var killedObject = CreateKilledObject(level: 100);
+
+        var gained = await player.AddExpAfterKillAsync(killedObject).ConfigureAwait(false);
+
+        Assert.That(plugIn.Gains, Has.Count.EqualTo(1));
+        Assert.That(plugIn.Gains[0].Experience, Is.EqualTo(gained));
+        Assert.That(plugIn.Gains[0].IsMasterExperience, Is.False);
+        Assert.That(plugIn.Gains[0].KilledObject, Is.SameAs(killedObject));
+    }
+
+    /// <summary>
+    /// Tests that no plugin is called when the player can't gain any experience.
+    /// </summary>
+    [Test]
+    public async ValueTask GainedExperienceIsNotReportedWithoutExperienceAsync()
+    {
+        var player = await this.CreatePlayerAsync(maximumLevel: 1).ConfigureAwait(false);
+        var plugIn = new ExperienceRecordingPlugIn();
+        player.GameContext.PlugInManager.RegisterPlugInAtPlugInPoint<IPlayerGainedExperiencePlugIn>(plugIn);
+
+        await player.AddExpAfterKillAsync(CreateKilledObject(level: 0)).ConfigureAwait(false);
+
+        Assert.That(plugIn.Gains, Is.Empty);
+    }
+
+    /// <summary>
+    /// Tests that a master level up is reported to the corresponding plugin point.
+    /// </summary>
+    [Test]
+    public async ValueTask MasterLevelUpIsReportedToPlugInAsync()
+    {
+        var player = await this.CreatePlayerAsync(maximumLevel: 10, isMasterClass: true, level: 10).ConfigureAwait(false);
+        var plugIn = new MasterLevelUpRecordingPlugIn();
+        player.GameContext.PlugInManager.RegisterPlugInAtPlugInPoint<ICharacterMasterLevelUpPlugIn>(plugIn);
+        // The level up happens when the required experience is exceeded, so one more point is needed.
+        var requiredExperience = player.GameContext.MasterExperienceTable[1] + 1;
+
+        await player.AddMasterExperienceAsync((int)requiredExperience, null).ConfigureAwait(false);
+
+        Assert.That(player.SelectedCharacter!.MasterExperience, Is.EqualTo(player.GameContext.MasterExperienceTable[1]));
+        Assert.That(plugIn.LevelUpCount, Is.EqualTo(1));
+    }
+
+    private static Mock<IAttackable> CreateKilledObjectMock(float level)
+    {
+        var attributes = new Mock<IAttributeSystem>();
+        attributes.Setup(a => a[Stats.Level]).Returns(level);
+
+        var result = new Mock<IAttackable>();
+        result.SetupGet(a => a.Attributes).Returns(attributes.Object);
+        result.SetupGet(a => a.CurrentMap).Returns((GameMap?)null);
+        return result;
+    }
+
+    private static IAttackable CreateKilledObject(float level) => CreateKilledObjectMock(level).Object;
+
+    private async ValueTask<Player> CreatePlayerAsync(short maximumLevel = 100, bool isMasterClass = false, short level = 1)
+    {
+        var contextProvider = new InMemoryPersistenceContextProvider();
+        var gameConfiguration = contextProvider.CreateNewContext().CreateNew<GameConfiguration>();
+        gameConfiguration.RecoveryInterval = int.MaxValue;
+        gameConfiguration.MaximumLevel = maximumLevel;
+        gameConfiguration.MaximumMasterLevel = 200;
+        gameConfiguration.MinimumMonsterLevelForMasterExperience = 0;
+        gameConfiguration.ExperienceRate = 1.0f;
+        gameConfiguration.MasterExperienceRate = 1.0f;
+        var map = contextProvider.CreateNewContext().CreateNew<GameMapDefinition>();
+        map.ExpMultiplier = 1.0f;
+        gameConfiguration.Maps.Add(map);
+
+        var mapInitializer = new MapInitializer(gameConfiguration, new NullLogger<MapInitializer>(), NullDropGenerator.Instance, null);
+        var gameContext = new GameContext(
+            gameConfiguration,
+            contextProvider,
+            mapInitializer,
+            new NullLoggerFactory(),
+            new PlugInManager(new List<PlugInConfiguration>(), new NullLoggerFactory(), null, null),
+            NullDropGenerator.Instance,
+            new ConfigurationChangeMediator());
+        mapInitializer.PlugInManager = gameContext.PlugInManager;
+        mapInitializer.PathFinderPool = gameContext.PathFinderPool;
+
+        var player = await PlayerTestHelper.CreatePlayerAsync(gameContext).ConfigureAwait(false);
+        player.SelectedCharacter!.CharacterClass!.IsMasterClass = isMasterClass;
+        player.Attributes![Stats.Level] = level;
+        player.Attributes[Stats.MasterLevel] = 0;
+        player.Attributes[Stats.PointsPerLevelUp] = 1;
+        player.Attributes[Stats.MasterPointsPerLevelUp] = 1;
+        player.Attributes.AddElement(new SimpleElement(1.0f, AggregateType.AddRaw), Stats.ExperienceRate);
+        player.Attributes.AddElement(new SimpleElement(1.0f, AggregateType.AddRaw), Stats.MasterExperienceRate);
+        player.Attributes.AddElement(new SimpleElement(level, AggregateType.AddRaw), Stats.TotalLevel);
+        player.SelectedCharacter.Experience = 0;
+        player.SelectedCharacter.MasterExperience = 0;
+        return player;
+    }
+
+    [Guid("A0C4C8E1-2D2E-4F1A-9C51-0B8E1E2A5D71")]
+    private sealed class DoubleExperiencePlugIn : IExperienceCalculationPlugIn
+    {
+        public ValueTask CalculateExperienceAsync(Player player, ExperienceCalculationArgs args)
+        {
+            args.Experience *= 2;
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Guid("B31E7E52-6F3B-4E0C-9C8A-8F0A2C4D6E13")]
+    private sealed class ExperienceRecordingPlugIn : IPlayerGainedExperiencePlugIn
+    {
+        public List<(int Experience, IAttackable KilledObject, bool IsMasterExperience)> Gains { get; } = new();
+
+        public ValueTask PlayerGainedExperienceAsync(Player player, int experience, IAttackable killedObject, bool isMasterExperience)
+        {
+            this.Gains.Add((experience, killedObject, isMasterExperience));
+            return ValueTask.CompletedTask;
+        }
+    }
+
+    [Guid("C2F5A9D3-8B1E-4A7C-B0D2-5E6F1A3C8B24")]
+    private sealed class MasterLevelUpRecordingPlugIn : ICharacterMasterLevelUpPlugIn
+    {
+        public int LevelUpCount { get; private set; }
+
+        public ValueTask CharacterMasterLeveledUpAsync(Player player)
+        {
+            this.LevelUpCount++;
+            return ValueTask.CompletedTask;
+        }
+    }
+}

--- a/tests/MUnique.OpenMU.Tests/ExperiencePlugInTests.cs
+++ b/tests/MUnique.OpenMU.Tests/ExperiencePlugInTests.cs
@@ -104,6 +104,7 @@ public class ExperiencePlugInTests
 
         await player.AddMasterExperienceAsync((int)requiredExperience, null).ConfigureAwait(false);
 
+        Assert.That((int)player.Attributes![Stats.MasterLevel], Is.EqualTo(1));
         Assert.That(player.SelectedCharacter!.MasterExperience, Is.EqualTo(player.GameContext.MasterExperienceTable[1]));
         Assert.That(plugIn.LevelUpCount, Is.EqualTo(1));
     }

--- a/tests/MUnique.OpenMU.Tests/PlayerTestHelper.cs
+++ b/tests/MUnique.OpenMU.Tests/PlayerTestHelper.cs
@@ -80,6 +80,7 @@ public static class PlayerTestHelper
             new List<StatAttributeDefinition>
             {
                 new (Stats.Level, 0, false),
+                new (Stats.MasterLevel, 0, false),
                 new (Stats.BaseStrength, 28, true),
                 new (Stats.BaseAgility, 20, true),
                 new (Stats.BaseVitality, 25, true),


### PR DESCRIPTION
Phase 3 of the `Player` refactoring (`docs/PlayerRefactoringPlan.md`). The experience and leveling move into a `PlayerExperience` component, and the parts of it which are game rules rather than mechanism become plugin points.

## New plugin points

| Point | Purpose |
|---|---|
| `IExperienceCalculationPlugIn` | modify the amount of experience gained for a kill — events, party or VIP bonuses, seasonal rates |
| `IPlayerGainedExperiencePlugIn` | react to a player gaining experience; this is where the pet experience now lives |
| `ICharacterMasterLevelUpPlugIn` | the counterpart of the existing `ICharacterLevelUpPlugIn` for the master level, which had no plugin point at all |

Since plugin points can't return values, `IExperienceCalculationPlugIn` uses a mutable `ExperienceCalculationArgs`, following the `SpeedHackCheckEventArgs` precedent.

**Pet experience is no longer hardcoded in `Player`.** The 20 % share, the split between riding and attacking pet, and the pet level-ups are now `PetExperiencePlugIn` on `IPlayerGainedExperiencePlugIn`. It is active by default (no `PlugInConfiguration` entry means active), so existing installations keep the current behavior, and a server that wants a different pet progression can replace it.

## One deviation from the plan

The plan proposed splitting the whole multiplier chain of `CalculateExpAfterKill` into individual plugins (map multiplier, bonus rate, random multipliers). I did not do that: plugins are unordered, and the random multiplier truncates to `int`, so it has to run last — as competing plugins their result would depend on the discovery order.

Instead the rates and the map multiplier stay in the component, and the plugin point runs **after** them and **before** the randomization, where factors compose independently of the order. The plan is updated with this reasoning. If plugin ordering (§3.1a) is implemented later, the chain can still be split.

## Breaking change

`CalculateExpAfterKill` becomes `CalculateExpAfterKillAsync`, because the calculation calls a plugin point now. It had no callers outside of `Player`.

**Player.cs: 2,269 → 2,058 lines** (3,098 before this refactoring started).

## Tests

New `ExperiencePlugInTests` with five cases: the calculation plugin changes the calculated and the actually granted experience, the gain is reported with the right amount and kind, nothing is reported when no experience is gained, and a master level up reaches its plugin point.

The mock character class of `PlayerTestHelper` also gets the master level as a stat attribute, like every real character class has it. Without it, a master level up didn't stick in tests and couldn't be asserted.

Full suite: 716 of 716 pass, solution builds with no errors.
