### PR TITLE
Implement Castle Siege Crown and switch mechanics

### DIFF
--- a/docs/Packets/C1-B2-14-CastleSiegeCrownSwitchState_by-server.md
+++ b/docs/Packets/C1-B2-14-CastleSiegeCrownSwitchState_by-server.md
@@ -16,7 +16,7 @@ The client updates the crown switch interaction state.
 | 1 | 1 |    Byte   |   9   | Packet header - length of the packet |
 | 2 | 1 |    Byte   | 0xB2  | Packet header - packet type identifier |
 | 3 | 1 |    Byte   | 0x14  | Packet header - sub packet type identifier |
-| 4 | 2 | ShortBigEndian |  | SwitchIndex |
+| 4 | 2 | ShortBigEndian |  | SwitchIndex; The network object identifier of the Crown switch. |
 | 6 | 2 | ShortBigEndian |  | PlayerIndex |
 | 8 | 1 | CastleSiegeCrownSwitchStateType |  | State |
 

--- a/docs/Packets/C1-B2-20-CastleSiegeSwitchInfo_by-server.md
+++ b/docs/Packets/C1-B2-20-CastleSiegeSwitchInfo_by-server.md
@@ -16,7 +16,7 @@ The client updates the crown switch occupation display.
 | 1 | 1 |    Byte   |   27   | Packet header - length of the packet |
 | 2 | 1 |    Byte   | 0xB2  | Packet header - packet type identifier |
 | 3 | 1 |    Byte   | 0x20  | Packet header - sub packet type identifier |
-| 4 | 2 | ShortBigEndian |  | SwitchIndex |
+| 4 | 2 | ShortBigEndian |  | SwitchIndex; The network object identifier of the Crown switch. |
 | 6 | 1 | Boolean |  | IsOccupied |
 | 7 | 1 | CastleSiegeJoinSide |  | JoinSide |
 | 8 | 8 | String |  | GuildName |

--- a/src/GameLogic/CastleSiege/CastleSiegeContext.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeContext.cs
@@ -126,6 +126,11 @@ public class CastleSiegeContext : IEventStateProvider
     public TimeSpan RemainingTime => this.GetRemainingTime(DateTime.UtcNow);
 
     /// <summary>
+    /// Gets or sets the player whose active Crown attempt was announced to the client.
+    /// </summary>
+    internal Player? PreviousCrownUser { get; set; }
+
+    /// <summary>
     /// Gets a value indicating whether the context has been initialized.
     /// </summary>
     internal bool IsInitialized { get; private set; }

--- a/src/GameLogic/CastleSiege/CastleSiegeContext.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeContext.cs
@@ -131,6 +131,21 @@ public class CastleSiegeContext : IEventStateProvider
     internal Player? PreviousCrownUser { get; set; }
 
     /// <summary>
+    /// Gets or sets the UTC time of the previous Crown progress update.
+    /// </summary>
+    internal DateTime LastCrownUpdateUtc { get; set; }
+
+    /// <summary>
+    /// Gets the switch information which was last broadcast to the siege map.
+    /// </summary>
+    internal CastleSiegeSwitchInfo?[] LastBroadcastSwitchInfos { get; } = new CastleSiegeSwitchInfo?[2];
+
+    /// <summary>
+    /// Gets or sets the Crown availability which was last broadcast to the siege map.
+    /// </summary>
+    internal bool? LastBroadcastCrownAvailability { get; set; }
+
+    /// <summary>
     /// Gets a value indicating whether the context has been initialized.
     /// </summary>
     internal bool IsInitialized { get; private set; }
@@ -390,8 +405,12 @@ public class CastleSiegeContext : IEventStateProvider
     internal void InitializeBattleOwner()
     {
         this.MiddleOwnerGuildId = this.FinalGuildList.Values
-            .FirstOrDefault(guild => guild.Side == CastleSiegeJoinSide.Defense && guild.IsAllianceMaster)
-            ?.GuildId;
+                                      .FirstOrDefault(guild => guild.Side == CastleSiegeJoinSide.Defense
+                                                               && guild.PersistentGuildId == this.SiegeData.OwnerGuildId)
+                                      ?.GuildId
+                                  ?? this.FinalGuildList.Values
+                                      .FirstOrDefault(guild => guild.Side == CastleSiegeJoinSide.Defense && guild.IsAllianceMaster)
+                                      ?.GuildId;
     }
 
     /// <summary>

--- a/src/GameLogic/CastleSiege/CastleSiegeContext.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeContext.cs
@@ -136,9 +136,9 @@ public class CastleSiegeContext : IEventStateProvider
     internal DateTime LastCrownUpdateUtc { get; set; }
 
     /// <summary>
-    /// Gets the switch information which was last broadcast to the siege map.
+    /// Gets the switch information which was last broadcast to the siege map, keyed by network object identifier.
     /// </summary>
-    internal CastleSiegeSwitchInfo?[] LastBroadcastSwitchInfos { get; } = new CastleSiegeSwitchInfo?[2];
+    internal Dictionary<ushort, CastleSiegeSwitchInfo> LastBroadcastSwitchInfos { get; } = [];
 
     /// <summary>
     /// Gets or sets the Crown availability which was last broadcast to the siege map.

--- a/src/GameLogic/CastleSiege/CastleSiegeCrownMechanics.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeCrownMechanics.cs
@@ -14,6 +14,8 @@ using MUnique.OpenMU.GameLogic.Views.CastleSiege;
 /// </summary>
 public static class CastleSiegeCrownMechanics
 {
+    private static readonly TimeSpan MaximumProgressInterval = TimeSpan.FromSeconds(2);
+
     /// <summary>
     /// Checks whether the Crown and both switches are held by the same attacking side.
     /// </summary>
@@ -25,6 +27,9 @@ public static class CastleSiegeCrownMechanics
         var elapsed = utcNow > context.LastCrownUpdateUtc
             ? utcNow - context.LastCrownUpdateUtc
             : TimeSpan.Zero;
+        elapsed = elapsed > MaximumProgressInterval
+            ? MaximumProgressInterval
+            : elapsed;
         context.LastCrownUpdateUtc = utcNow;
 
         var crownUser = context.CrownUser;
@@ -292,6 +297,8 @@ public static class CastleSiegeCrownMechanics
             return;
         }
 
+        // A successful seal changes the castle lord immediately. The previous ownership tenure's economy must not
+        // survive that handover, even when the former defender captures the Crown again before the battle ends.
         context.SiegeData.OwnerGuildId = winner.PersistentGuildId;
         context.SiegeData.IsOccupied = true;
         context.SiegeData.TaxChaos = 0;

