### PR TITLE
docs: pin patched versions of the documentation site's vulnerable build dependencies

### DIFF
--- a/docs-website/README.md
+++ b/docs-website/README.md
@@ -58,6 +58,29 @@ without a code change:
 A fork which deploys to `https://<user>.github.io/OpenMU/` would therefore build
 with `DOCS_URL=https://<user>.github.io DOCS_BASE_URL=/OpenMU/`.
 
+## Dependency overrides
+
+`package.json` contains an `overrides` block which forces two transitive
+dependencies to a patched version:
+
+| Package | Why |
+|---|---|
+| `serialize-javascript` | `copy-webpack-plugin` and `css-minimizer-webpack-plugin` pin `^6.0.0`, which is affected by [GHSA-5c6j-r48x-rmvq](https://github.com/advisories/GHSA-5c6j-r48x-rmvq) and [GHSA-qj8w-gfj5-8c6v](https://github.com/advisories/GHSA-qj8w-gfj5-8c6v). 7.1.0 is the fixed line. |
+| `uuid` | `sockjs` (via `webpack-dev-server`) pins `^8.3.2`, which is affected by [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq). |
+
+Remove an entry once the parent package ships a release which depends on the
+fixed version by itself — `npm ls <package>` no longer printing "overridden"
+next to it is the signal that the override became redundant.
+
+One advisory has no fix and is therefore not overridden: `image-size`, used by
+`@docusaurus/mdx-loader` to measure the images of a page, is affected by
+[GHSA-w3rx-r6r6-pgpr](https://github.com/advisories/GHSA-w3rx-r6r6-pgpr) and
+[GHSA-5p2g-fcmc-qvqq](https://github.com/advisories/GHSA-5p2g-fcmc-qvqq) in
+every published version. Both are denial of service through a crafted ICNS, JXL
+or HEIF file. It runs at build time over the images committed to this
+repository, so triggering it means committing a malicious image, and the damage
+is a hanging build — no published page and no game server is exposed to it.
+
 ## CI
 
 [`.github/workflows/docs-website.yml`](../.github/workflows/docs-website.yml)

--- a/docs-website/package-lock.json
+++ b/docs-website/package-lock.json
@@ -16838,15 +16838,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/randombytes": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.1.0.tgz",
-      "integrity": "sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "^5.1.0"
-      }
-    },
     "node_modules/range-parser": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
@@ -17832,12 +17823,12 @@
       }
     },
     "node_modules/serialize-javascript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.2.tgz",
-      "integrity": "sha512-Saa1xPByTTq2gdeFZYLLo+RFE35NHZkAbqZeWNd3BpzppeVisAqpDjcp8dyf6uIvEqJRd46jemmyA4iFIeVk8g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-7.1.0.tgz",
+      "integrity": "sha512-RNEqWOyhhUQYN9V1GfHwu9AR/g+NTciH6Z5u3/no6X3/w+04J2lVDL+svFQVXgXrEGBMG2puMVN3gq2SNGuTGw==",
       "license": "BSD-3-Clause",
-      "dependencies": {
-        "randombytes": "^2.1.0"
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/serve-handler": {
@@ -19309,13 +19300,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/value-equal": {

--- a/docs-website/package.json
+++ b/docs-website/package.json
@@ -42,5 +42,9 @@
   },
   "engines": {
     "node": ">=20.0"
+  },
+  "overrides": {
+    "serialize-javascript": "^7.1.0",
+    "uuid": "^11.1.1"
   }
 }


### PR DESCRIPTION
Resolves the fixable [Dependabot alerts](https://github.com/MUnique/OpenMU/security/dependabot) which appeared with the documentation site in #894.

All of them sit in the **build toolchain of `docs-website`**. Nothing here is shipped: the published site is static HTML, and the server is not affected. The alert count looks large because three root advisories cascade up through every Docusaurus package.

## What changed

An `overrides` block in `docs-website/package.json` forces two transitive dependencies to a patched version. That takes the audit from **25 findings (6 moderate, 19 high) to 18**, all of which are the cascade of a single advisory pair which has no fix.

| Package | Pinned by | Advisory | Fix |
|---|---|---|---|
| `serialize-javascript` 6.0.2 | `copy-webpack-plugin` and `css-minimizer-webpack-plugin` pin `^6.0.0` | [GHSA-5c6j-r48x-rmvq](https://github.com/advisories/GHSA-5c6j-r48x-rmvq) (RCE), [GHSA-qj8w-gfj5-8c6v](https://github.com/advisories/GHSA-qj8w-gfj5-8c6v) (CPU exhaustion) | `^7.1.0` |
| `uuid` 8.3.2 | `sockjs`, via `webpack-dev-server`, pins `^8.3.2` | [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) | `^11.1.1` |

`npm audit` reports `serialize-javascript` as "No fix available", which is misleading: 7.1.0 exists and is outside the vulnerable range, npm just cannot reach it through the parents' pins. An override can.

For `uuid`, only `v3`/`v5`/`v6` with a `buf` argument are affected and `sockjs` calls `v4`, so it was not exploitable here either way — the override is there to clear the alert.

## What is not fixed

`image-size`, used by `@docusaurus/mdx-loader` to measure the images of a page, is affected by [GHSA-w3rx-r6r6-pgpr](https://github.com/advisories/GHSA-w3rx-r6r6-pgpr) and [GHSA-5p2g-fcmc-qvqq](https://github.com/advisories/GHSA-5p2g-fcmc-qvqq) in **every published version** — the advisory range is `*` and the installed 2.0.2 is already the latest. There is no version to move to.

Both are a denial of service through a crafted ICNS, JXL or HEIF file, evaluated at build time over the images committed to this repository. Triggering it means committing a malicious image, and the damage is a hanging build; no published page and no game server is exposed. These 18 findings are reasonable candidates to dismiss as "risk is tolerable" if the open alerts are noisy.

## Notes

The reasoning, and the condition for removing each override again (`npm ls <package>` no longer printing "overridden"), is documented in `docs-website/README.md`, so the pins don't turn into cargo cult.

## Testing

Verified with a clean install from the lockfile, the way CI does it:

```bash
cd docs-website
rm -rf node_modules && npm ci
npm ls serialize-javascript uuid   # both report "overridden"
npm audit                          # 18 high, all image-size
npm run build                      # passes
```

The dev server (`npm start`) was started as well, since the `uuid` override lands in `sockjs`, which is the hot reload path — a build-only check would not have caught a break there. It compiles and serves pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LidmXPYjGN64P1RgCiY7Ri

---
_Generated by [Claude Code](https://claude.ai/code/session_01LidmXPYjGN64P1RgCiY7Ri)_