### PR TITLE
Fix concurrency crash in attribute value recalculation

### DIFF
--- a/src/AttributeSystem/AttributeRelationshipElement.cs
+++ b/src/AttributeSystem/AttributeRelationshipElement.cs
@@ -61,8 +61,13 @@ public class AttributeRelationshipElement : SimpleElement
 
     private float GetAndCacheValue()
     {
-        this._cachedValue = this.CalculateValue();
-        return this._cachedValue.Value;
+        // Return the freshly computed value rather than re-reading the field: a concurrent ElementChanged
+        // (e.g. from an input attribute whose element is removed when a magic effect expires) can reset
+        // _cachedValue to null between the assignment and the read, which would make _cachedValue.Value
+        // throw an InvalidOperationException.
+        var value = this.CalculateValue();
+        this._cachedValue = value;
+        return value;
     }
 
     private float CalculateValue()

--- a/src/AttributeSystem/AttributeRelationshipElement.cs
+++ b/src/AttributeSystem/AttributeRelationshipElement.cs
@@ -10,6 +10,15 @@ namespace MUnique.OpenMU.AttributeSystem;
 /// </summary>
 public class AttributeRelationshipElement : SimpleElement
 {
+    /// <summary>
+    /// Serializes the <see cref="_version"/> bump with the guarded cache write, so a recalculation that
+    /// races a concurrent input change (e.g. an input attribute whose element is removed when a magic
+    /// effect expires) cannot latch its stale result into <see cref="_cachedValue"/>.
+    /// </summary>
+    private readonly object _cacheLock = new();
+
+    private long _version;
+
     private float? _cachedValue;
 
     /// <summary>
@@ -55,7 +64,12 @@ public class AttributeRelationshipElement : SimpleElement
 
     private void ElementChanged(object? sender, EventArgs eventArgs)
     {
-        this._cachedValue = null;
+        lock (this._cacheLock)
+        {
+            this._version++;
+            this._cachedValue = null;
+        }
+
         this.RaiseValueChanged();
     }
 
@@ -64,9 +78,25 @@ public class AttributeRelationshipElement : SimpleElement
         // Return the freshly computed value rather than re-reading the field: a concurrent ElementChanged
         // (e.g. from an input attribute whose element is removed when a magic effect expires) can reset
         // _cachedValue to null between the assignment and the read, which would make _cachedValue.Value
-        // throw an InvalidOperationException.
+        // throw an InvalidOperationException. The version captured before calculating guards the cache
+        // write: if an input changed while CalculateValue was running, the fresh value is still returned
+        // to this caller but not cached, so the lost update cannot latch a stale value.
+        long versionAtStart;
+        lock (this._cacheLock)
+        {
+            versionAtStart = this._version;
+        }
+
         var value = this.CalculateValue();
-        this._cachedValue = value;
+
+        lock (this._cacheLock)
+        {
+            if (this._version == versionAtStart)
+            {
+                this._cachedValue = value;
+            }
+        }
+
         return value;
     }
 

--- a/src/AttributeSystem/AttributeSystem.cs
+++ b/src/AttributeSystem/AttributeSystem.cs
@@ -14,6 +14,17 @@ public class AttributeSystem : IAttributeSystem, IEnumerable<IAttribute>
     private readonly IDictionary<AttributeDefinition, IAttribute> _attributes = new Dictionary<AttributeDefinition, IAttribute>();
 
     /// <summary>
+    /// Synchronizes every access to <see cref="_attributes"/>. The dictionary is read on the game logic
+    /// thread (damage calculations, stat lookups) while an attribute can be removed from a thread pool
+    /// thread when a magic effect expires on its timer (see <see cref="RemoveElement"/>). Concurrent
+    /// mutation of a plain <see cref="Dictionary{TKey,TValue}"/> during reads is undefined - wrong
+    /// results, exceptions, or an infinite spin inside a resizing lookup. Only the dictionary operations
+    /// are guarded; element aggregation and value-changed dispatch run outside this lock, so it never
+    /// nests into another attribute system's lock and cannot deadlock.
+    /// </summary>
+    private readonly object _attributesLock = new();
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="AttributeSystem" /> class.
     /// </summary>
     /// <param name="statAttributes">The stat attributes. These attributes are added just as-is and are not wrapped by a <see cref="ComposableAttribute"/>.</param>
@@ -86,8 +97,13 @@ public class AttributeSystem : IAttributeSystem, IEnumerable<IAttribute>
             return false;
         }
 
