### PR TITLE
Add the packet capture service and the connection sources

### DIFF
--- a/src/ChatServer/ChatClient.cs
+++ b/src/ChatServer/ChatClient.cs
@@ -79,6 +79,11 @@ internal class ChatClient : IChatClient
     /// <inheritdoc/>
     public DateTime LastActivity { get; private set; }
 
+    /// <summary>
+    /// Gets the connection of this client, so that its traffic can be captured.
+    /// </summary>
+    internal IConnection? Connection => this._connection;
+
     /// <inheritdoc/>
     public async ValueTask SendMessageAsync(byte senderId, string message)
     {

--- a/src/ChatServer/ChatClientConnectionInfo.cs
+++ b/src/ChatServer/ChatClientConnectionInfo.cs
@@ -1,0 +1,81 @@
+// <copyright file="ChatClientConnectionInfo.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.ChatServer;
+
+using MUnique.OpenMU.Interfaces;
+using MUnique.OpenMU.Network;
+using MUnique.OpenMU.Network.Analyzer;
+using MUnique.OpenMU.Network.PlugIns;
+
+/// <summary>
+/// The <see cref="ICapturedConnectionInfo"/> of a client of the chat server.
+/// </summary>
+internal sealed class ChatClientConnectionInfo : ICapturedConnectionInfo
+{
+    private readonly ChatClient _client;
+
+    private readonly IConnection _connection;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ChatClientConnectionInfo"/> class.
+    /// </summary>
+    /// <param name="client">The client.</param>
+    /// <param name="connection">The connection of the client.</param>
+    /// <param name="serverId">The identifier of the chat server.</param>
+    public ChatClientConnectionInfo(ChatClient client, IConnection connection, int serverId)
+    {
+        this._client = client;
+        this._connection = connection;
+        this.ServerId = serverId;
+    }
+
+    /// <inheritdoc />
+    public Guid Id => this._connection.Id;
+
+    /// <inheritdoc />
+    public ServerType ServerType => ServerType.ChatServer;
+
+    /// <inheritdoc />
+    public int ServerId { get; }
+
+    /// <summary>
+    /// Gets the name of the account. The chat server doesn't know the account of its clients,
+    /// so it's always <see langword="null"/>.
+    /// </summary>
+    public string? AccountName => null;
+
+    /// <summary>
+    /// Gets the name of the character. The chat clients authenticate with the name of the
+    /// character which joined the chat room.
+    /// </summary>
+    public string? CharacterName => this._client.Nickname;
+
+    /// <inheritdoc />
+    public string? RemoteEndPoint => this._connection.EndPoint?.ToString();
+
+    /// <summary>
+    /// Gets the client version. The chat protocol doesn't depend on it, so the default
+    /// version is used.
+    /// </summary>
+    public ClientVersion ClientVersion => default;
+
+    /// <inheritdoc />
+    public PacketDefinitionSet DefinitionSet => PacketDefinitionSet.ChatServer;
+
+    /// <inheritdoc />
+    public bool IsConnected => this._connection.Connected;
+
+    /// <inheritdoc />
+    public string DisplayName => this.CharacterName ?? this.RemoteEndPoint ?? this.Id.ToString();
+
+    /// <inheritdoc />
+    public void AddCaptureSink(IPacketCaptureSink sink) => this._connection.AddCaptureSink(sink);
+
+    /// <inheritdoc />
+    public void RemoveCaptureSink(IPacketCaptureSink sink) => this._connection.RemoveCaptureSink(sink);
+
+    /// <inheritdoc />
+    public ValueTask DisconnectAsync() => this._client.LogOffAsync();
+}

--- a/src/ChatServer/ChatServer.cs
+++ b/src/ChatServer/ChatServer.cs
@@ -13,13 +13,14 @@ using System.Timers;
 using Microsoft.Extensions.Logging;
 using MUnique.OpenMU.Interfaces;
 using MUnique.OpenMU.Network;
+using MUnique.OpenMU.Network.Analyzer;
 using MUnique.OpenMU.PlugIns;
 using Timer = System.Timers.Timer;
 
 /// <summary>
 /// Chat Server Listener that accepts incoming connections.
 /// </summary>
-public sealed class ChatServer : IChatServer, IDisposable
+public sealed class ChatServer : IChatServer, IDisposable, IConnectionSource
 {
     private readonly ChatRoomManager _manager;
     private readonly ILogger<ChatServer> _logger;
@@ -94,6 +95,20 @@ public sealed class ChatServer : IChatServer, IDisposable
     public int CurrentConnections => this._connectedClients.Count;
 
     private ChatServerSettings Settings => this._settings ?? throw new InvalidOperationException("The server was not initialized before");
+
+    /// <inheritdoc />
+    public ValueTask<IReadOnlyList<ICapturedConnectionInfo>> GetConnectionsAsync()
+    {
+        IReadOnlyList<ICapturedConnectionInfo> result = this._connectedClients
+            .OfType<ChatClient>()
+            .Select(client => client.Connection is { } connection
+                ? new ChatClientConnectionInfo(client, connection, this.Id)
+                : null)
+            .Where(info => info is not null)
+            .Select(info => (ICapturedConnectionInfo)info!)
+            .ToList();
+        return ValueTask.FromResult(result);
+    }
 
     /// <inheritdoc/>
     public async ValueTask<ChatServerAuthenticationInfo?> RegisterClientAsync(ushort roomId, string clientName)

--- a/src/ChatServer/MUnique.OpenMU.ChatServer.csproj
+++ b/src/ChatServer/MUnique.OpenMU.ChatServer.csproj
@@ -25,6 +25,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Interfaces\MUnique.OpenMU.Interfaces.csproj" />
     <ProjectReference Include="..\Network\MUnique.OpenMU.Network.csproj" />
+    <ProjectReference Include="..\Network\Analyzer\MUnique.OpenMU.Network.Analyzer.csproj" />
     <ProjectReference Include="..\Network\Packets\MUnique.OpenMU.Network.Packets.csproj" />
   </ItemGroup>
 

--- a/src/ConnectServer/ClientConnectionInfo.cs
+++ b/src/ConnectServer/ClientConnectionInfo.cs
@@ -1,0 +1,76 @@
+// <copyright file="ClientConnectionInfo.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.ConnectServer;
+
+using MUnique.OpenMU.Interfaces;
+using MUnique.OpenMU.Network;
+using MUnique.OpenMU.Network.Analyzer;
+using MUnique.OpenMU.Network.PlugIns;
+
+/// <summary>
+/// The <see cref="ICapturedConnectionInfo"/> of a client of the connect server.
+/// </summary>
+internal sealed class ClientConnectionInfo : ICapturedConnectionInfo
+{
+    private readonly Client _client;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ClientConnectionInfo"/> class.
+    /// </summary>
+    /// <param name="client">The client.</param>
+    /// <param name="serverId">The identifier of the connect server.</param>
+    /// <param name="clientVersion">The client version of the connect server.</param>
+    public ClientConnectionInfo(Client client, int serverId, ClientVersion clientVersion)
+    {
+        this._client = client;
+        this.ServerId = serverId;
+        this.ClientVersion = clientVersion;
+    }
+
+    /// <inheritdoc />
+    public Guid Id => this._client.Connection.Id;
+
+    /// <inheritdoc />
+    public ServerType ServerType => ServerType.ConnectServer;
+
+    /// <inheritdoc />
+    public int ServerId { get; }
+
+    /// <summary>
+    /// Gets the name of the account. The clients of a connect server are never logged in, so
+    /// it's always <see langword="null"/>.
+    /// </summary>
+    public string? AccountName => null;
+
+    /// <summary>
+    /// Gets the name of the character. The clients of a connect server never selected one, so
+    /// it's always <see langword="null"/>.
+    /// </summary>
+    public string? CharacterName => null;
+
+    /// <inheritdoc />
+    public string? RemoteEndPoint => this._client.Connection.EndPoint?.ToString();
+
+    /// <inheritdoc />
+    public ClientVersion ClientVersion { get; }
+
+    /// <inheritdoc />
+    public PacketDefinitionSet DefinitionSet => PacketDefinitionSet.ConnectServer;
+
+    /// <inheritdoc />
+    public bool IsConnected => this._client.Connection.Connected;
+
+    /// <inheritdoc />
+    public string DisplayName => this.RemoteEndPoint ?? this.Id.ToString();
+
+    /// <inheritdoc />
+    public void AddCaptureSink(IPacketCaptureSink sink) => this._client.Connection.AddCaptureSink(sink);
+
+    /// <inheritdoc />
+    public void RemoveCaptureSink(IPacketCaptureSink sink) => this._client.Connection.RemoveCaptureSink(sink);
+
+    /// <inheritdoc />
+    public ValueTask DisconnectAsync() => this._client.Connection.DisconnectAsync();
+}

--- a/src/ConnectServer/ConnectServer.cs
+++ b/src/ConnectServer/ConnectServer.cs
@@ -11,12 +11,13 @@ using System.Runtime.CompilerServices;
 using System.Threading;
 using Microsoft.Extensions.Logging;
 using MUnique.OpenMU.Interfaces;
+using MUnique.OpenMU.Network.Analyzer;
 using MUnique.OpenMU.Network.PlugIns;
 
 /// <summary>
 /// The connect server.
 /// </summary>
-public class ConnectServer : IConnectServer, OpenMU.Interfaces.IConnectServer
+public class ConnectServer : IConnectServer, OpenMU.Interfaces.IConnectServer, IConnectionSource
 {
     private readonly ILoggerFactory _loggerFactory;
     private readonly ILogger _logger;
@@ -113,6 +114,15 @@ public class ConnectServer : IConnectServer, OpenMU.Interfaces.IConnectServer
     /// Gets the client listener.
     /// </summary>
     internal ClientListener ClientListener { get; }
+
+    /// <inheritdoc />
+    public ValueTask<IReadOnlyList<ICapturedConnectionInfo>> GetConnectionsAsync()
+    {
+        IReadOnlyList<ICapturedConnectionInfo> result = this.ClientListener.Clients
+            .Select(client => new ClientConnectionInfo(client, this.Id, this.ClientVersion))
+            .ToList();
+        return ValueTask.FromResult(result);
+    }
 
     /// <inheritdoc />
     public async Task StartAsync(CancellationToken cancellationToken)

--- a/src/ConnectServer/MUnique.OpenMU.ConnectServer.csproj
+++ b/src/ConnectServer/MUnique.OpenMU.ConnectServer.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <ProjectReference Include="..\Interfaces\MUnique.OpenMU.Interfaces.csproj" />
     <ProjectReference Include="..\Network\MUnique.OpenMU.Network.csproj" />
+    <ProjectReference Include="..\Network\Analyzer\MUnique.OpenMU.Network.Analyzer.csproj" />
     <ProjectReference Include="..\Network\Packets\MUnique.OpenMU.Network.Packets.csproj" />
   </ItemGroup>
 

--- a/src/GameServer/GameServer.cs
+++ b/src/GameServer/GameServer.cs
@@ -17,7 +17,9 @@ using MUnique.OpenMU.GameLogic.Views;
 using MUnique.OpenMU.GameLogic.Views.Guild;
 using MUnique.OpenMU.GameLogic.Views.Login;
 using MUnique.OpenMU.GameLogic.Views.Messenger;
+using MUnique.OpenMU.GameServer.RemoteView;
 using MUnique.OpenMU.Interfaces;
+using MUnique.OpenMU.Network.Analyzer;
 using MUnique.OpenMU.Persistence;
 using MUnique.OpenMU.PlugIns;
 using Nito.AsyncEx;
@@ -25,7 +27,7 @@ using Nito.AsyncEx;
 /// <summary>
 /// The game server to which game clients can connect.
 /// </summary>
-public sealed class GameServer : IGameServer, IDisposable, IGameServerContextProvider
+public sealed class GameServer : IGameServer, IDisposable, IGameServerContextProvider, IConnectionSource
 {
     private readonly ILogger<GameServer> _logger;
 
@@ -419,6 +421,20 @@ public sealed class GameServer : IGameServer, IDisposable, IGameServerContextPro
     public async ValueTask GuildHostilityChangedAsync(uint guildIdA, IReadOnlyList<uint> allianceGuildIdsA, uint guildIdB, IReadOnlyList<uint> allianceGuildIdsB, bool created)
     {
         this._gameContext.UpdateGuildHostility(guildIdA, allianceGuildIdsA, guildIdB, allianceGuildIdsB, created);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<IReadOnlyList<ICapturedConnectionInfo>> GetConnectionsAsync()
+    {
+        var players = await this._gameContext.GetPlayersAsync().ConfigureAwait(false);
+        return players
+            .OfType<RemotePlayer>()
+            .Select(player => player.Connection is { } connection
+                ? new RemotePlayerConnectionInfo(player, connection, this.Id)
+                : null)
+            .Where(info => info is not null)
+            .Select(info => (ICapturedConnectionInfo)info!)
+            .ToList();
     }
 
     /// <summary>

--- a/src/GameServer/MUnique.OpenMU.GameServer.csproj
+++ b/src/GameServer/MUnique.OpenMU.GameServer.csproj
@@ -23,6 +23,7 @@
     <ProjectReference Include="..\GameLogic\MUnique.OpenMU.GameLogic.csproj" />
     <ProjectReference Include="..\Interfaces\MUnique.OpenMU.Interfaces.csproj" />
     <ProjectReference Include="..\Network\MUnique.OpenMU.Network.csproj" />
+    <ProjectReference Include="..\Network\Analyzer\MUnique.OpenMU.Network.Analyzer.csproj" />
     <ProjectReference Include="..\Network\Packets\MUnique.OpenMU.Network.Packets.csproj" />
     <ProjectReference Include="..\Pathfinding\MUnique.OpenMU.Pathfinding.csproj" />
     <ProjectReference Include="..\Persistence\MUnique.OpenMU.Persistence.csproj" />

--- a/src/GameServer/RemotePlayerConnectionInfo.cs
+++ b/src/GameServer/RemotePlayerConnectionInfo.cs
@@ -1,0 +1,73 @@
+// <copyright file="RemotePlayerConnectionInfo.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer;
+
+using MUnique.OpenMU.GameServer.RemoteView;
+using MUnique.OpenMU.Interfaces;
+using MUnique.OpenMU.Network;
+using MUnique.OpenMU.Network.Analyzer;
+using MUnique.OpenMU.Network.PlugIns;
+
+/// <summary>
+/// The <see cref="ICapturedConnectionInfo"/> of a <see cref="RemotePlayer"/>.
+/// </summary>
+internal sealed class RemotePlayerConnectionInfo : ICapturedConnectionInfo
+{
+    private readonly RemotePlayer _player;
+
+    private readonly IConnection _connection;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RemotePlayerConnectionInfo"/> class.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="connection">The connection of the player.</param>
+    /// <param name="serverId">The identifier of the game server.</param>
+    public RemotePlayerConnectionInfo(RemotePlayer player, IConnection connection, int serverId)
+    {
+        this._player = player;
+        this._connection = connection;
+        this.ServerId = serverId;
+    }
+
+    /// <inheritdoc />
+    public Guid Id => this._connection.Id;
+
+    /// <inheritdoc />
+    public ServerType ServerType => ServerType.GameServer;
+
+    /// <inheritdoc />
+    public int ServerId { get; }
+
+    /// <inheritdoc />
+    public string? AccountName => this._player.Account?.LoginName;
+
+    /// <inheritdoc />
+    public string? CharacterName => this._player.SelectedCharacter?.Name;
+
+    /// <inheritdoc />
+    public string? RemoteEndPoint => this._connection.EndPoint?.ToString();
+
+    /// <inheritdoc />
+    public ClientVersion ClientVersion => this._player.ClientVersion;
+
+    /// <inheritdoc />
+    public PacketDefinitionSet DefinitionSet => PacketDefinitionSet.GameServer;
+
+    /// <inheritdoc />
+    public bool IsConnected => this._connection.Connected;
+
+    /// <inheritdoc />
+    public string DisplayName => this.CharacterName ?? this.AccountName ?? this.RemoteEndPoint ?? this.Id.ToString();
+
+    /// <inheritdoc />
+    public void AddCaptureSink(IPacketCaptureSink sink) => this._connection.AddCaptureSink(sink);
+
+    /// <inheritdoc />
+    public void RemoveCaptureSink(IPacketCaptureSink sink) => this._connection.RemoveCaptureSink(sink);
+
+    /// <inheritdoc />
+    public ValueTask DisconnectAsync() => this._player.DisconnectAsync();
+}

--- a/src/Network/Analyzer/ICapturedConnectionInfo.cs
+++ b/src/Network/Analyzer/ICapturedConnectionInfo.cs
@@ -1,0 +1,87 @@
+// <copyright file="ICapturedConnectionInfo.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Network.Analyzer;
+
+using MUnique.OpenMU.Interfaces;
+using MUnique.OpenMU.Network.PlugIns;
+
+/// <summary>
+/// Information about a connection of a server, whose traffic can be captured.
+/// </summary>
+/// <remarks>
+/// The implementations are provided by the servers themselves, so that the network connection
+/// stays inside the server which owns it.
+/// </remarks>
+public interface ICapturedConnectionInfo
+{
+    /// <summary>
+    /// Gets the identifier of the connection.
+    /// </summary>
+    Guid Id { get; }
+
+    /// <summary>
+    /// Gets the type of the server which handles this connection.
+    /// </summary>
+    ServerType ServerType { get; }
+
+    /// <summary>
+    /// Gets the identifier of the server which handles this connection.
+    /// </summary>
+    int ServerId { get; }
+
+    /// <summary>
+    /// Gets the name of the account, if the client is logged in.
+    /// </summary>
+    string? AccountName { get; }
+
+    /// <summary>
+    /// Gets the name of the selected character, if one is selected.
+    /// </summary>
+    string? CharacterName { get; }
+
+    /// <summary>
+    /// Gets the remote endpoint of the connection.
+    /// </summary>
+    string? RemoteEndPoint { get; }
+
+    /// <summary>
+    /// Gets the client version which currently applies to this connection.
+    /// </summary>
+    ClientVersion ClientVersion { get; }
+
+    /// <summary>
+    /// Gets the set of packet definitions which applies to this connection.
+    /// </summary>
+    PacketDefinitionSet DefinitionSet { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the connection is still connected.
+    /// </summary>
+    bool IsConnected { get; }
+
+    /// <summary>
+    /// Gets the name which should be shown for this connection. It's the character name, the
+    /// account name or the remote endpoint - whatever is known.
+    /// </summary>
+    string DisplayName { get; }
+
+    /// <summary>
+    /// Adds a sink which gets the data packets of this connection.
+    /// </summary>
+    /// <param name="sink">The sink.</param>
+    void AddCaptureSink(IPacketCaptureSink sink);
+
+    /// <summary>
+    /// Removes a previously added sink.
+    /// </summary>
+    /// <param name="sink">The sink.</param>
+    void RemoveCaptureSink(IPacketCaptureSink sink);
+
+    /// <summary>
+    /// Disconnects the client of this connection.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    ValueTask DisconnectAsync();
+}

--- a/src/Network/Analyzer/IConnectionSource.cs
+++ b/src/Network/Analyzer/IConnectionSource.cs
@@ -1,0 +1,22 @@
+// <copyright file="IConnectionSource.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Network.Analyzer;
+
+/// <summary>
+/// Interface for a server which can provide the connections of its clients, so that their
+/// traffic can be captured.
+/// </summary>
+/// <remarks>
+/// It's implemented by the servers themselves. A server which doesn't implement it, e.g.
+/// because it's just a proxy to a server in another process, is simply not listed.
+/// </remarks>
+public interface IConnectionSource
+{
+    /// <summary>
+    /// Gets the currently connected clients of this server.
+    /// </summary>
+    /// <returns>The currently connected clients of this server.</returns>
+    ValueTask<IReadOnlyList<ICapturedConnectionInfo>> GetConnectionsAsync();
+}

--- a/src/Network/Analyzer/ILiveCapturedConnection.cs
+++ b/src/Network/Analyzer/ILiveCapturedConnection.cs
@@ -1,0 +1,37 @@
+// <copyright file="ILiveCapturedConnection.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Network.Analyzer;
+
+/// <summary>
+/// A <see cref="ICapturedConnection"/> which captures the traffic of a connection which is
+/// currently handled by one of our servers.
+/// </summary>
+public interface ILiveCapturedConnection : ICapturedConnection
+{
+    /// <summary>
+    /// Occurs when packets have been added or removed.
+    /// </summary>
+    event EventHandler? PacketsChanged;
+
+    /// <summary>
+    /// Gets the information about the captured connection.
+    /// </summary>
+    ICapturedConnectionInfo ConnectionInfo { get; }
+
+    /// <summary>
+    /// Gets a snapshot of the currently captured packets.
+    /// </summary>
+    /// <returns>A snapshot of the currently captured packets.</returns>
+    /// <remarks>
+    /// The packets are captured on the network threads of the connection, so the
+    /// <see cref="ICapturedConnection.PacketList"/> must not be enumerated directly.
+    /// </remarks>
+    IReadOnlyList<Packet> GetPackets();
+
+    /// <summary>
+    /// Removes all captured packets.
+    /// </summary>
+    void Clear();
+}

--- a/src/Network/Analyzer/IPacketCaptureService.cs
+++ b/src/Network/Analyzer/IPacketCaptureService.cs
@@ -1,0 +1,59 @@
+// <copyright file="IPacketCaptureService.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Network.Analyzer;
+
+/// <summary>
+/// Service which provides the connections of all servers which run in this process, and which
+/// captures their traffic on request.
+/// </summary>
+public interface IPacketCaptureService
+{
+    /// <summary>
+    /// Gets the connections of all servers which can provide them.
+    /// </summary>
+    /// <returns>The connections of all servers which can provide them.</returns>
+    ValueTask<IReadOnlyList<ICapturedConnectionInfo>> GetConnectionsAsync();
+
+    /// <summary>
+    /// Gets the connection with the specified identifier.
+    /// </summary>
+    /// <param name="connectionId">The identifier of the connection.</param>
+    /// <returns>The connection, if it's still connected; Otherwise, <see langword="null"/>.</returns>
+    ValueTask<ICapturedConnectionInfo?> FindConnectionAsync(Guid connectionId);
+
+    /// <summary>
+    /// Gets the connection of the specified account or character name.
+    /// </summary>
+    /// <param name="serverId">The identifier of the server.</param>
+    /// <param name="accountOrCharacterName">The name of the account or character.</param>
+    /// <returns>The connection, if one was found; Otherwise, <see langword="null"/>.</returns>
+    ValueTask<ICapturedConnectionInfo?> FindConnectionAsync(int serverId, string accountOrCharacterName);
+
+    /// <summary>
+    /// Starts to capture the traffic of the specified connection, or returns the already
+    /// running capture of it.
+    /// </summary>
+    /// <param name="connectionId">The identifier of the connection.</param>
+    /// <returns>The capture of the connection, if it's still connected; Otherwise, <see langword="null"/>.</returns>
+    /// <remarks>
+    /// Each call has to be followed by a <see cref="StopCapture"/> when the caller isn't
+    /// interested anymore. The capture stops when the last interested caller is gone.
+    /// </remarks>
+    ValueTask<ILiveCapturedConnection?> StartCaptureAsync(Guid connectionId);
+
+    /// <summary>
+    /// Stops the capture of the specified connection, when no other caller is interested in
+    /// it anymore.
+    /// </summary>
+    /// <param name="connectionId">The identifier of the connection.</param>
+    void StopCapture(Guid connectionId);
+
+    /// <summary>
+    /// Gets the currently running capture of the specified connection.
+    /// </summary>
+    /// <param name="connectionId">The identifier of the connection.</param>
+    /// <returns>The running capture, if there is one; Otherwise, <see langword="null"/>.</returns>
+    ILiveCapturedConnection? GetRunningCapture(Guid connectionId);
+}

--- a/src/Network/Analyzer/LiveCapturedConnection.cs
+++ b/src/Network/Analyzer/LiveCapturedConnection.cs
@@ -1,0 +1,90 @@
+// <copyright file="LiveCapturedConnection.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Network.Analyzer;
+
+using System.ComponentModel;
+
+/// <summary>
+/// Captures the traffic of a connection which is currently handled by one of our servers.
+/// </summary>
+public sealed class LiveCapturedConnection : ILiveCapturedConnection, IPacketCaptureSink
+{
+    /// <summary>
+    /// The default maximum number of packets which are kept in memory.
+    /// </summary>
+    public const int DefaultMaximumPacketCount = 5000;
+
+    private readonly object _syncRoot = new();
+
+    private readonly int _maximumPacketCount;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="LiveCapturedConnection"/> class.
+    /// </summary>
+    /// <param name="connectionInfo">The information about the captured connection.</param>
+    /// <param name="maximumPacketCount">The maximum number of packets which are kept in
+    /// memory. When more packets arrive, the oldest ones are dropped.</param>
+    public LiveCapturedConnection(ICapturedConnectionInfo connectionInfo, int maximumPacketCount = DefaultMaximumPacketCount)
+    {
+        this.ConnectionInfo = connectionInfo;
+        this._maximumPacketCount = Math.Max(1, maximumPacketCount);
+        this.Name = connectionInfo.DisplayName;
+    }
+
+    /// <inheritdoc />
+    public event EventHandler? PacketsChanged;
+
+    /// <inheritdoc />
+    public ICapturedConnectionInfo ConnectionInfo { get; }
+
+    /// <inheritdoc />
+    public string Name { get; }
+
+    /// <inheritdoc />
+    public BindingList<Packet> PacketList { get; } = new();
+
+    /// <inheritdoc />
+    public DateTime StartTimestamp { get; } = DateTime.UtcNow;
+
+    /// <inheritdoc />
+    public IReadOnlyList<Packet> GetPackets()
+    {
+        lock (this._syncRoot)
+        {
+            return this.PacketList.ToList();
+        }
+    }
+
+    /// <inheritdoc />
+    public void Clear()
+    {
+        lock (this._syncRoot)
+        {
+            this.PacketList.Clear();
+        }
+
+        this.PacketsChanged?.Invoke(this, EventArgs.Empty);
+    }
+
+    /// <inheritdoc />
+    public void PacketCaptured(ReadOnlySpan<byte> packet, bool sent)
+    {
+        // A packet which was sent to the remote endpoint of a server connection is a packet
+        // which goes to the client; a received one goes to the server.
+        var capturedPacket = new Packet(DateTime.UtcNow - this.StartTimestamp, packet.ToArray(), !sent);
+
+        lock (this._syncRoot)
+        {
+            while (this.PacketList.Count >= this._maximumPacketCount)
+            {
+                this.PacketList.RemoveAt(0);
+            }
+
+            this.PacketList.Add(capturedPacket);
+        }
+
+        this.PacketsChanged?.Invoke(this, EventArgs.Empty);
+    }
+}

--- a/src/Network/Analyzer/MUnique.OpenMU.Network.Analyzer.csproj
+++ b/src/Network/Analyzer/MUnique.OpenMU.Network.Analyzer.csproj
@@ -36,6 +36,7 @@
     </Content>
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\..\Interfaces\MUnique.OpenMU.Interfaces.csproj" />
     <ProjectReference Include="..\MUnique.OpenMU.Network.csproj" />
     <ProjectReference Include="..\Packets\MUnique.OpenMU.Network.Packets.csproj" />
   </ItemGroup>

--- a/src/Network/Analyzer/PacketCaptureService.cs
+++ b/src/Network/Analyzer/PacketCaptureService.cs
@@ -1,0 +1,140 @@
+// <copyright file="PacketCaptureService.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Network.Analyzer;
+
+using System.Collections.Concurrent;
+using System.Threading;
+using MUnique.OpenMU.Interfaces;
+
+/// <summary>
+/// The implementation of the <see cref="IPacketCaptureService"/>, which collects the
+/// connections of all servers of this process which implement <see cref="IConnectionSource"/>.
+/// </summary>
+/// <remarks>
+/// In a distributed deployment, the servers of other processes are just proxies which don't
+/// implement <see cref="IConnectionSource"/> - their connections are simply not listed.
+/// </remarks>
+public sealed class PacketCaptureService : IPacketCaptureService
+{
+    private readonly IServerProvider _serverProvider;
+
+    private readonly int _maximumPacketCount;
+
+    private readonly ConcurrentDictionary<Guid, RunningCapture> _runningCaptures = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PacketCaptureService"/> class.
+    /// </summary>
+    /// <param name="serverProvider">The provider of the servers of this process.</param>
+    /// <param name="maximumPacketCount">The maximum number of packets which are kept in
+    /// memory per capture.</param>
+    public PacketCaptureService(IServerProvider serverProvider, int maximumPacketCount = LiveCapturedConnection.DefaultMaximumPacketCount)
+    {
+        this._serverProvider = serverProvider;
+        this._maximumPacketCount = maximumPacketCount;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<IReadOnlyList<ICapturedConnectionInfo>> GetConnectionsAsync()
+    {
+        var result = new List<ICapturedConnectionInfo>();
+        foreach (var source in this._serverProvider.Servers.OfType<IConnectionSource>())
+        {
+            result.AddRange(await source.GetConnectionsAsync().ConfigureAwait(false));
+        }
+
+        return result;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<ICapturedConnectionInfo?> FindConnectionAsync(Guid connectionId)
+    {
+        var connections = await this.GetConnectionsAsync().ConfigureAwait(false);
+        return connections.FirstOrDefault(connection => connection.Id == connectionId);
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<ICapturedConnectionInfo?> FindConnectionAsync(int serverId, string accountOrCharacterName)
+    {
+        var connections = await this.GetConnectionsAsync().ConfigureAwait(false);
+        return connections.FirstOrDefault(connection => connection.ServerId == serverId
+                                                        && (string.Equals(connection.CharacterName, accountOrCharacterName, StringComparison.OrdinalIgnoreCase)
+                                                            || string.Equals(connection.AccountName, accountOrCharacterName, StringComparison.OrdinalIgnoreCase)));
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<ILiveCapturedConnection?> StartCaptureAsync(Guid connectionId)
+    {
+        if (this._runningCaptures.TryGetValue(connectionId, out var running))
+        {
+            running.AddInterestedParty();
+            return running.Capture;
+        }
+
+        if (await this.FindConnectionAsync(connectionId).ConfigureAwait(false) is not { } connectionInfo)
+        {
+            return null;
+        }
+
+        var capture = new LiveCapturedConnection(connectionInfo, this._maximumPacketCount);
+        var newRunning = new RunningCapture(connectionInfo, capture);
+        var current = this._runningCaptures.GetOrAdd(connectionId, newRunning);
+        if (!ReferenceEquals(current, newRunning))
+        {
+            // Another caller was faster.
+            current.AddInterestedParty();
+            return current.Capture;
+        }
+
+        connectionInfo.AddCaptureSink(capture);
+        return capture;
+    }
+
+    /// <inheritdoc />
+    public void StopCapture(Guid connectionId)
+    {
+        if (!this._runningCaptures.TryGetValue(connectionId, out var running)
+            || running.RemoveInterestedParty() > 0)
+        {
+            return;
+        }
+
+        if (this._runningCaptures.TryRemove(connectionId, out _))
+        {
+            running.ConnectionInfo.RemoveCaptureSink(running.Capture);
+        }
+    }
+
+    /// <inheritdoc />
+    public ILiveCapturedConnection? GetRunningCapture(Guid connectionId)
+    {
+        return this._runningCaptures.TryGetValue(connectionId, out var running) ? running.Capture : null;
+    }
+
+    private sealed class RunningCapture
+    {
+        private int _interestedParties = 1;
+
+        public RunningCapture(ICapturedConnectionInfo connectionInfo, LiveCapturedConnection capture)
+        {
+            this.ConnectionInfo = connectionInfo;
+            this.Capture = capture;
+        }
+
+        public ICapturedConnectionInfo ConnectionInfo { get; }
+
+        public LiveCapturedConnection Capture { get; }
+
+        public void AddInterestedParty()
+        {
+            Interlocked.Increment(ref this._interestedParties);
+        }
+
+        public int RemoveInterestedParty()
+        {
+            return Interlocked.Decrement(ref this._interestedParties);
+        }
+    }
+}

--- a/src/Startup/MUnique.OpenMU.Startup.csproj
+++ b/src/Startup/MUnique.OpenMU.Startup.csproj
@@ -36,6 +36,7 @@
     <ProjectReference Include="..\GameServer\MUnique.OpenMU.GameServer.csproj" /> 
     <ProjectReference Include="..\GuildServer\MUnique.OpenMU.GuildServer.csproj" />
     <ProjectReference Include="..\Interfaces\MUnique.OpenMU.Interfaces.csproj" />    
+    <ProjectReference Include="..\Network\Analyzer\MUnique.OpenMU.Network.Analyzer.csproj" />
     <ProjectReference Include="..\LoginServer\MUnique.OpenMU.LoginServer.csproj" />
     <ProjectReference Include="..\Persistence\InMemory\MUnique.OpenMU.Persistence.InMemory.csproj" />
     <ProjectReference Include="..\Persistence\EntityFramework\MUnique.OpenMU.Persistence.EntityFramework.csproj" />

--- a/src/Startup/Program.cs
+++ b/src/Startup/Program.cs
@@ -24,6 +24,7 @@ using MUnique.OpenMU.GuildServer;
 using MUnique.OpenMU.Interfaces;
 using MUnique.OpenMU.LoginServer;
 using MUnique.OpenMU.Network;
+using MUnique.OpenMU.Network.Analyzer;
 using MUnique.OpenMU.Persistence;
 using MUnique.OpenMU.Persistence.EntityFramework;
 using MUnique.OpenMU.Persistence.EntityFramework.Json;
@@ -291,6 +292,7 @@ internal sealed class Program : IDisposable
             .AddSingleton<IFriendNotifier, FriendNotifierToGameServer>()
             .AddSingleton<PlugInManager>()
             .AddSingleton<IServerProvider, LocalServerProvider>()
+            .AddSingleton<IPacketCaptureService, PacketCaptureService>()
             .AddSingleton<ICollection<PlugInConfiguration>>(this.PlugInConfigurationsFactory)
             .AddTransient<ReferenceHandler, ByDataSourceReferenceHandler>(provider =>
             {

--- a/tests/MUnique.OpenMU.Network.Tests/PacketCaptureServiceTest.cs
+++ b/tests/MUnique.OpenMU.Network.Tests/PacketCaptureServiceTest.cs
@@ -1,0 +1,274 @@
+// <copyright file="PacketCaptureServiceTest.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Network.Tests;
+
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading;
+using Microsoft.Extensions.Hosting;
+using MUnique.OpenMU.Interfaces;
+using MUnique.OpenMU.Network.Analyzer;
+using MUnique.OpenMU.Network.PlugIns;
+
+/// <summary>
+/// Tests for the <see cref="PacketCaptureService"/> and the <see cref="LiveCapturedConnection"/>.
+/// </summary>
+[TestFixture]
+public class PacketCaptureServiceTest
+{
+    /// <summary>
+    /// Tests if the connections of all servers which can provide them are collected.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Test]
+    public async Task ConnectionsOfAllSourcesAreCollectedAsync()
+    {
+        var gameServerConnection = new TestConnectionInfo(ServerType.GameServer, 1) { CharacterName = "TestCharacter" };
+        var connectServerConnection = new TestConnectionInfo(ServerType.ConnectServer, 100);
+        var service = CreateService(
+            new TestServer(ServerType.GameServer, gameServerConnection),
+            new TestServer(ServerType.ConnectServer, connectServerConnection),
+            new ServerWithoutConnections());
+
+        var connections = await service.GetConnectionsAsync().ConfigureAwait(false);
+
+        Assert.That(connections, Has.Count.EqualTo(2));
+        Assert.That(connections, Does.Contain(gameServerConnection));
+        Assert.That(connections, Does.Contain(connectServerConnection));
+    }
+
+    /// <summary>
+    /// Tests if a connection is found by its identifier.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Test]
+    public async Task ConnectionIsFoundByIdAsync()
+    {
+        var connection = new TestConnectionInfo(ServerType.GameServer, 1);
+        var service = CreateService(new TestServer(ServerType.GameServer, connection));
+
+        Assert.That(await service.FindConnectionAsync(connection.Id).ConfigureAwait(false), Is.EqualTo(connection));
+        Assert.That(await service.FindConnectionAsync(Guid.NewGuid()).ConfigureAwait(false), Is.Null);
+    }
+
+    /// <summary>
+    /// Tests if a connection is found by the name of its account or character.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Test]
+    public async Task ConnectionIsFoundByNameAsync()
+    {
+        var connection = new TestConnectionInfo(ServerType.GameServer, 1) { AccountName = "testAccount", CharacterName = "TestCharacter" };
+        var service = CreateService(new TestServer(ServerType.GameServer, connection));
+
+        Assert.That(await service.FindConnectionAsync(1, "TestCharacter").ConfigureAwait(false), Is.EqualTo(connection));
+        Assert.That(await service.FindConnectionAsync(1, "testaccount").ConfigureAwait(false), Is.EqualTo(connection));
+        Assert.That(await service.FindConnectionAsync(2, "TestCharacter").ConfigureAwait(false), Is.Null);
+        Assert.That(await service.FindConnectionAsync(1, "Unknown").ConfigureAwait(false), Is.Null);
+    }
+
+    /// <summary>
+    /// Tests if a started capture registers itself at the connection, and if it's removed
+    /// again when the capture is stopped.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Test]
+    public async Task CaptureIsAttachedAndDetachedAsync()
+    {
+        var connection = new TestConnectionInfo(ServerType.GameServer, 1);
+        var service = CreateService(new TestServer(ServerType.GameServer, connection));
+
+        var capture = await service.StartCaptureAsync(connection.Id).ConfigureAwait(false);
+
+        Assert.That(capture, Is.Not.Null);
+        Assert.That(connection.Sinks, Has.Count.EqualTo(1));
+        Assert.That(service.GetRunningCapture(connection.Id), Is.EqualTo(capture));
+
+        service.StopCapture(connection.Id);
+
+        Assert.That(connection.Sinks, Is.Empty);
+        Assert.That(service.GetRunningCapture(connection.Id), Is.Null);
+    }
+
+    /// <summary>
+    /// Tests if a second interested party gets the same capture, and that the capture is only
+    /// stopped when the last one is gone.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Test]
+    public async Task CaptureIsSharedByInterestedPartiesAsync()
+    {
+        var connection = new TestConnectionInfo(ServerType.GameServer, 1);
+        var service = CreateService(new TestServer(ServerType.GameServer, connection));
+
+        var first = await service.StartCaptureAsync(connection.Id).ConfigureAwait(false);
+        var second = await service.StartCaptureAsync(connection.Id).ConfigureAwait(false);
+
+        Assert.That(second, Is.EqualTo(first));
+        Assert.That(connection.Sinks, Has.Count.EqualTo(1));
+
+        service.StopCapture(connection.Id);
+        Assert.That(connection.Sinks, Has.Count.EqualTo(1), "The capture is still watched.");
+
+        service.StopCapture(connection.Id);
+        Assert.That(connection.Sinks, Is.Empty);
+    }
+
+    /// <summary>
+    /// Tests if starting a capture of an unknown connection returns null.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Test]
+    public async Task CaptureOfUnknownConnectionIsNotStartedAsync()
+    {
+        var service = CreateService(new TestServer(ServerType.GameServer));
+
+        Assert.That(await service.StartCaptureAsync(Guid.NewGuid()).ConfigureAwait(false), Is.Null);
+    }
+
+    /// <summary>
+    /// Tests if the captured packets are added with the correct direction.
+    /// </summary>
+    [Test]
+    public void CapturedPacketsKeepTheirDirection()
+    {
+        var capture = new LiveCapturedConnection(new TestConnectionInfo(ServerType.GameServer, 1));
+
+        capture.PacketCaptured(new byte[] { 0xC1, 0x04, 0xF1, 0x00 }, false);
+        capture.PacketCaptured(new byte[] { 0xC1, 0x04, 0xF1, 0x01 }, true);
+
+        var packets = capture.GetPackets();
+        Assert.That(packets, Has.Count.EqualTo(2));
+        Assert.That(packets[0].ToServer, Is.True, "A received packet goes to the server.");
+        Assert.That(packets[1].ToServer, Is.False, "A sent packet goes to the client.");
+    }
+
+    /// <summary>
+    /// Tests if the oldest packets are dropped when the maximum count is reached.
+    /// </summary>
+    [Test]
+    public void OldestPacketsAreDroppedWhenBufferIsFull()
+    {
+        var capture = new LiveCapturedConnection(new TestConnectionInfo(ServerType.GameServer, 1), 3);
+
+        for (byte i = 0; i < 5; i++)
+        {
+            capture.PacketCaptured(new byte[] { 0xC1, 0x04, 0xF1, i }, false);
+        }
+
+        var packets = capture.GetPackets();
+        Assert.That(packets, Has.Count.EqualTo(3));
+        Assert.That(packets.Select(packet => packet.Data[3]), Is.EqualTo(new byte[] { 2, 3, 4 }));
+    }
+
+    private static PacketCaptureService CreateService(params IManageableServer[] servers)
+    {
+        return new PacketCaptureService(new TestServerProvider(servers));
+    }
+
+    private sealed class TestConnectionInfo : ICapturedConnectionInfo
+    {
+        public TestConnectionInfo(ServerType serverType, int serverId)
+        {
+            this.ServerType = serverType;
+            this.ServerId = serverId;
+        }
+
+        public IList<IPacketCaptureSink> Sinks { get; } = new List<IPacketCaptureSink>();
+
+        public Guid Id { get; } = Guid.NewGuid();
+
+        public ServerType ServerType { get; }
+
+        public int ServerId { get; }
+
+        public string? AccountName { get; init; }
+
+        public string? CharacterName { get; init; }
+
+        public string? RemoteEndPoint => "127.0.0.1:1234";
+
+        public ClientVersion ClientVersion => default;
+
+        public PacketDefinitionSet DefinitionSet => PacketDefinitionSet.GameServer;
+
+        public bool IsConnected => true;
+
+        public string DisplayName => this.CharacterName ?? this.AccountName ?? this.RemoteEndPoint!;
+
+        public void AddCaptureSink(IPacketCaptureSink sink) => this.Sinks.Add(sink);
+
+        public void RemoveCaptureSink(IPacketCaptureSink sink) => this.Sinks.Remove(sink);
+
+        public ValueTask DisconnectAsync() => ValueTask.CompletedTask;
+    }
+
+    private class ServerWithoutConnections : IManageableServer
+    {
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public int Id => 0;
+
+        public Guid ConfigurationId => Guid.Empty;
+
+        public string Description => "Test";
+
+        public ServerType Type => ServerType.GameServer;
+
+        public ServerState ServerState => ServerState.Started;
+
+        public int MaximumConnections => 100;
+
+        public int CurrentConnections => 0;
+
+        public ValueTask StartAsync() => ValueTask.CompletedTask;
+
+        public ValueTask ShutdownAsync() => ValueTask.CompletedTask;
+
+        public Task StartAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        public Task StopAsync(CancellationToken cancellationToken) => Task.CompletedTask;
+
+        protected void RaisePropertyChanged(string propertyName)
+        {
+            this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+
+    private sealed class TestServer : ServerWithoutConnections, IConnectionSource
+    {
+        private readonly IReadOnlyList<ICapturedConnectionInfo> _connections;
+
+        public TestServer(ServerType serverType, params ICapturedConnectionInfo[] connections)
+        {
+            this.ServerType = serverType;
+            this._connections = connections;
+        }
+
+        public ServerType ServerType { get; }
+
+        public ValueTask<IReadOnlyList<ICapturedConnectionInfo>> GetConnectionsAsync()
+        {
+            return ValueTask.FromResult(this._connections);
+        }
+    }
+
+    private sealed class TestServerProvider : IServerProvider
+    {
+        public TestServerProvider(IEnumerable<IManageableServer> servers)
+        {
+            this.Servers = servers.ToList();
+        }
+
+        public event PropertyChangedEventHandler? PropertyChanged
+        {
+            add { }
+            remove { }
+        }
+
+        public IList<IManageableServer> Servers { get; }
+    }
+}


### PR DESCRIPTION
Phase 2 of #895. **Targets the phase 1 branch of #897**, so it can be merged after that one — please review/merge #897 first, this PR then rebases onto master automatically.

The service is the layer between the capture hook of phase 1 and the admin panel page of phase 3: it collects the connections of all servers which run in this process and captures their traffic on request. Nothing uses it yet.

## How the servers provide their connections

A server which can provide the connections of its clients implements **`IConnectionSource`** — the game server, the connect server and the chat server do. The proxies of a distributed deployment don't, so their connections are simply not listed, which is exactly the graceful degradation we want.

Each connection is described by an **`ICapturedConnectionInfo`**, implemented by the servers themselves. That keeps the `IConnection` inside the server which owns it — the info exposes what the UI needs (account name, character name, endpoint, client version, the packet definition set which applies) and attaches or detaches a capture sink on request.

| Server | Connections from | Names | Version |
|---|---|---|---|
| Game server | `IGameContext.GetPlayersAsync()`, `RemotePlayer` with a connection | `Account.LoginName`, `SelectedCharacter.Name` — read live, so a login or character selection shows up right away | `RemotePlayer.ClientVersion` |
| Connect server | `ClientListener.Clients` | none, the clients aren't logged in | `ConnectServer.ClientVersion` from its settings |
| Chat server | its connected clients | `ChatClient.Nickname` | not applicable, the chat protocol has no versions |

The `PacketCaptureService` finds those servers through the **already registered `IServerProvider`**. That means no extra registration plumbing, and it covers game servers which are created or removed at runtime by the `GameServerContainer` for free. It's registered in the all-in-one startup only, like the live map page.

## Capturing

`StartCaptureAsync(connectionId)` returns a `LiveCapturedConnection` and registers it as a sink. A second caller for the same connection gets the same capture; the capture is only detached when the last interested party called `StopCapture` — so two admins watching the same player don't disturb each other.

The captured packets go into a capped buffer (default 5,000, oldest dropped), so a busy connection can't fill the memory. `LiveCapturedConnection` implements the existing `ICapturedConnection`, which means an admin panel page and the WinForms tool can consume the same model — and a capture can be saved as `.mucap` with the extensions we already have.

Direction: a packet *sent* on a server connection goes to the client, a *received* one goes to the server. The existing `Packet.ToServer` is set accordingly.

## Deviations from the plan in #895

* **No `PlayerAdded`/`PlayerRemoved` events on `GameContext`.** The plan wanted them so the connection list could update push-based. With the servers being queried on demand, they aren't needed, and adding unused public events felt speculative. If phase 3 wants push updates instead of refreshing on demand, they're easy to add then.
* **`SetObservationAsync` and `IsObserved` are not in the service yet.** They belong to the account flag, which arrives with the migration in phase 5.
* The three server projects now reference the analyzer library, and the analyzer library references `MUnique.OpenMU.Interfaces` (for `ServerType`). `Interfaces` itself stays free of project references. If you'd rather have the capture abstractions in a separate small project instead of the analyzer library, that's a straightforward move.

## Tests

8 new tests in `PacketCaptureServiceTest`: connections collected from several sources (and a server which isn't a source being skipped), lookup by id, lookup by account or character name (case insensitive, server scoped), a capture being attached and detached, a capture being shared by two parties and only stopped by the last one, an unknown connection returning null, the direction of captured packets, and the oldest packets being dropped when the buffer is full.

## Verification

* `dotnet build MUnique.OpenMU.sln -p:ci=true` → 0 errors; no warning originates in a file this PR adds or changes.
* The complete test suite passes: 1559 tests, 0 failures (`MUnique.OpenMU.Network.Tests` is at 59 passed, 4 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pb82LmoaUVdZtBtQs7xrtA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pb82LmoaUVdZtBtQs7xrtA)_