### PR TITLE
remove bot boredoom

### DIFF
--- a/docs/Bots.md
+++ b/docs/Bots.md
@@ -253,8 +253,9 @@ whole session. A living player takes precedence over the bot's own company
 — a bot hunting with other bots leaves them for the inviter, and breaks that bot
 party up if it was leading it, so a player never has to guess which bot happens
 to be free. In a party the bot follows its leader and defers a due reset, leaving
-only on the engine's own terms: when the party disbands, when it is kicked, or
-when the leader enters a map it may not access.
+only on the engine's own terms: when the party disbands, when it is kicked,
+when the leader enters a map it may not access, or before the bot's own logout (the
+presence rotation or a fault restart stops it).
 
 A bot fights back when a player attacks it, but only as far as the game's own
 PvP rules allow: inside the active self-defense window, or against a player

--- a/docs/Bots.md
+++ b/docs/Bots.md
@@ -254,8 +254,10 @@ whole session. A living player takes precedence over the bot's own company
 party up if it was leading it, so a player never has to guess which bot happens
 to be free. In a party the bot follows its leader and defers a due reset, leaving
 only on the engine's own terms: when the party disbands, when it is kicked,
-when the leader enters a map it may not access, or before the bot's own logout (the
-presence rotation or a fault restart stops it).
+when the leader enters a map it may not access, before the bot's own logout (the
+presence rotation or a fault restart stops it), or - once no live human is left
+in the party - ten minutes after its companion disconnects, so the bot is not
+stranded in a dead party forever.
 
 A bot fights back when a player attacks it, but only as far as the game's own
 PvP rules allow: inside the active self-defense window, or against a player

--- a/docs/Bots.md
+++ b/docs/Bots.md
@@ -254,10 +254,9 @@ whole session. A living player takes precedence over the bot's own company
 party up if it was leading it, so a player never has to guess which bot happens
 to be free. In a party the bot follows its leader and defers a due reset, leaving
 only on the engine's own terms: when the party disbands, when it is kicked,
-when the leader enters a map it may not access, before the bot's own logout (the
-presence rotation or a fault restart stops it), or - once no live human is left
-in the party - ten minutes after its companion disconnects, so the bot is not
-stranded in a dead party forever.
+when the leader enters a map it may not access, ten minutes after every human
+companion has disconnected without reconnecting, or before the bot's own logout (the
+presence rotation or a fault restart stops it).
 
 A bot fights back when a player attacks it, but only as far as the game's own
 PvP rules allow: inside the active self-defense window, or against a player

--- a/docs/Bots.md
+++ b/docs/Bots.md
@@ -255,8 +255,8 @@ party up if it was leading it, so a player never has to guess which bot happens
 to be free. In a party the bot follows its leader and defers a due reset, leaving
 only on the engine's own terms: when the party disbands, when it is kicked,
 when the leader enters a map it may not access, ten minutes after every human
-companion has disconnected without reconnecting, or before the bot's own logout (the
-presence rotation or a fault restart stops it).
+companion has disconnected without reconnecting, or before the bot's own logout
+(the presence rotation or a fault restart stops it).
 
 A bot fights back when a player attacks it, but only as far as the game's own
 PvP rules allow: inside the active self-defense window, or against a player

--- a/docs/Bots.md
+++ b/docs/Bots.md
@@ -233,7 +233,7 @@ requirement, the player-killer rule). A bot which does not qualify leaves the
 party and goes back to its own life instead of blocking the entry.
 
 Inside, its open-world routine is suspended: no shopping, no map changes, no
-boredom, no grudges. It fights what the event throws at it and keeps up with the
+grudges. It fights what the event throws at it and keeps up with the
 leader. Chaos Castle is a free-for-all, so there the other participants are
 targets like everyone else — and a fight inside leaves no grudge outside. A bot
 which dies respawns in the safezone like a player, which takes it out of the
@@ -248,13 +248,13 @@ experience bonus applies. Parties re-form every hour.
 A player may invite a bot into their own party: it accepts after a human-like
 pause of a few seconds, as long as it is not in the middle of an errand. There is
 no level gate — just like OpenMU's own party action, a bot accepts an inviter of
-any level, since it is the player who invites and the bot leaves once it gets
-bored. A living player takes precedence over the bot's own company
+any level, since it is the player who invites, and once it joins it stays for the
+whole session. A living player takes precedence over the bot's own company
 — a bot hunting with other bots leaves them for the inviter, and breaks that bot
 party up if it was leading it, so a player never has to guess which bot happens
-to be free. In a party the bot follows its leader, defers a due reset, and
-eventually leaves politely: when the leader enters a map it may not access,
-before its own logout, or simply when it gets bored.
+to be free. In a party the bot follows its leader and defers a due reset, leaving
+only on the engine's own terms: when the party disbands, when it is kicked, or
+when the leader enters a map it may not access.
 
 A bot fights back when a player attacks it, but only as far as the game's own
 PvP rules allow: inside the active self-defense window, or against a player