-        if (this._attributes.TryGetValue(attributeDefinition, out var attribute)
-            && attribute is StatAttribute statAttribute)
+        IAttribute? attribute;
+        lock (this._attributesLock)
+        {
+            this._attributes.TryGetValue(attributeDefinition, out attribute);
+        }
+
+        if (attribute is StatAttribute statAttribute)
         {
             statAttribute.Value = newValue;
 
@@ -128,39 +144,62 @@ public class AttributeSystem : IAttributeSystem, IEnumerable<IAttribute>
     /// <inheritdoc/>
     public void AddElement(IElement element, AttributeDefinition targetAttribute)
     {
-        if (!this._attributes.TryGetValue(targetAttribute, out var attribute))
+        // The get-or-create is atomic under the lock so two threads racing the first add of the same
+        // attribute cannot both create it (which would make the second Dictionary.Add throw). The
+        // element is then added - and its ValueChanged dispatched - outside the lock, so the lock is
+        // never held across a call that could reach another attribute system's lock.
+        IComposableAttribute composableAttribute;
+        ComposableAttribute? created = null;
+        lock (this._attributesLock)
         {
-            attribute = new ComposableAttribute(targetAttribute);
-            this._attributes.Add(targetAttribute, attribute);
-            this.OnAttributeAdded(attribute);
+            if (this._attributes.TryGetValue(targetAttribute, out var attribute))
+            {
+                composableAttribute = attribute as IComposableAttribute
+                    ?? throw new ArgumentException($"Attribute {targetAttribute} is not a composable attribute.");
+            }
+            else
+            {
+                var composable = new ComposableAttribute(targetAttribute);
+                this._attributes.Add(targetAttribute, composable);
+                composableAttribute = composable;
+                created = composable;
+            }
         }
 
-        if (attribute is IComposableAttribute composableAttribute)
+        if (created is not null)
         {
-            composableAttribute.AddElement(element);
+            this.OnAttributeAdded(created);
         }
-        else
-        {
-            throw new ArgumentException($"Attribute {targetAttribute} is not a composable attribute.");
-        }
+
+        composableAttribute.AddElement(element);
     }
 
     /// <inheritdoc/>
     public void RemoveElement(IElement element, AttributeDefinition targetAttribute)
     {
-        if (this._attributes.TryGetValue(targetAttribute, out var attribute))
+        IComposableAttribute composableAttribute;
+        lock (this._attributesLock)
         {
-            if (attribute is IComposableAttribute composableAttribute)
+            if (!this._attributes.TryGetValue(targetAttribute, out var attribute))
             {
-                composableAttribute.RemoveElement(element);
-                if (!composableAttribute.Elements.Any())
-                {
-                    this._attributes.Remove(targetAttribute);
-                }
+                return;
             }
-            else
+
+            composableAttribute = attribute as IComposableAttribute
+                ?? throw new ArgumentException($"Attribute {targetAttribute} is not a composable attribute.");
+        }
+
+        composableAttribute.RemoveElement(element);
+
+        lock (this._attributesLock)
+        {
+            // Only drop the attribute when it is still empty and still the very instance we just mutated,
+            // so a concurrent AddElement that repopulated it does not get its element discarded (TOCTOU).
+            if (!composableAttribute.Elements.Any()
+                && this._attributes.TryGetValue(targetAttribute, out var current)
+                && ReferenceEquals(current, composableAttribute))
             {
-                throw new ArgumentException($"Attribute {targetAttribute} is not a composable attribute.");
+                this._attributes.Remove(targetAttribute);
             }
         }
     }
@@ -168,15 +207,16 @@ public class AttributeSystem : IAttributeSystem, IEnumerable<IAttribute>
     /// <inheritdoc/>
     public override string ToString()
     {
+        var snapshot = this.GetAttributeSnapshot();
         var stringBuilder = new StringBuilder();
         stringBuilder.AppendLine("Stat Attributes:");
-        foreach (var statAttribute in this._attributes.Values.OfType<StatAttribute>())
+        foreach (var statAttribute in snapshot.OfType<StatAttribute>())
         {
             stringBuilder.AppendLine($"  {statAttribute.Definition}: {statAttribute.Value}");
         }
 
         stringBuilder.AppendLine("Others:");
-        foreach (var attribute in this._attributes.Values.OfType<IComposableAttribute>())
+        foreach (var attribute in snapshot.OfType<IComposableAttribute>())
         {
             stringBuilder.AppendLine($"  {attribute.Definition}: {attribute.Value}");
         }
@@ -187,7 +227,7 @@ public class AttributeSystem : IAttributeSystem, IEnumerable<IAttribute>
     /// <inheritdoc />
     public IEnumerator<IAttribute> GetEnumerator()
     {
-        return this._attributes.Values.GetEnumerator();
+        return ((IEnumerable<IAttribute>)this.GetAttributeSnapshot()).GetEnumerator();
     }
 
     /// <inheritdoc />
@@ -203,13 +243,26 @@ public class AttributeSystem : IAttributeSystem, IEnumerable<IAttribute>
     /// <returns>The element of the attribute.</returns>
     public IElement GetOrCreateAttribute(AttributeDefinition attributeDefinition)
     {
-        var element = this.GetAttribute(attributeDefinition);
-        if (element is null)
+        IElement element;
+        ComposableAttribute? created = null;
+        lock (this._attributesLock)
         {
-            var composableAttribute = new ComposableAttribute(attributeDefinition);
-            element = composableAttribute;
-            this._attributes.Add(attributeDefinition, composableAttribute);
-            this.OnAttributeAdded(composableAttribute);
+            if (this._attributes.TryGetValue(attributeDefinition, out var existing))
+            {
+                element = existing;
+            }
+            else
+            {
+                var composableAttribute = new ComposableAttribute(attributeDefinition);
+                this._attributes.Add(attributeDefinition, composableAttribute);
+                element = composableAttribute;
+                created = composableAttribute;
+            }
+        }
+
+        if (created is not null)
+        {
+            this.OnAttributeAdded(created);
         }
 
         return element;
@@ -249,11 +302,17 @@ public class AttributeSystem : IAttributeSystem, IEnumerable<IAttribute>
             return null;
         }
 
-        if (this._attributes.TryGetValue(attributeDefinition, out var attribute))
+        lock (this._attributesLock)
         {
-            return attribute;
+            return this._attributes.TryGetValue(attributeDefinition, out var attribute) ? attribute : null;
         }
+    }
 
-        return null;
+    private IAttribute[] GetAttributeSnapshot()
+    {
+        lock (this._attributesLock)
+        {
+            return this._attributes.Values.ToArray();
+        }
     }
 }