--- a/src/GameLogic/CastleSiege/CastleSiegeCrownMechanics.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeCrownMechanics.cs
@@ -14,6 +14,7 @@ using MUnique.OpenMU.GameLogic.Views.CastleSiege;
 /// </summary>
 public static class CastleSiegeCrownMechanics
 {
+    // GameContext executes periodic tasks once per second, so this permits at most two missed intervals.
     private static readonly TimeSpan MaximumProgressInterval = TimeSpan.FromSeconds(2);
 
     /// <summary>
@@ -124,7 +125,7 @@ public static class CastleSiegeCrownMechanics
         await RespawnAttackersAsync(context).ConfigureAwait(false);
 
         context.IsCrownAvailable = false;
-        foreach (var crown in context.ActiveNpcs
+        foreach (var crown in context.NpcController.GetRuntimeSnapshot()
                      .Select(runtime => runtime.SpawnedInstance)
                      .OfType<CastleSiegeCrown>())
         {
@@ -135,7 +136,7 @@ public static class CastleSiegeCrownMechanics
         context.CrownUser = null;
         context.PreviousCrownUser = null;
         Array.Clear(context.SwitchUsers);
-        foreach (var siegeSwitch in context.ActiveNpcs
+        foreach (var siegeSwitch in context.NpcController.GetRuntimeSnapshot()
                      .Select(runtime => runtime.SpawnedInstance)
                      .OfType<CastleSiegeSwitch>())
         {

--- a/src/GameLogic/CastleSiege/CastleSiegeCrownMechanics.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeCrownMechanics.cs
@@ -95,8 +95,10 @@ public static class CastleSiegeCrownMechanics
             if (guild.Side == capturingSide)
             {
                 guild.Side = CastleSiegeJoinSide.Defense;
+                continue;
             }
-            else if (guild.Side == CastleSiegeJoinSide.Defense)
+
+            if (guild.Side == CastleSiegeJoinSide.Defense)
             {
                 guild.Side = capturingSide;
             }

--- a/src/GameLogic/CastleSiege/CastleSiegeCrownMechanics.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeCrownMechanics.cs
@@ -4,6 +4,7 @@
 
 namespace MUnique.OpenMU.GameLogic.CastleSiege;
 
+using Microsoft.Extensions.Logging;
 using MUnique.OpenMU.DataModel.Configuration;
 using MUnique.OpenMU.GameLogic.CastleSiege.NPC;
 using MUnique.OpenMU.GameLogic.Views.CastleSiege;
@@ -13,15 +14,19 @@ using MUnique.OpenMU.GameLogic.Views.CastleSiege;
 /// </summary>
 public static class CastleSiegeCrownMechanics
 {
-    private static readonly TimeSpan TickInterval = TimeSpan.FromSeconds(1);
-
     /// <summary>
     /// Checks whether the Crown and both switches are held by the same attacking side.
     /// </summary>
     /// <param name="context">The Castle Siege context.</param>
+    /// <param name="utcNow">The current UTC time.</param>
     /// <returns>A task that represents the asynchronous check operation.</returns>
-    public static async ValueTask CheckMiddleWinnerAsync(CastleSiegeContext context)
+    public static async ValueTask CheckMiddleWinnerAsync(CastleSiegeContext context, DateTime utcNow)
     {
+        var elapsed = utcNow > context.LastCrownUpdateUtc
+            ? utcNow - context.LastCrownUpdateUtc
+            : TimeSpan.Zero;
+        context.LastCrownUpdateUtc = utcNow;
+
         var crownUser = context.CrownUser;
         var previousCrownUser = context.PreviousCrownUser;
         if (previousCrownUser is not null
@@ -47,13 +52,16 @@ public static class CastleSiegeCrownMechanics
             return;
         }
 
-        context.CrownAccumulatedTime += TickInterval;
+        context.CrownAccumulatedTime += elapsed;
         context.PreviousCrownUser = crownUser;
-        await SendAccessStateAsync(
-                crownUser!,
-                CastleSiegeCrownAccessState.Attempt,
-                context.CrownAccumulatedTime)
-            .ConfigureAwait(false);
+        if (elapsed > TimeSpan.Zero)
+        {
+            await SendAccessStateAsync(
+                    crownUser!,
+                    CastleSiegeCrownAccessState.Attempt,
+                    context.CrownAccumulatedTime)
+                .ConfigureAwait(false);
+        }
 
         var requiredTime = TimeSpan.FromSeconds(context.Configuration.CrownHoldTimeSeconds);
         if (context.CrownAccumulatedTime < requiredTime)
@@ -76,7 +84,7 @@ public static class CastleSiegeCrownMechanics
     /// <param name="crownUser">The player who captured the Crown.</param>
     /// <param name="capturingSide">The attacking side which captured the Crown.</param>
     /// <returns>A task that represents the asynchronous ownership change.</returns>
-    public static async ValueTask ChangeWinnerGuildAsync(
+    internal static async ValueTask ChangeWinnerGuildAsync(
         CastleSiegeContext context,
         Player crownUser,
         CastleSiegeJoinSide capturingSide)
@@ -104,7 +112,9 @@ public static class CastleSiegeCrownMechanics
             }
         }
 
+        ApplyOwner(context, capturingGuild);
         await context.SaveFinalGuildListAsync().ConfigureAwait(false);
+        await context.SaveOwnerAsync().ConfigureAwait(false);
         await context.SetPlayerJoinSideAsync().ConfigureAwait(false);
         await RespawnAttackersAsync(context).ConfigureAwait(false);
 
@@ -120,6 +130,13 @@ public static class CastleSiegeCrownMechanics
         context.CrownUser = null;
         context.PreviousCrownUser = null;
         Array.Clear(context.SwitchUsers);
+        foreach (var siegeSwitch in context.ActiveNpcs
+                     .Select(runtime => runtime.SpawnedInstance)
+                     .OfType<CastleSiegeSwitch>())
+        {
+            siegeSwitch.Occupant = null;
+        }
+
         await BroadcastOwnershipAsync(context, capturingGuild.GuildName).ConfigureAwait(false);
     }
 
@@ -128,26 +145,28 @@ public static class CastleSiegeCrownMechanics
     /// </summary>
     /// <param name="context">The Castle Siege context.</param>
     /// <returns>A task that represents the asynchronous result operation.</returns>
-    public static async ValueTask CheckResultAsync(CastleSiegeContext context)
+    internal static async ValueTask CheckResultAsync(CastleSiegeContext context)
     {
         CastleSiegeGuildParticipant? winner = null;
         if (context.MiddleOwnerGuildId is { } middleOwnerGuildId)
         {
-            winner = context.FinalGuildList.TryGetValue(middleOwnerGuildId, out var participant)
-                ? participant
-                : throw new InvalidOperationException("The intermediate Castle Siege owner is not in the selected guild list.");
+            if (context.FinalGuildList.TryGetValue(middleOwnerGuildId, out var participant))
+            {
+                winner = participant;
+            }
+            else
+            {
+                context.GameContext.LoggerFactory
+                    .CreateLogger(typeof(CastleSiegeCrownMechanics))
+                    .LogWarning(
+                        "The intermediate Castle Siege owner {guildId} is not in the selected guild list. The persisted owner is retained.",
+                        middleOwnerGuildId);
+            }
         }
 
-        if (winner is not null
-            && (!context.SiegeData.IsOccupied
-                || context.SiegeData.OwnerGuildId != winner.PersistentGuildId))
+        if (winner is not null)
         {
-            context.SiegeData.OwnerGuildId = winner.PersistentGuildId;
-            context.SiegeData.IsOccupied = true;
-            context.SiegeData.TaxChaos = 0;
-            context.SiegeData.TaxStore = 0;
-            context.SiegeData.TaxHunt = 0;
-            context.SiegeData.TributeMoney = 0;
+            ApplyOwner(context, winner);
         }
 
         await context.SaveOwnerAsync().ConfigureAwait(false);
@@ -191,6 +210,7 @@ public static class CastleSiegeCrownMechanics
 
     private static void CapAccumulatedTime(CastleSiegeContext context)
     {
+        // Crown progress is shared across interrupted attempts and attacking sides by design.
         var maximumSeconds = Math.Max(context.Configuration.CrownHoldTimeSeconds, 1) - 1;
         var maximumTime = TimeSpan.FromSeconds(maximumSeconds);
         if (context.CrownAccumulatedTime > maximumTime)
@@ -262,6 +282,22 @@ public static class CastleSiegeCrownMechanics
                     .GetGuildAsync(runtimeGuildId)
                     .ConfigureAwait(false))
                 ?.Name;
+    }
+
+    private static void ApplyOwner(CastleSiegeContext context, CastleSiegeGuildParticipant winner)
+    {
+        if (context.SiegeData.IsOccupied
+            && context.SiegeData.OwnerGuildId == winner.PersistentGuildId)
+        {
+            return;
+        }
+
+        context.SiegeData.OwnerGuildId = winner.PersistentGuildId;
+        context.SiegeData.IsOccupied = true;
+        context.SiegeData.TaxChaos = 0;
+        context.SiegeData.TaxStore = 0;
+        context.SiegeData.TaxHunt = 0;
+        context.SiegeData.TributeMoney = 0;
     }
 
     private static async ValueTask BroadcastOwnershipAsync(CastleSiegeContext context, string guildName)

--- a/src/GameLogic/CastleSiege/CastleSiegeCrownMechanics.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeCrownMechanics.cs
@@ -1,0 +1,274 @@
+// <copyright file="CastleSiegeCrownMechanics.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege;
+
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.GameLogic.CastleSiege.NPC;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// Implements Castle Siege Crown capture and ownership changes.
+/// </summary>
+public static class CastleSiegeCrownMechanics
+{
+    private static readonly TimeSpan TickInterval = TimeSpan.FromSeconds(1);
+
+    /// <summary>
+    /// Checks whether the Crown and both switches are held by the same attacking side.
+    /// </summary>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <returns>A task that represents the asynchronous check operation.</returns>
+    public static async ValueTask CheckMiddleWinnerAsync(CastleSiegeContext context)
+    {
+        var crownUser = context.CrownUser;
+        var previousCrownUser = context.PreviousCrownUser;
+        if (previousCrownUser is not null
+            && !ReferenceEquals(previousCrownUser, crownUser))
+        {
+            await FailAttemptAsync(context, previousCrownUser).ConfigureAwait(false);
+            context.PreviousCrownUser = null;
+        }
+
+        var captureSide = GetCaptureSide(context, crownUser);
+        if (captureSide is null)
+        {
+            if (context.PreviousCrownUser is { } interruptedUser)
+            {
+                await FailAttemptAsync(context, interruptedUser).ConfigureAwait(false);
+                context.PreviousCrownUser = null;
+            }
+            else
+            {
+                CapAccumulatedTime(context);
+            }
+
+            return;
+        }
+
+        context.CrownAccumulatedTime += TickInterval;
+        context.PreviousCrownUser = crownUser;
+        await SendAccessStateAsync(
+                crownUser!,
+                CastleSiegeCrownAccessState.Attempt,
+                context.CrownAccumulatedTime)
+            .ConfigureAwait(false);
+
+        var requiredTime = TimeSpan.FromSeconds(context.Configuration.CrownHoldTimeSeconds);
+        if (context.CrownAccumulatedTime < requiredTime)
+        {
+            return;
+        }
+
+        await SendAccessStateAsync(
+                crownUser!,
+                CastleSiegeCrownAccessState.Success,
+                context.CrownAccumulatedTime)
+            .ConfigureAwait(false);
+        await ChangeWinnerGuildAsync(context, crownUser!, captureSide.Value).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Changes the intermediate owner after a successful Crown capture.
+    /// </summary>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <param name="crownUser">The player who captured the Crown.</param>
+    /// <param name="capturingSide">The attacking side which captured the Crown.</param>
+    /// <returns>A task that represents the asynchronous ownership change.</returns>
+    public static async ValueTask ChangeWinnerGuildAsync(
+        CastleSiegeContext context,
+        Player crownUser,
+        CastleSiegeJoinSide capturingSide)
+    {
+        if (crownUser.GuildStatus is not { } guildStatus
+            || !context.FinalGuildList.TryGetValue(guildStatus.GuildId, out var capturingGuild)
+            || !IsAttackingSide(capturingSide)
+            || capturingGuild.Side != capturingSide)
+        {
+            throw new InvalidOperationException("The Crown winner is not a selected attacking guild.");
+        }
+
+        context.MiddleOwnerGuildId = guildStatus.GuildId;
+        foreach (var guild in context.FinalGuildList.Values)
+        {
+            if (guild.Side == capturingSide)
+            {
+                guild.Side = CastleSiegeJoinSide.Defense;
+            }
+            else if (guild.Side == CastleSiegeJoinSide.Defense)
+            {
+                guild.Side = capturingSide;
+            }
+        }
+
+        await context.SaveFinalGuildListAsync().ConfigureAwait(false);
+        await context.SetPlayerJoinSideAsync().ConfigureAwait(false);
+        await RespawnAttackersAsync(context).ConfigureAwait(false);
+
+        context.IsCrownAvailable = false;
+        foreach (var crown in context.ActiveNpcs
+                     .Select(runtime => runtime.SpawnedInstance)
+                     .OfType<CastleSiegeCrown>())
+        {
+            crown.State = CastleSiegeCrownState.Locked;
+        }
+
+        context.CrownAccumulatedTime = TimeSpan.Zero;
+        context.CrownUser = null;
+        context.PreviousCrownUser = null;
+        Array.Clear(context.SwitchUsers);
+        await BroadcastOwnershipAsync(context, capturingGuild.GuildName).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Applies and persists the final Castle Siege result.
+    /// </summary>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <returns>A task that represents the asynchronous result operation.</returns>
+    public static async ValueTask CheckResultAsync(CastleSiegeContext context)
+    {
+        CastleSiegeGuildParticipant? winner = null;
+        if (context.MiddleOwnerGuildId is { } middleOwnerGuildId)
+        {
+            winner = context.FinalGuildList.TryGetValue(middleOwnerGuildId, out var participant)
+                ? participant
+                : throw new InvalidOperationException("The intermediate Castle Siege owner is not in the selected guild list.");
+        }
+
+        if (winner is not null
+            && (!context.SiegeData.IsOccupied
+                || context.SiegeData.OwnerGuildId != winner.PersistentGuildId))
+        {
+            context.SiegeData.OwnerGuildId = winner.PersistentGuildId;
+            context.SiegeData.IsOccupied = true;
+            context.SiegeData.TaxChaos = 0;
+            context.SiegeData.TaxStore = 0;
+            context.SiegeData.TaxHunt = 0;
+            context.SiegeData.TributeMoney = 0;
+        }
+
+        await context.SaveOwnerAsync().ConfigureAwait(false);
+        var ownerName = winner?.GuildName
+                        ?? await GetOwnerGuildNameAsync(context).ConfigureAwait(false)
+                        ?? string.Empty;
+        await BroadcastOwnershipAsync(context, ownerName).ConfigureAwait(false);
+    }
+
+    private static CastleSiegeJoinSide? GetCaptureSide(CastleSiegeContext context, Player? crownUser)
+    {
+        if (crownUser is not { IsAlive: true, GuildStatus: not null }
+            || context.SwitchUsers[0] is not { IsAlive: true, GuildStatus: not null } firstSwitchUser
+            || context.SwitchUsers[1] is not { IsAlive: true, GuildStatus: not null } secondSwitchUser)
+        {
+            return null;
+        }
+
+        var crownSide = context.GetPlayerJoinSide(crownUser);
+        return IsAttackingSide(crownSide)
+               && context.GetPlayerJoinSide(firstSwitchUser) == crownSide
+               && context.GetPlayerJoinSide(secondSwitchUser) == crownSide
+            ? crownSide
+            : null;
+    }
+
+    private static bool IsAttackingSide(CastleSiegeJoinSide side)
+    {
+        return side is not CastleSiegeJoinSide.None and not CastleSiegeJoinSide.Defense;
+    }
+
+    private static async ValueTask FailAttemptAsync(CastleSiegeContext context, Player player)
+    {
+        CapAccumulatedTime(context);
+        await SendAccessStateAsync(
+                player,
+                CastleSiegeCrownAccessState.Fail,
+                context.CrownAccumulatedTime)
+            .ConfigureAwait(false);
+    }
+
+    private static void CapAccumulatedTime(CastleSiegeContext context)
+    {
+        var maximumSeconds = Math.Max(context.Configuration.CrownHoldTimeSeconds, 1) - 1;
+        var maximumTime = TimeSpan.FromSeconds(maximumSeconds);
+        if (context.CrownAccumulatedTime > maximumTime)
+        {
+            context.CrownAccumulatedTime = maximumTime;
+        }
+    }
+
+    private static ValueTask SendAccessStateAsync(
+        Player player,
+        CastleSiegeCrownAccessState state,
+        TimeSpan accumulatedTime)
+    {
+        return player.InvokeViewPlugInAsync<ICastleSiegeCrownAccessStatePlugIn>(
+            plugIn => plugIn.ShowCrownAccessStateAsync(state, accumulatedTime));
+    }
+
+    private static async ValueTask RespawnAttackersAsync(CastleSiegeContext context)
+    {
+        if (context.Configuration.AttackRespawnArea is not { } respawnArea
+            || context.Configuration.CastleSiegeMapDefinition is not { } siegeMap)
+        {
+            return;
+        }
+
+        var respawnGate = new ExitGate
+        {
+            Map = siegeMap,
+            X1 = respawnArea.X1,
+            Y1 = respawnArea.Y1,
+            X2 = respawnArea.X2,
+            Y2 = respawnArea.Y2,
+            Direction = Direction.South,
+        };
+        foreach (var player in context.GetSiegePlayers())
+        {
+            if (IsAttackingSide(context.GetPlayerJoinSide(player)))
+            {
+                await player.RespawnAtAsync(respawnGate).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static async ValueTask<string?> GetOwnerGuildNameAsync(CastleSiegeContext context)
+    {
+        if (context.SiegeData.OwnerGuildId is not { } ownerGuildId)
+        {
+            return null;
+        }
+
+        var selectedOwner = context.FinalGuildList.Values
+            .FirstOrDefault(guild => guild.PersistentGuildId == ownerGuildId);
+        if (selectedOwner is not null)
+        {
+            return selectedOwner.GuildName;
+        }
+
+        if (context.GameContext is not IGameServerContext gameServerContext)
+        {
+            return null;
+        }
+
+        var runtimeGuildId = await gameServerContext.GuildServer
+            .GetGuildIdAsync(ownerGuildId)
+            .ConfigureAwait(false);
+        return runtimeGuildId == 0
+            ? null
+            : (await gameServerContext.GuildServer
+                    .GetGuildAsync(runtimeGuildId)
+                    .ConfigureAwait(false))
+                ?.Name;
+    }
+
+    private static async ValueTask BroadcastOwnershipAsync(CastleSiegeContext context, string guildName)
+    {
+        await context.ForEachSiegePlayerAsync(async player =>
+        {
+            await player.InvokeViewPlugInAsync<ICastleSiegeOwnershipChangePlugIn>(
+                    plugIn => plugIn.ShowOwnershipChangeAsync(guildName))
+                .ConfigureAwait(false);
+        }).ConfigureAwait(false);
+    }
+}

--- a/src/GameLogic/CastleSiege/CastleSiegePlugIn.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegePlugIn.cs
@@ -257,7 +257,11 @@ public class CastleSiegePlugIn : IPeriodicTaskPlugIn, IObjectAddedToMapPlugIn, I
         context.SetPeriod(period);
         this.ConfigureNotifications(context, period.StartUtc);
         await this.OnEnterStateAsync(context, false).ConfigureAwait(false);
-        await context.SaveOwnerAsync().ConfigureAwait(false);
+        if (period.State != CastleSiegeState.End)
+        {
+            await context.SaveOwnerAsync().ConfigureAwait(false);
+        }
+
         await this.BroadcastStateUpdateAsync(context).ConfigureAwait(false);
 
         logger.LogInformation(
@@ -325,6 +329,11 @@ public class CastleSiegePlugIn : IPeriodicTaskPlugIn, IObjectAddedToMapPlugIn, I
                     context.ParticipantTracking.Clear();
                 }
 
+                context.CrownUser = null;
+                context.PreviousCrownUser = null;
+                Array.Clear(context.SwitchUsers);
+                context.CrownAccumulatedTime = TimeSpan.Zero;
+                context.IsCrownAvailable = false;
                 await context.NpcController.PrepareAsync().ConfigureAwait(false);
                 await context.NpcController.CloseGatesAsync().ConfigureAwait(false);
                 await context.NpcController.SpawnMachinesAsync().ConfigureAwait(false);
@@ -334,6 +343,7 @@ public class CastleSiegePlugIn : IPeriodicTaskPlugIn, IObjectAddedToMapPlugIn, I
                 context.NextParticipantUpdateUtc = utcNow + ParticipantUpdateInterval;
                 break;
             case CastleSiegeState.End:
+                await CastleSiegeCrownMechanics.CheckResultAsync(context).ConfigureAwait(false);
                 if (!isStartup)
                 {
                     await CastleSiegeParticipantTracker.AwardRewardsAsync(context).ConfigureAwait(false);
@@ -353,6 +363,7 @@ public class CastleSiegePlugIn : IPeriodicTaskPlugIn, IObjectAddedToMapPlugIn, I
                 await context.NpcController.DespawnAllAsync().ConfigureAwait(false);
                 context.MiddleOwnerGuildId = null;
                 context.CrownUser = null;
+                context.PreviousCrownUser = null;
                 Array.Clear(context.SwitchUsers);
                 context.CrownAccumulatedTime = TimeSpan.Zero;
                 context.IsCrownAvailable = false;
@@ -394,13 +405,17 @@ public class CastleSiegePlugIn : IPeriodicTaskPlugIn, IObjectAddedToMapPlugIn, I
                 ParticipantUpdateInterval);
         }
 
+        if (context.CurrentState == CastleSiegeState.Start)
+        {
+            await CastleSiegeSwitchMechanics.SendSwitchInfoAsync(context).ConfigureAwait(false);
+            await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(context).ConfigureAwait(false);
+        }
+
         if (!context.IsEventRunning && context.NextNpcSaveUtc <= utcNow)
         {
             await context.SaveNpcStatesAsync().ConfigureAwait(false);
             context.NextNpcSaveUtc = utcNow + NpcSaveInterval;
         }
-
-        // Start-state Crown, switch and mini-map ticks are implemented by their dedicated phases.
     }
 
     private async ValueTask SendReadyCountdownIfDueAsync(CastleSiegeContext context, DateTime utcNow)

--- a/src/GameLogic/CastleSiege/CastleSiegePlugIn.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegePlugIn.cs
@@ -230,6 +230,10 @@ public class CastleSiegePlugIn : IPeriodicTaskPlugIn, IObjectAddedToMapPlugIn, I
                 context,
                 player,
                 this._timeProvider.GetUtcNow().UtcDateTime);
+            if (context.CurrentState == CastleSiegeState.Start)
+            {
+                await CastleSiegeSwitchMechanics.SynchronizePlayerAsync(context, player).ConfigureAwait(false);
+            }
         }
     }
 
@@ -334,11 +338,14 @@ public class CastleSiegePlugIn : IPeriodicTaskPlugIn, IObjectAddedToMapPlugIn, I
                 Array.Clear(context.SwitchUsers);
                 context.CrownAccumulatedTime = TimeSpan.Zero;
                 context.IsCrownAvailable = false;
+                Array.Clear(context.LastBroadcastSwitchInfos);
+                context.LastBroadcastCrownAvailability = null;
                 await context.NpcController.PrepareAsync().ConfigureAwait(false);
                 await context.NpcController.CloseGatesAsync().ConfigureAwait(false);
                 await context.NpcController.SpawnMachinesAsync().ConfigureAwait(false);
                 await context.SetPlayerJoinSideAsync().ConfigureAwait(false);
                 var utcNow = this._timeProvider.GetUtcNow().UtcDateTime;
+                context.LastCrownUpdateUtc = utcNow;
                 await CastleSiegeParticipantTracker.TrackAsync(context, utcNow).ConfigureAwait(false);
                 context.NextParticipantUpdateUtc = utcNow + ParticipantUpdateInterval;
                 break;
@@ -367,6 +374,9 @@ public class CastleSiegePlugIn : IPeriodicTaskPlugIn, IObjectAddedToMapPlugIn, I
                 Array.Clear(context.SwitchUsers);
                 context.CrownAccumulatedTime = TimeSpan.Zero;
                 context.IsCrownAvailable = false;
+                context.LastCrownUpdateUtc = DateTime.MinValue;
+                Array.Clear(context.LastBroadcastSwitchInfos);
+                context.LastBroadcastCrownAvailability = null;
                 context.NextParticipantUpdateUtc = DateTime.MaxValue;
                 break;
         }
@@ -408,7 +418,7 @@ public class CastleSiegePlugIn : IPeriodicTaskPlugIn, IObjectAddedToMapPlugIn, I
         if (context.CurrentState == CastleSiegeState.Start)
         {
             await CastleSiegeSwitchMechanics.SendSwitchInfoAsync(context).ConfigureAwait(false);
-            await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(context).ConfigureAwait(false);
+            await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(context, utcNow).ConfigureAwait(false);
         }
 
         if (!context.IsEventRunning && context.NextNpcSaveUtc <= utcNow)

--- a/src/GameLogic/CastleSiege/CastleSiegePlugIn.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegePlugIn.cs
@@ -338,7 +338,7 @@ public class CastleSiegePlugIn : IPeriodicTaskPlugIn, IObjectAddedToMapPlugIn, I
                 Array.Clear(context.SwitchUsers);
                 context.CrownAccumulatedTime = TimeSpan.Zero;
                 context.IsCrownAvailable = false;
-                Array.Clear(context.LastBroadcastSwitchInfos);
+                context.LastBroadcastSwitchInfos.Clear();
                 context.LastBroadcastCrownAvailability = null;
                 await context.NpcController.PrepareAsync().ConfigureAwait(false);
                 await context.NpcController.CloseGatesAsync().ConfigureAwait(false);
@@ -375,7 +375,7 @@ public class CastleSiegePlugIn : IPeriodicTaskPlugIn, IObjectAddedToMapPlugIn, I
                 context.CrownAccumulatedTime = TimeSpan.Zero;
                 context.IsCrownAvailable = false;
                 context.LastCrownUpdateUtc = DateTime.MinValue;
-                Array.Clear(context.LastBroadcastSwitchInfos);
+                context.LastBroadcastSwitchInfos.Clear();
                 context.LastBroadcastCrownAvailability = null;
                 context.NextParticipantUpdateUtc = DateTime.MaxValue;
                 break;

--- a/src/GameLogic/CastleSiege/CastleSiegeSwitchMechanics.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeSwitchMechanics.cs
@@ -20,7 +20,66 @@ public static class CastleSiegeSwitchMechanics
     /// <returns>A task that represents the asynchronous broadcast operation.</returns>
     public static async ValueTask SendSwitchInfoAsync(CastleSiegeContext context)
     {
-        var switchInfos = context.ActiveNpcs
+        var switchInfos = CreateSwitchInfos(context);
+        var crownAvailability = UpdateCrownState(context);
+        var changedSwitches = switchInfos
+            .Where((switchInfo, index) => !Equals(switchInfo, context.LastBroadcastSwitchInfos[index]))
+            .ToList();
+        var crownStateChanged = context.LastBroadcastCrownAvailability != crownAvailability;
+        if (changedSwitches.Count == 0 && !crownStateChanged)
+        {
+            return;
+        }
+
+        await context.ForEachSiegePlayerAsync(async player =>
+        {
+            foreach (var switchInfo in changedSwitches)
+            {
+                await player.InvokeViewPlugInAsync<ICastleSiegeSwitchInfoPlugIn>(
+                        plugIn => plugIn.ShowSwitchInfoAsync(switchInfo))
+                    .ConfigureAwait(false);
+            }
+
+            if (crownStateChanged)
+            {
+                await player.InvokeViewPlugInAsync<ICastleSiegeCrownStatePlugIn>(
+                        plugIn => plugIn.ShowCrownStateAsync(crownAvailability))
+                    .ConfigureAwait(false);
+            }
+        }).ConfigureAwait(false);
+
+        for (var index = 0; index < switchInfos.Count; index++)
+        {
+            context.LastBroadcastSwitchInfos[index] = switchInfos[index];
+        }
+
+        context.LastBroadcastCrownAvailability = crownAvailability;
+    }
+
+    /// <summary>
+    /// Sends the current switch and Crown state to one player who entered the siege map.
+    /// </summary>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <param name="player">The player to synchronize.</param>
+    /// <returns>A task that represents the asynchronous synchronization operation.</returns>
+    public static async ValueTask SynchronizePlayerAsync(CastleSiegeContext context, Player player)
+    {
+        foreach (var switchInfo in CreateSwitchInfos(context))
+        {
+            await player.InvokeViewPlugInAsync<ICastleSiegeSwitchInfoPlugIn>(
+                    plugIn => plugIn.ShowSwitchInfoAsync(switchInfo))
+                .ConfigureAwait(false);
+        }
+
+        var crownAvailability = UpdateCrownState(context);
+        await player.InvokeViewPlugInAsync<ICastleSiegeCrownStatePlugIn>(
+                plugIn => plugIn.ShowCrownStateAsync(crownAvailability))
+            .ConfigureAwait(false);
+    }
+
+    private static List<CastleSiegeSwitchInfo> CreateSwitchInfos(CastleSiegeContext context)
+    {
+        return context.ActiveNpcs
             .Select(runtime => runtime.SpawnedInstance)
             .OfType<CastleSiegeSwitch>()
             .OrderBy(candidate => candidate.SwitchIndex)
@@ -29,30 +88,6 @@ public static class CastleSiegeSwitchMechanics
                 siegeSwitch,
                 context.SwitchUsers[siegeSwitch.SwitchIndex]))
             .ToList();
-
-        context.IsCrownAvailable = AreSwitchesHeldBySameAttackingSide(context);
-        foreach (var crown in context.ActiveNpcs
-                     .Select(runtime => runtime.SpawnedInstance)
-                     .OfType<CastleSiegeCrown>())
-        {
-            crown.State = context.IsCrownAvailable
-                ? CastleSiegeCrownState.Idle
-                : CastleSiegeCrownState.Locked;
-        }
-
-        await context.ForEachSiegePlayerAsync(async player =>
-        {
-            foreach (var switchInfo in switchInfos)
-            {
-                await player.InvokeViewPlugInAsync<ICastleSiegeSwitchInfoPlugIn>(
-                        plugIn => plugIn.ShowSwitchInfoAsync(switchInfo))
-                    .ConfigureAwait(false);
-            }
-
-            await player.InvokeViewPlugInAsync<ICastleSiegeCrownStatePlugIn>(
-                    plugIn => plugIn.ShowCrownStateAsync(context.IsCrownAvailable))
-                .ConfigureAwait(false);
-        }).ConfigureAwait(false);
     }
 
     private static CastleSiegeSwitchInfo CreateSwitchInfo(
@@ -67,12 +102,29 @@ public static class CastleSiegeSwitchMechanics
                         && context.FinalGuildList.TryGetValue(guildStatus.GuildId, out var participant)
             ? participant.GuildName
             : string.Empty;
+
+        // MuMain resolves the legacy switch-index field through its visible-object table, so the object id is required.
         return new(
             siegeSwitch.Id,
             occupant is not null,
             side,
             guildName,
             occupant?.Name ?? string.Empty);
+    }
+
+    private static bool UpdateCrownState(CastleSiegeContext context)
+    {
+        context.IsCrownAvailable = AreSwitchesHeldBySameAttackingSide(context);
+        foreach (var crown in context.ActiveNpcs
+                     .Select(runtime => runtime.SpawnedInstance)
+                     .OfType<CastleSiegeCrown>())
+        {
+            crown.State = context.IsCrownAvailable
+                ? CastleSiegeCrownState.Idle
+                : CastleSiegeCrownState.Locked;
+        }
+
+        return context.IsCrownAvailable;
     }
 
     private static bool AreSwitchesHeldBySameAttackingSide(CastleSiegeContext context)

--- a/src/GameLogic/CastleSiege/CastleSiegeSwitchMechanics.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeSwitchMechanics.cs
@@ -1,0 +1,90 @@
+// <copyright file="CastleSiegeSwitchMechanics.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege;
+
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.GameLogic.CastleSiege.NPC;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// Broadcasts Castle Siege Crown switch occupants and Crown availability.
+/// </summary>
+public static class CastleSiegeSwitchMechanics
+{
+    /// <summary>
+    /// Sends the current switch and Crown state to all players on the Castle Siege map.
+    /// </summary>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <returns>A task that represents the asynchronous broadcast operation.</returns>
+    public static async ValueTask SendSwitchInfoAsync(CastleSiegeContext context)
+    {
+        var switchInfos = context.ActiveNpcs
+            .Select(runtime => runtime.SpawnedInstance)
+            .OfType<CastleSiegeSwitch>()
+            .OrderBy(candidate => candidate.SwitchIndex)
+            .Select(siegeSwitch => CreateSwitchInfo(
+                context,
+                siegeSwitch,
+                context.SwitchUsers[siegeSwitch.SwitchIndex]))
+            .ToList();
+
+        context.IsCrownAvailable = AreSwitchesHeldBySameAttackingSide(context);
+        foreach (var crown in context.ActiveNpcs
+                     .Select(runtime => runtime.SpawnedInstance)
+                     .OfType<CastleSiegeCrown>())
+        {
+            crown.State = context.IsCrownAvailable
+                ? CastleSiegeCrownState.Idle
+                : CastleSiegeCrownState.Locked;
+        }
+
+        await context.ForEachSiegePlayerAsync(async player =>
+        {
+            foreach (var switchInfo in switchInfos)
+            {
+                await player.InvokeViewPlugInAsync<ICastleSiegeSwitchInfoPlugIn>(
+                        plugIn => plugIn.ShowSwitchInfoAsync(switchInfo))
+                    .ConfigureAwait(false);
+            }
+
+            await player.InvokeViewPlugInAsync<ICastleSiegeCrownStatePlugIn>(
+                    plugIn => plugIn.ShowCrownStateAsync(context.IsCrownAvailable))
+                .ConfigureAwait(false);
+        }).ConfigureAwait(false);
+    }
+
+    private static CastleSiegeSwitchInfo CreateSwitchInfo(
+        CastleSiegeContext context,
+        CastleSiegeSwitch siegeSwitch,
+        Player? occupant)
+    {
+        var side = occupant is null
+            ? CastleSiegeJoinSide.None
+            : context.GetPlayerJoinSide(occupant);
+        var guildName = occupant?.GuildStatus is { } guildStatus
+                        && context.FinalGuildList.TryGetValue(guildStatus.GuildId, out var participant)
+            ? participant.GuildName
+            : string.Empty;
+        return new(
+            siegeSwitch.Id,
+            occupant is not null,
+            side,
+            guildName,
+            occupant?.Name ?? string.Empty);
+    }
+
+    private static bool AreSwitchesHeldBySameAttackingSide(CastleSiegeContext context)
+    {
+        if (context.SwitchUsers[0] is not { IsAlive: true, GuildStatus: not null } firstSwitchUser
+            || context.SwitchUsers[1] is not { IsAlive: true, GuildStatus: not null } secondSwitchUser)
+        {
+            return false;
+        }
+
+        var firstSide = context.GetPlayerJoinSide(firstSwitchUser);
+        return firstSide is not CastleSiegeJoinSide.None and not CastleSiegeJoinSide.Defense
+               && context.GetPlayerJoinSide(secondSwitchUser) == firstSide;
+    }
+}

--- a/src/GameLogic/CastleSiege/CastleSiegeSwitchMechanics.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeSwitchMechanics.cs
@@ -23,7 +23,8 @@ public static class CastleSiegeSwitchMechanics
         var switchInfos = CreateSwitchInfos(context);
         var crownAvailability = UpdateCrownState(context);
         var changedSwitches = switchInfos
-            .Where((switchInfo, index) => !Equals(switchInfo, context.LastBroadcastSwitchInfos[index]))
+            .Where(switchInfo => !context.LastBroadcastSwitchInfos.TryGetValue(switchInfo.ObjectId, out var previous)
+                                 || !Equals(switchInfo, previous))
             .ToList();
         var crownStateChanged = context.LastBroadcastCrownAvailability != crownAvailability;
         if (changedSwitches.Count == 0 && !crownStateChanged)
@@ -48,9 +49,10 @@ public static class CastleSiegeSwitchMechanics
             }
         }).ConfigureAwait(false);
 