--- a/src/GameLogic/Bots/BotManager.cs
+++ b/src/GameLogic/Bots/BotManager.cs
@@ -230,7 +230,7 @@ public sealed class BotManager
         const int minPartySize = 2;
         const int maxPartySize = 5;
         const int maxLevelGap = 12;
-        const int partiedSharePercent = 60;
+        const int partiedSharePercent = 80;
 
         // Matched by the reset-aware effective level (see BotResetHandler.GetEffectiveLevel), so on a
         // reset server a freshly reset veteran groups with its peers instead of with real newbies.

--- a/src/GameLogic/Bots/BotNavigator.cs
+++ b/src/GameLogic/Bots/BotNavigator.cs
@@ -464,7 +464,7 @@ internal sealed class BotNavigator : AsyncDisposable
         }
 
         // Party bookkeeping: answer a pending invitation from a player once its human-like delay
-        // passed, and leave a party with a human again when the bot got bored (see BotPartyHandler).
+        // passed (see BotPartyHandler).
         await BotPartyHandler.ProcessAsync(this._player).ConfigureAwait(false);
 
         // Make sure the bot always carries healing and mana potions. Without them, the offline handlers
@@ -949,10 +949,6 @@ internal sealed class BotNavigator : AsyncDisposable
         // Fight from wherever the bot stands; the combat handler engages the targets around it.
         this._player.HuntingOrigin = this._player.Position;
 
-        // The party boredom timer must not run down (let alone fire) mid-event; the window
-        // restarts once the event is over.
-        this._player.PartyBoredomAtUtc = null;
-
         if (this._player.IsWalking)
         {
             return;
@@ -1151,8 +1147,8 @@ internal sealed class BotNavigator : AsyncDisposable
         if (BotPartyHandler.HasHumanCompanion(this._player))
         {
             // Not in the middle of a hunting session with a player: the reset would wipe the bot's
-            // strength and teleport it home, deserting the group. It resets right after the party
-            // ends (the boredom timer of BotPartyHandler bounds how long that takes).
+            // strength and teleport it home, deserting the group. It resets once the party with the
+            // human companion ends.
             return false;
         }
 

--- a/src/GameLogic/Bots/BotPartyHandler.cs
+++ b/src/GameLogic/Bots/BotPartyHandler.cs
@@ -11,10 +11,11 @@ using MUnique.OpenMU.GameLogic.Offline;
 /// <see cref="BotMuHelperSettings.AutoAcceptAnyone"/>): the invitation is accepted after a short
 /// human-like delay, and the bot then follows the leader like any party member (see the follow logic
 /// in <see cref="BotNavigator"/>). A bot stays in the party with its human companion for as long as
-/// the party exists - a player who groups a bot keeps a companion for the whole session, and the bot
-/// only leaves on the engine's own terms (the party disbands, it is kicked, it can no longer
-/// legally follow the leader to another map, or before its own logout, as when the presence
-/// rotation or a fault restart stops it). Safeguards keep it believable: no acceptance while
+/// the party exists and the companion is reachable - a player who groups a bot keeps a companion for
+/// the whole session, and the bot only leaves on the engine's own terms: the party disbands, it is
+/// kicked, it can no longer legally follow the leader to another map, every human companion has been
+/// disconnected without reconnecting for longer than the grace period, or before its own logout, as
+/// when the presence rotation or a fault restart stops it. Safeguards keep it believable: no acceptance while
 /// the bot is on an errand (shopping trip) or has unfinished business (revenge), and
 /// the invitation is re-validated when the delay has passed - the inviter may have joined another
 /// party or left. There is no level gate, matching OpenMU's own party action: it is the player who
@@ -81,9 +82,12 @@ internal static class BotPartyHandler
     /// pending invitation once its delay passed.
     /// </summary>
     /// <param name="bot">The bot.</param>
-    internal static async ValueTask ProcessAsync(OfflinePlayer bot)
+    /// <param name="utcNow">Overrides the current time used for the grace-period check (used by tests).</param>
+    internal static async ValueTask ProcessAsync(OfflinePlayer bot, DateTime? utcNow = null)
     {
-        if (bot.PendingPartyInvite is { } invite && DateTime.UtcNow >= invite.AcceptAtUtc)
+        var now = utcNow ?? DateTime.UtcNow;
+
+        if (bot.PendingPartyInvite is { } invite && now >= invite.AcceptAtUtc)
         {
             bot.PendingPartyInvite = null;
             try
@@ -96,20 +100,20 @@ internal static class BotPartyHandler
             }
         }
 
-        // The grouped human disconnected: the engine keeps their slot by swapping them for an offline
-        // snapshot, stranding the bot in a dead party. Wait out the grace period (they may reconnect or
-        // be off-leveling), then leave; bot-only parties are untouched (their master is a live bot).
-        if (bot.Party is { } party
-            && !HasHumanCompanion(bot)
-            && party.PartyMaster is OfflinePartyMember disconnectedHuman)
+        // No live human is left in the party: every human slot still present is an offline snapshot.
+        // Wait out the grace period (they may reconnect or be off-leveling) before leaving.
+        // This is independent of who currently holds the
+        // master slot, since mastership moves to a live bot when the previous master leaves properly -
+        // a bot-only party carries no such snapshot, since bots kick themselves before stopping.
+        if (bot.Party is { } party && !HasHumanCompanion(bot))
         {
-            var isOffLeveling = bot.GameContext.OfflinePlayerManager.IsOffLeveling(disconnectedHuman.Name);
-            if (isOffLeveling)
-            {
-                return;
-            }
+            var mostRecentlyDisconnectedHuman = party.PartyList
+                .OfType<OfflinePartyMember>()
+                .OrderByDescending(member => member.DisconnectedAtUtc)
+                .FirstOrDefault();
 
-            if (DateTime.UtcNow - disconnectedHuman.DisconnectedAtUtc < PartyDisconnectGracePeriod)
+            if (mostRecentlyDisconnectedHuman is null
+                || now - mostRecentlyDisconnectedHuman.DisconnectedAtUtc < PartyDisconnectGracePeriod)
             {
                 return;
             }
@@ -117,7 +121,7 @@ internal static class BotPartyHandler
             bot.Logger.LogDebug(
                 "Bot '{Name}' leaves the party of the disconnected player '{Master}'.",
                 bot.Name,
-                disconnectedHuman.Name);
+                mostRecentlyDisconnectedHuman.Name);
             await party.KickMySelfAsync(bot).ConfigureAwait(false);
         }
     }