--- a/src/AttributeSystem/ComposableAttribute.cs
+++ b/src/AttributeSystem/ComposableAttribute.cs
@@ -9,16 +9,32 @@ namespace MUnique.OpenMU.AttributeSystem;
 /// </summary>
 public class ComposableAttribute : BaseAttribute, IComposableAttribute
 {
-    private readonly IList<IElement> _elementList;
-
     /// <summary>
-    /// Synchronizes access to <see cref="_elementList"/>. Elements are usually added on the game logic
-    /// thread, but they can also be removed from a thread pool thread when a magic effect expires on its
-    /// timer, while a value recalculation may be enumerating the list at the same time. Without this lock
-    /// the concurrent <see cref="List{T}.Remove"/> can transiently expose a <c>null</c> slot to the
-    /// enumeration in <see cref="GetAndCacheValue"/>, causing a <see cref="NullReferenceException"/>.
+    /// Serializes the copy-on-write mutations of <see cref="_elements"/>, the element subscription
+    /// changes and the <see cref="_version"/> bump. Elements are usually added on the game logic thread,
+    /// but they can also be removed from a thread pool thread when a magic effect expires on its timer,
+    /// while a value recalculation is aggregating at the same time. The cached fast path of
+    /// <see cref="Value"/> and the <see cref="Elements"/> getter are lock-free (a single volatile read of
+    /// <see cref="_elements"/>); on a cache miss, <see cref="GetAndCacheValue"/> takes this lock only
+    /// briefly to capture a consistent (snapshot, version) pair and again to write the cache, and does the
+    /// aggregation itself outside the lock on the immutable snapshot.
     /// </summary>
     private readonly object _elementLock = new();
+
+    /// <summary>
+    /// The elements this attribute is composed of. Treated as immutable: mutations replace the whole
+    /// array under <see cref="_elementLock"/> (copy-on-write), so a reader that captured the reference
+    /// can keep enumerating it safely while another thread adds or removes an element.
+    /// </summary>
+    private volatile IElement[] _elements = [];
+
+    /// <summary>
+    /// Incremented under <see cref="_elementLock"/> on every structural change or cache invalidation.
+    /// <see cref="GetAndCacheValue"/> captures it before aggregating and only writes the result back into
+    /// <see cref="_cachedValue"/> when it is still unchanged, so a recalculation that raced a concurrent
+    /// removal cannot latch a stale value into the cache.
+    /// </summary>
+    private long _version;
 
     private float? _maximumValue;
 
@@ -33,25 +49,16 @@ public class ComposableAttribute : BaseAttribute, IComposableAttribute
     public ComposableAttribute(AttributeDefinition definition, AggregateType aggregateType = AggregateType.AddRaw, float? maximumValue = null)
         : base(definition, aggregateType)
     {
-        this._elementList = new List<IElement>();
         this._maximumValue = maximumValue;
     }
 
     /// <inheritdoc/>
     /// <remarks>
-    /// Returns a snapshot of the current elements, detached from the internal list on purpose, so the
-    /// caller can enumerate it safely even while elements are concurrently added or removed.
+    /// Returns the current copy-on-write snapshot of the elements. It is detached from later mutations on
+    /// purpose, so the caller can enumerate it safely even while elements are concurrently added or
+    /// removed; a previously obtained sequence will not reflect subsequent changes.
     /// </remarks>
-    public IEnumerable<IElement> Elements
-    {
-        get
-        {
-            lock (this._elementLock)
-            {
-                return this._elementList.ToArray();
-            }
-        }
-    }
+    public IEnumerable<IElement> Elements => this._elements;
 
     /// <inheritdoc/>
     public override float Value => this._cachedValue ?? this.GetAndCacheValue();
@@ -61,10 +68,14 @@ public class ComposableAttribute : BaseAttribute, IComposableAttribute
     {
         lock (this._elementLock)
         {
-            this._elementList.Add(element);
+            this._elements = [.. this._elements, element];
+
+            // Subscribing inside the lock keeps a concurrent Add/Remove of the same element from
+            // interleaving into a live subscription on an element that is no longer in the list. It does
+            // not call into user code, so it is safe to hold the lock across it.
+            element.ValueChanged += this.ElementChanged;
         }
 
-        element.ValueChanged += this.ElementChanged;
         this.ElementChanged(element, EventArgs.Empty);
 
         return this;
@@ -76,35 +87,51 @@ public class ComposableAttribute : BaseAttribute, IComposableAttribute
         bool removed;
         lock (this._elementLock)
         {
-            removed = this._elementList.Remove(element);
+            var index = Array.IndexOf(this._elements, element);
+            removed = index >= 0;
+            if (removed)
+            {
+                var newElements = new IElement[this._elements.Length - 1];
+                Array.Copy(this._elements, 0, newElements, 0, index);
+                Array.Copy(this._elements, index + 1, newElements, index, this._elements.Length - index - 1);
+                this._elements = newElements;
+                element.ValueChanged -= this.ElementChanged;
+            }
         }
 
         if (removed)
         {
-            element.ValueChanged -= this.ElementChanged;
             this.ElementChanged(element, EventArgs.Empty);
         }
     }
 
     private float GetAndCacheValue()
     {
-        // Enumerate a snapshot taken under the lock, so a concurrent AddElement/RemoveElement (e.g. an
-        // expiring magic effect on a timer thread) cannot expose a torn list - the transiently null slot
-        // that would otherwise be dereferenced here and throw a NullReferenceException. The aggregation
-        // itself runs outside the lock on purpose: reading an element's value recurses into other
-        // attributes, and holding the lock across that traversal would invite lock-ordering issues and
-        // lengthen contention. The value cache stays best-effort - an occasional stale or torn read
-        // corrects itself on the next recalculation - which matches the pre-existing behavior.
+        // Aggregate a copy-on-write snapshot, so a concurrent AddElement/RemoveElement (e.g. an expiring
+        // magic effect on a timer thread) cannot tear the list. The version captured alongside the
+        // snapshot guards the cache write below: if anything changed the composition or invalidated the
+        // cache while this recomputation was running, the freshly computed value is still returned to this
+        // caller, but it is not written back - otherwise the lost update would latch a stale value into
+        // _cachedValue until some unrelated element change happened to invalidate it again.
         IElement[] elements;
+        long versionAtStart;
         lock (this._elementLock)
         {
-            if (this._elementList.Count == 0)
+            elements = this._elements;
+            versionAtStart = this._version;
+        }
+
+        if (elements.Length == 0)
+        {
+            lock (this._elementLock)
             {
-                this._cachedValue = 0;
-                return 0;
+                if (this._version == versionAtStart)
+                {
+                    this._cachedValue = 0;
+                }
             }
 
-            elements = this._elementList.ToArray();
+            return 0;
         }
 
         var rawValues = elements.Where(e => e.AggregateType == AggregateType.AddRaw).Sum(e => e.Value);
@@ -129,14 +156,25 @@ public class ComposableAttribute : BaseAttribute, IComposableAttribute
             newValue = Math.Min(this.Definition.MaximumValue.Value, newValue);
         }
 
-        this._cachedValue = newValue;
+        lock (this._elementLock)
+        {
+            if (this._version == versionAtStart)
+            {
+                this._cachedValue = newValue;
+            }
+        }
 
         return newValue;
     }
 
     private void ElementChanged(object? sender, EventArgs eventArgs)
     {
-        this._cachedValue = null;
+        lock (this._elementLock)
+        {
+            this._version++;
+            this._cachedValue = null;
+        }
+
         this.RaiseValueChanged();
     }
 }