-        for (var index = 0; index < switchInfos.Count; index++)
+        context.LastBroadcastSwitchInfos.Clear();
+        foreach (var switchInfo in switchInfos)
         {
-            context.LastBroadcastSwitchInfos[index] = switchInfos[index];
+            context.LastBroadcastSwitchInfos[switchInfo.ObjectId] = switchInfo;
         }
 
         context.LastBroadcastCrownAvailability = crownAvailability;

--- a/src/GameLogic/CastleSiege/CastleSiegeSwitchMechanics.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeSwitchMechanics.cs
@@ -73,7 +73,7 @@ public static class CastleSiegeSwitchMechanics
                 .ConfigureAwait(false);
         }
 
-        var crownAvailability = UpdateCrownState(context);
+        var crownAvailability = AreSwitchesHeldBySameAttackingSide(context);
         await player.InvokeViewPlugInAsync<ICastleSiegeCrownStatePlugIn>(
                 plugIn => plugIn.ShowCrownStateAsync(crownAvailability))
             .ConfigureAwait(false);
@@ -81,7 +81,7 @@ public static class CastleSiegeSwitchMechanics
 
     private static List<CastleSiegeSwitchInfo> CreateSwitchInfos(CastleSiegeContext context)
     {
-        return context.ActiveNpcs
+        return context.NpcController.GetRuntimeSnapshot()
             .Select(runtime => runtime.SpawnedInstance)
             .OfType<CastleSiegeSwitch>()
             .OrderBy(candidate => candidate.SwitchIndex)
@@ -117,7 +117,7 @@ public static class CastleSiegeSwitchMechanics
     private static bool UpdateCrownState(CastleSiegeContext context)
     {
         context.IsCrownAvailable = AreSwitchesHeldBySameAttackingSide(context);
-        foreach (var crown in context.ActiveNpcs
+        foreach (var crown in context.NpcController.GetRuntimeSnapshot()
                      .Select(runtime => runtime.SpawnedInstance)
                      .OfType<CastleSiegeCrown>())
         {

--- a/src/GameLogic/CastleSiege/Intelligence/CastleSiegeCrownIntelligence.cs
+++ b/src/GameLogic/CastleSiege/Intelligence/CastleSiegeCrownIntelligence.cs
@@ -68,9 +68,6 @@ public sealed class CastleSiegeCrownIntelligence : CastleSiegeNpcIntelligenceBas
                              && player.CurrentMap == crown.CurrentMap)
             .MinBy(player => player.Id);
         this._context.CrownUser = candidate;
-        crown.State = this._context.IsCrownAvailable
-            ? CastleSiegeCrownState.Idle
-            : CastleSiegeCrownState.Locked;
         return ValueTask.CompletedTask;
     }
 

--- a/src/GameLogic/Views/CastleSiege/CastleSiegeCrownAccessState.cs
+++ b/src/GameLogic/Views/CastleSiege/CastleSiegeCrownAccessState.cs
@@ -1,0 +1,26 @@
+// <copyright file="CastleSiegeCrownAccessState.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// Defines the state of a Castle Siege Crown capture attempt.
+/// </summary>
+public enum CastleSiegeCrownAccessState : byte
+{
+    /// <summary>
+    /// The player is actively operating the Crown.
+    /// </summary>
+    Attempt = 0,
+
+    /// <summary>
+    /// The player captured the Crown successfully.
+    /// </summary>
+    Success = 1,
+
+    /// <summary>
+    /// The player's Crown operation was interrupted.
+    /// </summary>
+    Fail = 2,
+}

--- a/src/GameLogic/Views/CastleSiege/CastleSiegeSwitchInfo.cs
+++ b/src/GameLogic/Views/CastleSiege/CastleSiegeSwitchInfo.cs
@@ -1,0 +1,22 @@
+// <copyright file="CastleSiegeSwitchInfo.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+using MUnique.OpenMU.DataModel.Configuration;
+
+/// <summary>
+/// Describes the current occupant of a Castle Siege Crown switch.
+/// </summary>
+/// <param name="ObjectId">The switch object's network identifier.</param>
+/// <param name="IsOccupied">Whether a player currently occupies the switch.</param>
+/// <param name="JoinSide">The occupant's Castle Siege side.</param>
+/// <param name="GuildName">The occupant's guild name.</param>
+/// <param name="CharacterName">The occupant's character name.</param>
+public sealed record CastleSiegeSwitchInfo(
+    ushort ObjectId,
+    bool IsOccupied,
+    CastleSiegeJoinSide JoinSide,
+    string GuildName,
+    string CharacterName);

--- a/src/GameLogic/Views/CastleSiege/ICastleSiegeCrownAccessStatePlugIn.cs
+++ b/src/GameLogic/Views/CastleSiege/ICastleSiegeCrownAccessStatePlugIn.cs
@@ -1,0 +1,21 @@
+// <copyright file="ICastleSiegeCrownAccessStatePlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// A view which updates a player's Castle Siege Crown capture attempt.
+/// </summary>
+public interface ICastleSiegeCrownAccessStatePlugIn : IViewPlugIn
+{
+    /// <summary>
+    /// Shows the Crown access state and accumulated capture time.
+    /// </summary>
+    /// <param name="state">The access state.</param>
+    /// <param name="accumulatedTime">The accumulated capture time.</param>
+    /// <returns>A task that represents the asynchronous show operation.</returns>
+    ValueTask ShowCrownAccessStateAsync(
+        CastleSiegeCrownAccessState state,
+        TimeSpan accumulatedTime);
+}

--- a/src/GameLogic/Views/CastleSiege/ICastleSiegeCrownStatePlugIn.cs
+++ b/src/GameLogic/Views/CastleSiege/ICastleSiegeCrownStatePlugIn.cs
@@ -1,0 +1,18 @@
+// <copyright file="ICastleSiegeCrownStatePlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// A view which updates the Castle Siege Crown lock state.
+/// </summary>
+public interface ICastleSiegeCrownStatePlugIn : IViewPlugIn
+{
+    /// <summary>
+    /// Shows whether the Crown is available for capture.
+    /// </summary>
+    /// <param name="isAvailable">Whether the Crown is unlocked.</param>
+    /// <returns>A task that represents the asynchronous show operation.</returns>
+    ValueTask ShowCrownStateAsync(bool isAvailable);
+}

--- a/src/GameLogic/Views/CastleSiege/ICastleSiegeOwnershipChangePlugIn.cs
+++ b/src/GameLogic/Views/CastleSiege/ICastleSiegeOwnershipChangePlugIn.cs
@@ -1,0 +1,18 @@
+// <copyright file="ICastleSiegeOwnershipChangePlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// A view which announces the current Castle Siege owner.
+/// </summary>
+public interface ICastleSiegeOwnershipChangePlugIn : IViewPlugIn
+{
+    /// <summary>
+    /// Shows the guild which owns the castle.
+    /// </summary>
+    /// <param name="guildName">The owner guild name, or an empty string when the castle has no owner.</param>
+    /// <returns>A task that represents the asynchronous show operation.</returns>
+    ValueTask ShowOwnershipChangeAsync(string guildName);
+}

--- a/src/GameLogic/Views/CastleSiege/ICastleSiegeSwitchInfoPlugIn.cs
+++ b/src/GameLogic/Views/CastleSiege/ICastleSiegeSwitchInfoPlugIn.cs
@@ -1,0 +1,18 @@
+// <copyright file="ICastleSiegeSwitchInfoPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// A view which updates a Castle Siege Crown switch occupant.
+/// </summary>
+public interface ICastleSiegeSwitchInfoPlugIn : IViewPlugIn
+{
+    /// <summary>
+    /// Shows the current state of a Crown switch.
+    /// </summary>
+    /// <param name="switchInfo">The switch state.</param>
+    /// <returns>A task that represents the asynchronous show operation.</returns>
+    ValueTask ShowSwitchInfoAsync(CastleSiegeSwitchInfo switchInfo);
+}

--- a/src/GameServer/Properties/PlugInResources.Designer.cs
+++ b/src/GameServer/Properties/PlugInResources.Designer.cs
@@ -6665,5 +6665,77 @@ namespace MUnique.OpenMU.GameServer.Properties {
                 return ResourceManager.GetString("WhisperedChatMessageHandlerPlugIn_Name", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Sends Castle Siege Crown capture progress to the game client..
+        /// </summary>
+        public static string CastleSiegeCrownAccessStatePlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeCrownAccessStatePlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege Crown Access State View.
+        /// </summary>
+        public static string CastleSiegeCrownAccessStatePlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeCrownAccessStatePlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Sends the current Castle Siege Crown lock state to the game client..
+        /// </summary>
+        public static string CastleSiegeCrownStatePlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeCrownStatePlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege Crown State View.
+        /// </summary>
+        public static string CastleSiegeCrownStatePlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeCrownStatePlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Sends Castle Siege ownership changes to the game client..
+        /// </summary>
+        public static string CastleSiegeOwnershipChangePlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeOwnershipChangePlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege Ownership Change View.
+        /// </summary>
+        public static string CastleSiegeOwnershipChangePlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeOwnershipChangePlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Sends Castle Siege Crown switch occupancy information to the game client..
+        /// </summary>
+        public static string CastleSiegeSwitchInfoPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeSwitchInfoPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege Switch Information View.
+        /// </summary>
+        public static string CastleSiegeSwitchInfoPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeSwitchInfoPlugIn_Name", resourceCulture);
+            }
+        }
     }
 }