--- a/src/GameLogic/Bots/BotPartyHandler.cs
+++ b/src/GameLogic/Bots/BotPartyHandler.cs
@@ -10,11 +10,14 @@ using MUnique.OpenMU.GameLogic.Offline;
 /// Lets a server-side bot party up with players who invite it (enabled by
 /// <see cref="BotMuHelperSettings.AutoAcceptAnyone"/>): the invitation is accepted after a short
 /// human-like delay, and the bot then follows the leader like any party member (see the follow logic
-/// in <see cref="BotNavigator"/>) until it gets bored and politely leaves. Safeguards keep it
-/// believable and abuse-free: no acceptance while the bot is on an errand (shopping trip) or has
-/// unfinished business (revenge), and the invitation is re-validated when the delay has passed - the
-/// inviter may have joined another party or left. There is no level gate, matching OpenMU's own party
-/// action: it is the player who invites, and the bot leaves again once it gets bored.
+/// in <see cref="BotNavigator"/>). A bot stays in the party with its human companion for as long as
+/// the party exists - a player who groups a bot keeps a companion for the whole session, and the bot
+/// only leaves on the engine's own terms (the party disbands, it is kicked, or it can no longer
+/// legally follow the leader to another map). Safeguards keep it believable and abuse-free: no
+/// acceptance while the bot is on an errand (shopping trip) or has unfinished business (revenge), and
+/// the invitation is re-validated when the delay has passed - the inviter may have joined another
+/// party or left. There is no level gate, matching OpenMU's own party action: it is the player who
+/// invites.
 /// </summary>
 internal static class BotPartyHandler
 {
@@ -23,16 +26,6 @@ internal static class BotPartyHandler
 
     /// <summary>Upper bound of the human-like delay before the bot answers an invitation.</summary>
     private static readonly TimeSpan MaxAcceptDelay = TimeSpan.FromSeconds(5);
-
-    /// <summary>
-    /// Lower bound of the time the bot stays in a party with a human before it gets bored and leaves.
-    /// A player who groups a bot gets a companion for a decent hunting session, but not a permanent
-    /// follower - the bot has its own goals (its resets, its shopping, its own pace).
-    /// </summary>
-    private static readonly TimeSpan MinPartyDuration = TimeSpan.FromMinutes(10);
-
-    /// <summary>Upper bound of the time the bot stays in a party with a human, see <see cref="MinPartyDuration"/>.</summary>
-    private static readonly TimeSpan MaxPartyDuration = TimeSpan.FromMinutes(20);
 
     /// <summary>
     /// Schedules the acceptance of a party invitation to a bot, if the bot is available for it.
@@ -79,9 +72,7 @@ internal static class BotPartyHandler
 
     /// <summary>
     /// Drives the bot's party behavior; called from the bot's regular evaluation tick. Answers a
-    /// pending invitation once its delay passed, and leaves the party again when the bot got bored
-    /// of grouping with a human (bot-only parties are exempt - they are managed by the hourly
-    /// re-formation of <see cref="BotManager"/>).
+    /// pending invitation once its delay passed.
     /// </summary>
     /// <param name="bot">The bot.</param>
     internal static async ValueTask ProcessAsync(OfflinePlayer bot)
@@ -97,22 +88,6 @@ internal static class BotPartyHandler
             {
                 bot.LastPartyRequester = null;
             }
-        }
-
-        if (bot.Party is { } party && HasHumanCompanion(bot))
-        {
-            bot.PartyBoredomAtUtc ??= DateTime.UtcNow + MinPartyDuration
-                + TimeSpan.FromSeconds(Rand.NextInt(0, (int)(MaxPartyDuration - MinPartyDuration).TotalSeconds + 1));
-            if (DateTime.UtcNow >= bot.PartyBoredomAtUtc)
-            {
-                bot.PartyBoredomAtUtc = null;
-                bot.Logger.LogDebug("Bot '{Name}' got bored and leaves its party.", bot.Name);
-                await party.KickMySelfAsync(bot).ConfigureAwait(false);
-            }
-        }
-        else
-        {
-            bot.PartyBoredomAtUtc = null;
         }
     }
 