--- a/src/AttributeSystem/ComposableAttribute.cs
+++ b/src/AttributeSystem/ComposableAttribute.cs
@@ -11,6 +11,15 @@ public class ComposableAttribute : BaseAttribute, IComposableAttribute
 {
     private readonly IList<IElement> _elementList;
 
+    /// <summary>
+    /// Synchronizes access to <see cref="_elementList"/>. Elements are usually added on the game logic
+    /// thread, but they can also be removed from a thread pool thread when a magic effect expires on its
+    /// timer, while a value recalculation may be enumerating the list at the same time. Without this lock
+    /// the concurrent <see cref="List{T}.Remove"/> can transiently expose a <c>null</c> slot to the
+    /// enumeration in <see cref="GetAndCacheValue"/>, causing a <see cref="NullReferenceException"/>.
+    /// </summary>
+    private readonly object _elementLock = new();
+
     private float? _maximumValue;
 
     private float? _cachedValue;
@@ -29,7 +38,20 @@ public class ComposableAttribute : BaseAttribute, IComposableAttribute
     }
 
     /// <inheritdoc/>
-    public IEnumerable<IElement> Elements => this._elementList;
+    /// <remarks>
+    /// Returns a snapshot of the current elements, detached from the internal list on purpose, so the
+    /// caller can enumerate it safely even while elements are concurrently added or removed.
+    /// </remarks>
+    public IEnumerable<IElement> Elements
+    {
+        get
+        {
+            lock (this._elementLock)
+            {
+                return this._elementList.ToArray();
+            }
+        }
+    }
 
     /// <inheritdoc/>
     public override float Value => this._cachedValue ?? this.GetAndCacheValue();