--- a/src/GameServer/Properties/PlugInResources.resx
+++ b/src/GameServer/Properties/PlugInResources.resx
@@ -2319,4 +2319,28 @@
   <data name="ChatCommandListRequestHandlerPlugIn_Description" xml:space="preserve">
     <value>Handles the request for the list of chat commands which are available to the player.</value>
   </data>
+  <data name="CastleSiegeCrownStatePlugIn_Name" xml:space="preserve">
+    <value>Castle Siege Crown State View</value>
+  </data>
+  <data name="CastleSiegeCrownStatePlugIn_Description" xml:space="preserve">
+    <value>Sends the current Castle Siege Crown lock state to the game client.</value>
+  </data>
+  <data name="CastleSiegeCrownAccessStatePlugIn_Name" xml:space="preserve">
+    <value>Castle Siege Crown Access State View</value>
+  </data>
+  <data name="CastleSiegeCrownAccessStatePlugIn_Description" xml:space="preserve">
+    <value>Sends Castle Siege Crown capture progress to the game client.</value>
+  </data>
+  <data name="CastleSiegeSwitchInfoPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege Switch Information View</value>
+  </data>
+  <data name="CastleSiegeSwitchInfoPlugIn_Description" xml:space="preserve">
+    <value>Sends Castle Siege Crown switch occupancy information to the game client.</value>
+  </data>
+  <data name="CastleSiegeOwnershipChangePlugIn_Name" xml:space="preserve">
+    <value>Castle Siege Ownership Change View</value>
+  </data>
+  <data name="CastleSiegeOwnershipChangePlugIn_Description" xml:space="preserve">
+    <value>Sends Castle Siege ownership changes to the game client.</value>
+  </data>
 </root>

--- a/src/GameServer/RemoteView/CastleSiege/CastleSiegeCrownAccessStatePlugIn.cs
+++ b/src/GameServer/RemoteView/CastleSiege/CastleSiegeCrownAccessStatePlugIn.cs
@@ -1,0 +1,37 @@
+// <copyright file="CastleSiegeCrownAccessStatePlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.RemoteView.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+using MUnique.OpenMU.Network.Packets.ServerToClient;
+using MUnique.OpenMU.PlugIns;
+using CrownAccessState = MUnique.OpenMU.GameLogic.Views.CastleSiege.CastleSiegeCrownAccessState;
+
+/// <summary>
+/// The default implementation of the <see cref="ICastleSiegeCrownAccessStatePlugIn"/>
+/// which forwards Crown capture progress to the game client.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeCrownAccessStatePlugIn_Name), Description = nameof(PlugInResources.CastleSiegeCrownAccessStatePlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("9F13B1D3-70F6-47A1-AE2A-A3F1BCC35A6A")]
+public class CastleSiegeCrownAccessStatePlugIn : ICastleSiegeCrownAccessStatePlugIn
+{
+    private readonly RemotePlayer _player;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeCrownAccessStatePlugIn"/> class.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    public CastleSiegeCrownAccessStatePlugIn(RemotePlayer player) => this._player = player;
+
+    /// <inheritdoc />
+    public ValueTask ShowCrownAccessStateAsync(
+        CrownAccessState state,
+        TimeSpan accumulatedTime)
+        => this._player.Connection?.SendCastleSiegeCrownAccessStateAsync(
+            (CastleSiegeCrownAccessStateType)state,
+            checked((uint)accumulatedTime.TotalMilliseconds)) ?? default;
+}

--- a/src/GameServer/RemoteView/CastleSiege/CastleSiegeCrownStatePlugIn.cs
+++ b/src/GameServer/RemoteView/CastleSiege/CastleSiegeCrownStatePlugIn.cs
@@ -1,0 +1,33 @@
+// <copyright file="CastleSiegeCrownStatePlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.RemoteView.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+using MUnique.OpenMU.Network.Packets.ServerToClient;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// The default implementation of the <see cref="ICastleSiegeCrownStatePlugIn"/>
+/// which forwards the Crown lock state to the game client.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeCrownStatePlugIn_Name), Description = nameof(PlugInResources.CastleSiegeCrownStatePlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("50531428-FE54-458D-85D0-143DF1106D38")]
+public class CastleSiegeCrownStatePlugIn : ICastleSiegeCrownStatePlugIn
+{
+    private readonly RemotePlayer _player;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeCrownStatePlugIn"/> class.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    public CastleSiegeCrownStatePlugIn(RemotePlayer player) => this._player = player;
+
+    /// <inheritdoc />
+    public ValueTask ShowCrownStateAsync(bool isAvailable)
+        => this._player.Connection?.SendCastleSiegeCrownStateUpdateAsync(
+            isAvailable ? CastleSiegeCrownState.Accessible : CastleSiegeCrownState.Protected) ?? default;
+}

--- a/src/GameServer/RemoteView/CastleSiege/CastleSiegeOwnershipChangePlugIn.cs
+++ b/src/GameServer/RemoteView/CastleSiege/CastleSiegeOwnershipChangePlugIn.cs
@@ -1,0 +1,34 @@
+// <copyright file="CastleSiegeOwnershipChangePlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.RemoteView.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+using MUnique.OpenMU.Network.Packets.ServerToClient;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// The default implementation of the <see cref="ICastleSiegeOwnershipChangePlugIn"/>
+/// which announces the new castle owner to the game client.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeOwnershipChangePlugIn_Name), Description = nameof(PlugInResources.CastleSiegeOwnershipChangePlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("11A4F0AF-7EA7-4534-8470-50EEF31BF464")]
+public class CastleSiegeOwnershipChangePlugIn : ICastleSiegeOwnershipChangePlugIn
+{
+    private readonly RemotePlayer _player;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeOwnershipChangePlugIn"/> class.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    public CastleSiegeOwnershipChangePlugIn(RemotePlayer player) => this._player = player;
+
+    /// <inheritdoc />
+    public ValueTask ShowOwnershipChangeAsync(string guildName)
+        => this._player.Connection?.SendCastleSiegeBattleProcessAsync(
+            CastleSiegeBattleProcessState.CrownRegistrationSucceeded,
+            guildName) ?? default;
+}

--- a/src/GameServer/RemoteView/CastleSiege/CastleSiegeSwitchInfoPlugIn.cs
+++ b/src/GameServer/RemoteView/CastleSiege/CastleSiegeSwitchInfoPlugIn.cs
@@ -1,0 +1,38 @@
+// <copyright file="CastleSiegeSwitchInfoPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.RemoteView.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+using MUnique.OpenMU.Network.Packets.ServerToClient;
+using MUnique.OpenMU.PlugIns;
+using SwitchInfo = MUnique.OpenMU.GameLogic.Views.CastleSiege.CastleSiegeSwitchInfo;
+
+/// <summary>
+/// The default implementation of the <see cref="ICastleSiegeSwitchInfoPlugIn"/>
+/// which forwards Crown-switch occupancy to the game client.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeSwitchInfoPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeSwitchInfoPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("28A5C92F-D3CF-42D6-B0D6-77C1CDB0913F")]
+public class CastleSiegeSwitchInfoPlugIn : ICastleSiegeSwitchInfoPlugIn
+{
+    private readonly RemotePlayer _player;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeSwitchInfoPlugIn"/> class.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    public CastleSiegeSwitchInfoPlugIn(RemotePlayer player) => this._player = player;
+
+    /// <inheritdoc />
+    public ValueTask ShowSwitchInfoAsync(SwitchInfo switchInfo)
+        => this._player.Connection?.SendCastleSiegeSwitchInfoAsync(
+            switchInfo.ObjectId,
+            switchInfo.IsOccupied,
+            (CastleSiegeJoinSide)switchInfo.JoinSide,
+            switchInfo.GuildName,
+            switchInfo.CharacterName) ?? default;
+}

--- a/src/Network/Packets/ServerToClient/ConnectionExtensions.cs
+++ b/src/Network/Packets/ServerToClient/ConnectionExtensions.cs
@@ -6814,7 +6814,7 @@ public static class ConnectionExtensions
     /// Sends a <see cref="CastleSiegeCrownSwitchState" /> to this connection.
     /// </summary>
     /// <param name="connection">The connection.</param>
-    /// <param name="switchIndex">The switch index.</param>
+    /// <param name="switchIndex">The network object identifier of the Crown switch.</param>
     /// <param name="playerIndex">The player index.</param>
     /// <param name="state">The state.</param>
     /// <remarks>
@@ -7142,7 +7142,7 @@ public static class ConnectionExtensions
     /// Sends a <see cref="CastleSiegeSwitchInfo" /> to this connection.
     /// </summary>
     /// <param name="connection">The connection.</param>
-    /// <param name="switchIndex">The switch index.</param>
+    /// <param name="switchIndex">The network object identifier of the Crown switch.</param>
     /// <param name="isOccupied">The is occupied.</param>
     /// <param name="joinSide">The join side.</param>
     /// <param name="guildName">The guild name.</param>

--- a/src/Network/Packets/ServerToClient/ServerToClientPackets.cs
+++ b/src/Network/Packets/ServerToClient/ServerToClientPackets.cs
@@ -32683,7 +32683,7 @@ public readonly struct CastleSiegeCrownSwitchState
     public C1HeaderWithSubCode Header => new (this._data);
 
     /// <summary>