--- a/src/GameLogic/Bots/BotPartyHandler.cs
+++ b/src/GameLogic/Bots/BotPartyHandler.cs
@@ -12,9 +12,10 @@ using MUnique.OpenMU.GameLogic.Offline;
 /// human-like delay, and the bot then follows the leader like any party member (see the follow logic
 /// in <see cref="BotNavigator"/>). A bot stays in the party with its human companion for as long as
 /// the party exists - a player who groups a bot keeps a companion for the whole session, and the bot
-/// only leaves on the engine's own terms (the party disbands, it is kicked, or it can no longer
-/// legally follow the leader to another map). Safeguards keep it believable and abuse-free: no
-/// acceptance while the bot is on an errand (shopping trip) or has unfinished business (revenge), and
+/// only leaves on the engine's own terms (the party disbands, it is kicked, it can no longer
+/// legally follow the leader to another map, or before its own logout, as when the presence
+/// rotation or a fault restart stops it). Safeguards keep it believable: no acceptance while
+/// the bot is on an errand (shopping trip) or has unfinished business (revenge), and
 /// the invitation is re-validated when the delay has passed - the inviter may have joined another
 /// party or left. There is no level gate, matching OpenMU's own party action: it is the player who
 /// invites.
@@ -26,6 +27,11 @@ internal static class BotPartyHandler
 
     /// <summary>Upper bound of the human-like delay before the bot answers an invitation.</summary>
     private static readonly TimeSpan MaxAcceptDelay = TimeSpan.FromSeconds(5);
+
+    /// <summary>
+    /// How long a bot waits in a dead party before leaving (grace for reconnect/off-level).
+    /// </summary>
+    private static readonly TimeSpan PartyDisconnectGracePeriod = TimeSpan.FromMinutes(10);
 
     /// <summary>
     /// Schedules the acceptance of a party invitation to a bot, if the bot is available for it.
@@ -88,6 +94,31 @@ internal static class BotPartyHandler
             {
                 bot.LastPartyRequester = null;
             }
+        }
+
+        // The grouped human disconnected: the engine keeps their slot by swapping them for an offline
+        // snapshot, stranding the bot in a dead party. Wait out the grace period (they may reconnect or
+        // be off-leveling), then leave; bot-only parties are untouched (their master is a live bot).
+        if (bot.Party is { } party
+            && !HasHumanCompanion(bot)
+            && party.PartyMaster is OfflinePartyMember disconnectedHuman)
+        {
+            var isOffLeveling = bot.GameContext.OfflinePlayerManager.IsOffLeveling(disconnectedHuman.Name);
+            if (isOffLeveling)
+            {
+                return;
+            }
+
+            if (DateTime.UtcNow - disconnectedHuman.DisconnectedAtUtc < PartyDisconnectGracePeriod)
+            {
+                return;
+            }
+
+            bot.Logger.LogDebug(
+                "Bot '{Name}' leaves the party of the disconnected player '{Master}'.",
+                bot.Name,
+                disconnectedHuman.Name);
+            await party.KickMySelfAsync(bot).ConfigureAwait(false);
         }
     }
 

--- a/src/GameLogic/Bots/BotPartyHandler.cs
+++ b/src/GameLogic/Bots/BotPartyHandler.cs
@@ -79,7 +79,8 @@ internal static class BotPartyHandler
 
     /// <summary>
     /// Drives the bot's party behavior; called from the bot's regular evaluation tick. Answers a
-    /// pending invitation once its delay passed.
+    /// pending invitation once its delay passed, and walks the bot out of a dead party once the
+    /// disconnect grace period has elapsed.
     /// </summary>
     /// <param name="bot">The bot.</param>
     /// <param name="utcNow">Overrides the current time used for the grace-period check (used by tests).</param>
@@ -100,28 +101,36 @@ internal static class BotPartyHandler
             }
         }
 