@@ -37,7 +59,11 @@ public class ComposableAttribute : BaseAttribute, IComposableAttribute
     /// <inheritdoc/>
     public IComposableAttribute AddElement(IElement element)
     {
-        this._elementList.Add(element);
+        lock (this._elementLock)
+        {
+            this._elementList.Add(element);
+        }
+
         element.ValueChanged += this.ElementChanged;
         this.ElementChanged(element, EventArgs.Empty);
 
@@ -47,7 +73,13 @@ public class ComposableAttribute : BaseAttribute, IComposableAttribute
     /// <inheritdoc/>
     public void RemoveElement(IElement element)
     {
-        if (this._elementList.Remove(element))
+        bool removed;
+        lock (this._elementLock)
+        {
+            removed = this._elementList.Remove(element);
+        }
+
+        if (removed)
         {
             element.ValueChanged -= this.ElementChanged;
             this.ElementChanged(element, EventArgs.Empty);
@@ -56,19 +88,32 @@ public class ComposableAttribute : BaseAttribute, IComposableAttribute
 
     private float GetAndCacheValue()
     {
-        if (this._elementList.Count == 0)
+        // Enumerate a snapshot taken under the lock, so a concurrent AddElement/RemoveElement (e.g. an
+        // expiring magic effect on a timer thread) cannot expose a torn list - the transiently null slot
+        // that would otherwise be dereferenced here and throw a NullReferenceException. The aggregation
+        // itself runs outside the lock on purpose: reading an element's value recurses into other
+        // attributes, and holding the lock across that traversal would invite lock-ordering issues and
+        // lengthen contention. The value cache stays best-effort - an occasional stale or torn read
+        // corrects itself on the next recalculation - which matches the pre-existing behavior.
+        IElement[] elements;
+        lock (this._elementLock)
         {
-            this._cachedValue = 0;
-            return 0;
+            if (this._elementList.Count == 0)
+            {
+                this._cachedValue = 0;
+                return 0;
+            }
+
+            elements = this._elementList.ToArray();
         }
 
-        var rawValues = this.Elements.Where(e => e.AggregateType == AggregateType.AddRaw).Sum(e => e.Value);
-        var multiValues = this.Elements.Where(e => e.AggregateType == AggregateType.Multiplicate).Select(e => e.Value).Concat(Enumerable.Repeat(1.0F, 1)).Aggregate((a, b) => a * b);
-        var finalValues = this.Elements.Where(e => e.AggregateType == AggregateType.AddFinal).Sum(e => e.Value);
-        var maxValues = this.Elements.Where(e => e.AggregateType == AggregateType.Maximum).MaxBy(e => e.Value)?.Value ?? 0;
+        var rawValues = elements.Where(e => e.AggregateType == AggregateType.AddRaw).Sum(e => e.Value);
+        var multiValues = elements.Where(e => e.AggregateType == AggregateType.Multiplicate).Select(e => e.Value).Concat(Enumerable.Repeat(1.0F, 1)).Aggregate((a, b) => a * b);
+        var finalValues = elements.Where(e => e.AggregateType == AggregateType.AddFinal).Sum(e => e.Value);
+        var maxValues = elements.Where(e => e.AggregateType == AggregateType.Maximum).MaxBy(e => e.Value)?.Value ?? 0;
         rawValues += maxValues;
 
-        if (this.Elements.All(e => e.AggregateType == AggregateType.Multiplicate))
+        if (elements.All(e => e.AggregateType == AggregateType.Multiplicate))
         {
             rawValues = 1;
         }
@@ -86,7 +131,7 @@ public class ComposableAttribute : BaseAttribute, IComposableAttribute
 
         this._cachedValue = newValue;
 
-        return this._cachedValue.Value;
+        return newValue;
     }
 
     private void ElementChanged(object? sender, EventArgs eventArgs)

--- a/src/AttributeSystem/IComposableAttribute.cs
+++ b/src/AttributeSystem/IComposableAttribute.cs
@@ -17,6 +17,8 @@ public interface IComposableAttribute : IAttribute
 {
     /// <summary>
     /// Gets the elements, of which this attribute is calculated.
+    /// Implementations may return a detached snapshot rather than a live view, so that the sequence can
+    /// be enumerated safely while elements are concurrently added or removed.
     /// </summary>
     IEnumerable<IElement> Elements { get; }
 

--- a/src/AttributeSystem/IComposableAttribute.cs
+++ b/src/AttributeSystem/IComposableAttribute.cs
@@ -18,7 +18,8 @@ public interface IComposableAttribute : IAttribute
     /// <summary>
     /// Gets the elements, of which this attribute is calculated.
     /// Implementations may return a detached snapshot rather than a live view, so that the sequence can
-    /// be enumerated safely while elements are concurrently added or removed.
+    /// be enumerated safely while elements are concurrently added or removed. Callers must therefore not
+    /// expect to observe later additions or removals through a sequence obtained from a previous access.
     /// </summary>
     IEnumerable<IElement> Elements { get; }
 

--- a/tests/MUnique.OpenMU.AttributeSystem.Tests/ComposableAttributeTests.cs
+++ b/tests/MUnique.OpenMU.AttributeSystem.Tests/ComposableAttributeTests.cs
@@ -195,4 +195,113 @@ public class ComposableAttributeTests
         this._composableAttribute.RemoveElement(element);
         Assert.That(eventCalled, Is.True);
     }
+
+    /// <summary>
+    /// Tests that reading <see cref="ComposableAttribute.Value"/> on one thread while elements are
+    /// added and removed on another thread does not throw. This is a regression test for the race
+    /// condition where a magic effect expiring on a timer thread removed an element while the value was
+    /// being recalculated, exposing a <c>null</c> list slot to the enumeration and throwing a
+    /// <see cref="NullReferenceException"/> (or an <see cref="InvalidOperationException"/>).
+    /// </summary>
+    /// <returns>The task representing the asynchronous test.</returns>
+    [Test]
+    public async Task ConcurrentAddRemoveWhileReadingValueDoesNotThrow()
+    {
+        const int cycles = 20000;
+        foreach (var seed in Enumerable.Range(1, 64))
+        {
+            this._composableAttribute.AddElement(new SimpleElement { Value = seed, AggregateType = AggregateType.AddRaw });
+        }
+
+        Exception? readerError = null;
+
+        var writer = Task.Run(() =>
+        {
+            for (var i = 0; i < cycles; i++)
+            {
+                // Each cycle mutates the element list twice and invalidates the cached value, mirroring
+                // a magic effect that is applied and then expires on a background thread.
+                var element = new SimpleElement { Value = 1, AggregateType = AggregateType.AddRaw };
+                this._composableAttribute.AddElement(element);
+                this._composableAttribute.RemoveElement(element);
+            }
+        });
+
+        var reader = Task.Run(() =>
+        {
+            try
+            {
+                while (!writer.IsCompleted)
+                {
+                    // The concurrent cache invalidation forces a recompute, which enumerates the list.
+                    _ = this._composableAttribute.Value;
+                }
+            }
+            catch (Exception ex)
+            {
+                readerError = ex;
+            }
+        });
+
+        await Task.WhenAll(writer, reader).ConfigureAwait(false);
+
+        // The fix guarantees crash-freedom, not value coherency: the value cache stays best-effort under
+        // concurrency (a stale or torn read corrects itself on the next recalculation), so this test only
+        // asserts that the concurrent reads never threw.
+        Assert.That(readerError, Is.Null, $"Reading the value concurrently threw: {readerError}");
+    }
+
+    /// <summary>
+    /// Tests that recalculating a parent attribute concurrently with mutations of a child attribute it
+    /// depends on neither throws nor deadlocks. The parent's value is computed from an
+    /// <see cref="AttributeRelationshipElement"/> that wraps the child attribute, so a recalculation
+    /// walks into the child while the child's elements are being added and removed on another thread.
+    /// This reproduces the nested variant of the race that surfaced through
+    /// <see cref="AttributeRelationshipElement"/> in the field, and it fails with a timeout instead of
+    /// hanging should the locking ever deadlock.
+    /// </summary>
+    /// <returns>The task representing the asynchronous test.</returns>
+    [Test]
+    public async Task ConcurrentRecalculationOfDependentAttributesDoesNotDeadlock()
+    {
+        const int cycles = 50000;
+        var childDefinition = new AttributeDefinition(new Guid("7C2E4C1B-2C0A-4E7A-9C9E-1B0D3F5A6E77"), "Child attribute", "Child attribute");
+        var child = new ComposableAttribute(childDefinition);
+        child.AddElement(new ConstantElement(10));
+
+        // The parent reads the child attribute as an input element, so recalculating the parent recurses
+        // into the child while the child is mutated concurrently.
+        this._composableAttribute.AddElement(new AttributeRelationshipElement(new IElement[] { child }, new ConstantElement(0), InputOperator.Add));
+
+        Exception? error = null;
+
+        var writer = Task.Run(() =>
+        {
+            for (var i = 0; i < cycles; i++)
+            {
+                var element = new SimpleElement { Value = 1, AggregateType = AggregateType.AddRaw };
+                child.AddElement(element);
+                child.RemoveElement(element);
+            }
+        });
+
+        var reader = Task.Run(() =>
+        {
+            try
+            {
+                while (!writer.IsCompleted)
+                {
+                    _ = this._composableAttribute.Value;
+                }
+            }
+            catch (Exception ex)
+            {
+                error = ex;
+            }
+        });
+
+        await Task.WhenAll(writer, reader).WaitAsync(TimeSpan.FromSeconds(30)).ConfigureAwait(false);
+
+        Assert.That(error, Is.Null, $"Reading the dependent value concurrently threw: {error}");
+    }
 }

--- a/tests/MUnique.OpenMU.AttributeSystem.Tests/ComposableAttributeTests.cs
+++ b/tests/MUnique.OpenMU.AttributeSystem.Tests/ComposableAttributeTests.cs
@@ -243,12 +243,35 @@ public class ComposableAttributeTests
             }
         });
 