-    /// Gets or sets the switch index.
+    /// Gets or sets the network object identifier of the Crown switch.
     /// </summary>
     public ushort SwitchIndex
     {
@@ -33719,7 +33719,7 @@ public readonly struct CastleSiegeSwitchInfo
     public C1HeaderWithSubCode Header => new (this._data);
 
     /// <summary>
-    /// Gets or sets the switch index.
+    /// Gets or sets the network object identifier of the Crown switch.
     /// </summary>
     public ushort SwitchIndex
     {

--- a/src/Network/Packets/ServerToClient/ServerToClientPackets.xml
+++ b/src/Network/Packets/ServerToClient/ServerToClientPackets.xml
@@ -11700,6 +11700,7 @@
           <Index>4</Index>
           <Type>ShortBigEndian</Type>
           <Name>SwitchIndex</Name>
+          <Description>The network object identifier of the Crown switch.</Description>
         </Field>
         <Field>
           <Index>6</Index>
@@ -11947,6 +11948,7 @@
           <Index>4</Index>
           <Type>ShortBigEndian</Type>
           <Name>SwitchIndex</Name>
+          <Description>The network object identifier of the Crown switch.</Description>
         </Field>
         <Field>
           <Index>6</Index>

--- a/src/Network/Packets/ServerToClient/ServerToClientPacketsRef.cs
+++ b/src/Network/Packets/ServerToClient/ServerToClientPacketsRef.cs
@@ -31046,7 +31046,7 @@ public readonly ref struct CastleSiegeCrownSwitchStateRef
     public C1HeaderWithSubCodeRef Header => new (this._data);
 
     /// <summary>
-    /// Gets or sets the switch index.
+    /// Gets or sets the network object identifier of the Crown switch.
     /// </summary>
     public ushort SwitchIndex
     {
@@ -32082,7 +32082,7 @@ public readonly ref struct CastleSiegeSwitchInfoRef
     public C1HeaderWithSubCodeRef Header => new (this._data);
 
     /// <summary>
-    /// Gets or sets the switch index.
+    /// Gets or sets the network object identifier of the Crown switch.
     /// </summary>
     public ushort SwitchIndex
     {

--- a/tests/MUnique.OpenMU.Tests/CastleSiegeCrownMechanicsTests.cs
+++ b/tests/MUnique.OpenMU.Tests/CastleSiegeCrownMechanicsTests.cs
@@ -1,0 +1,613 @@
+// <copyright file="CastleSiegeCrownMechanicsTests.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Tests;
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.DataModel.Entities;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.Attributes;
+using MUnique.OpenMU.GameLogic.CastleSiege;
+using MUnique.OpenMU.GameLogic.CastleSiege.NPC;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+using MUnique.OpenMU.GameServer;
+using MUnique.OpenMU.Interfaces;
+using MUnique.OpenMU.Persistence.InMemory;
+using MUnique.OpenMU.PlugIns;
+using BasicModel = MUnique.OpenMU.Persistence.BasicModel;
+using RuntimeGuild = MUnique.OpenMU.Interfaces.Guild;
+
+/// <summary>
+/// Tests Castle Siege Crown capture, switch state, and final ownership mechanics.
+/// </summary>
+[TestFixture]
+public class CastleSiegeCrownMechanicsTests
+{
+    private const uint DefenseGuildId = 10;
+    private const uint AttackGuildId = 20;
+
+    /// <summary>
+    /// Verifies that an interrupted attempt keeps capped progress and reports the failure once.
+    /// </summary>
+    [Test]
+    public async ValueTask InterruptedCaptureKeepsCappedProgressAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var crownUser = await fixture.CreatePlayerAsync(
+                AttackGuildId,
+                "CrownUser",
+                CastleSiegeJoinSide.Attack1,
+                60,
+                60)
+            .ConfigureAwait(false);
+        var firstSwitchUser = await fixture.CreatePlayerAsync(
+                AttackGuildId,
+                "SwitchOne",
+                CastleSiegeJoinSide.Attack1,
+                70,
+                60)
+            .ConfigureAwait(false);
+        var secondSwitchUser = await fixture.CreatePlayerAsync(
+                AttackGuildId,
+                "SwitchTwo",
+                CastleSiegeJoinSide.Attack1,
+                80,
+                60)
+            .ConfigureAwait(false);
+        fixture.Context.CrownUser = crownUser;
+        fixture.Context.SwitchUsers[0] = firstSwitchUser;
+        fixture.Context.SwitchUsers[1] = secondSwitchUser;
+
+        await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(fixture.Context).ConfigureAwait(false);
+        fixture.Context.CrownAccumulatedTime = TimeSpan.FromSeconds(10);
+        fixture.Context.SwitchUsers[1] = null;
+        await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(fixture.Context).ConfigureAwait(false);
+        await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(fixture.Context).ConfigureAwait(false);
+
+        Assert.That(fixture.Context.CrownAccumulatedTime, Is.EqualTo(TimeSpan.FromSeconds(2)));
+        Mock.Get(crownUser.ViewPlugIns.GetPlugIn<ICastleSiegeCrownAccessStatePlugIn>()!)
+            .Verify(
+                plugIn => plugIn.ShowCrownAccessStateAsync(
+                    CastleSiegeCrownAccessState.Fail,
+                    TimeSpan.FromSeconds(2)),
+                Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that only three alive and guilded players on the same attacking side can make progress.
+    /// </summary>
+    [Test]
+    public async ValueTask CaptureRequiresThreeEligiblePlayersOnSameAttackingSideAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var crownUser = await fixture.CreatePlayerAsync(
+                AttackGuildId,
+                "CrownUser",
+                CastleSiegeJoinSide.Attack1,
+                60,
+                60)
+            .ConfigureAwait(false);
+        var firstSwitchUser = await fixture.CreatePlayerAsync(
+                AttackGuildId,
+                "SwitchOne",
+                CastleSiegeJoinSide.Attack1,
+                70,
+                60)
+            .ConfigureAwait(false);
+        var secondSwitchUser = await fixture.CreatePlayerAsync(
+                AttackGuildId,
+                "SwitchTwo",
+                CastleSiegeJoinSide.Attack2,
+                80,
+                60)
+            .ConfigureAwait(false);
+        fixture.Context.CrownUser = crownUser;
+        fixture.Context.SwitchUsers[0] = firstSwitchUser;
+        fixture.Context.SwitchUsers[1] = secondSwitchUser;
+        await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(fixture.Context).ConfigureAwait(false);
+        Assert.That(fixture.Context.CrownAccumulatedTime, Is.EqualTo(TimeSpan.Zero), "Different attacking sides must not capture.");
+
+        fixture.Context.PlayerJoinSides[secondSwitchUser.SelectedCharacter!.Id] = CastleSiegeJoinSide.Attack1;
+        secondSwitchUser.IsAlive = false;
+        await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(fixture.Context).ConfigureAwait(false);
+        Assert.That(fixture.Context.CrownAccumulatedTime, Is.EqualTo(TimeSpan.Zero), "Dead switch users must not capture.");
+
+        secondSwitchUser.IsAlive = true;
+        secondSwitchUser.GuildStatus = null;
+        await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(fixture.Context).ConfigureAwait(false);
+        Assert.That(fixture.Context.CrownAccumulatedTime, Is.EqualTo(TimeSpan.Zero), "Guildless switch users must not capture.");
+
+        secondSwitchUser.GuildStatus = new GuildMemberStatus(AttackGuildId, GuildPosition.NormalMember);
+        fixture.Context.PlayerJoinSides[crownUser.SelectedCharacter!.Id] = CastleSiegeJoinSide.Defense;
+        fixture.Context.PlayerJoinSides[firstSwitchUser.SelectedCharacter!.Id] = CastleSiegeJoinSide.Defense;
+        fixture.Context.PlayerJoinSides[secondSwitchUser.SelectedCharacter.Id] = CastleSiegeJoinSide.Defense;
+        await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(fixture.Context).ConfigureAwait(false);
+        Assert.That(fixture.Context.CrownAccumulatedTime, Is.EqualTo(TimeSpan.Zero), "The defending side must not capture.");
+
+        fixture.Context.PlayerJoinSides[crownUser.SelectedCharacter.Id] = CastleSiegeJoinSide.Attack1;
+        fixture.Context.PlayerJoinSides[firstSwitchUser.SelectedCharacter.Id] = CastleSiegeJoinSide.Attack1;
+        fixture.Context.PlayerJoinSides[secondSwitchUser.SelectedCharacter.Id] = CastleSiegeJoinSide.Attack1;
+        await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(fixture.Context).ConfigureAwait(false);
+        Assert.That(fixture.Context.CrownAccumulatedTime, Is.EqualTo(TimeSpan.FromSeconds(1)));
+    }
+
+    /// <summary>
+    /// Verifies that changing the Crown user fails the previous attempt without resetting its progress.
+    /// </summary>
+    [Test]
+    public async ValueTask ChangedCrownUserContinuesCappedProgressAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var previousCrownUser = await fixture.CreatePlayerAsync(
+                AttackGuildId,
+                "PreviousUser",
+                CastleSiegeJoinSide.Attack1,
+                60,
+                60)
+            .ConfigureAwait(false);
+        var newCrownUser = await fixture.CreatePlayerAsync(
+                AttackGuildId,
+                "NewUser",
+                CastleSiegeJoinSide.Attack1,
+                61,
+                60)
+            .ConfigureAwait(false);
+        var firstSwitchUser = await fixture.CreatePlayerAsync(
+                AttackGuildId,
+                "SwitchOne",
+                CastleSiegeJoinSide.Attack1,
+                70,
+                60)
+            .ConfigureAwait(false);
+        var secondSwitchUser = await fixture.CreatePlayerAsync(
+                AttackGuildId,
+                "SwitchTwo",
+                CastleSiegeJoinSide.Attack1,
+                80,
+                60)
+            .ConfigureAwait(false);
+        fixture.Context.CrownUser = previousCrownUser;
+        fixture.Context.SwitchUsers[0] = firstSwitchUser;
+        fixture.Context.SwitchUsers[1] = secondSwitchUser;
+        await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(fixture.Context).ConfigureAwait(false);
+
+        fixture.Context.CrownUser = newCrownUser;
+        await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(fixture.Context).ConfigureAwait(false);
+
+        Assert.That(fixture.Context.CrownAccumulatedTime, Is.EqualTo(TimeSpan.FromSeconds(2)));
+        Mock.Get(previousCrownUser.ViewPlugIns.GetPlugIn<ICastleSiegeCrownAccessStatePlugIn>()!)
+            .Verify(
+                plugIn => plugIn.ShowCrownAccessStateAsync(
+                    CastleSiegeCrownAccessState.Fail,
+                    TimeSpan.FromSeconds(1)),
+                Times.Once);
+        Mock.Get(newCrownUser.ViewPlugIns.GetPlugIn<ICastleSiegeCrownAccessStatePlugIn>()!)
+            .Verify(
+                plugIn => plugIn.ShowCrownAccessStateAsync(
+                    CastleSiegeCrownAccessState.Attempt,
+                    TimeSpan.FromSeconds(2)),
+                Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies a successful capture, side swap, participant update, respawn, and restart recovery.
+    /// </summary>
+    [Test]
+    public async ValueTask SuccessfulCaptureChangesIntermediateOwnerAndSwapsSidesAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var crownUser = await fixture.CreatePlayerAsync(
+                AttackGuildId,
+                "CrownUser",
+                CastleSiegeJoinSide.Attack1,
+                60,
+                60)
+            .ConfigureAwait(false);
+        var firstSwitchUser = await fixture.CreatePlayerAsync(
+                AttackGuildId,
+                "SwitchOne",
+                CastleSiegeJoinSide.Attack1,
+                70,
+                60)
+            .ConfigureAwait(false);
+        var secondSwitchUser = await fixture.CreatePlayerAsync(
+                AttackGuildId,
+                "SwitchTwo",
+                CastleSiegeJoinSide.Attack1,
+                80,
+                60)
+            .ConfigureAwait(false);
+        var formerDefender = await fixture.CreatePlayerAsync(
+                DefenseGuildId,
+                "Defender",
+                CastleSiegeJoinSide.Defense,
+                200,
+                200)
+            .ConfigureAwait(false);
+        fixture.Context.CrownUser = crownUser;
+        fixture.Context.SwitchUsers[0] = firstSwitchUser;
+        fixture.Context.SwitchUsers[1] = secondSwitchUser;
+        fixture.Context.IsCrownAvailable = true;
+
+        await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(fixture.Context).ConfigureAwait(false);
+        await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(fixture.Context).ConfigureAwait(false);
+        await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(fixture.Context).ConfigureAwait(false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(fixture.Context.MiddleOwnerGuildId, Is.EqualTo(AttackGuildId));
+            Assert.That(fixture.Context.FinalGuildList[AttackGuildId].Side, Is.EqualTo(CastleSiegeJoinSide.Defense));
+            Assert.That(fixture.Context.FinalGuildList[DefenseGuildId].Side, Is.EqualTo(CastleSiegeJoinSide.Attack1));
+            Assert.That(fixture.Context.GetPlayerJoinSide(crownUser), Is.EqualTo(CastleSiegeJoinSide.Defense));
+            Assert.That(fixture.Context.GetPlayerJoinSide(formerDefender), Is.EqualTo(CastleSiegeJoinSide.Attack1));
+            Assert.That(fixture.Context.IsCrownAvailable, Is.False);
+            Assert.That(fixture.Context.CrownAccumulatedTime, Is.EqualTo(TimeSpan.Zero));
+            Assert.That(fixture.Context.CrownUser, Is.Null);
+            Assert.That(fixture.Context.SwitchUsers, Is.All.Null);
+            Assert.That(formerDefender.Position.X, Is.InRange((byte)35, (byte)40));
+            Assert.That(formerDefender.Position.Y, Is.InRange((byte)11, (byte)16));
+        });
+        Mock.Get(crownUser.ViewPlugIns.GetPlugIn<ICastleSiegeCrownAccessStatePlugIn>()!)
+            .Verify(
+                plugIn => plugIn.ShowCrownAccessStateAsync(
+                    CastleSiegeCrownAccessState.Success,
+                    TimeSpan.FromSeconds(3)),
+                Times.Once);
+        Mock.Get(formerDefender.ViewPlugIns.GetPlugIn<ICastleSiegeOwnershipChangePlugIn>()!)
+            .Verify(
+                plugIn => plugIn.ShowOwnershipChangeAsync("Attackers"),
+                Times.Once);
+
+        var restartedContext = new CastleSiegeContext(fixture.GameServerContext, fixture.Configuration);
+        await restartedContext.InitializeAsync(fixture.InitializationTimeUtc).ConfigureAwait(false);
+        Assert.Multiple(() =>
+        {
+            Assert.That(restartedContext.FinalGuildList[AttackGuildId].Side, Is.EqualTo(CastleSiegeJoinSide.Defense));
+            Assert.That(restartedContext.FinalGuildList[DefenseGuildId].Side, Is.EqualTo(CastleSiegeJoinSide.Attack1));
+            Assert.That(restartedContext.MiddleOwnerGuildId, Is.EqualTo(AttackGuildId));
+        });
+    }
+
+    /// <summary>
+    /// Verifies switch occupant broadcasts and Crown lock-state calculation.
+    /// </summary>
+    [Test]
+    public async ValueTask SwitchInformationControlsCrownAvailabilityAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        try
+        {
+            await fixture.Context.NpcController.PrepareAsync().ConfigureAwait(false);
+            var firstSwitch = fixture.Context.ActiveNpcs
+                .Select(runtime => runtime.SpawnedInstance)
+                .OfType<CastleSiegeSwitch>()
+                .Single(siegeSwitch => siegeSwitch.SwitchIndex == 0);
+            var crown = fixture.Context.ActiveNpcs
+                .Select(runtime => runtime.SpawnedInstance)
+                .OfType<CastleSiegeCrown>()
+                .Single();
+            var firstSwitchUser = await fixture.CreatePlayerAsync(
+                    AttackGuildId,
+                    "SwitchOne",
+                    CastleSiegeJoinSide.Attack1,
+                    firstSwitch.Position.X,
+                    firstSwitch.Position.Y)
+                .ConfigureAwait(false);
+            var secondSwitch = fixture.Context.ActiveNpcs
+                .Select(runtime => runtime.SpawnedInstance)
+                .OfType<CastleSiegeSwitch>()
+                .Single(siegeSwitch => siegeSwitch.SwitchIndex == 1);
+            var secondSwitchUser = await fixture.CreatePlayerAsync(
+                    AttackGuildId,
+                    "SwitchTwo",
+                    CastleSiegeJoinSide.Attack1,
+                    secondSwitch.Position.X,
+                    secondSwitch.Position.Y)
+                .ConfigureAwait(false);
+            fixture.Context.SwitchUsers[0] = firstSwitchUser;
+            fixture.Context.SwitchUsers[1] = secondSwitchUser;
+
+            await CastleSiegeSwitchMechanics.SendSwitchInfoAsync(fixture.Context).ConfigureAwait(false);
+            Assert.Multiple(() =>
+            {
+                Assert.That(fixture.Context.IsCrownAvailable, Is.True);
+                Assert.That(crown.State, Is.EqualTo(CastleSiegeCrownState.Idle));
+            });
+            Mock.Get(firstSwitchUser.ViewPlugIns.GetPlugIn<ICastleSiegeSwitchInfoPlugIn>()!)
+                .Verify(
+                    plugIn => plugIn.ShowSwitchInfoAsync(
+                        It.Is<CastleSiegeSwitchInfo>(info =>
+                            info.ObjectId == firstSwitch.Id
+                            && info.IsOccupied
+                            && info.JoinSide == CastleSiegeJoinSide.Attack1
+                            && info.GuildName == "Attackers"
+                            && info.CharacterName == "SwitchOne")),
+                    Times.Once);
+            Mock.Get(firstSwitchUser.ViewPlugIns.GetPlugIn<ICastleSiegeCrownStatePlugIn>()!)
+                .Verify(plugIn => plugIn.ShowCrownStateAsync(true), Times.Once);
+
+            fixture.Context.PlayerJoinSides[secondSwitchUser.SelectedCharacter!.Id] = CastleSiegeJoinSide.Attack2;
+            await CastleSiegeSwitchMechanics.SendSwitchInfoAsync(fixture.Context).ConfigureAwait(false);
+            Assert.Multiple(() =>
+            {
+                Assert.That(fixture.Context.IsCrownAvailable, Is.False);
+                Assert.That(crown.State, Is.EqualTo(CastleSiegeCrownState.Locked));
+            });
+            Mock.Get(firstSwitchUser.ViewPlugIns.GetPlugIn<ICastleSiegeCrownStatePlugIn>()!)
+                .Verify(plugIn => plugIn.ShowCrownStateAsync(false), Times.Once);
+        }
+        finally
+        {
+            await fixture.Context.NpcController.DespawnAllAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Verifies that a new owner is persisted and the Castle Siege economy is reset.
+    /// </summary>
+    [Test]
+    public async ValueTask FinalResultPersistsWinnerAndResetsEconomyAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var observer = await fixture.CreatePlayerAsync(
+                AttackGuildId,
+                "Observer",
+                CastleSiegeJoinSide.Attack1,
+                100,
+                100)
+            .ConfigureAwait(false);
+        fixture.Context.MiddleOwnerGuildId = AttackGuildId;
+        fixture.Context.SiegeData.TaxChaos = 3;
+        fixture.Context.SiegeData.TaxStore = 3;
+        fixture.Context.SiegeData.TaxHunt = 300_000;
+        fixture.Context.SiegeData.TributeMoney = 6_000;
+        fixture.Context.SiegeData.IsHuntZoneEnabled = true;
+
+        await CastleSiegeCrownMechanics
+            .CheckResultAsync(fixture.Context)
+            .ConfigureAwait(false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(fixture.Context.SiegeData.OwnerGuildId, Is.EqualTo(fixture.AttackPersistentGuildId));
+            Assert.That(fixture.Context.SiegeData.IsOccupied, Is.True);
+            Assert.That(fixture.Context.SiegeData.TaxChaos, Is.Zero);
+            Assert.That(fixture.Context.SiegeData.TaxStore, Is.Zero);
+            Assert.That(fixture.Context.SiegeData.TaxHunt, Is.Zero);
+            Assert.That(fixture.Context.SiegeData.TributeMoney, Is.Zero);
+            Assert.That(fixture.Context.SiegeData.IsHuntZoneEnabled, Is.True);
+        });
+        using (var persistenceContext = fixture.PersistenceContextProvider.CreateNewTypedContext(
+                   typeof(CastleSiegeData),
+                   false,
+                   fixture.GameServerContext.Configuration))
+        {
+            var persistedData = (await persistenceContext.GetAsync<CastleSiegeData>().ConfigureAwait(false)).Single();
+            Assert.That(persistedData.OwnerGuildId, Is.EqualTo(fixture.AttackPersistentGuildId));
+            Assert.That(persistedData.TributeMoney, Is.Zero);
+        }
+
+        Mock.Get(observer.ViewPlugIns.GetPlugIn<ICastleSiegeOwnershipChangePlugIn>()!)
+            .Verify(
+                plugIn => plugIn.ShowOwnershipChangeAsync("Attackers"),
+                Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that the current owner and economy are retained when the Crown was not captured.
+    /// </summary>
+    [Test]
+    public async ValueTask FinalResultRetainsCurrentOwnerWithoutCaptureAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        fixture.Context.MiddleOwnerGuildId = null;
+        fixture.Context.SiegeData.TaxChaos = 3;
+        fixture.Context.SiegeData.TaxStore = 2;
+        fixture.Context.SiegeData.TaxHunt = 100_000;
+        fixture.Context.SiegeData.TributeMoney = 6_000;
+
+        await CastleSiegeCrownMechanics
+            .CheckResultAsync(fixture.Context)
+            .ConfigureAwait(false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(fixture.Context.SiegeData.OwnerGuildId, Is.EqualTo(fixture.DefensePersistentGuildId));
+            Assert.That(fixture.Context.SiegeData.TaxChaos, Is.EqualTo(3));
+            Assert.That(fixture.Context.SiegeData.TaxStore, Is.EqualTo(2));
+            Assert.That(fixture.Context.SiegeData.TaxHunt, Is.EqualTo(100_000));
+            Assert.That(fixture.Context.SiegeData.TributeMoney, Is.EqualTo(6_000));
+        });
+    }
+
+    private static async ValueTask<TestFixture> CreateFixtureAsync()
+    {
+        var persistenceContextProvider = new InMemoryPersistenceContextProvider();
+        BasicModel.GameConfiguration gameConfiguration;
+        BasicModel.CastleSiegeConfiguration configuration;
+        BasicModel.GameMapDefinition siegeMap;
+        Guid defensePersistentGuildId;
+        Guid attackPersistentGuildId;
+        using (var persistenceContext = persistenceContextProvider.CreateNewContext())
+        {
+            gameConfiguration = persistenceContext.CreateNew<BasicModel.GameConfiguration>();
+            var normalMap = persistenceContext.CreateNew<BasicModel.GameMapDefinition>();
+            normalMap.Number = 0;
+            normalMap.TerrainData = new byte[65_539];
+            gameConfiguration.Maps.Add(normalMap);
+
+            siegeMap = persistenceContext.CreateNew<BasicModel.GameMapDefinition>();
+            siegeMap.Number = 30;
+            siegeMap.TerrainData = new byte[65_539];
+            gameConfiguration.Maps.Add(siegeMap);
+
+            configuration = persistenceContext.CreateNew<BasicModel.CastleSiegeConfiguration>();
+            configuration.Enabled = true;
+            configuration.CastleSiegeMapDefinition = siegeMap;
+            configuration.CrownHoldTimeSeconds = 3;
+            configuration.AttackRespawnArea = persistenceContext.CreateNew<BasicModel.CastleSiegeZoneDefinition>();
+            configuration.AttackRespawnArea.X1 = 35;
+            configuration.AttackRespawnArea.Y1 = 11;
+            configuration.AttackRespawnArea.X2 = 40;
+            configuration.AttackRespawnArea.Y2 = 16;
+            configuration.StateSchedule.Add(new BasicModel.CastleSiegeStateScheduleEntry
+            {
+                State = CastleSiegeState.Ready,
+                DayOfWeek = DayOfWeek.Monday,
+            });
+            configuration.StateSchedule.Add(new BasicModel.CastleSiegeStateScheduleEntry
+            {
+                State = CastleSiegeState.Start,
+                DayOfWeek = DayOfWeek.Tuesday,
+            });
+            gameConfiguration.CastleSiegeConfiguration = configuration;
+
+            AddNpc(CastleSiegeCrown.MonsterNumber, 1, 60, 60);
+            AddNpc(CastleSiegeSwitch.FirstMonsterNumber, 1, 70, 60);
+            AddNpc(CastleSiegeSwitch.SecondMonsterNumber, 2, 80, 60);
+
+            var defenseGuild = persistenceContext.CreateNew<BasicModel.Guild>();
+            defenseGuild.Name = "Defenders";
+            defensePersistentGuildId = defenseGuild.Id;
+            var attackGuild = persistenceContext.CreateNew<BasicModel.Guild>();
+            attackGuild.Name = "Attackers";
+            attackPersistentGuildId = attackGuild.Id;
+            var siegeData = persistenceContext.CreateNew<BasicModel.CastleSiegeData>();
+            siegeData.OwnerGuildId = defensePersistentGuildId;
+            siegeData.IsOccupied = true;
+            await persistenceContext.SaveChangesAsync().ConfigureAwait(false);
+
+            void AddNpc(short monsterNumber, byte instanceId, byte x, byte y)
+            {
+                var monster = persistenceContext.CreateNew<BasicModel.MonsterDefinition>();
+                monster.Number = monsterNumber;
+                monster.ObjectKind = NpcObjectKind.PassiveNpc;
+                gameConfiguration.Monsters.Add(monster);
+                configuration.NpcDefinitions.Add(new BasicModel.CastleSiegeNpcDefinition
+                {
+                    MonsterDefinition = monster,
+                    InstanceId = instanceId,
+                    SpawnX = x,
+                    SpawnY = y,
+                    Direction = Direction.South,
+                });
+            }
+        }
+
+        var guildServer = new Mock<IGuildServer>();
+        guildServer
+            .Setup(server => server.GetGuildIdAsync(defensePersistentGuildId))
+            .Returns(new ValueTask<uint>(DefenseGuildId));
+        guildServer
+            .Setup(server => server.GetGuildIdAsync(attackPersistentGuildId))
+            .Returns(new ValueTask<uint>(AttackGuildId));
+        guildServer
+            .Setup(server => server.GetGuildAsync(DefenseGuildId))
+            .Returns(new ValueTask<RuntimeGuild?>(new RuntimeGuild { Name = "Defenders" }));
+        guildServer
+            .Setup(server => server.GetGuildAsync(AttackGuildId))
+            .Returns(new ValueTask<RuntimeGuild?>(new RuntimeGuild { Name = "Attackers" }));
+
+        var plugInManager = new PlugInManager([], NullLoggerFactory.Instance, null, null);
+        var mapInitializer = new MapInitializer(
+            gameConfiguration,
+            new NullLogger<MapInitializer>(),
+            NullDropGenerator.Instance,
+            null);
+        var gameServerContext = new GameServerContext(
+            new BasicModel.GameServerDefinition
+            {
+                GameConfiguration = gameConfiguration,
+                ServerConfiguration = new BasicModel.GameServerConfiguration(),
+            },
+            guildServer.Object,
+            new Mock<IEventPublisher>().Object,
+            new Mock<ILoginServer>().Object,
+            new Mock<IFriendServer>().Object,
+            persistenceContextProvider,
+            mapInitializer,
+            NullLoggerFactory.Instance,
+            plugInManager,
+            NullDropGenerator.Instance,
+            new ConfigurationChangeMediator());
+        mapInitializer.PlugInManager = gameServerContext.PlugInManager;
+        mapInitializer.PathFinderPool = gameServerContext.PathFinderPool;
+
+        var initializationTimeUtc = new DateTime(2026, 8, 3, 12, 0, 0, DateTimeKind.Utc);
+        var context = new CastleSiegeContext(gameServerContext, configuration);
+        await context.InitializeAsync(initializationTimeUtc).ConfigureAwait(false);
+        context.CurrentState = CastleSiegeState.Start;
+        context.FinalGuildList[DefenseGuildId] = new CastleSiegeGuildParticipant
+        {
+            GuildId = DefenseGuildId,
+            PersistentGuildId = defensePersistentGuildId,
+            GuildName = "Defenders",
+            Side = CastleSiegeJoinSide.Defense,
+            IsAllianceMaster = true,
+        };
+        context.FinalGuildList[AttackGuildId] = new CastleSiegeGuildParticipant
+        {
+            GuildId = AttackGuildId,
+            PersistentGuildId = attackPersistentGuildId,
+            GuildName = "Attackers",
+            Side = CastleSiegeJoinSide.Attack1,
+            IsAllianceMaster = true,
+        };
+        var map = await gameServerContext.GetMapAsync(30).ConfigureAwait(false)
+                  ?? throw new InvalidOperationException("The Castle Siege test map could not be initialized.");
+        return new(
+            persistenceContextProvider,
+            configuration,
+            gameServerContext,
+            context,
+            map,
+            defensePersistentGuildId,
+            attackPersistentGuildId,
+            initializationTimeUtc);
+    }
+
+    private sealed record TestFixture(
+        InMemoryPersistenceContextProvider PersistenceContextProvider,
+        CastleSiegeConfiguration Configuration,
+        GameServerContext GameServerContext,
+        CastleSiegeContext Context,
+        GameMap SiegeMap,
+        Guid DefensePersistentGuildId,
+        Guid AttackPersistentGuildId,
+        DateTime InitializationTimeUtc)
+    {
+        /// <summary>
+        /// Creates and tracks a Castle Siege participant.
+        /// </summary>
+        internal async ValueTask<Player> CreatePlayerAsync(
+            uint guildId,
+            string characterName,
+            CastleSiegeJoinSide side,
+            byte x,
+            byte y)
+        {
+            var player = await PlayerTestHelper.CreatePlayerAsync(this.GameServerContext).ConfigureAwait(false);
+            player.SelectedCharacter!.Id = Guid.NewGuid();
+            player.SelectedCharacter.Name = characterName;
+            player.GuildStatus = new GuildMemberStatus(guildId, GuildPosition.NormalMember);
+            await this.GameServerContext.AddPlayerAsync(player).ConfigureAwait(false);
+            await player.WarpToAsync(new ExitGate
+            {
+                Map = this.Configuration.CastleSiegeMapDefinition,
+                X1 = x,
+                X2 = x,
+                Y1 = y,
+                Y2 = y,
+                Direction = Direction.South,
+            }).ConfigureAwait(false);
+            await player.ClientReadyAfterMapChangeAsync().ConfigureAwait(false);
+            player.IsAlive = true;
+            this.Context.TrackPlayer(player, this.SiegeMap);
+            this.Context.PlayerJoinSides[player.SelectedCharacter.Id] = side;
+            return player;
+        }
+    }
+}

--- a/tests/MUnique.OpenMU.Tests/CastleSiegeCrownMechanicsTests.cs
+++ b/tests/MUnique.OpenMU.Tests/CastleSiegeCrownMechanicsTests.cs
@@ -353,6 +353,8 @@ public class CastleSiegeCrownMechanicsTests
                     90,
                     60)
                 .ConfigureAwait(false);
+            fixture.Context.IsCrownAvailable = false;
+            crown.State = CastleSiegeCrownState.Locked;
             await CastleSiegeSwitchMechanics
                 .SynchronizePlayerAsync(fixture.Context, enteringPlayer)
                 .ConfigureAwait(false);
@@ -360,6 +362,11 @@ public class CastleSiegeCrownMechanicsTests
                 .Verify(plugIn => plugIn.ShowSwitchInfoAsync(It.IsAny<CastleSiegeSwitchInfo>()), Times.Exactly(2));
             Mock.Get(enteringPlayer.ViewPlugIns.GetPlugIn<ICastleSiegeCrownStatePlugIn>()!)
                 .Verify(plugIn => plugIn.ShowCrownStateAsync(true), Times.Once);
+            Assert.Multiple(() =>
+            {
+                Assert.That(fixture.Context.IsCrownAvailable, Is.False);
+                Assert.That(crown.State, Is.EqualTo(CastleSiegeCrownState.Locked));
+            });
 
             fixture.Context.PlayerJoinSides[secondSwitchUser.SelectedCharacter!.Id] = CastleSiegeJoinSide.Attack2;
             await CastleSiegeSwitchMechanics.SendSwitchInfoAsync(fixture.Context).ConfigureAwait(false);

--- a/tests/MUnique.OpenMU.Tests/CastleSiegeCrownMechanicsTests.cs
+++ b/tests/MUnique.OpenMU.Tests/CastleSiegeCrownMechanicsTests.cs
@@ -380,6 +380,50 @@ public class CastleSiegeCrownMechanicsTests
     }
 
     /// <summary>