-        // No live human is left in the party: every human slot still present is an offline snapshot.
-        // Wait out the grace period (they may reconnect or be off-leveling) before leaving.
-        // This is independent of who currently holds the
-        // master slot, since mastership moves to a live bot when the previous master leaves properly -
-        // a bot-only party carries no such snapshot, since bots kick themselves before stopping.
+        // No live human is left in the party: every human slot still present is an offline snapshot,
+        // kept by the engine to reserve the spot for reconnection. Wait out the grace period (they may
+        // reconnect or be off-leveling) before leaving. This is independent of who currently holds the
+        // master slot, since mastership moves to a live bot when the previous master leaves properly.
+        // A bot-only party carries no such snapshot, since bots kick themselves before stopping - which
+        // is also the common case this loop must stay cheap for, so it avoids allocating an iterator or
+        // sorting the list just to find out there is nothing to find.
         if (bot.Party is { } party && !HasHumanCompanion(bot))
         {
-            var mostRecentlyDisconnectedHuman = party.PartyList
-                .OfType<OfflinePartyMember>()
-                .OrderByDescending(member => member.DisconnectedAtUtc)
-                .FirstOrDefault();
+            DateTime? mostRecentDisconnect = null;
+            string? mostRecentlyDisconnectedMemberName = null;
+            foreach (var member in party.PartyList)
+            {
+                if (member is OfflinePartyMember snapshot
+                    && (mostRecentDisconnect is null || snapshot.DisconnectedAtUtc > mostRecentDisconnect))
+                {
+                    mostRecentDisconnect = snapshot.DisconnectedAtUtc;
+                    mostRecentlyDisconnectedMemberName = snapshot.Name;
+                }
+            }
 
-            if (mostRecentlyDisconnectedHuman is null
-                || now - mostRecentlyDisconnectedHuman.DisconnectedAtUtc < PartyDisconnectGracePeriod)
+            if (mostRecentDisconnect is null || now - mostRecentDisconnect < PartyDisconnectGracePeriod)
             {
                 return;
             }
 
             bot.Logger.LogDebug(
-                "Bot '{Name}' leaves the party of the disconnected player '{Master}'.",
+                "Bot '{Name}' leaves the party of the disconnected player '{Player}'.",
                 bot.Name,
-                mostRecentlyDisconnectedHuman.Name);
+                mostRecentlyDisconnectedMemberName);
             await party.KickMySelfAsync(bot).ConfigureAwait(false);
         }
     }

--- a/src/GameLogic/Offline/OfflinePlayer.cs
+++ b/src/GameLogic/Offline/OfflinePlayer.cs
@@ -139,12 +139,6 @@ public class OfflinePlayer : Player
     internal Bots.PendingPartyInvite? PendingPartyInvite { get; set; }
 
     /// <summary>
-    /// Gets or sets the time at which the bot gets bored of its current party with a human player
-    /// and politely leaves it (managed by <see cref="Bots.BotPartyHandler"/>).
-    /// </summary>
-    internal DateTime? PartyBoredomAtUtc { get; set; }
-
-    /// <summary>
     /// Gets or sets a value indicating whether the bot is currently on a shopping trip (walking to
     /// or trading with a merchant), maintained by <see cref="Bots.BotNavigator"/>. While on an errand
     /// the bot declines party invitations, like a busy player would.

--- a/src/GameLogic/Offline/OfflinePlayerManager.cs
+++ b/src/GameLogic/Offline/OfflinePlayerManager.cs
@@ -99,13 +99,6 @@ public sealed class OfflinePlayerManager
     }
 
     /// <summary>
-    /// Returns whether the named character is currently off-leveling.
-    /// </summary>
-    /// <param name="characterName">The character name.</param>
-    public bool IsOffLeveling(string characterName) =>
-        this._activePlayers.Values.Any(p => string.Equals(p.Name, characterName, StringComparison.OrdinalIgnoreCase));
-
-    /// <summary>
     /// Returns whether an offline player session is currently active for <paramref name="loginName"/>.
     /// </summary>
     /// <param name="loginName">The account login name.</param>

--- a/src/GameLogic/Offline/OfflinePlayerManager.cs
+++ b/src/GameLogic/Offline/OfflinePlayerManager.cs
@@ -72,7 +72,7 @@ public sealed class OfflinePlayerManager
     }
 
     /// <summary>
-    /// Stops and removes the offline session for the given account, if one exists.
+    /// Stops and removes the offline session for the given account if one exists.
     /// </summary>
     /// <param name="loginName">The account login name.</param>
     public async ValueTask StopAsync(string loginName)
@@ -97,6 +97,13 @@ public sealed class OfflinePlayerManager
             await offlinePlayer.DisposeAsync().ConfigureAwait(false);
         }
     }
+
+    /// <summary>
+    /// Returns whether the named character is currently off-leveling.
+    /// </summary>
+    /// <param name="characterName">The character name.</param>
+    public bool IsOffLeveling(string characterName) =>
+        this._activePlayers.Values.Any(p => string.Equals(p.Name, characterName, StringComparison.OrdinalIgnoreCase));
 
     /// <summary>
     /// Returns whether an offline player session is currently active for <paramref name="loginName"/>.