-        await Task.WhenAll(writer, reader).ConfigureAwait(false);
+        await Task.WhenAll(writer, reader).WaitAsync(TimeSpan.FromSeconds(30)).ConfigureAwait(false);
 
-        // The fix guarantees crash-freedom, not value coherency: the value cache stays best-effort under
-        // concurrency (a stale or torn read corrects itself on the next recalculation), so this test only
-        // asserts that the concurrent reads never threw.
+        // This test asserts crash-freedom under concurrency; it fails with a timeout instead of hanging
+        // should the locking ever deadlock. Cache coherency (that a removal is never latched as a stale
+        // value) is covered deterministically by ConcurrentRemovalDuringReadDoesNotLatchStaleValue.
         Assert.That(readerError, Is.Null, $"Reading the value concurrently threw: {readerError}");
+    }
+
+    /// <summary>
+    /// Tests that a removal happening while the value is being recalculated is not latched into the cache
+    /// as a stale value. The reentrant element removes another element mid-aggregation - the same lost
+    /// update the version guard in <see cref="ComposableAttribute"/> closes - so without the guard the
+    /// pre-removal value would stick on every subsequent read until an unrelated change invalidated it.
+    /// </summary>
+    [Test]
+    public void ConcurrentRemovalDuringReadDoesNotLatchStaleValue()
+    {
+        var buff = new SimpleElement { Value = 100, AggregateType = AggregateType.AddRaw };
+        this._composableAttribute.AddElement(buff);
+
+        // Removes the buff the first time its value is read during aggregation, deterministically
+        // reproducing "an element is removed on another thread while the value is being computed".
+        this._composableAttribute.AddElement(new ReentrantElement(() => this._composableAttribute.RemoveElement(buff)));
+
+        // Triggers the aggregation during which the buff removes itself.
+        _ = this._composableAttribute.Value;
+
+        // The buff is gone, so the very next read must reflect that (0), not the pre-removal 100.
+        Assert.That(this._composableAttribute.Value, Is.EqualTo(0));
     }
 
     /// <summary>