+    /// Verifies that duplicate configured switch spawns do not overflow the broadcast snapshot.
+    /// </summary>
+    [Test]
+    public async ValueTask DuplicateSwitchSpawnsAreTrackedByObjectIdAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var firstSwitchDefinition = fixture.Configuration.NpcDefinitions
+            .Single(definition => definition.MonsterDefinition?.Number == CastleSiegeSwitch.FirstMonsterNumber);
+        fixture.Configuration.NpcDefinitions.Add(new BasicModel.CastleSiegeNpcDefinition
+        {
+            MonsterDefinition = firstSwitchDefinition.MonsterDefinition,
+            InstanceId = 3,
+            SpawnX = 71,
+            SpawnY = 60,
+            Direction = Direction.South,
+        });
+
+        try
+        {
+            await fixture.Context.NpcController.PrepareAsync().ConfigureAwait(false);
+            var observer = await fixture.CreatePlayerAsync(
+                    AttackGuildId,
+                    "Observer",
+                    CastleSiegeJoinSide.Attack1,
+                    90,
+                    60)
+                .ConfigureAwait(false);
+
+            await CastleSiegeSwitchMechanics.SendSwitchInfoAsync(fixture.Context).ConfigureAwait(false);
+            await CastleSiegeSwitchMechanics.SendSwitchInfoAsync(fixture.Context).ConfigureAwait(false);
+
+            Mock.Get(observer.ViewPlugIns.GetPlugIn<ICastleSiegeSwitchInfoPlugIn>()!)
+                .Verify(
+                    plugIn => plugIn.ShowSwitchInfoAsync(It.IsAny<CastleSiegeSwitchInfo>()),
+                    Times.Exactly(3));
+            Assert.That(fixture.Context.LastBroadcastSwitchInfos, Has.Count.EqualTo(3));
+        }
+        finally
+        {
+            await fixture.Context.NpcController.DespawnAllAsync().ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
     /// Verifies that a new owner is persisted and the Castle Siege economy is reset.
     /// </summary>
     [Test]
@@ -476,6 +520,49 @@ public class CastleSiegeCrownMechanicsTests
     }
 
     /// <summary>