--- a/src/GameLogic/OfflinePartyMember.cs
+++ b/src/GameLogic/OfflinePartyMember.cs
@@ -34,7 +34,7 @@ public sealed class OfflinePartyMember : IPartyMember
     /// <summary>
     /// Gets the member disconnected time.
     /// </summary>
-    public DateTime DisconnectedAtUtc { get; internal set; }
+    public DateTime DisconnectedAtUtc { get; }
 
     /// <inheritdoc />
     public Party? Party { get; set; }

--- a/src/GameLogic/OfflinePartyMember.cs
+++ b/src/GameLogic/OfflinePartyMember.cs
@@ -28,7 +28,13 @@ public sealed class OfflinePartyMember : IPartyMember
         this.CurrentMap = player.CurrentMap;
         this.Position = player.Position;
         this.Logger = player?.Logger ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance;
+        this.DisconnectedAtUtc = DateTime.UtcNow;
     }
+
+    /// <summary>
+    /// Gets the member disconnected time.
+    /// </summary>
+    public DateTime DisconnectedAtUtc { get; internal set; }
 
     /// <inheritdoc />
     public Party? Party { get; set; }

--- a/tests/MUnique.OpenMU.Tests/Offline/OfflinePlayerManagerTests.cs
+++ b/tests/MUnique.OpenMU.Tests/Offline/OfflinePlayerManagerTests.cs
@@ -97,35 +97,6 @@ public class OfflinePlayerManagerTests
     }
 
     /// <summary>
-    /// Tests that <see cref="OfflinePlayerManager.IsOffLeveling"/> returns true once an off-level
-    /// session is active for the character.
-    /// </summary>
-    [Test]
-    public async ValueTask IsOffLeveling_WhenSessionActive_ReturnsTrueAsync()
-    {
-        var manager = new OfflinePlayerManager();
-        var realPlayer = await this.CreatePlayerWithPersistedAccountAsync().ConfigureAwait(false);
-        realPlayer.TryAddMoney(1_000_000);
-        realPlayer.Attributes![Stats.Level] = 100;
-
-        await manager.StartAsync(realPlayer, TestUserLoginName).ConfigureAwait(false);
-
-        Assert.That(manager.IsOffLeveling(TestCharacterName), Is.True);
-    }
-
-    /// <summary>
-    /// Tests that <see cref="OfflinePlayerManager.IsOffLeveling"/> returns false when no off-level
-    /// session exists for the character.
-    /// </summary>
-    [Test]
-    public async ValueTask IsOffLeveling_WhenNoSession_ReturnsFalseAsync()
-    {
-        var manager = new OfflinePlayerManager();
-
-        Assert.That(manager.IsOffLeveling(TestCharacterName), Is.False);
-    }
-
-    /// <summary>
     /// Creates a player whose account is stored in the in-memory repository,
     /// so that <see cref="OfflinePlayer.InitializeAsync"/> can find it.
     /// </summary>

--- a/tests/MUnique.OpenMU.Tests/Offline/OfflinePlayerManagerTests.cs
+++ b/tests/MUnique.OpenMU.Tests/Offline/OfflinePlayerManagerTests.cs
@@ -97,6 +97,35 @@ public class OfflinePlayerManagerTests
     }
 
     /// <summary>
+    /// Tests that <see cref="OfflinePlayerManager.IsOffLeveling"/> returns true once an off-level
+    /// session is active for the character.
+    /// </summary>
+    [Test]
+    public async ValueTask IsOffLeveling_WhenSessionActive_ReturnsTrueAsync()
+    {
+        var manager = new OfflinePlayerManager();
+        var realPlayer = await this.CreatePlayerWithPersistedAccountAsync().ConfigureAwait(false);
+        realPlayer.TryAddMoney(1_000_000);
+        realPlayer.Attributes![Stats.Level] = 100;
+
+        await manager.StartAsync(realPlayer, TestUserLoginName).ConfigureAwait(false);
+
+        Assert.That(manager.IsOffLeveling(TestCharacterName), Is.True);
+    }
+
+    /// <summary>
+    /// Tests that <see cref="OfflinePlayerManager.IsOffLeveling"/> returns false when no off-level
+    /// session exists for the character.
+    /// </summary>
+    [Test]
+    public async ValueTask IsOffLeveling_WhenNoSession_ReturnsFalseAsync()
+    {
+        var manager = new OfflinePlayerManager();
+
+        Assert.That(manager.IsOffLeveling(TestCharacterName), Is.False);
+    }
+
+    /// <summary>
     /// Creates a player whose account is stored in the in-memory repository,
     /// so that <see cref="OfflinePlayer.InitializeAsync"/> can find it.
     /// </summary>