@@ -303,5 +326,37 @@ public class ComposableAttributeTests
         await Task.WhenAll(writer, reader).WaitAsync(TimeSpan.FromSeconds(30)).ConfigureAwait(false);
 
         Assert.That(error, Is.Null, $"Reading the dependent value concurrently threw: {error}");
+    }
+
+    /// <summary>
+    /// An element that runs a one-shot side effect the first time its <see cref="Value"/> is read, used to
+    /// deterministically mutate the composition while it is being aggregated.
+    /// </summary>
+    private sealed class ReentrantElement : IElement
+    {
+        private readonly Action _onFirstRead;
+        private bool _fired;
+
+        public ReentrantElement(Action onFirstRead) => this._onFirstRead = onFirstRead;
+
+#pragma warning disable CS0067 // required by IElement; this test element never raises it
+        public event EventHandler? ValueChanged;
+#pragma warning restore CS0067
+
+        public AggregateType AggregateType => AggregateType.AddRaw;
+
+        public float Value
+        {
+            get
+            {
+                if (!this._fired)
+                {
+                    this._fired = true;
+                    this._onFirstRead();
+                }
+
+                return 0;
+            }
+        }
     }
 }


### PR DESCRIPTION
Fixes #883.

## Problem

`ComposableAttribute` keeps its elements in a plain, unsynchronized `List<IElement>` and enumerates it live while recomputing a value (`GetAndCacheValue`). A `MagicEffect` schedules its expiry on a `System.Threading.Timer`; when it fires, `MagicEffectsList.OnEffectTimeOutAsync` runs on a thread-pool thread and calls `Attributes.RemoveElement(...)`, mutating that same list with no lock shared with the reader.

When an effect expires at the moment an attribute in the same dependency chain is recalculated, the concurrent `List<T>.Remove` shifts the backing array and the reader can observe a transiently `null` slot, throwing a `NullReferenceException` at the `Where(e => e.AggregateType == ...)` predicate.

This was effectively never hit until server-side offline bots started reading attributes in a tight loop (the offline MU Helper ticks ~every 500 ms and reads `MaximumHealth`/`CurrentHealth`) while buffing themselves (buffs expire on timers). On a server with many offline bots the log fills with:

```
[Error] [MUnique.OpenMU.GameLogic.Bots.BotPlayer] Error in offline player helper tick for "botNNNN".
System.NullReferenceException: Object reference not set to an instance of an object.
   at MUnique.OpenMU.AttributeSystem.ComposableAttribute.<>c.<GetAndCacheValue>b__10_0(IElement e) in ComposableAttribute.cs:line 65
   at MUnique.OpenMU.AttributeSystem.ComposableAttribute.GetAndCacheValue()
   at MUnique.OpenMU.AttributeSystem.AttributeRelationshipElement.CalculateValue()
   ... (nested AttributeRelationshipElement / ComposableAttribute frames) ...
   at MUnique.OpenMU.GameLogic.Offline.HealingHandler.PerformSelfHealingAsync()
   at MUnique.OpenMU.GameLogic.Offline.OfflinePlayerMuHelper.TickAsync(...)
```