+    /// Verifies that a completed ownership tenure's economy is not restored when its guild recaptures the Crown.
+    /// </summary>
+    [Test]
+    public async ValueTask RecaptureDoesNotRestorePreviousOwnershipEconomyAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var attacker = await fixture.CreatePlayerAsync(
+                AttackGuildId,
+                "Attacker",
+                CastleSiegeJoinSide.Attack1,
+                60,
+                60)
+            .ConfigureAwait(false);
+        var formerDefender = await fixture.CreatePlayerAsync(
+                DefenseGuildId,
+                "FormerDefender",
+                CastleSiegeJoinSide.Defense,
+                61,
+                60)
+            .ConfigureAwait(false);
+        fixture.Context.SiegeData.TaxChaos = 3;
+        fixture.Context.SiegeData.TaxStore = 2;
+        fixture.Context.SiegeData.TaxHunt = 100_000;
+        fixture.Context.SiegeData.TributeMoney = 6_000;
+
+        await CastleSiegeCrownMechanics
+            .ChangeWinnerGuildAsync(fixture.Context, attacker, CastleSiegeJoinSide.Attack1)
+            .ConfigureAwait(false);
+        await CastleSiegeCrownMechanics
+            .ChangeWinnerGuildAsync(fixture.Context, formerDefender, CastleSiegeJoinSide.Attack1)
+            .ConfigureAwait(false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(fixture.Context.SiegeData.OwnerGuildId, Is.EqualTo(fixture.DefensePersistentGuildId));
+            Assert.That(fixture.Context.SiegeData.TaxChaos, Is.Zero);
+            Assert.That(fixture.Context.SiegeData.TaxStore, Is.Zero);
+            Assert.That(fixture.Context.SiegeData.TaxHunt, Is.Zero);
+            Assert.That(fixture.Context.SiegeData.TributeMoney, Is.Zero);
+        });
+    }
+
+    /// <summary>
     /// Verifies that Crown progress uses elapsed wall time when periodic ticks are delayed.
     /// </summary>
     [Test]
@@ -490,6 +577,30 @@ public class CastleSiegeCrownMechanicsTests
         await fixture.CheckCrownAsync(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
 
         Assert.That(fixture.Context.CrownAccumulatedTime, Is.EqualTo(TimeSpan.FromSeconds(2)));
+        Mock.Get(crownUser.ViewPlugIns.GetPlugIn<ICastleSiegeCrownAccessStatePlugIn>()!)
+            .Verify(
+                plugIn => plugIn.ShowCrownAccessStateAsync(
+                    CastleSiegeCrownAccessState.Attempt,
+                    TimeSpan.FromSeconds(2)),
+                Times.Once);
+    }
+
+    /// <summary>
+    /// Verifies that a delayed periodic tick cannot satisfy the Crown hold duration in one update.
+    /// </summary>
+    [Test]
+    public async ValueTask CrownProgressClampsDelayedUpdatesAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var crownUser = await fixture.CreatePlayerAsync(AttackGuildId, "CrownUser", CastleSiegeJoinSide.Attack1, 60, 60).ConfigureAwait(false);
+        fixture.Context.CrownUser = crownUser;
+        fixture.Context.SwitchUsers[0] = await fixture.CreatePlayerAsync(AttackGuildId, "SwitchOne", CastleSiegeJoinSide.Attack1, 70, 60).ConfigureAwait(false);
+        fixture.Context.SwitchUsers[1] = await fixture.CreatePlayerAsync(AttackGuildId, "SwitchTwo", CastleSiegeJoinSide.Attack1, 80, 60).ConfigureAwait(false);
+
+        await fixture.CheckCrownAsync(TimeSpan.FromSeconds(30)).ConfigureAwait(false);
+
+        Assert.That(fixture.Context.CrownAccumulatedTime, Is.EqualTo(TimeSpan.FromSeconds(2)));
+        Assert.That(fixture.Context.SiegeData.OwnerGuildId, Is.EqualTo(fixture.DefensePersistentGuildId));
         Mock.Get(crownUser.ViewPlugIns.GetPlugIn<ICastleSiegeCrownAccessStatePlugIn>()!)
             .Verify(
                 plugIn => plugIn.ShowCrownAccessStateAsync(

--- a/tests/MUnique.OpenMU.Tests/CastleSiegeCrownMechanicsTests.cs
+++ b/tests/MUnique.OpenMU.Tests/CastleSiegeCrownMechanicsTests.cs
@@ -61,11 +61,11 @@ public class CastleSiegeCrownMechanicsTests
         fixture.Context.SwitchUsers[0] = firstSwitchUser;
         fixture.Context.SwitchUsers[1] = secondSwitchUser;
 
-        await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(fixture.Context).ConfigureAwait(false);
+        await fixture.CheckCrownAsync().ConfigureAwait(false);
         fixture.Context.CrownAccumulatedTime = TimeSpan.FromSeconds(10);
         fixture.Context.SwitchUsers[1] = null;
-        await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(fixture.Context).ConfigureAwait(false);
-        await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(fixture.Context).ConfigureAwait(false);
+        await fixture.CheckCrownAsync().ConfigureAwait(false);
+        await fixture.CheckCrownAsync().ConfigureAwait(false);
 
         Assert.That(fixture.Context.CrownAccumulatedTime, Is.EqualTo(TimeSpan.FromSeconds(2)));
         Mock.Get(crownUser.ViewPlugIns.GetPlugIn<ICastleSiegeCrownAccessStatePlugIn>()!)
@@ -107,30 +107,30 @@ public class CastleSiegeCrownMechanicsTests
         fixture.Context.CrownUser = crownUser;
         fixture.Context.SwitchUsers[0] = firstSwitchUser;
         fixture.Context.SwitchUsers[1] = secondSwitchUser;
-        await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(fixture.Context).ConfigureAwait(false);
+        await fixture.CheckCrownAsync().ConfigureAwait(false);
         Assert.That(fixture.Context.CrownAccumulatedTime, Is.EqualTo(TimeSpan.Zero), "Different attacking sides must not capture.");
 
         fixture.Context.PlayerJoinSides[secondSwitchUser.SelectedCharacter!.Id] = CastleSiegeJoinSide.Attack1;
         secondSwitchUser.IsAlive = false;
-        await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(fixture.Context).ConfigureAwait(false);
+        await fixture.CheckCrownAsync().ConfigureAwait(false);
         Assert.That(fixture.Context.CrownAccumulatedTime, Is.EqualTo(TimeSpan.Zero), "Dead switch users must not capture.");
 
         secondSwitchUser.IsAlive = true;
         secondSwitchUser.GuildStatus = null;
-        await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(fixture.Context).ConfigureAwait(false);
+        await fixture.CheckCrownAsync().ConfigureAwait(false);
         Assert.That(fixture.Context.CrownAccumulatedTime, Is.EqualTo(TimeSpan.Zero), "Guildless switch users must not capture.");
 
         secondSwitchUser.GuildStatus = new GuildMemberStatus(AttackGuildId, GuildPosition.NormalMember);
         fixture.Context.PlayerJoinSides[crownUser.SelectedCharacter!.Id] = CastleSiegeJoinSide.Defense;
         fixture.Context.PlayerJoinSides[firstSwitchUser.SelectedCharacter!.Id] = CastleSiegeJoinSide.Defense;
         fixture.Context.PlayerJoinSides[secondSwitchUser.SelectedCharacter.Id] = CastleSiegeJoinSide.Defense;
-        await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(fixture.Context).ConfigureAwait(false);
+        await fixture.CheckCrownAsync().ConfigureAwait(false);
         Assert.That(fixture.Context.CrownAccumulatedTime, Is.EqualTo(TimeSpan.Zero), "The defending side must not capture.");
 
         fixture.Context.PlayerJoinSides[crownUser.SelectedCharacter.Id] = CastleSiegeJoinSide.Attack1;
         fixture.Context.PlayerJoinSides[firstSwitchUser.SelectedCharacter.Id] = CastleSiegeJoinSide.Attack1;
         fixture.Context.PlayerJoinSides[secondSwitchUser.SelectedCharacter.Id] = CastleSiegeJoinSide.Attack1;
-        await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(fixture.Context).ConfigureAwait(false);
+        await fixture.CheckCrownAsync().ConfigureAwait(false);
         Assert.That(fixture.Context.CrownAccumulatedTime, Is.EqualTo(TimeSpan.FromSeconds(1)));
     }
 
@@ -172,10 +172,10 @@ public class CastleSiegeCrownMechanicsTests
         fixture.Context.CrownUser = previousCrownUser;
         fixture.Context.SwitchUsers[0] = firstSwitchUser;
         fixture.Context.SwitchUsers[1] = secondSwitchUser;
-        await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(fixture.Context).ConfigureAwait(false);
+        await fixture.CheckCrownAsync().ConfigureAwait(false);
 
         fixture.Context.CrownUser = newCrownUser;
-        await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(fixture.Context).ConfigureAwait(false);
+        await fixture.CheckCrownAsync().ConfigureAwait(false);
 
         Assert.That(fixture.Context.CrownAccumulatedTime, Is.EqualTo(TimeSpan.FromSeconds(2)));
         Mock.Get(previousCrownUser.ViewPlugIns.GetPlugIn<ICastleSiegeCrownAccessStatePlugIn>()!)
@@ -231,10 +231,11 @@ public class CastleSiegeCrownMechanicsTests
         fixture.Context.SwitchUsers[0] = firstSwitchUser;
         fixture.Context.SwitchUsers[1] = secondSwitchUser;
         fixture.Context.IsCrownAvailable = true;
+        fixture.Context.FinalGuildList[AttackGuildId].IsAllianceMaster = false;
 
-        await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(fixture.Context).ConfigureAwait(false);
-        await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(fixture.Context).ConfigureAwait(false);
-        await CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(fixture.Context).ConfigureAwait(false);
+        await fixture.CheckCrownAsync().ConfigureAwait(false);
+        await fixture.CheckCrownAsync().ConfigureAwait(false);
+        await fixture.CheckCrownAsync().ConfigureAwait(false);
 
         Assert.Multiple(() =>
         {
@@ -247,6 +248,7 @@ public class CastleSiegeCrownMechanicsTests
             Assert.That(fixture.Context.CrownAccumulatedTime, Is.EqualTo(TimeSpan.Zero));
             Assert.That(fixture.Context.CrownUser, Is.Null);
             Assert.That(fixture.Context.SwitchUsers, Is.All.Null);
+            Assert.That(fixture.Context.SiegeData.OwnerGuildId, Is.EqualTo(fixture.AttackPersistentGuildId));
             Assert.That(formerDefender.Position.X, Is.InRange((byte)35, (byte)40));
             Assert.That(formerDefender.Position.Y, Is.InRange((byte)11, (byte)16));
         });
@@ -260,6 +262,15 @@ public class CastleSiegeCrownMechanicsTests
             .Verify(
                 plugIn => plugIn.ShowOwnershipChangeAsync("Attackers"),
                 Times.Once);
+
+        using (var persistenceContext = fixture.PersistenceContextProvider.CreateNewTypedContext(
+                   typeof(CastleSiegeData),
+                   false,
+                   fixture.GameServerContext.Configuration))
+        {
+            var persistedData = (await persistenceContext.GetAsync<CastleSiegeData>().ConfigureAwait(false)).Single();
+            Assert.That(persistedData.OwnerGuildId, Is.EqualTo(fixture.AttackPersistentGuildId));
+        }
 
         var restartedContext = new CastleSiegeContext(fixture.GameServerContext, fixture.Configuration);
         await restartedContext.InitializeAsync(fixture.InitializationTimeUtc).ConfigureAwait(false);
@@ -329,6 +340,27 @@ public class CastleSiegeCrownMechanicsTests
             Mock.Get(firstSwitchUser.ViewPlugIns.GetPlugIn<ICastleSiegeCrownStatePlugIn>()!)
                 .Verify(plugIn => plugIn.ShowCrownStateAsync(true), Times.Once);
 
+            await CastleSiegeSwitchMechanics.SendSwitchInfoAsync(fixture.Context).ConfigureAwait(false);
+            Mock.Get(firstSwitchUser.ViewPlugIns.GetPlugIn<ICastleSiegeSwitchInfoPlugIn>()!)
+                .Verify(plugIn => plugIn.ShowSwitchInfoAsync(It.IsAny<CastleSiegeSwitchInfo>()), Times.Exactly(2));
+            Mock.Get(firstSwitchUser.ViewPlugIns.GetPlugIn<ICastleSiegeCrownStatePlugIn>()!)
+                .Verify(plugIn => plugIn.ShowCrownStateAsync(true), Times.Once);
+
+            var enteringPlayer = await fixture.CreatePlayerAsync(
+                    AttackGuildId,
+                    "EnteringPlayer",
+                    CastleSiegeJoinSide.Attack1,
+                    90,
+                    60)
+                .ConfigureAwait(false);
+            await CastleSiegeSwitchMechanics
+                .SynchronizePlayerAsync(fixture.Context, enteringPlayer)
+                .ConfigureAwait(false);
+            Mock.Get(enteringPlayer.ViewPlugIns.GetPlugIn<ICastleSiegeSwitchInfoPlugIn>()!)
+                .Verify(plugIn => plugIn.ShowSwitchInfoAsync(It.IsAny<CastleSiegeSwitchInfo>()), Times.Exactly(2));
+            Mock.Get(enteringPlayer.ViewPlugIns.GetPlugIn<ICastleSiegeCrownStatePlugIn>()!)
+                .Verify(plugIn => plugIn.ShowCrownStateAsync(true), Times.Once);
+
             fixture.Context.PlayerJoinSides[secondSwitchUser.SelectedCharacter!.Id] = CastleSiegeJoinSide.Attack2;
             await CastleSiegeSwitchMechanics.SendSwitchInfoAsync(fixture.Context).ConfigureAwait(false);
             Assert.Multiple(() =>
@@ -338,6 +370,8 @@ public class CastleSiegeCrownMechanicsTests
             });
             Mock.Get(firstSwitchUser.ViewPlugIns.GetPlugIn<ICastleSiegeCrownStatePlugIn>()!)
                 .Verify(plugIn => plugIn.ShowCrownStateAsync(false), Times.Once);