--- a/tests/MUnique.OpenMU.Tests/Party/BotPartyHandlerTest.cs
+++ b/tests/MUnique.OpenMU.Tests/Party/BotPartyHandlerTest.cs
@@ -13,7 +13,7 @@ using MUnique.OpenMU.GameLogic.PlayerActions.Party;
 
 /// <summary>
 /// Tests <see cref="BotPartyHandler"/> - how a server-side bot answers party invitations from
-/// players and when it leaves the party again.
+/// players and how long it stays in a party.
 /// </summary>
 [TestFixture]
 public class BotPartyHandlerTest
@@ -45,7 +45,7 @@ public class BotPartyHandlerTest
 
     /// <summary>
     /// There is no level gate (matching OpenMU's own party action): a bot accepts an inviter of any
-    /// level, since it is the player who invites and the bot leaves again once it gets bored. The
+    /// level, since it is the player who invites and the bot stays with the party once it joined. The
     /// inviter here is a maxed veteran (character level 400 plus the master level cap of 200, i.e. the
     /// ceiling of the Season 6 seed) inviting a low-level bot - the widest gap a stock server produces.
     /// </summary>
@@ -125,10 +125,12 @@ public class BotPartyHandlerTest
     }
 
     /// <summary>
-    /// After its rolled party time is up, the bot gets bored of the party with a human and leaves.
+    /// The bot stays in a party with a human instead of leaving on its own: a player who groups a
+    /// bot keeps a companion for the whole session, and the bot only leaves on the engine's own
+    /// terms (party disbands, kicked, or it cannot legally follow the leader anymore).
     /// </summary>
     [Test]
-    public async ValueTask LeavesPartyWithHumanWhenBoredAsync()
+    public async ValueTask StaysInPartyWithHumanAsync()
     {
         var gameContext = GameContextTestHelper.CreateGameContext();
         var bot = await CreateBotAsync(gameContext, "Bot").ConfigureAwait(false);
@@ -137,16 +139,15 @@ public class BotPartyHandlerTest
         await party.AddAsync(requester).ConfigureAwait(false);
         await party.AddAsync(bot).ConfigureAwait(false);
 
-        bot.PartyBoredomAtUtc = DateTime.UtcNow - TimeSpan.FromSeconds(1);
         await BotPartyHandler.ProcessAsync(bot).ConfigureAwait(false);
 
-        Assert.That(bot.Party, Is.Null);
-        Assert.That(bot.PartyBoredomAtUtc, Is.Null);
+        Assert.That(bot.Party, Is.SameAs(party));
+        Assert.That(requester.Party, Is.SameAs(party));
     }
 
     /// <summary>
-    /// Bot-only parties are managed by the hourly re-formation instead - no boredom timer runs, and
-    /// the bot stays with its group.
+    /// Bot-only parties are managed by the hourly re-formation (see <see cref="BotManager"/>), and a
+    /// bot never leaves such a party on its own - it stays with its group.
     /// </summary>
     [Test]
     public async ValueTask StaysInBotOnlyPartyAsync()
@@ -158,11 +159,9 @@ public class BotPartyHandlerTest
         await party.AddAsync(otherBot).ConfigureAwait(false);
         await party.AddAsync(bot).ConfigureAwait(false);
 
-        bot.PartyBoredomAtUtc = DateTime.UtcNow - TimeSpan.FromSeconds(1);
         await BotPartyHandler.ProcessAsync(bot).ConfigureAwait(false);
 
         Assert.That(bot.Party, Is.SameAs(party));
-        Assert.That(bot.PartyBoredomAtUtc, Is.Null);
     }
 
     /// <summary>

--- a/tests/MUnique.OpenMU.Tests/Party/BotPartyHandlerTest.cs
+++ b/tests/MUnique.OpenMU.Tests/Party/BotPartyHandlerTest.cs
@@ -165,6 +165,55 @@ public class BotPartyHandlerTest
     }
 
     /// <summary>