The offline helper's `SafeTickAsync` swallows the exception, so bots keep running, but online players are exposed to the same race (e.g. damage calculation reading defense/max HP as a buff expires) with no such safety net.

`AttributeRelationshipElement` — the element type that sits between attributes in the dependency chain — has the **same class of race** in a second place: its `GetAndCacheValue` did `this._cachedValue = this.CalculateValue(); return this._cachedValue.Value;`, and a concurrent `ElementChanged` (from an input attribute whose element was just removed) could reset `_cachedValue` to `null` between the assignment and the read, making `_cachedValue.Value` throw `InvalidOperationException: Nullable object must have a value`.

## Fix

- **`ComposableAttribute`** — the element list is now **copy-on-write** (`private volatile IElement[] _elements`): mutations replace the whole array under a lock, so a reader can aggregate an immutable snapshot with a single volatile read. The cached fast path of `Value` and the `Elements` getter are therefore lock-free and allocation-free; only a cache miss briefly takes the lock (to capture a consistent snapshot and to write the cache) and the aggregation itself runs outside the lock. Element subscribe/unsubscribe now happen inside the lock, so a concurrent add/remove of the same element cannot leave a live subscription on an element no longer in the list.
- **Cache coherency (version counter)** — both `ComposableAttribute` and `AttributeRelationshipElement` now carry a version counter, bumped under the lock whenever the composition changes or the cache is invalidated. A recomputation captures the version before aggregating and only writes its result into `_cachedValue` if the version is still unchanged. This closes a lost-update where a recomputation that raced a concurrent removal would **latch a stale value into the cache** and keep serving it until some unrelated change happened to invalidate it (e.g. an offline bot sitting on an expired buff's value indefinitely). It also removes the `InvalidOperationException` in `AttributeRelationshipElement` by returning the freshly computed local value.
- **`AttributeSystem`** — every access to the `_attributes` dictionary is now guarded by a lock. It was a plain `Dictionary` mutated from the magic-effect timer thread (`RemoveElement`) while read on the game-logic thread — the same class of race, with a worse failure mode (undefined behavior / an infinite spin inside a resizing lookup). The get-or-create is now atomic, and an empty attribute is only dropped when it is still empty **and** still the same instance (a `ReferenceEquals` guard). Element addition/removal and the value-changed dispatch stay **outside** the lock, so it is never held across a call that could reach another attribute system.

### Known follow-ups (deliberately out of scope for this crash fix)

- The fast-path read of the cached value (`Value => this._cachedValue ?? ...`) is still unsynchronized. A torn or late read of the 8-byte `Nullable<float>` can return a transiently wrong value; it is self-correcting and never crashes. Making the read strictly coherent would need `volatile` (not possible on `Nullable<float>`) or a lock on every read (contention on a very hot path).
- An empty attribute can still be dropped from `AttributeSystem._attributes` in a narrow window while another thread is adding an element to it, orphaning that contribution. Closing this cleanly requires holding the lock across `composable.AddElement`, whose dispatch synchronously raises the public `AttributeValueChanged` event — a reentrancy/cross-system-lock risk not worth taking in a crash fix.
- Relatedly, `RemoveElement` does not call `OnAttributeRemoved` when it drops an emptied attribute (pre-existing), so an `ItemAwareAttributeSystem` subscription on that instance is only cleaned up at `Dispose`.

These are safe to address in a separate change if they ever prove worthwhile.

## Tests

`MUnique.OpenMU.AttributeSystem.Tests`: **44/44**.

- `ConcurrentAddRemoveWhileReadingValueDoesNotThrow` — single attribute; reproduces the `ComposableAttribute` list race. Reads `Value` on one thread while another adds/removes elements.
- `ConcurrentRecalculationOfDependentAttributesDoesNotDeadlock` — a parent attribute whose value depends on a child attribute (via `AttributeRelationshipElement`) that is mutated concurrently; reproduces the nested race. Both concurrency tests fail with a 30 s timeout instead of hanging should the locking ever deadlock.
- `ConcurrentRemovalDuringReadDoesNotLatchStaleValue` — deterministic (single-threaded, reentrant): an element removes another mid-aggregation, and the test asserts the pre-removal value is not latched into the cache. Confirmed to fail (`Expected 0, but was 100`) without the version guard.

The two threaded tests were confirmed to fail (NRE / `Collection was modified` / `InvalidOperationException`) against the unpatched code and to pass with the fix; the suite was run repeatedly to confirm there is no flakiness.

## Affected files

- `src/AttributeSystem/ComposableAttribute.cs`
- `src/AttributeSystem/AttributeRelationshipElement.cs`
- `src/AttributeSystem/AttributeSystem.cs`
- `src/AttributeSystem/IComposableAttribute.cs` (doc note that `Elements` may be a snapshot)
- `tests/MUnique.OpenMU.AttributeSystem.Tests/ComposableAttributeTests.cs`