+            Mock.Get(firstSwitchUser.ViewPlugIns.GetPlugIn<ICastleSiegeSwitchInfoPlugIn>()!)
+                .Verify(plugIn => plugIn.ShowSwitchInfoAsync(It.IsAny<CastleSiegeSwitchInfo>()), Times.Exactly(3));
         }
         finally
         {
@@ -421,6 +455,47 @@ public class CastleSiegeCrownMechanicsTests
             Assert.That(fixture.Context.SiegeData.TaxHunt, Is.EqualTo(100_000));
             Assert.That(fixture.Context.SiegeData.TributeMoney, Is.EqualTo(6_000));
         });
+    }
+
+    /// <summary>
+    /// Verifies that an unresolved intermediate owner does not abort End-state processing.
+    /// </summary>
+    [Test]
+    public async ValueTask FinalResultRetainsPersistedOwnerWhenIntermediateOwnerIsMissingAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        fixture.Context.MiddleOwnerGuildId = uint.MaxValue;
+
+        await CastleSiegeCrownMechanics.CheckResultAsync(fixture.Context).ConfigureAwait(false);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(fixture.Context.SiegeData.OwnerGuildId, Is.EqualTo(fixture.DefensePersistentGuildId));
+            Assert.That(fixture.Context.SiegeData.IsOccupied, Is.True);
+        });
+    }
+
+    /// <summary>
+    /// Verifies that Crown progress uses elapsed wall time when periodic ticks are delayed.
+    /// </summary>
+    [Test]
+    public async ValueTask CrownProgressUsesElapsedTimeAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var crownUser = await fixture.CreatePlayerAsync(AttackGuildId, "CrownUser", CastleSiegeJoinSide.Attack1, 60, 60).ConfigureAwait(false);
+        fixture.Context.CrownUser = crownUser;
+        fixture.Context.SwitchUsers[0] = await fixture.CreatePlayerAsync(AttackGuildId, "SwitchOne", CastleSiegeJoinSide.Attack1, 70, 60).ConfigureAwait(false);
+        fixture.Context.SwitchUsers[1] = await fixture.CreatePlayerAsync(AttackGuildId, "SwitchTwo", CastleSiegeJoinSide.Attack1, 80, 60).ConfigureAwait(false);
+
+        await fixture.CheckCrownAsync(TimeSpan.FromSeconds(2)).ConfigureAwait(false);
+
+        Assert.That(fixture.Context.CrownAccumulatedTime, Is.EqualTo(TimeSpan.FromSeconds(2)));
+        Mock.Get(crownUser.ViewPlugIns.GetPlugIn<ICastleSiegeCrownAccessStatePlugIn>()!)
+            .Verify(
+                plugIn => plugIn.ShowCrownAccessStateAsync(
+                    CastleSiegeCrownAccessState.Attempt,
+                    TimeSpan.FromSeconds(2)),
+                Times.Once);
     }
 
     private static async ValueTask<TestFixture> CreateFixtureAsync()
@@ -579,6 +654,8 @@ public class CastleSiegeCrownMechanicsTests
         Guid AttackPersistentGuildId,
         DateTime InitializationTimeUtc)
     {
+        private DateTime? _crownTimeUtc;
+
         /// <summary>
         /// Creates and tracks a Castle Siege participant.
         /// </summary>
@@ -608,6 +685,23 @@ public class CastleSiegeCrownMechanicsTests
             this.Context.TrackPlayer(player, this.SiegeMap);
             this.Context.PlayerJoinSides[player.SelectedCharacter.Id] = side;
             return player;
+        }
+
+        /// <summary>
+        /// Advances the Crown mechanics clock and executes one progress check.
+        /// </summary>
+        /// <param name="elapsed">The elapsed time since the previous check.</param>
+        /// <returns>A task that represents the asynchronous check.</returns>
+        internal ValueTask CheckCrownAsync(TimeSpan? elapsed = null)
+        {
+            if (this._crownTimeUtc is null)
+            {
+                this._crownTimeUtc = this.InitializationTimeUtc;
+                this.Context.LastCrownUpdateUtc = this.InitializationTimeUtc;
+            }
+
+            this._crownTimeUtc += elapsed ?? TimeSpan.FromSeconds(1);
+            return CastleSiegeCrownMechanics.CheckMiddleWinnerAsync(this.Context, this._crownTimeUtc.Value);
         }
     }
 }

--- a/tests/MUnique.OpenMU.Tests/CastleSiegeCrownRemoteViewTests.cs
+++ b/tests/MUnique.OpenMU.Tests/CastleSiegeCrownRemoteViewTests.cs
@@ -1,0 +1,115 @@
+// <copyright file="CastleSiegeCrownRemoteViewTests.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Tests;
+
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameServer.RemoteView.CastleSiege;
+using MUnique.OpenMU.Network.Packets.ServerToClient;
+using CrownAccessPacket = MUnique.OpenMU.Network.Packets.ServerToClient.CastleSiegeCrownAccessState;
+using CrownAccessState = MUnique.OpenMU.GameLogic.Views.CastleSiege.CastleSiegeCrownAccessState;
+using DataJoinSide = MUnique.OpenMU.DataModel.Configuration.CastleSiegeJoinSide;
+using SwitchInfo = MUnique.OpenMU.GameLogic.Views.CastleSiege.CastleSiegeSwitchInfo;
+using SwitchInfoPacket = MUnique.OpenMU.Network.Packets.ServerToClient.CastleSiegeSwitchInfo;
+
+/// <summary>
+/// Tests Castle Siege Crown remote-view packet serialization.
+/// </summary>
+[TestFixture]
+public class CastleSiegeCrownRemoteViewTests
+{
+    /// <summary>
+    /// Verifies that Crown notifications are ignored after the player disconnected.
+    /// </summary>
+    [Test]
+    public async ValueTask IgnoreCrownNotificationsAfterDisconnectAsync()
+    {
+        var (player, output) = CastleSiegeRemoteViewTestHelper.CreatePlayer();
+        await player.PlayerState.TryAdvanceToAsync(PlayerState.LoginScreen).ConfigureAwait(false);
+        await player.DisconnectAsync().ConfigureAwait(false);
+        var outputLengthAfterDisconnect = output.Length;
+        Assert.That(player.Connection, Is.Null);
+
+        await new CastleSiegeCrownStatePlugIn(player).ShowCrownStateAsync(true).ConfigureAwait(false);
+        await new CastleSiegeCrownAccessStatePlugIn(player)
+            .ShowCrownAccessStateAsync(CrownAccessState.Attempt, TimeSpan.Zero)
+            .ConfigureAwait(false);
+        await new CastleSiegeSwitchInfoPlugIn(player)
+            .ShowSwitchInfoAsync(new(1, false, DataJoinSide.None, string.Empty, string.Empty))
+            .ConfigureAwait(false);
+        await new CastleSiegeOwnershipChangePlugIn(player)
+            .ShowOwnershipChangeAsync("Owner")
+            .ConfigureAwait(false);
+
+        Assert.That(output.Length, Is.EqualTo(outputLengthAfterDisconnect));
+    }
+
+    /// <summary>
+    /// Verifies Crown, switch, and ownership notification packets.
+    /// </summary>
+    [Test]
+    public async ValueTask SerializeCrownAndSwitchNotificationsAsync()
+    {
+        var (player, output) = CastleSiegeRemoteViewTestHelper.CreatePlayer();
+
+        await new CastleSiegeCrownStatePlugIn(player)
+            .ShowCrownStateAsync(true)
+            .ConfigureAwait(false);
+        await new CastleSiegeCrownAccessStatePlugIn(player)
+            .ShowCrownAccessStateAsync(CrownAccessState.Success, TimeSpan.FromMilliseconds(12_345))
+            .ConfigureAwait(false);
+        await new CastleSiegeSwitchInfoPlugIn(player)
+            .ShowSwitchInfoAsync(
+                new SwitchInfo(
+                    0x1234,
+                    true,
+                    DataJoinSide.Attack2,
+                    "Attackr",
+                    "Attacker"))
+            .ConfigureAwait(false);
+        await new CastleSiegeOwnershipChangePlugIn(player)
+            .ShowOwnershipChangeAsync("Defender")
+            .ConfigureAwait(false);
+
+        var data = output.ToArray().AsMemory();
+        Assert.That(
+            data.Length,
+            Is.EqualTo(
+                CastleSiegeCrownStateUpdate.Length
+                + CrownAccessPacket.Length
+                + SwitchInfoPacket.Length
+                + CastleSiegeBattleProcess.Length));
+
+        var crownState = (CastleSiegeCrownStateUpdate)data[..CastleSiegeCrownStateUpdate.Length];
+        Assert.That(crownState.State, Is.EqualTo(CastleSiegeCrownState.Accessible));
+
+        var offset = CastleSiegeCrownStateUpdate.Length;
+        var crownAccess = (CrownAccessPacket)data.Slice(offset, CrownAccessPacket.Length);
+        Assert.Multiple(() =>
+        {
+            Assert.That(crownAccess.State, Is.EqualTo(CastleSiegeCrownAccessStateType.Succeeded));
+            Assert.That(crownAccess.AccumulatedTimeMs, Is.EqualTo(12_345));
+        });
+
+        offset += CrownAccessPacket.Length;
+        var switchInfo = (SwitchInfoPacket)data.Slice(offset, SwitchInfoPacket.Length);
+        Assert.Multiple(() =>
+        {
+            Assert.That(switchInfo.SwitchIndex, Is.EqualTo(0x1234));
+            Assert.That(switchInfo.IsOccupied, Is.True);
+            Assert.That(switchInfo.JoinSide, Is.EqualTo(MUnique.OpenMU.Network.Packets.ServerToClient.CastleSiegeJoinSide.Attack2));
+            Assert.That(switchInfo.GuildName, Is.EqualTo("Attackr"));
+            Assert.That(switchInfo.UserName, Is.EqualTo("Attacker"));
+        });
+
+        offset += SwitchInfoPacket.Length;
+        var ownership = (CastleSiegeBattleProcess)data.Slice(offset, CastleSiegeBattleProcess.Length);
+        Assert.Multiple(() =>
+        {
+            Assert.That(ownership.State, Is.EqualTo(CastleSiegeBattleProcessState.CrownRegistrationSucceeded));
+            Assert.That(ownership.GuildName, Is.EqualTo("Defender"));
+        });
+    }
+}

--- a/tests/MUnique.OpenMU.Tests/CastleSiegeNpcTests.cs
+++ b/tests/MUnique.OpenMU.Tests/CastleSiegeNpcTests.cs
@@ -686,6 +686,7 @@ public class CastleSiegeNpcTests
 
     /// <summary>
     /// Verifies Crown and switch proximity tracking without applying the later win-condition mechanics.
+    /// Crown availability remains owned by the switch mechanics.
     /// </summary>
     [Test]
     public async ValueTask CrownAndSwitchTrackNearbyAlivePlayerAsync()
@@ -734,7 +735,7 @@ public class CastleSiegeNpcTests
             {
                 Assert.That(fixture.Context.CrownUser, Is.SameAs(fixture.Player));
                 Assert.That(fixture.Context.CrownAccumulatedTime, Is.EqualTo(TimeSpan.FromSeconds(12)));
-                Assert.That(crown.State, Is.EqualTo(CastleSiegeCrownState.Idle));
+                Assert.That(crown.State, Is.EqualTo(CastleSiegeCrownState.Locked));
             });
 
             await fixture.Player.WarpToAsync(new ExitGate


### PR DESCRIPTION
## Summary

Implements the Castle Siege Crown capture and switch mechanics described in #726.

## Changes

- Validate that the Crown and both switches are occupied by alive, guilded players from the same attacking side.
- Accumulate Crown capture time and preserve capped progress when an attempt is interrupted.
- Send attempt, failure, and success notifications to the Crown user.
- Swap the capturing and defending sides after a successful capture.
- Reassign participant sides and respawn non-defending players.
- Persist the intermediate guild-side changes for restart recovery.
- Broadcast switch occupants, Crown availability, and ownership changes.
- Persist the final castle owner when the battle ends.
- Reset taxes and tribute money when ownership changes.
- Add null-safe remote views for the required Castle Siege packets.
- Add regression tests for the mechanics, persistence, restart recovery, and packet serialization.

## Testing

- GameLogic build succeeded.
- GameServer build succeeded.
- 9 focused Crown and switch tests passed.
- 89 complete Castle Siege tests passed.
- Formatting and diff checks passed.

## Scope note

Life Stone destruction during side reassignment depends on the runtime Life Stone implementation from #727. The current change performs the side reassignment and respawn flow without introducing temporary or unused Life Stone code.