+    /// When the player who grouped the bot disconnects, the engine swaps them for an offline snapshot
+    /// to keep the slot reserved. The bot must not leave immediately - it waits out the grace period,
+    /// so a quick reconnect (or the player starting off-level) does not strand or churn the party.
+    /// </summary>
+    [Test]
+    public async ValueTask StaysInPartyDuringGracePeriodAfterHumanDisconnectsAsync()
+    {
+        var gameContext = GameContextTestHelper.CreateGameContext();
+        var bot = await CreateBotAsync(gameContext, "Bot").ConfigureAwait(false);
+        var requester = await CreateHumanAsync(gameContext, "Human").ConfigureAwait(false);
+        var party = gameContext.PartyManager.CreateParty();
+        await party.AddAsync(requester).ConfigureAwait(false);
+        await party.AddAsync(bot).ConfigureAwait(false);
+
+        // The human disconnects: the engine keeps the slot by replacing them with an offline snapshot.
+        await party.LeaveTemporarilyAsync(requester).ConfigureAwait(false);
+
+        await BotPartyHandler.ProcessAsync(bot).ConfigureAwait(false);
+
+        Assert.That(bot.Party, Is.SameAs(party));
+    }
+
+    /// <summary>
+    /// Once the human who grouped the bot has been gone for longer than the grace period - and is
+    /// neither reconnected nor off-leveling - the bot leaves the dead party so it returns to the
+    /// party-less pool the hourly re-formation draws from, instead of being stranded forever.
+    /// </summary>
+    [Test]
+    public async ValueTask LeavesPartyAfterGracePeriodWhenHumanStaysGoneAsync()
+    {
+        var gameContext = GameContextTestHelper.CreateGameContext();
+        var bot = await CreateBotAsync(gameContext, "Bot").ConfigureAwait(false);
+        var requester = await CreateHumanAsync(gameContext, "Human").ConfigureAwait(false);
+        var party = gameContext.PartyManager.CreateParty();
+        await party.AddAsync(requester).ConfigureAwait(false);
+        await party.AddAsync(bot).ConfigureAwait(false);
+
+        await party.LeaveTemporarilyAsync(requester).ConfigureAwait(false);
+
+        // Simulate the human having been gone past the grace period.
+        var master = (OfflinePartyMember)party.PartyMaster!;
+        master.DisconnectedAtUtc = DateTime.UtcNow - TimeSpan.FromMinutes(11);
+
+        await BotPartyHandler.ProcessAsync(bot).ConfigureAwait(false);
+
+        Assert.That(bot.Party, Is.Null);
+    }
+
+    /// <summary>
     /// The full wiring: a party request through the regular request action reaches the bot via the
     /// <see cref="GameLogic.MuHelper.PartyRequestHandler"/> criteria and schedules the delayed answer.
     /// </summary>

--- a/tests/MUnique.OpenMU.Tests/Party/BotPartyHandlerTest.cs
+++ b/tests/MUnique.OpenMU.Tests/Party/BotPartyHandlerTest.cs
@@ -205,10 +205,42 @@ public class BotPartyHandlerTest
         await party.LeaveTemporarilyAsync(requester).ConfigureAwait(false);
 
         // Simulate the human having been gone past the grace period.
-        var master = (OfflinePartyMember)party.PartyMaster!;
-        master.DisconnectedAtUtc = DateTime.UtcNow - TimeSpan.FromMinutes(11);
+        var pastGracePeriod = DateTime.UtcNow + TimeSpan.FromMinutes(11);
 
-        await BotPartyHandler.ProcessAsync(bot).ConfigureAwait(false);
+        await BotPartyHandler.ProcessAsync(bot, pastGracePeriod).ConfigureAwait(false);
+
+        Assert.That(bot.Party, Is.Null);
+    }
+
+    /// <summary>
+    /// Mastership moves off the disconnected human when a live member leaves the party properly
+    /// (<see cref="Party"/> hands the master slot to the first remaining member), so a dead party can
+    /// end up with a live bot as master while a human's snapshot is still seated in it. The bot must
+    /// still leave once the grace period elapses - keying off the master's type instead of whether any
+    /// human snapshot remains would let this shape through.
+    /// </summary>
+    [Test]
+    public async ValueTask LeavesPartyWhenMasterIsBotButHumanSnapshotRemainsAsync()
+    {
+        var gameContext = GameContextTestHelper.CreateGameContext();
+        var master = await CreateHumanAsync(gameContext, "Master").ConfigureAwait(false);
+        var bot = await CreateBotAsync(gameContext, "Bot").ConfigureAwait(false);
+        var other = await CreateHumanAsync(gameContext, "Other").ConfigureAwait(false);
+        var party = gameContext.PartyManager.CreateParty();
+        await party.AddAsync(master).ConfigureAwait(false);
+        await party.AddAsync(bot).ConfigureAwait(false);
+        await party.AddAsync(other).ConfigureAwait(false);
+
+        // The master leaves properly: mastership moves to the first remaining member, the bot.
+        await party.KickMySelfAsync(master).ConfigureAwait(false);
+        Assert.That(party.PartyMaster, Is.SameAs(bot));
+
+        // The remaining human then disconnects, leaving a snapshot behind a live bot master.
+        await party.LeaveTemporarilyAsync(other).ConfigureAwait(false);
+
+        var pastGracePeriod = DateTime.UtcNow + TimeSpan.FromMinutes(11);
+
+        await BotPartyHandler.ProcessAsync(bot, pastGracePeriod).ConfigureAwait(false);
 
         Assert.That(bot.Party, Is.Null);
     }


### PR DESCRIPTION
## Remove bot party boredom and raise bot party share

Bots no longer get "bored" and leave a party with a human player after a few minutes.
Previously a bot would walk away from a player who grouped it once a random 10–20 minute
boredom timer ran out.

Additionally, more bots group together: the share of bots placed into parties during the
hourly re-formation rises from 60% to 80%, so bot parties are more common on the server.

