### PR TITLE
Implement Castle Siege tax, tribute, and economy

### DIFF
--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeHuntZoneEnterAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeHuntZoneEnterAction.cs
@@ -39,7 +39,7 @@ public sealed class CastleSiegeHuntZoneEnterAction
 
         if (!await this._taxProvider.TryPayHuntEntryFeeAsync(player, context).ConfigureAwait(false))
         {
-            var fee = await this._taxProvider.GetHuntEntryFeeAsync(player).ConfigureAwait(false);
+            var fee = await this._taxProvider.GetHuntEntryFeeAsync(player, context).ConfigureAwait(false);
             if (fee > player.Money)
             {
                 await player.ShowLocalizedBlueMessageAsync(

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeHuntZoneEnterAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeHuntZoneEnterAction.cs
@@ -1,0 +1,58 @@
+// <copyright file="CastleSiegeHuntZoneEnterAction.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+
+using MUnique.OpenMU.GameLogic.PlayerActions;
+
+/// <summary>
+/// Enters the Castle Siege hunting zone.
+/// </summary>
+public sealed class CastleSiegeHuntZoneEnterAction
+{
+    private const short GuardsmanNumber = 224;
+    private readonly CastleSiegeTaxProvider _taxProvider = new();
+
+    /// <summary>
+    /// Tries to charge the configured entry fee and warp the player to the Land of Trials.
+    /// </summary>
+    /// <param name="player">The entering player.</param>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <returns><see langword="true"/> when the player entered the map.</returns>
+    public async ValueTask<bool> EnterAsync(Player player, CastleSiegeContext? context)
+    {
+        if (context is not { Configuration.Enabled: true }
+            || player.OpenedNpc?.Definition.Number != GuardsmanNumber
+            || player.CurrentMap?.Definition.Number != context.Configuration.CastleSiegeMapDefinition?.Number
+            || context.Configuration.LandOfTrialsMapDefinition is not { } targetMap
+            || targetMap.ExitGates.FirstOrDefault() is not { } targetGate)
+        {
+            return false;
+        }
+
+        if (targetMap.TryGetRequirementError(player, out var errorMessage))
+        {
+            await player.ShowBlueMessageAsync(errorMessage).ConfigureAwait(false);
+            return false;
+        }
+
+        if (!await this._taxProvider.TryPayHuntEntryFeeAsync(player, context).ConfigureAwait(false))
+        {
+            var fee = await this._taxProvider.GetHuntEntryFeeAsync(player).ConfigureAwait(false);
+            if (fee > player.Money)
+            {
+                await player.ShowLocalizedBlueMessageAsync(
+                        nameof(PlayerMessage.NotEnoughMoneyToEnter),
+                        targetMap.Name.GetTranslation(player.Culture))
+                    .ConfigureAwait(false);
+            }
+
+            return false;
+        }
+
+        player.OpenedNpc = null;
+        await player.WarpToAsync(targetGate).ConfigureAwait(false);
+        return true;
+    }
+}

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeHuntZoneToggleAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeHuntZoneToggleAction.cs
@@ -1,0 +1,66 @@
+// <copyright file="CastleSiegeHuntZoneToggleAction.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// Changes public access to the Land of Trials.
+/// </summary>
+public sealed class CastleSiegeHuntZoneToggleAction
+{
+    /// <summary>
+    /// Tries to change public Land of Trials access.
+    /// </summary>
+    /// <param name="player">The requesting player.</param>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <param name="isPublic">Whether public entry should be enabled.</param>
+    /// <returns><see langword="true"/> when the setting was changed.</returns>
+    public async ValueTask<bool> SetPublicAccessAsync(
+        Player player,
+        CastleSiegeContext? context,
+        bool isPublic)
+    {
+        var result = CastleSiegeRequestResult.Failed;
+        if (context is { Configuration.Enabled: true })
+        {
+            var ownerGuildId = await CastleSiegeTaxProvider.GetPersistentGuildMasterIdAsync(player).ConfigureAwait(false);
+            await context.ExecutionLock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                if (context.CurrentState != CastleSiegeState.Start)
+                {
+                    if (context.SiegeData.IsOccupied
+                        && ownerGuildId is not null
+                        && ownerGuildId == context.SiegeData.OwnerGuildId)
+                    {
+                        context.SiegeData.IsHuntZoneEnabled = isPublic;
+                        await context.SaveOwnerAsync().ConfigureAwait(false);
+                        result = CastleSiegeRequestResult.Success;
+                    }
+                    else
+                    {
+                        result = CastleSiegeRequestResult.NotAuthorized;
+                    }
+                }
+            }
+            finally
+            {
+                context.ExecutionLock.Release();
+            }
+        }
+
+        var currentSetting = result == CastleSiegeRequestResult.Success
+            ? isPublic
+            : context?.SiegeData.IsHuntZoneEnabled ?? false;
+        await player.InvokeViewPlugInAsync<ICastleSiegeHuntZoneResultPlugIn>(
+                view => view.ShowEntranceSettingResultAsync(
+                    result,
+                    currentSetting))
+            .ConfigureAwait(false);
+
+        return result == CastleSiegeRequestResult.Success;
+    }
+}

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeTaxInfoAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeTaxInfoAction.cs
@@ -1,0 +1,42 @@
+// <copyright file="CastleSiegeTaxInfoAction.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// Shows the current Castle Siege economy state.
+/// </summary>
+public sealed class CastleSiegeTaxInfoAction
+{
+    private readonly CastleSiegeTaxProvider _taxProvider = new();
+
+    /// <summary>
+    /// Shows the tax configuration and the treasury balance visible to the player.
+    /// </summary>
+    /// <param name="player">The requesting player.</param>
+    /// <param name="context">The Castle Siege context.</param>
+    public async ValueTask ShowAsync(Player player, CastleSiegeContext? context)
+    {
+        var result = CastleSiegeRequestResult.Failed;
+        var data = context is { Configuration.Enabled: true, SiegeData.IsOccupied: true }
+            ? context.SiegeData
+            : null;
+        if (data is not null)
+        {
+            result = await this._taxProvider.IsOwnerGuildMasterAsync(player, context).ConfigureAwait(false)
+                ? CastleSiegeRequestResult.Success
+                : CastleSiegeRequestResult.NotAuthorized;
+        }
+
+        await player.InvokeViewPlugInAsync<ICastleSiegeTaxInfoPlugIn>(
+                view => view.ShowTaxInfoAsync(
+                    result,
+                    data?.TaxChaos ?? 0,
+                    data?.TaxStore ?? 0,
+                    result == CastleSiegeRequestResult.Success ? Math.Max(0, data!.TributeMoney) : 0))
+            .ConfigureAwait(false);
+    }
+}

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeTaxInfoAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeTaxInfoAction.cs
@@ -31,6 +31,7 @@ public sealed class CastleSiegeTaxInfoAction
                 : CastleSiegeRequestResult.NotAuthorized;
         }
 
+        // Percentage rates are public protocol state; only the treasury balance is restricted to the owner guild master.
         await player.InvokeViewPlugInAsync<ICastleSiegeTaxInfoPlugIn>(
                 view => view.ShowTaxInfoAsync(
                     result,

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeTaxRateChangeAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeTaxRateChangeAction.cs
@@ -1,0 +1,91 @@
+// <copyright file="CastleSiegeTaxRateChangeAction.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// Changes one of the Castle Siege tax rates.
+/// </summary>
+public sealed class CastleSiegeTaxRateChangeAction
+{
+    /// <summary>
+    /// Tries to change a Castle Siege tax rate.
+    /// </summary>
+    /// <param name="player">The requesting player.</param>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <param name="taxType">The tax type.</param>
+    /// <param name="taxRate">The requested tax rate or fee.</param>
+    /// <returns><see langword="true"/> when the rate was changed.</returns>
+    public async ValueTask<bool> ChangeAsync(
+        Player player,
+        CastleSiegeContext? context,
+        CastleSiegeTaxType taxType,
+        uint taxRate)
+    {
+        var result = CastleSiegeRequestResult.Failed;
+        if (context is { Configuration.Enabled: true })
+        {
+            var ownerGuildId = await CastleSiegeTaxProvider.GetPersistentGuildMasterIdAsync(player).ConfigureAwait(false);
+            await context.ExecutionLock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                if (!context.SiegeData.IsOccupied
+                    || ownerGuildId is null
+                    || ownerGuildId != context.SiegeData.OwnerGuildId)
+                {
+                    result = CastleSiegeRequestResult.NotAuthorized;
+                }
+                else if (context.CurrentState != CastleSiegeState.Start
+                         && IsValid(taxType, taxRate))
+                {
+                    switch (taxType)
+                    {
+                        case CastleSiegeTaxType.ChaosMachine:
+                            context.SiegeData.TaxChaos = (byte)taxRate;
+                            break;
+                        case CastleSiegeTaxType.Store:
+                            context.SiegeData.TaxStore = (byte)taxRate;
+                            break;
+                        case CastleSiegeTaxType.HuntZone:
+                            context.SiegeData.TaxHunt = (int)taxRate;
+                            break;
+                        default:
+                            throw new InvalidOperationException($"Unexpected validated tax type {taxType}.");
+                    }
+
+                    await context.SaveOwnerAsync().ConfigureAwait(false);
+                    result = CastleSiegeRequestResult.Success;
+                }
+            }
+            finally
+            {
+                context.ExecutionLock.Release();
+            }
+        }
+
+        await player.InvokeViewPlugInAsync<ICastleSiegeTaxChangeResultPlugIn>(
+                view => view.ShowTaxChangeResultAsync(result, taxType, taxRate))
+            .ConfigureAwait(false);
+        if (result == CastleSiegeRequestResult.Success
+            && context is not null
+            && taxType is CastleSiegeTaxType.ChaosMachine or CastleSiegeTaxType.Store)
+        {
+            await CastleSiegeEconomyNotifier.BroadcastTaxRateAsync(context, taxType).ConfigureAwait(false);
+        }
+
+        return result == CastleSiegeRequestResult.Success;
+    }
+
+    private static bool IsValid(CastleSiegeTaxType taxType, uint taxRate)
+    {
+        return taxType switch
+        {
+            CastleSiegeTaxType.ChaosMachine or CastleSiegeTaxType.Store => taxRate <= CastleSiegeTaxProvider.MaximumPercentageTax,
+            CastleSiegeTaxType.HuntZone => taxRate <= CastleSiegeTaxProvider.MaximumHuntTax,
+            _ => false,
+        };
+    }
+}

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeTaxRateChangeAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeTaxRateChangeAction.cs
@@ -26,6 +26,7 @@ public sealed class CastleSiegeTaxRateChangeAction
         uint taxRate)
     {
         var result = CastleSiegeRequestResult.Failed;
+        byte? broadcastTaxRate = null;
         if (context is { Configuration.Enabled: true })
         {
             var ownerGuildId = await CastleSiegeTaxProvider.GetPersistentGuildMasterIdAsync(player).ConfigureAwait(false);
@@ -60,6 +61,10 @@ public sealed class CastleSiegeTaxRateChangeAction
 
                         await context.SaveOwnerAsync().ConfigureAwait(false);
                         result = CastleSiegeRequestResult.Success;
+                        if (taxType is CastleSiegeTaxType.ChaosMachine or CastleSiegeTaxType.Store)
+                        {
+                            broadcastTaxRate = checked((byte)taxRate);
+                        }
                     }
                 }
             }
@@ -72,11 +77,9 @@ public sealed class CastleSiegeTaxRateChangeAction
         await player.InvokeViewPlugInAsync<ICastleSiegeTaxChangeResultPlugIn>(
                 view => view.ShowTaxChangeResultAsync(result, taxType, taxRate))
             .ConfigureAwait(false);
-        if (result == CastleSiegeRequestResult.Success
-            && context is not null
-            && taxType is CastleSiegeTaxType.ChaosMachine or CastleSiegeTaxType.Store)
+        if (context is not null && broadcastTaxRate is { } rate)
         {
-            await CastleSiegeEconomyNotifier.BroadcastTaxRateAsync(context, taxType).ConfigureAwait(false);
+            await CastleSiegeEconomyNotifier.BroadcastTaxRateAsync(context, taxType, rate).ConfigureAwait(false);
         }
 
         return result == CastleSiegeRequestResult.Success;

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeTaxRateChangeAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeTaxRateChangeAction.cs
@@ -38,26 +38,29 @@ public sealed class CastleSiegeTaxRateChangeAction
                 {
                     result = CastleSiegeRequestResult.NotAuthorized;
                 }
-                else if (context.CurrentState != CastleSiegeState.Start
-                         && IsValid(taxType, taxRate))
+                else
                 {
-                    switch (taxType)
+                    if (context.CurrentState != CastleSiegeState.Start
+                        && IsValid(taxType, taxRate))
                     {
-                        case CastleSiegeTaxType.ChaosMachine:
-                            context.SiegeData.TaxChaos = (byte)taxRate;
-                            break;
-                        case CastleSiegeTaxType.Store:
-                            context.SiegeData.TaxStore = (byte)taxRate;
-                            break;
-                        case CastleSiegeTaxType.HuntZone:
-                            context.SiegeData.TaxHunt = (int)taxRate;
-                            break;
-                        default:
-                            throw new InvalidOperationException($"Unexpected validated tax type {taxType}.");
-                    }
+                        switch (taxType)
+                        {
+                            case CastleSiegeTaxType.ChaosMachine:
+                                context.SiegeData.TaxChaos = (byte)taxRate;
+                                break;
+                            case CastleSiegeTaxType.Store:
+                                context.SiegeData.TaxStore = (byte)taxRate;
+                                break;
+                            case CastleSiegeTaxType.HuntZone:
+                                context.SiegeData.TaxHunt = (int)taxRate;
+                                break;
+                            default:
+                                throw new InvalidOperationException($"Unexpected validated tax type {taxType}.");
+                        }
 
-                    await context.SaveOwnerAsync().ConfigureAwait(false);
-                    result = CastleSiegeRequestResult.Success;
+                        await context.SaveOwnerAsync().ConfigureAwait(false);
+                        result = CastleSiegeRequestResult.Success;
+                    }
                 }
             }
             finally

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeTributeWithdrawAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeTributeWithdrawAction.cs
@@ -34,23 +34,26 @@ public sealed class CastleSiegeTributeWithdrawAction
                 {
                     result = CastleSiegeRequestResult.NotAuthorized;
                 }
-                else if (amount is > 0 and <= int.MaxValue
-                         && amount <= context.SiegeData.TributeMoney
-                         && amount <= player.GameContext.Configuration.MaximumInventoryMoney - (long)player.Money
-                         && player.TryAddMoney((int)amount))
+                else
                 {
-                    var previousTribute = context.SiegeData.TributeMoney;
-                    context.SiegeData.TributeMoney -= amount;
-                    try
+                    if (amount is > 0 and <= int.MaxValue
+                        && amount <= context.SiegeData.TributeMoney
+                        && amount <= player.GameContext.Configuration.MaximumInventoryMoney - (long)player.Money
+                        && player.TryAddMoney((int)amount))
                     {
-                        await context.SaveOwnerAsync().ConfigureAwait(false);
-                        result = CastleSiegeRequestResult.Success;
-                    }
-                    catch
-                    {
-                        context.SiegeData.TributeMoney = previousTribute;
-                        _ = player.TryRemoveMoney((int)amount);
-                        throw;
+                        var previousTribute = context.SiegeData.TributeMoney;
+                        context.SiegeData.TributeMoney -= amount;
+                        try
+                        {
+                            await context.SaveOwnerAsync().ConfigureAwait(false);
+                            result = CastleSiegeRequestResult.Success;
+                        }
+                        catch
+                        {
+                            context.SiegeData.TributeMoney = previousTribute;
+                            _ = player.TryRemoveMoney((int)amount);
+                            throw;
+                        }
                     }
                 }
             }

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeTributeWithdrawAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeTributeWithdrawAction.cs
@@ -38,7 +38,6 @@ public sealed class CastleSiegeTributeWithdrawAction
                 {
                     if (amount is > 0 and <= int.MaxValue
                         && amount <= context.SiegeData.TributeMoney
-                        && amount <= player.GameContext.Configuration.MaximumInventoryMoney - (long)player.Money
                         && player.TryAddMoney((int)amount))
                     {
                         var previousTribute = context.SiegeData.TributeMoney;

--- a/src/GameLogic/CastleSiege/Actions/CastleSiegeTributeWithdrawAction.cs
+++ b/src/GameLogic/CastleSiege/Actions/CastleSiegeTributeWithdrawAction.cs
@@ -1,0 +1,75 @@
+// <copyright file="CastleSiegeTributeWithdrawAction.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+using MUnique.OpenMU.GameLogic.Views.Inventory;
+
+/// <summary>
+/// Withdraws money from the Castle Siege treasury.
+/// </summary>
+public sealed class CastleSiegeTributeWithdrawAction
+{
+    /// <summary>
+    /// Tries to withdraw tribute money into the castle owner guild master's inventory.
+    /// </summary>
+    /// <param name="player">The requesting player.</param>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <param name="amount">The requested amount.</param>
+    /// <returns><see langword="true"/> when the money was withdrawn.</returns>
+    public async ValueTask<bool> WithdrawAsync(Player player, CastleSiegeContext? context, long amount)
+    {
+        var result = CastleSiegeRequestResult.Failed;
+        if (context is { Configuration.Enabled: true })
+        {
+            var ownerGuildId = await CastleSiegeTaxProvider.GetPersistentGuildMasterIdAsync(player).ConfigureAwait(false);
+            await context.ExecutionLock.WaitAsync().ConfigureAwait(false);
+            try
+            {
+                if (!context.SiegeData.IsOccupied
+                    || ownerGuildId is null
+                    || ownerGuildId != context.SiegeData.OwnerGuildId)
+                {
+                    result = CastleSiegeRequestResult.NotAuthorized;
+                }
+                else if (amount is > 0 and <= int.MaxValue
+                         && amount <= context.SiegeData.TributeMoney
+                         && amount <= player.GameContext.Configuration.MaximumInventoryMoney - (long)player.Money
+                         && player.TryAddMoney((int)amount))
+                {
+                    var previousTribute = context.SiegeData.TributeMoney;
+                    context.SiegeData.TributeMoney -= amount;
+                    try
+                    {
+                        await context.SaveOwnerAsync().ConfigureAwait(false);
+                        result = CastleSiegeRequestResult.Success;
+                    }
+                    catch
+                    {
+                        context.SiegeData.TributeMoney = previousTribute;
+                        _ = player.TryRemoveMoney((int)amount);
+                        throw;
+                    }
+                }
+            }
+            finally
+            {
+                context.ExecutionLock.Release();
+            }
+        }
+
+        if (result == CastleSiegeRequestResult.Success)
+        {
+            await player.InvokeViewPlugInAsync<IUpdateMoneyPlugIn>(view => view.UpdateMoneyAsync()).ConfigureAwait(false);
+        }
+
+        await player.InvokeViewPlugInAsync<ICastleSiegeTributeWithdrawResultPlugIn>(
+                view => view.ShowTributeWithdrawResultAsync(
+                    result,
+                    result == CastleSiegeRequestResult.Success ? amount : 0))
+            .ConfigureAwait(false);
+        return result == CastleSiegeRequestResult.Success;
+    }
+}

--- a/src/GameLogic/CastleSiege/CastleSiegeContext.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeContext.cs
@@ -176,6 +176,16 @@ public class CastleSiegeContext : IEventStateProvider
     internal DateTime NextNpcSaveUtc { get; set; } = DateTime.MaxValue;
 
     /// <summary>
+    /// Gets or sets the next economy persistence time.
+    /// </summary>
+    internal DateTime NextEconomySaveUtc { get; set; } = DateTime.MinValue;
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the in-memory economy state needs to be persisted.
+    /// </summary>
+    internal bool IsEconomyPersistencePending { get; set; }
+
+    /// <summary>
     /// Gets or sets the next participant tracking time.
     /// </summary>
     internal DateTime NextParticipantUpdateUtc { get; set; } = DateTime.MaxValue;
@@ -272,6 +282,7 @@ public class CastleSiegeContext : IEventStateProvider
 
         CopyScalarState(this.SiegeData, persistentData);
         await context.SaveChangesAsync().ConfigureAwait(false);
+        this.IsEconomyPersistencePending = false;
     }
 
     /// <summary>

--- a/src/GameLogic/CastleSiege/CastleSiegeCrownMechanics.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeCrownMechanics.cs
@@ -118,9 +118,14 @@ public static class CastleSiegeCrownMechanics
             }
         }
 
-        ApplyOwner(context, capturingGuild);
+        var ownershipChanged = ApplyOwner(context, capturingGuild);
         await context.SaveFinalGuildListAsync().ConfigureAwait(false);
         await context.SaveOwnerAsync().ConfigureAwait(false);
+        if (ownershipChanged)
+        {
+            await CastleSiegeEconomyNotifier.BroadcastTaxRatesAsync(context).ConfigureAwait(false);
+        }
+
         await context.SetPlayerJoinSideAsync().ConfigureAwait(false);
         await RespawnAttackersAsync(context).ConfigureAwait(false);
 
@@ -170,12 +175,14 @@ public static class CastleSiegeCrownMechanics
             }
         }
 
-        if (winner is not null)
-        {
-            ApplyOwner(context, winner);
-        }
+        var ownershipChanged = winner is not null && ApplyOwner(context, winner);
 
         await context.SaveOwnerAsync().ConfigureAwait(false);
+        if (ownershipChanged)
+        {
+            await CastleSiegeEconomyNotifier.BroadcastTaxRatesAsync(context).ConfigureAwait(false);
+        }
+
         var ownerName = winner?.GuildName
                         ?? await GetOwnerGuildNameAsync(context).ConfigureAwait(false)
                         ?? string.Empty;
@@ -290,12 +297,12 @@ public static class CastleSiegeCrownMechanics
                 ?.Name;
     }
 
-    private static void ApplyOwner(CastleSiegeContext context, CastleSiegeGuildParticipant winner)
+    private static bool ApplyOwner(CastleSiegeContext context, CastleSiegeGuildParticipant winner)
     {
         if (context.SiegeData.IsOccupied
             && context.SiegeData.OwnerGuildId == winner.PersistentGuildId)
         {
-            return;
+            return false;
         }
 
         // A successful seal changes the castle lord immediately. The previous ownership tenure's economy must not
@@ -306,6 +313,8 @@ public static class CastleSiegeCrownMechanics
         context.SiegeData.TaxStore = 0;
         context.SiegeData.TaxHunt = 0;
         context.SiegeData.TributeMoney = 0;
+        context.SiegeData.IsHuntZoneEnabled = false;
+        return true;
     }
 
     private static async ValueTask BroadcastOwnershipAsync(CastleSiegeContext context, string guildName)

--- a/src/GameLogic/CastleSiege/CastleSiegeEconomyNotifier.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeEconomyNotifier.cs
@@ -1,0 +1,72 @@
+// <copyright file="CastleSiegeEconomyNotifier.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege;
+
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// Synchronizes Castle Siege tax rates with game clients.
+/// </summary>
+internal static class CastleSiegeEconomyNotifier
+{
+    /// <summary>
+    /// Sends the current percentage tax rates to a player.
+    /// </summary>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <param name="player">The player.</param>
+    internal static async ValueTask SynchronizePlayerAsync(CastleSiegeContext context, Player player)
+    {
+        await SendTaxRateAsync(context, player, CastleSiegeTaxType.ChaosMachine).ConfigureAwait(false);
+        await SendTaxRateAsync(context, player, CastleSiegeTaxType.Store).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Broadcasts a percentage tax rate to all connected players.
+    /// </summary>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <param name="taxType">The tax type.</param>
+    internal static async ValueTask BroadcastTaxRateAsync(CastleSiegeContext context, CastleSiegeTaxType taxType)
+    {
+        if (taxType is not (CastleSiegeTaxType.ChaosMachine or CastleSiegeTaxType.Store))
+        {
+            return;
+        }
+
+        foreach (var player in await context.GameContext.GetPlayersAsync().ConfigureAwait(false))
+        {
+            await SendTaxRateAsync(context, player, taxType).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Broadcasts all percentage tax rates to connected players.
+    /// </summary>
+    /// <param name="context">The Castle Siege context.</param>
+    internal static async ValueTask BroadcastTaxRatesAsync(CastleSiegeContext context)
+    {
+        foreach (var player in await context.GameContext.GetPlayersAsync().ConfigureAwait(false))
+        {
+            if (player.PlayerState.CurrentState == PlayerState.EnteredWorld)
+            {
+                await SynchronizePlayerAsync(context, player).ConfigureAwait(false);
+            }
+        }
+    }
+
+    private static ValueTask SendTaxRateAsync(
+        CastleSiegeContext context,
+        Player player,
+        CastleSiegeTaxType taxType)
+    {
+        var taxRate = taxType switch
+        {
+            CastleSiegeTaxType.ChaosMachine => Math.Min((int)context.SiegeData.TaxChaos, CastleSiegeTaxProvider.MaximumPercentageTax),
+            CastleSiegeTaxType.Store => Math.Min((int)context.SiegeData.TaxStore, CastleSiegeTaxProvider.MaximumPercentageTax),
+            _ => 0,
+        };
+        return player.InvokeViewPlugInAsync<ICastleSiegeTaxChangeResultPlugIn>(
+            view => view.ShowTaxRateUpdateAsync(taxType, checked((byte)taxRate)));
+    }
+}

--- a/src/GameLogic/CastleSiege/CastleSiegeEconomyNotifier.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeEconomyNotifier.cs
@@ -27,7 +27,11 @@ internal static class CastleSiegeEconomyNotifier
     /// </summary>
     /// <param name="context">The Castle Siege context.</param>
     /// <param name="taxType">The tax type.</param>
-    internal static async ValueTask BroadcastTaxRateAsync(CastleSiegeContext context, CastleSiegeTaxType taxType)
+    /// <param name="taxRate">The tax rate captured when the change was applied.</param>
+    internal static async ValueTask BroadcastTaxRateAsync(
+        CastleSiegeContext context,
+        CastleSiegeTaxType taxType,
+        byte taxRate)
     {
         if (taxType is not (CastleSiegeTaxType.ChaosMachine or CastleSiegeTaxType.Store))
         {
@@ -36,7 +40,10 @@ internal static class CastleSiegeEconomyNotifier
 
         foreach (var player in await context.GameContext.GetPlayersAsync().ConfigureAwait(false))
         {
-            await SendTaxRateAsync(context, player, taxType).ConfigureAwait(false);
+            if (player.PlayerState.CurrentState == PlayerState.EnteredWorld)
+            {
+                await SendTaxRateAsync(player, taxType, taxRate).ConfigureAwait(false);
+            }
         }
     }
 
@@ -66,7 +73,15 @@ internal static class CastleSiegeEconomyNotifier
             CastleSiegeTaxType.Store => Math.Min((int)context.SiegeData.TaxStore, CastleSiegeTaxProvider.MaximumPercentageTax),
             _ => 0,
         };
+        return SendTaxRateAsync(player, taxType, checked((byte)taxRate));
+    }
+
+    private static ValueTask SendTaxRateAsync(
+        Player player,
+        CastleSiegeTaxType taxType,
+        byte taxRate)
+    {
         return player.InvokeViewPlugInAsync<ICastleSiegeTaxChangeResultPlugIn>(
-            view => view.ShowTaxRateUpdateAsync(taxType, checked((byte)taxRate)));
+            view => view.ShowTaxRateUpdateAsync(taxType, taxRate));
     }
 }

--- a/src/GameLogic/CastleSiege/CastleSiegeGuardsmanTalkPlugIn.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeGuardsmanTalkPlugIn.cs
@@ -1,0 +1,61 @@
+// <copyright file="CastleSiegeGuardsmanTalkPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic.NPC;
+using MUnique.OpenMU.GameLogic.PlugIns;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Opens the Land of Trials entry dialog when a player talks to a Castle Siege guardsman.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeGuardsmanTalkPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeGuardsmanTalkPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("3E2AD5FD-E5D0-4464-91EE-70DF686BBB6A")]
+public sealed class CastleSiegeGuardsmanTalkPlugIn : IPlayerTalkToNpcPlugIn
+{
+    private const short GuardsmanNumber = 224;
+    private readonly CastleSiegeTaxProvider _taxProvider = new();
+
+    /// <inheritdoc />
+    public async ValueTask PlayerTalksToNpcAsync(Player player, NonPlayerCharacter npc, NpcTalkEventArgs eventArgs)
+    {
+        var context = CastleSiegeTaxProvider.GetContext(player);
+        if (npc.Definition.Number != GuardsmanNumber
+            || context is not { Configuration.Enabled: true }
+            || player.CurrentMap?.Definition.Number != context.Configuration.CastleSiegeMapDefinition?.Number)
+        {
+            return;
+        }
+
+        eventArgs.HasBeenHandled = true;
+        eventArgs.LeavesDialogOpen = true;
+        var isOwnerMaster = await this._taxProvider.IsOwnerGuildMasterAsync(player, context).ConfigureAwait(false);
+        var isExempt = isOwnerMaster
+                       || await this._taxProvider.IsExemptAsync(player, context).ConfigureAwait(false);
+        var accessType = !context.SiegeData.IsOccupied
+            ? CastleSiegeHuntZoneAccessType.Failed
+            : isOwnerMaster
+                ? CastleSiegeHuntZoneAccessType.OwnerGuildMaster
+                : isExempt
+                    ? CastleSiegeHuntZoneAccessType.OwnerAllianceMember
+                    : CastleSiegeHuntZoneAccessType.Guest;
+        var configuredFee = Math.Clamp(context.SiegeData.TaxHunt, 0, CastleSiegeTaxProvider.MaximumHuntTax);
+        var fee = accessType is CastleSiegeHuntZoneAccessType.Guest
+            or CastleSiegeHuntZoneAccessType.OwnerGuildMaster
+            ? configuredFee
+            : 0;
+        await player.InvokeViewPlugInAsync<ICastleSiegeHuntZoneGuardInfoPlugIn>(
+                view => view.ShowHuntZoneGuardInfoAsync(
+                    accessType,
+                    context.SiegeData.IsHuntZoneEnabled,
+                    fee,
+                    CastleSiegeTaxProvider.MaximumHuntTax,
+                    CastleSiegeTaxProvider.HuntTaxStep))
+            .ConfigureAwait(false);
+    }
+}

--- a/src/GameLogic/CastleSiege/CastleSiegePlugIn.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegePlugIn.cs
@@ -19,6 +19,7 @@ using MUnique.OpenMU.PlugIns;
 [Guid("B7F62FA9-59E6-49E9-B499-0358A14957CF")]
 public class CastleSiegePlugIn : IPeriodicTaskPlugIn, IObjectAddedToMapPlugIn, IObjectRemovedFromMapPlugIn, IPlayerStateChangedPlugIn
 {
+    private static readonly TimeSpan EconomySaveInterval = TimeSpan.FromSeconds(30);
     private static readonly TimeSpan NpcSaveInterval = TimeSpan.FromMinutes(2);
     private static readonly TimeSpan ParticipantUpdateInterval = TimeSpan.FromSeconds(5);
 
@@ -116,6 +117,22 @@ public class CastleSiegePlugIn : IPeriodicTaskPlugIn, IObjectAddedToMapPlugIn, I
     }
 
     /// <summary>
+    /// Persists accumulated Castle Siege economy changes when the batch interval is due.
+    /// </summary>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <param name="utcNow">The current UTC time.</param>
+    internal static async ValueTask PersistEconomyIfDueAsync(CastleSiegeContext context, DateTime utcNow)
+    {
+        if (!context.IsEconomyPersistencePending || context.NextEconomySaveUtc > utcNow)
+        {
+            return;
+        }
+
+        await context.SaveOwnerAsync().ConfigureAwait(false);
+        context.NextEconomySaveUtc = utcNow + EconomySaveInterval;
+    }
+
+    /// <summary>
     /// Executes the periodic task against an abstract game context.
     /// </summary>
     /// <param name="gameContext">The game context.</param>
@@ -151,6 +168,7 @@ public class CastleSiegePlugIn : IPeriodicTaskPlugIn, IObjectAddedToMapPlugIn, I
             if (!context.IsInitialized)
             {
                 await context.InitializeAsync(utcNow).ConfigureAwait(false);
+                context.NextEconomySaveUtc = utcNow + EconomySaveInterval;
                 this.ConfigureNotifications(context, utcNow);
                 await this.OnEnterStateAsync(context, true).ConfigureAwait(false);
                 await CastleSiegeEconomyNotifier.BroadcastTaxRatesAsync(context).ConfigureAwait(false);
@@ -390,6 +408,8 @@ public class CastleSiegePlugIn : IPeriodicTaskPlugIn, IObjectAddedToMapPlugIn, I
 
     private async ValueTask OnTickAsync(CastleSiegeContext context, DateTime utcNow)
     {
+        await PersistEconomyIfDueAsync(context, utcNow).ConfigureAwait(false);
+
         if (context.NextNotificationUtc <= utcNow)
         {
             await this.SendStateNotificationAsync(context).ConfigureAwait(false);

--- a/src/GameLogic/CastleSiege/CastleSiegePlugIn.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegePlugIn.cs
@@ -153,6 +153,7 @@ public class CastleSiegePlugIn : IPeriodicTaskPlugIn, IObjectAddedToMapPlugIn, I
                 await context.InitializeAsync(utcNow).ConfigureAwait(false);
                 this.ConfigureNotifications(context, utcNow);
                 await this.OnEnterStateAsync(context, true).ConfigureAwait(false);
+                await CastleSiegeEconomyNotifier.BroadcastTaxRatesAsync(context).ConfigureAwait(false);
                 await this.BroadcastStateUpdateAsync(context).ConfigureAwait(false);
                 logger.LogInformation(
                     "Castle Siege initialized in state {state}; the state ends at {stateEndUtc}.",
@@ -215,6 +216,7 @@ public class CastleSiegePlugIn : IPeriodicTaskPlugIn, IObjectAddedToMapPlugIn, I
         GameMap map,
         CastleSiegeContext context)
     {
+        await CastleSiegeEconomyNotifier.SynchronizePlayerAsync(context, player).ConfigureAwait(false);
         if (context.CurrentState is not (CastleSiegeState.Ready or CastleSiegeState.Start)
             || context.Configuration.CastleSiegeMapDefinition?.Number != map.Definition.Number)
         {

--- a/src/GameLogic/CastleSiege/CastleSiegeTaxProvider.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeTaxProvider.cs
@@ -1,0 +1,333 @@
+// <copyright file="CastleSiegeTaxProvider.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege;
+
+using System.Diagnostics.CodeAnalysis;
+using MUnique.OpenMU.GameLogic.PlugIns;
+using MUnique.OpenMU.Interfaces;
+
+/// <summary>
+/// Provides the Castle Siege taxes which apply to a player and collects the resulting tribute.
+/// </summary>
+public sealed class CastleSiegeTaxProvider
+{
+    /// <summary>
+    /// The maximum percentage which can be configured for Chaos Machine and NPC store taxes.
+    /// </summary>
+    internal const int MaximumPercentageTax = 3;
+
+    /// <summary>
+    /// The maximum Land of Trials entry fee.
+    /// </summary>
+    internal const int MaximumHuntTax = 300_000;
+
+    /// <summary>
+    /// The increment used when changing the Land of Trials entry fee.
+    /// </summary>
+    internal const int HuntTaxStep = 10_000;
+
+    /// <summary>
+    /// Gets the Chaos Machine tax rate which applies to a player.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <returns>The additional percentage, or zero when no tax applies.</returns>
+    public ValueTask<int> GetChaosTaxAsync(Player player)
+        => this.GetTaxAsync(player, GetContext(player), CastleSiegeTaxType.ChaosMachine);
+
+    /// <summary>
+    /// Gets the NPC store tax rate which applies to a player.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <returns>The additional percentage, or zero when no tax applies.</returns>
+    public ValueTask<int> GetStoreTaxAsync(Player player)
+        => this.GetTaxAsync(player, GetContext(player), CastleSiegeTaxType.Store);
+
+    /// <summary>
+    /// Gets the Land of Trials entry fee which applies to a player.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <returns>The flat entry fee, or zero when the player is exempt.</returns>
+    public ValueTask<int> GetHuntEntryFeeAsync(Player player)
+        => this.GetTaxAsync(player, GetContext(player), CastleSiegeTaxType.HuntZone);
+
+    /// <summary>
+    /// Determines whether a player belongs to the castle owner's guild or alliance.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <returns><see langword="true"/> when the player is exempt from Castle Siege taxes.</returns>
+    public ValueTask<bool> IsExemptAsync(Player player)
+        => this.IsExemptAsync(player, GetContext(player));
+
+    /// <summary>
+    /// Removes a Chaos Machine crafting cost, including Castle Siege tax, and persists the tax as tribute.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="baseCost">The untaxed crafting cost.</param>
+    /// <returns><see langword="true"/> when the player paid the complete cost.</returns>
+    public ValueTask<bool> TryPayChaosCostAsync(Player player, int baseCost)
+        => this.TryPayPercentageCostAsync(player, baseCost, GetContext(player), CastleSiegeTaxType.ChaosMachine);
+
+    /// <summary>
+    /// Removes an NPC store cost, including Castle Siege tax, and persists the tax as tribute.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="baseCost">The untaxed store cost.</param>
+    /// <returns><see langword="true"/> when the player paid the complete cost.</returns>
+    public ValueTask<bool> TryPayStoreCostAsync(Player player, long baseCost)
+        => this.TryPayPercentageCostAsync(player, baseCost, GetContext(player), CastleSiegeTaxType.Store);
+
+    /// <summary>
+    /// Gets the initialized Castle Siege context of a player.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <returns>The context, or <see langword="null"/> when Castle Siege is not active.</returns>
+    internal static CastleSiegeContext? GetContext(Player player)
+    {
+        return player.GameContext.PlugInManager
+            .GetActivePlugInsOf<IPeriodicTaskPlugIn>()
+            .OfType<CastleSiegePlugIn>()
+            .FirstOrDefault()
+            ?.GetContext(player.GameContext);
+    }
+
+    /// <summary>
+    /// Resolves the persistent identifier under which a player's guild participates in alliance events.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <returns>The persistent identifier of the alliance master guild, or <see langword="null"/>.</returns>
+    internal static ValueTask<Guid?> GetPersistentAllianceMasterGuildIdAsync(Player player)
+    {
+        return player.GuildStatus is { } guildStatus
+               && player.GameContext is IGameServerContext gameServerContext
+            ? gameServerContext.GuildServer.GetPersistentAllianceMasterGuildIdAsync(guildStatus.GuildId)
+            : new ValueTask<Guid?>((Guid?)null);
+    }
+
+    /// <summary>
+    /// Resolves the persistent guild identifier when the player is its guild master.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <returns>The persistent guild identifier, or <see langword="null"/>.</returns>
+    internal static ValueTask<Guid?> GetPersistentGuildMasterIdAsync(Player player)
+    {
+        return player.GuildStatus is { Position: GuildPosition.GuildMaster } guildStatus
+               && player.GameContext is IGameServerContext gameServerContext
+            ? gameServerContext.GuildServer.GetPersistentGuildIdAsync(guildStatus.GuildId)
+            : new ValueTask<Guid?>((Guid?)null);
+    }
+
+    /// <summary>
+    /// Removes a Chaos Machine crafting cost against a known Castle Siege context.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="baseCost">The untaxed crafting cost.</param>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <returns><see langword="true"/> when the player paid the complete cost.</returns>
+    internal ValueTask<bool> TryPayChaosCostAsync(Player player, int baseCost, CastleSiegeContext? context)
+        => this.TryPayPercentageCostAsync(player, baseCost, context, CastleSiegeTaxType.ChaosMachine);
+
+    /// <summary>
+    /// Removes an NPC store cost against a known Castle Siege context.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="baseCost">The untaxed store cost.</param>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <returns><see langword="true"/> when the player paid the complete cost.</returns>
+    internal ValueTask<bool> TryPayStoreCostAsync(Player player, long baseCost, CastleSiegeContext? context)
+        => this.TryPayPercentageCostAsync(player, baseCost, context, CastleSiegeTaxType.Store);
+
+    /// <summary>
+    /// Determines whether a player belongs to the castle owner's guild or alliance.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <returns><see langword="true"/> when the player is exempt from Castle Siege taxes.</returns>
+    internal async ValueTask<bool> IsExemptAsync(Player player, CastleSiegeContext? context)
+    {
+        if (!IsEconomyActive(context))
+        {
+            return false;
+        }
+
+        var persistentGuildId = await GetPersistentAllianceMasterGuildIdAsync(player).ConfigureAwait(false);
+        return IsEconomyActive(context) && persistentGuildId == context.SiegeData.OwnerGuildId;
+    }
+
+    /// <summary>
+    /// Determines whether a player is the guild master of the castle-owner guild.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <returns><see langword="true"/> when the player is the castle owner guild master.</returns>
+    internal async ValueTask<bool> IsOwnerGuildMasterAsync(Player player, CastleSiegeContext? context)
+    {
+        if (!IsEconomyActive(context))
+        {
+            return false;
+        }
+
+        var persistentGuildId = await GetPersistentGuildMasterIdAsync(player).ConfigureAwait(false);
+        return IsEconomyActive(context) && persistentGuildId == context.SiegeData.OwnerGuildId;
+    }
+
+    /// <summary>
+    /// Pays the configured Land of Trials fee and persists it as tribute.
+    /// </summary>
+    /// <param name="player">The entering player.</param>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <returns><see langword="true"/> when entry is allowed and the required fee was paid.</returns>
+    internal async ValueTask<bool> TryPayHuntEntryFeeAsync(Player player, CastleSiegeContext? context)
+    {
+        if (!IsEconomyActive(context))
+        {
+            return false;
+        }
+
+        var persistentGuildId = await GetPersistentAllianceMasterGuildIdAsync(player).ConfigureAwait(false);
+        await context.ExecutionLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (!IsEconomyActive(context))
+            {
+                return false;
+            }
+
+            var isExempt = persistentGuildId == context.SiegeData.OwnerGuildId;
+            if (!isExempt && !context.SiegeData.IsHuntZoneEnabled)
+            {
+                return false;
+            }
+
+            var fee = isExempt ? 0 : Math.Min(context.SiegeData.TaxHunt, MaximumHuntTax);
+            if (fee < 0)
+            {
+                return false;
+            }
+
+            return await this.TryPayAndCollectAsync(player, context, 0, fee).ConfigureAwait(false);
+        }
+        finally
+        {
+            context.ExecutionLock.Release();
+        }
+    }
+
+    private static bool IsEconomyActive([NotNullWhen(true)] CastleSiegeContext? context)
+        => context is
+        {
+            Configuration.Enabled: true,
+            SiegeData:
+            {
+                IsOccupied: true,
+                OwnerGuildId: not null,
+            },
+        };
+
+    private static int GetTax(CastleSiegeContext context, CastleSiegeTaxType taxType)
+    {
+        return taxType switch
+        {
+            CastleSiegeTaxType.ChaosMachine => Math.Min((int)context.SiegeData.TaxChaos, MaximumPercentageTax),
+            CastleSiegeTaxType.Store => Math.Min((int)context.SiegeData.TaxStore, MaximumPercentageTax),
+            CastleSiegeTaxType.HuntZone => Math.Min(context.SiegeData.TaxHunt, MaximumHuntTax),
+            _ => 0,
+        };
+    }
+
+    private async ValueTask<int> GetTaxAsync(
+        Player player,
+        CastleSiegeContext? context,
+        CastleSiegeTaxType taxType)
+    {
+        if (!IsEconomyActive(context))
+        {
+            return 0;
+        }
+
+        var persistentGuildId = await GetPersistentAllianceMasterGuildIdAsync(player).ConfigureAwait(false);
+        return IsEconomyActive(context) && persistentGuildId != context.SiegeData.OwnerGuildId
+            ? GetTax(context, taxType)
+            : 0;
+    }
+
+    private async ValueTask<bool> TryPayPercentageCostAsync(
+        Player player,
+        long baseCost,
+        CastleSiegeContext? context,
+        CastleSiegeTaxType taxType)
+    {
+        if (baseCost is < 0 or > int.MaxValue)
+        {
+            return false;
+        }
+
+        if (!IsEconomyActive(context))
+        {
+            return player.TryRemoveMoney((int)baseCost);
+        }
+
+        var persistentGuildId = await GetPersistentAllianceMasterGuildIdAsync(player).ConfigureAwait(false);
+        await context.ExecutionLock.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (!IsEconomyActive(context))
+            {
+                return player.TryRemoveMoney((int)baseCost);
+            }
+
+            var isExempt = persistentGuildId == context.SiegeData.OwnerGuildId;
+            var rate = isExempt ? 0 : GetTax(context, taxType);
+            var tax = checked((baseCost * rate) / 100);
+            return await this.TryPayAndCollectAsync(player, context, baseCost, tax).ConfigureAwait(false);
+        }
+        finally
+        {
+            context.ExecutionLock.Release();
+        }
+    }
+
+    private async ValueTask<bool> TryPayAndCollectAsync(
+        Player player,
+        CastleSiegeContext context,
+        long baseCost,
+        long tax)
+    {
+        var totalCost = checked(baseCost + tax);
+        if (totalCost is < 0 or > int.MaxValue)
+        {
+            return false;
+        }
+
+        var previousTribute = context.SiegeData.TributeMoney;
+        if (tax > 0 && previousTribute > long.MaxValue - tax)
+        {
+            return false;
+        }
+
+        var updatedTribute = previousTribute + tax;
+        if (!player.TryRemoveMoney((int)totalCost))
+        {
+            return false;
+        }
+
+        if (tax == 0)
+        {
+            return true;
+        }
+
+        context.SiegeData.TributeMoney = updatedTribute;
+        try
+        {
+            await context.SaveOwnerAsync().ConfigureAwait(false);
+            return true;
+        }
+        catch
+        {
+            context.SiegeData.TributeMoney = previousTribute;
+            _ = player.TryAddMoney((int)totalCost);
+            throw;
+        }
+    }
+}

--- a/src/GameLogic/CastleSiege/CastleSiegeTaxProvider.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeTaxProvider.cs
@@ -5,6 +5,7 @@
 namespace MUnique.OpenMU.GameLogic.CastleSiege;
 
 using System.Diagnostics.CodeAnalysis;
+using MUnique.OpenMU.DataModel.Configuration;
 using MUnique.OpenMU.GameLogic.PlugIns;
 using MUnique.OpenMU.Interfaces;
 
@@ -50,7 +51,7 @@ public sealed class CastleSiegeTaxProvider
     /// <param name="player">The player.</param>
     /// <returns>The flat entry fee, or zero when the player is exempt.</returns>
     public ValueTask<int> GetHuntEntryFeeAsync(Player player)
-        => this.GetTaxAsync(player, GetContext(player), CastleSiegeTaxType.HuntZone);
+        => this.GetHuntEntryFeeAsync(player, GetContext(player));
 
     /// <summary>
     /// Determines whether a player belongs to the castle owner's guild or alliance.
@@ -67,7 +68,10 @@ public sealed class CastleSiegeTaxProvider
     /// <param name="baseCost">The untaxed crafting cost.</param>
     /// <returns><see langword="true"/> when the player paid the complete cost.</returns>
     public ValueTask<bool> TryPayChaosCostAsync(Player player, int baseCost)
-        => this.TryPayPercentageCostAsync(player, baseCost, GetContext(player), CastleSiegeTaxType.ChaosMachine);
+        => this.TryPayChaosCostAsync(
+            player,
+            baseCost,
+            player.OpenedNpc?.Definition.NpcWindow == NpcWindow.ChaosMachine ? GetContext(player) : null);
 
     /// <summary>
     /// Removes an NPC store cost, including Castle Siege tax, and persists the tax as tribute.
@@ -126,7 +130,11 @@ public sealed class CastleSiegeTaxProvider
     /// <param name="context">The Castle Siege context.</param>
     /// <returns><see langword="true"/> when the player paid the complete cost.</returns>
     internal ValueTask<bool> TryPayChaosCostAsync(Player player, int baseCost, CastleSiegeContext? context)
-        => this.TryPayPercentageCostAsync(player, baseCost, context, CastleSiegeTaxType.ChaosMachine);
+        => this.TryPayPercentageCostAsync(
+            player,
+            baseCost,
+            player.OpenedNpc?.Definition.NpcWindow == NpcWindow.ChaosMachine ? context : null,
+            CastleSiegeTaxType.ChaosMachine);
 
     /// <summary>
     /// Removes an NPC store cost against a known Castle Siege context.
@@ -137,6 +145,15 @@ public sealed class CastleSiegeTaxProvider
     /// <returns><see langword="true"/> when the player paid the complete cost.</returns>
     internal ValueTask<bool> TryPayStoreCostAsync(Player player, long baseCost, CastleSiegeContext? context)
         => this.TryPayPercentageCostAsync(player, baseCost, context, CastleSiegeTaxType.Store);
+
+    /// <summary>
+    /// Gets the configured Land of Trials fee against a known Castle Siege context.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    /// <param name="context">The Castle Siege context.</param>
+    /// <returns>The flat entry fee, or zero when the player is exempt.</returns>
+    internal ValueTask<int> GetHuntEntryFeeAsync(Player player, CastleSiegeContext? context)
+        => this.GetTaxAsync(player, context, CastleSiegeTaxType.HuntZone);
 
     /// <summary>
     /// Determines whether a player belongs to the castle owner's guild or alliance.
@@ -206,7 +223,7 @@ public sealed class CastleSiegeTaxProvider
                 return false;
             }
 
-            return await this.TryPayAndCollectAsync(player, context, 0, fee).ConfigureAwait(false);
+            return this.TryPayAndCollect(player, context, 0, fee);
         }
         finally
         {
@@ -268,6 +285,11 @@ public sealed class CastleSiegeTaxProvider
             return player.TryRemoveMoney((int)baseCost);
         }
 
+        if (GetTax(context, taxType) == 0)
+        {
+            return player.TryRemoveMoney((int)baseCost);
+        }
+
         var persistentGuildId = await GetPersistentAllianceMasterGuildIdAsync(player).ConfigureAwait(false);
         await context.ExecutionLock.WaitAsync().ConfigureAwait(false);
         try
@@ -280,7 +302,7 @@ public sealed class CastleSiegeTaxProvider
             var isExempt = persistentGuildId == context.SiegeData.OwnerGuildId;
             var rate = isExempt ? 0 : GetTax(context, taxType);
             var tax = checked((baseCost * rate) / 100);
-            return await this.TryPayAndCollectAsync(player, context, baseCost, tax).ConfigureAwait(false);
+            return this.TryPayAndCollect(player, context, baseCost, tax);
         }
         finally
         {
@@ -288,7 +310,7 @@ public sealed class CastleSiegeTaxProvider
         }
     }
 
-    private async ValueTask<bool> TryPayAndCollectAsync(
+    private bool TryPayAndCollect(
         Player player,
         CastleSiegeContext context,
         long baseCost,
@@ -300,13 +322,11 @@ public sealed class CastleSiegeTaxProvider
             return false;
         }
 
-        var previousTribute = context.SiegeData.TributeMoney;
-        if (tax > 0 && previousTribute > long.MaxValue - tax)
+        if (tax > 0 && context.SiegeData.TributeMoney > long.MaxValue - tax)
         {
             return false;
         }
 
-        var updatedTribute = previousTribute + tax;
         if (!player.TryRemoveMoney((int)totalCost))
         {
             return false;
@@ -317,17 +337,8 @@ public sealed class CastleSiegeTaxProvider
             return true;
         }
 
-        context.SiegeData.TributeMoney = updatedTribute;
-        try
-        {
-            await context.SaveOwnerAsync().ConfigureAwait(false);
-            return true;
-        }
-        catch
-        {
-            context.SiegeData.TributeMoney = previousTribute;
-            _ = player.TryAddMoney((int)totalCost);
-            throw;
-        }
+        context.SiegeData.TributeMoney += tax;
+        context.IsEconomyPersistencePending = true;
+        return true;
     }
 }

--- a/src/GameLogic/CastleSiege/CastleSiegeTaxType.cs
+++ b/src/GameLogic/CastleSiege/CastleSiegeTaxType.cs
@@ -1,0 +1,31 @@
+// <copyright file="CastleSiegeTaxType.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.CastleSiege;
+
+/// <summary>
+/// Defines a Castle Siege tax type.
+/// </summary>
+public enum CastleSiegeTaxType : byte
+{
+    /// <summary>
+    /// No tax type.
+    /// </summary>
+    Undefined = 0,
+
+    /// <summary>
+    /// The percentage added to Chaos Machine crafting costs.
+    /// </summary>
+    ChaosMachine = 1,
+
+    /// <summary>
+    /// The percentage added to NPC store prices.
+    /// </summary>
+    Store = 2,
+
+    /// <summary>
+    /// The flat Land of Trials entrance fee.
+    /// </summary>
+    HuntZone = 3,
+}

--- a/src/GameLogic/PlayerActions/Items/BaseItemCraftingHandler.cs
+++ b/src/GameLogic/PlayerActions/Items/BaseItemCraftingHandler.cs
@@ -6,6 +6,7 @@ namespace MUnique.OpenMU.GameLogic.PlayerActions.Items;
 
 using MUnique.OpenMU.DataModel.Configuration.ItemCrafting;
 using MUnique.OpenMU.DataModel.Configuration.Items;
+using MUnique.OpenMU.GameLogic.CastleSiege;
 using MUnique.OpenMU.GameLogic.PlugIns;
 using MUnique.OpenMU.GameLogic.Views.Inventory;
 using MUnique.OpenMU.GameLogic.Views.NPC;
@@ -15,6 +16,8 @@ using MUnique.OpenMU.GameLogic.Views.NPC;
 /// </summary>
 public abstract class BaseItemCraftingHandler : IItemCraftingHandler
 {
+    private readonly CastleSiegeTaxProvider _castleSiegeTaxProvider = new();
+
     /// <inheritdoc/>
     public async ValueTask<(CraftingResult Result, Item? Item)> DoMixAsync(Player player, byte socketSlot)
     {
@@ -32,7 +35,7 @@ public abstract class BaseItemCraftingHandler : IItemCraftingHandler
         player.Logger.LogInformation("Crafting success chance: {successRate} %", successRate);
 
         var price = this.GetPrice(successRate, items);
-        if (!player.TryRemoveMoney(price))
+        if (!await this._castleSiegeTaxProvider.TryPayChaosCostAsync(player, price).ConfigureAwait(false))
         {
             return (CraftingResult.NotEnoughMoney, null);
         }

--- a/src/GameLogic/PlayerActions/Items/BuyNpcItemAction.cs
+++ b/src/GameLogic/PlayerActions/Items/BuyNpcItemAction.cs
@@ -4,6 +4,7 @@
 
 namespace MUnique.OpenMU.GameLogic.PlayerActions.Items;
 
+using MUnique.OpenMU.GameLogic.CastleSiege;
 using MUnique.OpenMU.GameLogic.PlugIns;
 using MUnique.OpenMU.GameLogic.Views.Inventory;
 
@@ -12,6 +13,7 @@ using MUnique.OpenMU.GameLogic.Views.Inventory;
 /// </summary>
 public class BuyNpcItemAction
 {
+    private readonly CastleSiegeTaxProvider _castleSiegeTaxProvider = new();
     private readonly ItemPriceCalculator _priceCalculator;
 
     /// <summary>
@@ -53,7 +55,7 @@ public class BuyNpcItemAction
         // Inventory Update:
         if (storeItem.IsStackable() && player.Inventory!.Items.FirstOrDefault(item => storeItem.CanCompletelyStackOn(item)) is { } targetItem)
         {
-            if (!this.CheckMoney(player, storeItem))
+            if (!await this.CheckMoneyAsync(player, storeItem).ConfigureAwait(false))
             {
                 return;
             }
@@ -72,7 +74,7 @@ public class BuyNpcItemAction
                 return;
             }
 
-            if (!this.CheckMoney(player, storeItem))
+            if (!await this.CheckMoneyAsync(player, storeItem).ConfigureAwait(false))
             {
                 await player.ShowLocalizedBlueMessageAsync(nameof(PlayerMessage.NotEnoughMoney)).ConfigureAwait(false);
                 await player.InvokeViewPlugInAsync<IBuyNpcItemFailedPlugIn>(p => p.BuyNpcItemFailedAsync()).ConfigureAwait(false);
@@ -90,14 +92,9 @@ public class BuyNpcItemAction
         await player.InvokeViewPlugInAsync<IUpdateMoneyPlugIn>(p => p.UpdateMoneyAsync()).ConfigureAwait(false);
     }
 
-    private bool CheckMoney(Player player, Item item)
+    private ValueTask<bool> CheckMoneyAsync(Player player, Item item)
     {
         var price = this._priceCalculator.CalculateFinalBuyingPrice(item);
-        if (!player.TryRemoveMoney((int)price))
-        {
-            return false;
-        }
-
-        return true;
+        return this._castleSiegeTaxProvider.TryPayStoreCostAsync(player, price);
     }
 }

--- a/src/GameLogic/Properties/PlugInResources.Designer.cs
+++ b/src/GameLogic/Properties/PlugInResources.Designer.cs
@@ -304,6 +304,24 @@ namespace MUnique.OpenMU.GameLogic.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Shows Land of Trials availability and its applicable entry fee..
+        /// </summary>
+        public static string CastleSiegeGuardsmanTalkPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeGuardsmanTalkPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege Guardsman.
+        /// </summary>
+        public static string CastleSiegeGuardsmanTalkPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeGuardsmanTalkPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Drives the weekly Castle Siege state cycle..
         /// </summary>
         public static string CastleSiegePlugIn_Description {

--- a/src/GameLogic/Properties/PlugInResources.resx
+++ b/src/GameLogic/Properties/PlugInResources.resx
@@ -135,6 +135,12 @@
   <data name="CastleSiegePendingRewardPlugIn_Description" xml:space="preserve">
     <value>Delivers queued Castle Siege participant rewards when a character enters the game.</value>
   </data>
+  <data name="CastleSiegeGuardsmanTalkPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege Guardsman</value>
+  </data>
+  <data name="CastleSiegeGuardsmanTalkPlugIn_Description" xml:space="preserve">
+    <value>Shows Land of Trials availability and its applicable entry fee.</value>
+  </data>
   <data name="MuHelperFeaturePlugIn_Name" xml:space="preserve">
     <value>MU Helper Feature</value>
   </data>

--- a/src/GameLogic/Views/CastleSiege/CastleSiegeHuntZoneAccessType.cs
+++ b/src/GameLogic/Views/CastleSiege/CastleSiegeHuntZoneAccessType.cs
@@ -1,0 +1,31 @@
+// <copyright file="CastleSiegeHuntZoneAccessType.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// Defines the access mode which the Land of Trials dialog shows to a player.
+/// </summary>
+public enum CastleSiegeHuntZoneAccessType : byte
+{
+    /// <summary>
+    /// The dialog could not be opened.
+    /// </summary>
+    Failed = 0,
+
+    /// <summary>
+    /// The player enters as a paying guest.
+    /// </summary>
+    Guest = 1,
+
+    /// <summary>
+    /// The player belongs to the castle owner's guild or alliance.
+    /// </summary>
+    OwnerAllianceMember = 2,
+
+    /// <summary>
+    /// The player is the castle owner guild master.
+    /// </summary>
+    OwnerGuildMaster = 3,
+}

--- a/src/GameLogic/Views/CastleSiege/CastleSiegeRequestResult.cs
+++ b/src/GameLogic/Views/CastleSiege/CastleSiegeRequestResult.cs
@@ -1,0 +1,26 @@
+// <copyright file="CastleSiegeRequestResult.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// Defines the common result codes of Castle Siege management requests.
+/// </summary>
+public enum CastleSiegeRequestResult : byte
+{
+    /// <summary>
+    /// The request failed.
+    /// </summary>
+    Failed = 0,
+
+    /// <summary>
+    /// The request succeeded.
+    /// </summary>
+    Success = 1,
+
+    /// <summary>
+    /// The player is not authorized to perform the request.
+    /// </summary>
+    NotAuthorized = 2,
+}

--- a/src/GameLogic/Views/CastleSiege/ICastleSiegeHuntZoneGuardInfoPlugIn.cs
+++ b/src/GameLogic/Views/CastleSiege/ICastleSiegeHuntZoneGuardInfoPlugIn.cs
@@ -1,0 +1,26 @@
+// <copyright file="ICastleSiegeHuntZoneGuardInfoPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// A view which shows the Land of Trials guardsman dialog.
+/// </summary>
+public interface ICastleSiegeHuntZoneGuardInfoPlugIn : IViewPlugIn
+{
+    /// <summary>
+    /// Shows the available actions and the entrance fee which applies to the player.
+    /// </summary>
+    /// <param name="accessType">The player's access type.</param>
+    /// <param name="isPublic">Whether public access is enabled.</param>
+    /// <param name="currentPrice">The configured entrance fee.</param>
+    /// <param name="maximumPrice">The maximum entrance fee.</param>
+    /// <param name="priceStep">The fee adjustment step.</param>
+    ValueTask ShowHuntZoneGuardInfoAsync(
+        CastleSiegeHuntZoneAccessType accessType,
+        bool isPublic,
+        int currentPrice,
+        int maximumPrice,
+        int priceStep);
+}

--- a/src/GameLogic/Views/CastleSiege/ICastleSiegeHuntZoneResultPlugIn.cs
+++ b/src/GameLogic/Views/CastleSiege/ICastleSiegeHuntZoneResultPlugIn.cs
@@ -1,0 +1,24 @@
+// <copyright file="ICastleSiegeHuntZoneResultPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// A view which reports Land of Trials management and entrance results.
+/// </summary>
+public interface ICastleSiegeHuntZoneResultPlugIn : IViewPlugIn
+{
+    /// <summary>
+    /// Shows the result of changing public Land of Trials access.
+    /// </summary>
+    /// <param name="result">The request result.</param>
+    /// <param name="isPublic">Whether public access is enabled.</param>
+    ValueTask ShowEntranceSettingResultAsync(CastleSiegeRequestResult result, bool isPublic);
+
+    /// <summary>
+    /// Shows the result of a Land of Trials entrance request.
+    /// </summary>
+    /// <param name="success">Whether the request succeeded.</param>
+    ValueTask ShowEnterResultAsync(bool success);
+}

--- a/src/GameLogic/Views/CastleSiege/ICastleSiegeTaxChangeResultPlugIn.cs
+++ b/src/GameLogic/Views/CastleSiege/ICastleSiegeTaxChangeResultPlugIn.cs
@@ -1,0 +1,28 @@
+// <copyright file="ICastleSiegeTaxChangeResultPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+using MUnique.OpenMU.GameLogic.CastleSiege;
+
+/// <summary>
+/// A view which reports a Castle Siege tax-rate change result.
+/// </summary>
+public interface ICastleSiegeTaxChangeResultPlugIn : IViewPlugIn
+{
+    /// <summary>
+    /// Shows the tax-rate change result.
+    /// </summary>
+    /// <param name="result">The request result.</param>
+    /// <param name="taxType">The requested tax type.</param>
+    /// <param name="taxRate">The requested tax rate.</param>
+    ValueTask ShowTaxChangeResultAsync(CastleSiegeRequestResult result, CastleSiegeTaxType taxType, uint taxRate);
+
+    /// <summary>
+    /// Updates a tax rate which affects all players.
+    /// </summary>
+    /// <param name="taxType">The tax type.</param>
+    /// <param name="taxRate">The current tax rate.</param>
+    ValueTask ShowTaxRateUpdateAsync(CastleSiegeTaxType taxType, byte taxRate);
+}

--- a/src/GameLogic/Views/CastleSiege/ICastleSiegeTaxInfoPlugIn.cs
+++ b/src/GameLogic/Views/CastleSiege/ICastleSiegeTaxInfoPlugIn.cs
@@ -1,0 +1,24 @@
+// <copyright file="ICastleSiegeTaxInfoPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// A view which shows the current Castle Siege tax configuration.
+/// </summary>
+public interface ICastleSiegeTaxInfoPlugIn : IViewPlugIn
+{
+    /// <summary>
+    /// Shows the current tax rates and visible treasury balance.
+    /// </summary>
+    /// <param name="result">The request result.</param>
+    /// <param name="chaosTax">The Chaos Machine tax percentage.</param>
+    /// <param name="storeTax">The NPC store tax percentage.</param>
+    /// <param name="tributeMoney">The visible treasury balance.</param>
+    ValueTask ShowTaxInfoAsync(
+        CastleSiegeRequestResult result,
+        byte chaosTax,
+        byte storeTax,
+        long tributeMoney);
+}

--- a/src/GameLogic/Views/CastleSiege/ICastleSiegeTributeWithdrawResultPlugIn.cs
+++ b/src/GameLogic/Views/CastleSiege/ICastleSiegeTributeWithdrawResultPlugIn.cs
@@ -1,0 +1,18 @@
+// <copyright file="ICastleSiegeTributeWithdrawResultPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameLogic.Views.CastleSiege;
+
+/// <summary>
+/// A view which reports a Castle Siege treasury withdrawal result.
+/// </summary>
+public interface ICastleSiegeTributeWithdrawResultPlugIn : IViewPlugIn
+{
+    /// <summary>
+    /// Shows the treasury withdrawal result.
+    /// </summary>
+    /// <param name="result">The request result.</param>
+    /// <param name="amount">The withdrawn amount, or zero on failure.</param>
+    ValueTask ShowTributeWithdrawResultAsync(CastleSiegeRequestResult result, long amount);
+}

--- a/src/GameServer/MessageHandler/CastleSiege/CastleSiegeHuntZoneEnterHandlerPlugIn.cs
+++ b/src/GameServer/MessageHandler/CastleSiege/CastleSiegeHuntZoneEnterHandlerPlugIn.cs
@@ -1,0 +1,44 @@
+// <copyright file="CastleSiegeHuntZoneEnterHandlerPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.MessageHandler.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+using MUnique.OpenMU.Network.Packets.ClientToServer;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Handles Land of Trials entry requests.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeHuntZoneEnterHandlerPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeHuntZoneEnterHandlerPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("9D8A4C2C-44E2-4FA3-9991-DA9FA8DED2AD")]
+[BelongsToGroup(CastleSiegeHuntZoneGroupHandlerPlugIn.GroupKey)]
+internal sealed class CastleSiegeHuntZoneEnterHandlerPlugIn : ISubPacketHandlerPlugIn
+{
+    private readonly CastleSiegeHuntZoneEnterAction _action = new();
+
+    /// <inheritdoc />
+    public bool IsEncryptionExpected => false;
+
+    /// <inheritdoc />
+    public byte Key => CastleSiegeHuntingZoneEnterRequest.SubCode;
+
+    /// <inheritdoc />
+    public async ValueTask HandlePacketAsync(Player player, Memory<byte> packet)
+    {
+        if (packet.Length < CastleSiegeHuntingZoneEnterRequest.Length)
+        {
+            return;
+        }
+
+        var success = await this._action.EnterAsync(player, CastleSiegeHandlerContext.Get(player)).ConfigureAwait(false);
+        await player.InvokeViewPlugInAsync<ICastleSiegeHuntZoneResultPlugIn>(
+                view => view.ShowEnterResultAsync(success))
+            .ConfigureAwait(false);
+    }
+}

--- a/src/GameServer/MessageHandler/CastleSiege/CastleSiegeHuntZoneGroupHandlerPlugIn.cs
+++ b/src/GameServer/MessageHandler/CastleSiege/CastleSiegeHuntZoneGroupHandlerPlugIn.cs
@@ -1,0 +1,43 @@
+// <copyright file="CastleSiegeHuntZoneGroupHandlerPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.MessageHandler.CastleSiege;
+
+using System.Runtime.InteropServices;
+using Microsoft.Extensions.Logging;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Packet handler for Castle Siege hunting-zone packets with the 0xB9 identifier.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeHuntZoneGroupHandlerPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeHuntZoneGroupHandlerPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("87916020-23B1-494A-AC41-58AF2BB19DE1")]
+internal sealed class CastleSiegeHuntZoneGroupHandlerPlugIn : GroupPacketHandlerPlugIn
+{
+    /// <summary>
+    /// The group key.
+    /// </summary>
+    internal const byte GroupKey = 0xB9;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeHuntZoneGroupHandlerPlugIn"/> class.
+    /// </summary>
+    /// <param name="clientVersionProvider">The client version provider.</param>
+    /// <param name="manager">The plug-in manager.</param>
+    /// <param name="loggerFactory">The logger factory.</param>
+    public CastleSiegeHuntZoneGroupHandlerPlugIn(
+        IClientVersionProvider clientVersionProvider,
+        PlugInManager manager,
+        ILoggerFactory loggerFactory)
+        : base(clientVersionProvider, manager, loggerFactory)
+    {
+    }
+
+    /// <inheritdoc />
+    public override bool IsEncryptionExpected => false;
+
+    /// <inheritdoc />
+    public override byte Key => GroupKey;
+}

--- a/src/GameServer/MessageHandler/CastleSiege/CastleSiegeHuntZoneToggleHandlerPlugIn.cs
+++ b/src/GameServer/MessageHandler/CastleSiege/CastleSiegeHuntZoneToggleHandlerPlugIn.cs
@@ -1,0 +1,47 @@
+// <copyright file="CastleSiegeHuntZoneToggleHandlerPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.MessageHandler.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+using MUnique.OpenMU.Network.Packets.ClientToServer;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Handles public Land of Trials access-setting requests.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeHuntZoneToggleHandlerPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeHuntZoneToggleHandlerPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("A97C3953-BE03-4C03-AB5A-C4FED16A629E")]
+[BelongsToGroup(CastleSiegeGroupHandlerPlugIn.GroupKey)]
+internal sealed class CastleSiegeHuntZoneToggleHandlerPlugIn : ISubPacketHandlerPlugIn
+{
+    private const short SeniorNumber = 223;
+    private readonly CastleSiegeHuntZoneToggleAction _action = new();
+
+    /// <inheritdoc />
+    public bool IsEncryptionExpected => false;
+
+    /// <inheritdoc />
+    public byte Key => CastleSiegeHuntingZoneEntranceSetting.SubCode;
+
+    /// <inheritdoc />
+    public async ValueTask HandlePacketAsync(Player player, Memory<byte> packet)
+    {
+        if (packet.Length < CastleSiegeHuntingZoneEntranceSetting.Length
+            || player.OpenedNpc?.Definition.Number != SeniorNumber)
+        {
+            return;
+        }
+
+        var request = new CastleSiegeHuntingZoneEntranceSetting(packet);
+        _ = await this._action.SetPublicAccessAsync(
+                player,
+                CastleSiegeHandlerContext.Get(player),
+                request.IsPublic)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/GameServer/MessageHandler/CastleSiege/CastleSiegeTaxChangeHandlerPlugIn.cs
+++ b/src/GameServer/MessageHandler/CastleSiege/CastleSiegeTaxChangeHandlerPlugIn.cs
@@ -1,0 +1,49 @@
+// <copyright file="CastleSiegeTaxChangeHandlerPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.MessageHandler.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+using MUnique.OpenMU.Network.Packets.ClientToServer;
+using MUnique.OpenMU.PlugIns;
+using TaxType = MUnique.OpenMU.GameLogic.CastleSiege.CastleSiegeTaxType;
+
+/// <summary>
+/// Handles Castle Siege tax-rate change requests.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeTaxChangeHandlerPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeTaxChangeHandlerPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("52F0F2F3-643A-433A-9A1A-7F70B827E18D")]
+[BelongsToGroup(CastleSiegeGroupHandlerPlugIn.GroupKey)]
+internal sealed class CastleSiegeTaxChangeHandlerPlugIn : ISubPacketHandlerPlugIn
+{
+    private const short SeniorNumber = 223;
+    private readonly CastleSiegeTaxRateChangeAction _action = new();
+
+    /// <inheritdoc />
+    public bool IsEncryptionExpected => false;
+
+    /// <inheritdoc />
+    public byte Key => CastleSiegeTaxChangeRequest.SubCode;
+
+    /// <inheritdoc />
+    public async ValueTask HandlePacketAsync(Player player, Memory<byte> packet)
+    {
+        if (packet.Length < CastleSiegeTaxChangeRequest.Length
+            || player.OpenedNpc?.Definition.Number != SeniorNumber)
+        {
+            return;
+        }
+
+        var request = new CastleSiegeTaxChangeRequest(packet);
+        _ = await this._action.ChangeAsync(
+                player,
+                CastleSiegeHandlerContext.Get(player),
+                (TaxType)request.TaxType,
+                request.TaxValue)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/GameServer/MessageHandler/CastleSiege/CastleSiegeTaxInfoHandlerPlugIn.cs
+++ b/src/GameServer/MessageHandler/CastleSiege/CastleSiegeTaxInfoHandlerPlugIn.cs
@@ -1,0 +1,39 @@
+// <copyright file="CastleSiegeTaxInfoHandlerPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.MessageHandler.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+using MUnique.OpenMU.Network.Packets.ClientToServer;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Handles Castle Siege tax information requests.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeTaxInfoHandlerPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeTaxInfoHandlerPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("190A4CCF-F15E-483D-886A-7E960E7750D6")]
+[BelongsToGroup(CastleSiegeGroupHandlerPlugIn.GroupKey)]
+internal sealed class CastleSiegeTaxInfoHandlerPlugIn : ISubPacketHandlerPlugIn
+{
+    private const short SeniorNumber = 223;
+    private readonly CastleSiegeTaxInfoAction _action = new();
+
+    /// <inheritdoc />
+    public bool IsEncryptionExpected => false;
+
+    /// <inheritdoc />
+    public byte Key => CastleSiegeTaxInfoRequest.SubCode;
+
+    /// <inheritdoc />
+    public ValueTask HandlePacketAsync(Player player, Memory<byte> packet)
+    {
+        return packet.Length >= CastleSiegeTaxInfoRequest.Length
+               && player.OpenedNpc?.Definition.Number == SeniorNumber
+            ? this._action.ShowAsync(player, CastleSiegeHandlerContext.Get(player))
+            : ValueTask.CompletedTask;
+    }
+}

--- a/src/GameServer/MessageHandler/CastleSiege/CastleSiegeTributeWithdrawHandlerPlugIn.cs
+++ b/src/GameServer/MessageHandler/CastleSiege/CastleSiegeTributeWithdrawHandlerPlugIn.cs
@@ -1,0 +1,47 @@
+// <copyright file="CastleSiegeTributeWithdrawHandlerPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.MessageHandler.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+using MUnique.OpenMU.Network.Packets.ClientToServer;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Handles Castle Siege treasury withdrawal requests.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeTributeWithdrawHandlerPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeTributeWithdrawHandlerPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("79B23122-5450-4CEB-AA6F-9FD879BCCB0C")]
+[BelongsToGroup(CastleSiegeGroupHandlerPlugIn.GroupKey)]
+internal sealed class CastleSiegeTributeWithdrawHandlerPlugIn : ISubPacketHandlerPlugIn
+{
+    private const short SeniorNumber = 223;
+    private readonly CastleSiegeTributeWithdrawAction _action = new();
+
+    /// <inheritdoc />
+    public bool IsEncryptionExpected => false;
+
+    /// <inheritdoc />
+    public byte Key => CastleSiegeTaxMoneyWithdraw.SubCode;
+
+    /// <inheritdoc />
+    public async ValueTask HandlePacketAsync(Player player, Memory<byte> packet)
+    {
+        if (packet.Length < CastleSiegeTaxMoneyWithdraw.Length
+            || player.OpenedNpc?.Definition.Number != SeniorNumber)
+        {
+            return;
+        }
+
+        var request = new CastleSiegeTaxMoneyWithdraw(packet);
+        _ = await this._action.WithdrawAsync(
+                player,
+                CastleSiegeHandlerContext.Get(player),
+                request.Amount)
+            .ConfigureAwait(false);
+    }
+}

--- a/src/GameServer/Properties/PlugInResources.Designer.cs
+++ b/src/GameServer/Properties/PlugInResources.Designer.cs
@@ -727,6 +727,24 @@ namespace MUnique.OpenMU.GameServer.Properties {
         }
 
         /// <summary>
+        ///   Looks up a localized string similar to Handles grouped Castle Siege hunting-zone packets..
+        /// </summary>
+        public static string CastleSiegeHuntZoneGroupHandlerPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeHuntZoneGroupHandlerPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege Hunting-Zone Packet Group.
+        /// </summary>
+        public static string CastleSiegeHuntZoneGroupHandlerPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeHuntZoneGroupHandlerPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
         ///   Looks up a localized string similar to Handles Castle Siege Sign of Lord registration requests..
         /// </summary>
         public static string CastleSiegeMarkRegistrationHandlerPlugIn_Description {
@@ -6735,6 +6753,186 @@ namespace MUnique.OpenMU.GameServer.Properties {
         public static string CastleSiegeSwitchInfoPlugIn_Name {
             get {
                 return ResourceManager.GetString("CastleSiegeSwitchInfoPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Handles requests to enter the Castle Siege hunting zone..
+        /// </summary>
+        public static string CastleSiegeHuntZoneEnterHandlerPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeHuntZoneEnterHandlerPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege hunting-zone entry request handler.
+        /// </summary>
+        public static string CastleSiegeHuntZoneEnterHandlerPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeHuntZoneEnterHandlerPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Sends Castle Siege hunting-zone access information to the game client..
+        /// </summary>
+        public static string CastleSiegeHuntZoneGuardInfoPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeHuntZoneGuardInfoPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege hunting-zone guardsman view.
+        /// </summary>
+        public static string CastleSiegeHuntZoneGuardInfoPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeHuntZoneGuardInfoPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Sends Castle Siege hunting-zone request results to the game client..
+        /// </summary>
+        public static string CastleSiegeHuntZoneResultPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeHuntZoneResultPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege hunting-zone result view.
+        /// </summary>
+        public static string CastleSiegeHuntZoneResultPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeHuntZoneResultPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Handles requests to change public access to the Castle Siege hunting zone..
+        /// </summary>
+        public static string CastleSiegeHuntZoneToggleHandlerPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeHuntZoneToggleHandlerPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege hunting-zone access request handler.
+        /// </summary>
+        public static string CastleSiegeHuntZoneToggleHandlerPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeHuntZoneToggleHandlerPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Handles requests to change a Castle Siege tax rate..
+        /// </summary>
+        public static string CastleSiegeTaxChangeHandlerPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeTaxChangeHandlerPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege tax change request handler.
+        /// </summary>
+        public static string CastleSiegeTaxChangeHandlerPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeTaxChangeHandlerPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Sends Castle Siege tax changes and their results to the game client..
+        /// </summary>
+        public static string CastleSiegeTaxChangeResultPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeTaxChangeResultPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege tax change result view.
+        /// </summary>
+        public static string CastleSiegeTaxChangeResultPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeTaxChangeResultPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Handles requests for the current Castle Siege tax and treasury information..
+        /// </summary>
+        public static string CastleSiegeTaxInfoHandlerPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeTaxInfoHandlerPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege tax information request handler.
+        /// </summary>
+        public static string CastleSiegeTaxInfoHandlerPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeTaxInfoHandlerPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Sends the current Castle Siege tax and treasury information to the game client..
+        /// </summary>
+        public static string CastleSiegeTaxInfoPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeTaxInfoPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege tax information view.
+        /// </summary>
+        public static string CastleSiegeTaxInfoPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeTaxInfoPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Handles requests to withdraw money from the Castle Siege treasury..
+        /// </summary>
+        public static string CastleSiegeTributeWithdrawHandlerPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeTributeWithdrawHandlerPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege tribute withdrawal request handler.
+        /// </summary>
+        public static string CastleSiegeTributeWithdrawHandlerPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeTributeWithdrawHandlerPlugIn_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Sends Castle Siege treasury withdrawal results to the game client..
+        /// </summary>
+        public static string CastleSiegeTributeWithdrawResultPlugIn_Description {
+            get {
+                return ResourceManager.GetString("CastleSiegeTributeWithdrawResultPlugIn_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Castle Siege tribute withdrawal result view.
+        /// </summary>
+        public static string CastleSiegeTributeWithdrawResultPlugIn_Name {
+            get {
+                return ResourceManager.GetString("CastleSiegeTributeWithdrawResultPlugIn_Name", resourceCulture);
             }
         }
     }

--- a/src/GameServer/Properties/PlugInResources.resx
+++ b/src/GameServer/Properties/PlugInResources.resx
@@ -1953,6 +1953,12 @@
   <data name="CastleSiegeGroupHandlerPlugIn_Description" xml:space="preserve">
     <value>Routes Castle Siege packet subcodes.</value>
   </data>
+  <data name="CastleSiegeHuntZoneGroupHandlerPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege Hunting-Zone Packet Group</value>
+  </data>
+  <data name="CastleSiegeHuntZoneGroupHandlerPlugIn_Description" xml:space="preserve">
+    <value>Handles grouped Castle Siege hunting-zone packets.</value>
+  </data>
   <data name="CastleSiegeDefenseBuyHandlerPlugIn_Name" xml:space="preserve">
     <value>Castle Siege Defense Purchase Handler</value>
   </data>
@@ -2342,5 +2348,65 @@
   </data>
   <data name="CastleSiegeOwnershipChangePlugIn_Description" xml:space="preserve">
     <value>Sends Castle Siege ownership changes to the game client.</value>
+  </data>
+  <data name="CastleSiegeTaxInfoHandlerPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege tax information request handler</value>
+  </data>
+  <data name="CastleSiegeTaxInfoHandlerPlugIn_Description" xml:space="preserve">
+    <value>Handles requests for the current Castle Siege tax and treasury information.</value>
+  </data>
+  <data name="CastleSiegeTaxChangeHandlerPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege tax change request handler</value>
+  </data>
+  <data name="CastleSiegeTaxChangeHandlerPlugIn_Description" xml:space="preserve">
+    <value>Handles requests to change a Castle Siege tax rate.</value>
+  </data>
+  <data name="CastleSiegeTributeWithdrawHandlerPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege tribute withdrawal request handler</value>
+  </data>
+  <data name="CastleSiegeTributeWithdrawHandlerPlugIn_Description" xml:space="preserve">
+    <value>Handles requests to withdraw money from the Castle Siege treasury.</value>
+  </data>
+  <data name="CastleSiegeHuntZoneToggleHandlerPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege hunting-zone access request handler</value>
+  </data>
+  <data name="CastleSiegeHuntZoneToggleHandlerPlugIn_Description" xml:space="preserve">
+    <value>Handles requests to change public access to the Castle Siege hunting zone.</value>
+  </data>
+  <data name="CastleSiegeHuntZoneEnterHandlerPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege hunting-zone entry request handler</value>
+  </data>
+  <data name="CastleSiegeHuntZoneEnterHandlerPlugIn_Description" xml:space="preserve">
+    <value>Handles requests to enter the Castle Siege hunting zone.</value>
+  </data>
+  <data name="CastleSiegeTaxInfoPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege tax information view</value>
+  </data>
+  <data name="CastleSiegeTaxInfoPlugIn_Description" xml:space="preserve">
+    <value>Sends the current Castle Siege tax and treasury information to the game client.</value>
+  </data>
+  <data name="CastleSiegeTaxChangeResultPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege tax change result view</value>
+  </data>
+  <data name="CastleSiegeTaxChangeResultPlugIn_Description" xml:space="preserve">
+    <value>Sends Castle Siege tax changes and their results to the game client.</value>
+  </data>
+  <data name="CastleSiegeTributeWithdrawResultPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege tribute withdrawal result view</value>
+  </data>
+  <data name="CastleSiegeTributeWithdrawResultPlugIn_Description" xml:space="preserve">
+    <value>Sends Castle Siege treasury withdrawal results to the game client.</value>
+  </data>
+  <data name="CastleSiegeHuntZoneGuardInfoPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege hunting-zone guardsman view</value>
+  </data>
+  <data name="CastleSiegeHuntZoneGuardInfoPlugIn_Description" xml:space="preserve">
+    <value>Sends Castle Siege hunting-zone access information to the game client.</value>
+  </data>
+  <data name="CastleSiegeHuntZoneResultPlugIn_Name" xml:space="preserve">
+    <value>Castle Siege hunting-zone result view</value>
+  </data>
+  <data name="CastleSiegeHuntZoneResultPlugIn_Description" xml:space="preserve">
+    <value>Sends Castle Siege hunting-zone request results to the game client.</value>
   </data>
 </root>

--- a/src/GameServer/RemoteView/CastleSiege/CastleSiegeHuntZoneGuardInfoPlugIn.cs
+++ b/src/GameServer/RemoteView/CastleSiege/CastleSiegeHuntZoneGuardInfoPlugIn.cs
@@ -1,0 +1,42 @@
+// <copyright file="CastleSiegeHuntZoneGuardInfoPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.RemoteView.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+using MUnique.OpenMU.Network.Packets.ServerToClient;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// The default implementation of the <see cref="ICastleSiegeHuntZoneGuardInfoPlugIn"/>
+/// which forwards Land of Trials guardsman information to the game client.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeHuntZoneGuardInfoPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeHuntZoneGuardInfoPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("66A19818-AE03-4812-B870-1D80AF8C4F1A")]
+public class CastleSiegeHuntZoneGuardInfoPlugIn : ICastleSiegeHuntZoneGuardInfoPlugIn
+{
+    private readonly RemotePlayer _player;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeHuntZoneGuardInfoPlugIn"/> class.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    public CastleSiegeHuntZoneGuardInfoPlugIn(RemotePlayer player) => this._player = player;
+
+    /// <inheritdoc />
+    public ValueTask ShowHuntZoneGuardInfoAsync(
+        CastleSiegeHuntZoneAccessType accessType,
+        bool isPublic,
+        int currentPrice,
+        int maximumPrice,
+        int priceStep)
+        => this._player.Connection?.SendCastleSiegeHuntingZoneGuardInfoAsync(
+            (byte)accessType,
+            isPublic,
+            checked((uint)currentPrice),
+            checked((uint)maximumPrice),
+            checked((uint)priceStep)) ?? default;
+}

--- a/src/GameServer/RemoteView/CastleSiege/CastleSiegeHuntZoneResultPlugIn.cs
+++ b/src/GameServer/RemoteView/CastleSiege/CastleSiegeHuntZoneResultPlugIn.cs
@@ -1,0 +1,38 @@
+// <copyright file="CastleSiegeHuntZoneResultPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.RemoteView.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+using MUnique.OpenMU.Network.Packets.ServerToClient;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// The default implementation of the <see cref="ICastleSiegeHuntZoneResultPlugIn"/>
+/// which forwards Land of Trials request results to the game client.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeHuntZoneResultPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeHuntZoneResultPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("ACD57B49-E816-45D9-8C70-39FB4EC0F2AF")]
+public class CastleSiegeHuntZoneResultPlugIn : ICastleSiegeHuntZoneResultPlugIn
+{
+    private readonly RemotePlayer _player;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeHuntZoneResultPlugIn"/> class.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    public CastleSiegeHuntZoneResultPlugIn(RemotePlayer player) => this._player = player;
+
+    /// <inheritdoc />
+    public ValueTask ShowEntranceSettingResultAsync(CastleSiegeRequestResult result, bool isPublic)
+        => this._player.Connection?.SendCastleSiegeHuntingZoneEntranceSettingResponseAsync(
+            (byte)result,
+            isPublic) ?? default;
+
+    /// <inheritdoc />
+    public ValueTask ShowEnterResultAsync(bool success)
+        => this._player.Connection?.SendCastleSiegeHuntingZoneEnterResponseAsync(success ? (byte)1 : (byte)0) ?? default;
+}

--- a/src/GameServer/RemoteView/CastleSiege/CastleSiegeTaxChangeResultPlugIn.cs
+++ b/src/GameServer/RemoteView/CastleSiege/CastleSiegeTaxChangeResultPlugIn.cs
@@ -1,0 +1,46 @@
+// <copyright file="CastleSiegeTaxChangeResultPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.RemoteView.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+using MUnique.OpenMU.Network.Packets.ServerToClient;
+using MUnique.OpenMU.PlugIns;
+using NetworkTaxType = MUnique.OpenMU.Network.Packets.ServerToClient.CastleSiegeTaxType;
+using TaxType = MUnique.OpenMU.GameLogic.CastleSiege.CastleSiegeTaxType;
+
+/// <summary>
+/// The default implementation of the <see cref="ICastleSiegeTaxChangeResultPlugIn"/>
+/// which forwards tax-change results to the game client.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeTaxChangeResultPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeTaxChangeResultPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("CAC60298-A993-4F29-A936-B7D1BEFF2A4E")]
+public class CastleSiegeTaxChangeResultPlugIn : ICastleSiegeTaxChangeResultPlugIn
+{
+    private readonly RemotePlayer _player;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeTaxChangeResultPlugIn"/> class.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    public CastleSiegeTaxChangeResultPlugIn(RemotePlayer player) => this._player = player;
+
+    /// <inheritdoc />
+    public ValueTask ShowTaxChangeResultAsync(
+        CastleSiegeRequestResult result,
+        TaxType taxType,
+        uint taxRate)
+        => this._player.Connection?.SendCastleSiegeTaxChangeResponseAsync(
+            (byte)result,
+            (NetworkTaxType)taxType,
+            taxRate) ?? default;
+
+    /// <inheritdoc />
+    public ValueTask ShowTaxRateUpdateAsync(TaxType taxType, byte taxRate)
+        => this._player.Connection?.SendCastleSiegeTaxRateNotificationAsync(
+            (NetworkTaxType)taxType,
+            taxRate) ?? default;
+}

--- a/src/GameServer/RemoteView/CastleSiege/CastleSiegeTaxInfoPlugIn.cs
+++ b/src/GameServer/RemoteView/CastleSiege/CastleSiegeTaxInfoPlugIn.cs
@@ -1,0 +1,40 @@
+// <copyright file="CastleSiegeTaxInfoPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.RemoteView.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+using MUnique.OpenMU.Network.Packets.ServerToClient;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// The default implementation of the <see cref="ICastleSiegeTaxInfoPlugIn"/>
+/// which forwards the Castle Siege economy state to the game client.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeTaxInfoPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeTaxInfoPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("5B79A56E-1D22-4AC6-96CC-BAB269315490")]
+public class CastleSiegeTaxInfoPlugIn : ICastleSiegeTaxInfoPlugIn
+{
+    private readonly RemotePlayer _player;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeTaxInfoPlugIn"/> class.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    public CastleSiegeTaxInfoPlugIn(RemotePlayer player) => this._player = player;
+
+    /// <inheritdoc />
+    public ValueTask ShowTaxInfoAsync(
+        CastleSiegeRequestResult result,
+        byte chaosTax,
+        byte storeTax,
+        long tributeMoney)
+        => this._player.Connection?.SendCastleSiegeTaxInfoResponseAsync(
+            (byte)result,
+            chaosTax,
+            storeTax,
+            checked((ulong)tributeMoney)) ?? default;
+}

--- a/src/GameServer/RemoteView/CastleSiege/CastleSiegeTributeWithdrawResultPlugIn.cs
+++ b/src/GameServer/RemoteView/CastleSiege/CastleSiegeTributeWithdrawResultPlugIn.cs
@@ -1,0 +1,34 @@
+// <copyright file="CastleSiegeTributeWithdrawResultPlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer.RemoteView.CastleSiege;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+using MUnique.OpenMU.Network.Packets.ServerToClient;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// The default implementation of the <see cref="ICastleSiegeTributeWithdrawResultPlugIn"/>
+/// which forwards treasury-withdrawal results to the game client.
+/// </summary>
+[PlugIn]
+[Display(Name = nameof(PlugInResources.CastleSiegeTributeWithdrawResultPlugIn_Name), Description = nameof(PlugInResources.CastleSiegeTributeWithdrawResultPlugIn_Description), ResourceType = typeof(PlugInResources))]
+[Guid("6B84EE67-9FE7-4C69-BC54-FA72BE7E3D6A")]
+public class CastleSiegeTributeWithdrawResultPlugIn : ICastleSiegeTributeWithdrawResultPlugIn
+{
+    private readonly RemotePlayer _player;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CastleSiegeTributeWithdrawResultPlugIn"/> class.
+    /// </summary>
+    /// <param name="player">The player.</param>
+    public CastleSiegeTributeWithdrawResultPlugIn(RemotePlayer player) => this._player = player;
+
+    /// <inheritdoc />
+    public ValueTask ShowTributeWithdrawResultAsync(CastleSiegeRequestResult result, long amount)
+        => this._player.Connection?.SendCastleSiegeTributeWithdrawResponseAsync(
+            (byte)result,
+            checked((ulong)amount)) ?? default;
+}

--- a/src/Persistence/Initialization/Updates/ConfigureCastleSiegeEconomyUpdatePlugIn.cs
+++ b/src/Persistence/Initialization/Updates/ConfigureCastleSiegeEconomyUpdatePlugIn.cs
@@ -1,0 +1,60 @@
+// <copyright file="ConfigureCastleSiegeEconomyUpdatePlugIn.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Persistence.Initialization.Updates;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// Configures the Castle Siege economy interface for an existing Season 6 database.
+/// </summary>
+[PlugIn]
+[Display(Name = PlugInName, Description = PlugInDescription)]
+[Guid("7ED67868-5C82-4B10-9BDA-732F51704DB9")]
+public class ConfigureCastleSiegeEconomyUpdatePlugIn : UpdatePlugInBase
+{
+    /// <summary>
+    /// The plug-in name.
+    /// </summary>
+    internal const string PlugInName = "Configure Castle Siege economy";
+
+    /// <summary>
+    /// The plug-in description.
+    /// </summary>
+    internal const string PlugInDescription = "This update enables the Castle Siege economy interface of the Senior NPC.";
+
+    private const short SeniorNpcNumber = 223;
+
+    /// <inheritdoc />
+    public override string Name => PlugInName;
+
+    /// <inheritdoc />
+    public override string Description => PlugInDescription;
+
+    /// <inheritdoc />
+    public override UpdateVersion Version => UpdateVersion.ConfigureCastleSiegeEconomy;
+
+    /// <inheritdoc />
+    public override string DataInitializationKey => VersionSeasonSix.DataInitialization.Id;
+
+    /// <inheritdoc />
+    public override bool IsMandatory => true;
+
+    /// <inheritdoc />
+    public override DateTime CreatedAt => new(2026, 08, 27, 0, 0, 0, DateTimeKind.Utc);
+
+    /// <inheritdoc />
+    protected override ValueTask ApplyAsync(IContext context, GameConfiguration gameConfiguration)
+    {
+        var senior = gameConfiguration.Monsters.FirstOrDefault(monster => monster.Number == SeniorNpcNumber);
+        if (senior is not null)
+        {
+            senior.NpcWindow = NpcWindow.CastleSeniorNPC;
+        }
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Persistence/Initialization/Updates/UpdateVersion.cs
+++ b/src/Persistence/Initialization/Updates/UpdateVersion.cs
@@ -544,4 +544,9 @@ public enum UpdateVersion
     /// The version of the <see cref="RegenerationsRefactorPlugInSeason6"/>.
     /// </summary>
     RegenerationsRefactorSeason6 = 107,
+
+    /// <summary>
+    /// The version of the <see cref="ConfigureCastleSiegeEconomyUpdatePlugIn"/>.
+    /// </summary>
+    ConfigureCastleSiegeEconomy = 108,
 }

--- a/src/Persistence/Initialization/VersionSeasonSix/NpcInitialization.cs
+++ b/src/Persistence/Initialization/VersionSeasonSix/NpcInitialization.cs
@@ -395,6 +395,7 @@ internal partial class NpcInitialization : Version095d.NpcInitialization
             def.Number = 223;
             def.Designation = "Senior";
             def.ObjectKind = NpcObjectKind.PassiveNpc;
+            def.NpcWindow = NpcWindow.CastleSeniorNPC;
             this.GameConfiguration.Monsters.Add(def);
             def.SetGuid(def.Number);
         }

--- a/tests/MUnique.OpenMU.Persistence.Initialization.Tests/TestInitializationWithEfCore.cs
+++ b/tests/MUnique.OpenMU.Persistence.Initialization.Tests/TestInitializationWithEfCore.cs
@@ -390,6 +390,14 @@ internal class TestInitializationWithEfCore
                 .Select(effect => effect.Number),
             Is.EquivalentTo(Enum.GetValues<CastleSiegeMagicEffectNumber>().Select(number => (short)number)));
 
+        var senior = gameConfiguration.Monsters.Single(monster => monster.Number == 223);
+        Assert.That(senior.NpcWindow, Is.EqualTo(NpcWindow.CastleSeniorNPC));
+        senior.NpcWindow = NpcWindow.Undefined;
+        var economyUpdate = new ConfigureCastleSiegeEconomyUpdatePlugIn();
+        await economyUpdate.ApplyUpdateAsync(context, gameConfiguration).ConfigureAwait(false);
+        await economyUpdate.ApplyUpdateAsync(context, gameConfiguration).ConfigureAwait(false);
+        Assert.That(senior.NpcWindow, Is.EqualTo(NpcWindow.CastleSeniorNPC));
+
         gameConfiguration.Items.Add(signOfLord);
         configuration.SignOfLordItemDefinition = signOfLord;
         configuration.SignOfLordItemLevel = 3;

--- a/tests/MUnique.OpenMU.Tests/CastleSiegeCrownMechanicsTests.cs
+++ b/tests/MUnique.OpenMU.Tests/CastleSiegeCrownMechanicsTests.cs
@@ -463,7 +463,7 @@ public class CastleSiegeCrownMechanicsTests
             Assert.That(fixture.Context.SiegeData.TaxStore, Is.Zero);
             Assert.That(fixture.Context.SiegeData.TaxHunt, Is.Zero);
             Assert.That(fixture.Context.SiegeData.TributeMoney, Is.Zero);
-            Assert.That(fixture.Context.SiegeData.IsHuntZoneEnabled, Is.True);
+            Assert.That(fixture.Context.SiegeData.IsHuntZoneEnabled, Is.False);
         });
         using (var persistenceContext = fixture.PersistenceContextProvider.CreateNewTypedContext(
                    typeof(CastleSiegeData),

--- a/tests/MUnique.OpenMU.Tests/CastleSiegeEconomyRemoteViewTests.cs
+++ b/tests/MUnique.OpenMU.Tests/CastleSiegeEconomyRemoteViewTests.cs
@@ -1,0 +1,142 @@
+// <copyright file="CastleSiegeEconomyRemoteViewTests.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Tests;
+
+using MUnique.OpenMU.GameLogic.CastleSiege;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
+using MUnique.OpenMU.GameServer.RemoteView.CastleSiege;
+using MUnique.OpenMU.Network.Packets.ServerToClient;
+
+/// <summary>
+/// Tests Castle Siege economy remote-view packet serialization.
+/// </summary>
+[TestFixture]
+public class CastleSiegeEconomyRemoteViewTests
+{
+    /// <summary>
+    /// Verifies tax, treasury, and Land of Trials response packets.
+    /// </summary>
+    [Test]
+    public async ValueTask SerializeEconomyResponsesAsync()
+    {
+        var (player, output) = CastleSiegeRemoteViewTestHelper.CreatePlayer();
+        await new CastleSiegeTaxInfoPlugIn(player)
+            .ShowTaxInfoAsync(CastleSiegeRequestResult.Success, 3, 2, 123_456_789)
+            .ConfigureAwait(false);
+        var taxChangeView = new CastleSiegeTaxChangeResultPlugIn(player);
+        await taxChangeView
+            .ShowTaxChangeResultAsync(
+                CastleSiegeRequestResult.Success,
+                MUnique.OpenMU.GameLogic.CastleSiege.CastleSiegeTaxType.HuntZone,
+                300_000)
+            .ConfigureAwait(false);
+        await taxChangeView
+            .ShowTaxRateUpdateAsync(
+                MUnique.OpenMU.GameLogic.CastleSiege.CastleSiegeTaxType.Store,
+                3)
+            .ConfigureAwait(false);
+        await new CastleSiegeTributeWithdrawResultPlugIn(player)
+            .ShowTributeWithdrawResultAsync(CastleSiegeRequestResult.Success, 10_000)
+            .ConfigureAwait(false);
+        await new CastleSiegeHuntZoneGuardInfoPlugIn(player)
+            .ShowHuntZoneGuardInfoAsync(
+                CastleSiegeHuntZoneAccessType.OwnerGuildMaster,
+                true,
+                300_000,
+                300_000,
+                10_000)
+            .ConfigureAwait(false);
+        var huntZoneResultView = new CastleSiegeHuntZoneResultPlugIn(player);
+        await huntZoneResultView
+            .ShowEntranceSettingResultAsync(CastleSiegeRequestResult.Success, true)
+            .ConfigureAwait(false);
+        await huntZoneResultView.ShowEnterResultAsync(true).ConfigureAwait(false);
+
+        var data = output.ToArray().AsMemory();
+        Assert.That(
+            data.Length,
+            Is.EqualTo(
+                CastleSiegeTaxInfoResponse.Length
+                + CastleSiegeTaxChangeResponse.Length
+                + CastleSiegeTaxRateNotification.Length
+                + CastleSiegeTributeWithdrawResponse.Length
+                + CastleSiegeHuntingZoneGuardInfo.Length
+                + CastleSiegeHuntingZoneEntranceSettingResponse.Length
+                + CastleSiegeHuntingZoneEnterResponse.Length));
+
+        var taxInfo = (CastleSiegeTaxInfoResponse)data[..CastleSiegeTaxInfoResponse.Length];
+        Assert.Multiple(() =>
+        {
+            Assert.That(taxInfo.Result, Is.EqualTo((byte)CastleSiegeRequestResult.Success));
+            Assert.That(taxInfo.TaxRateChaosMachine, Is.EqualTo(3));
+            Assert.That(taxInfo.TaxRateNormal, Is.EqualTo(2));
+            Assert.That(taxInfo.Treasury, Is.EqualTo(123_456_789));
+        });
+
+        var offset = CastleSiegeTaxInfoResponse.Length;
+        var taxChange = (CastleSiegeTaxChangeResponse)data.Slice(
+            offset,
+            CastleSiegeTaxChangeResponse.Length);
+        Assert.Multiple(() =>
+        {
+            Assert.That(taxChange.Result, Is.EqualTo(1));
+            Assert.That(
+                taxChange.TaxType,
+                Is.EqualTo(MUnique.OpenMU.Network.Packets.ServerToClient.CastleSiegeTaxType.HuntingZoneEntranceFee));
+            Assert.That(taxChange.TaxValue, Is.EqualTo(300_000));
+        });
+
+        offset += CastleSiegeTaxChangeResponse.Length;
+        var taxRateNotification = (CastleSiegeTaxRateNotification)data.Slice(
+            offset,
+            CastleSiegeTaxRateNotification.Length);
+        Assert.Multiple(() =>
+        {
+            Assert.That(
+                taxRateNotification.TaxType,
+                Is.EqualTo(MUnique.OpenMU.Network.Packets.ServerToClient.CastleSiegeTaxType.Store));
+            Assert.That(taxRateNotification.TaxRate, Is.EqualTo(3));
+        });
+
+        offset += CastleSiegeTaxRateNotification.Length;
+        var withdrawal = (CastleSiegeTributeWithdrawResponse)data.Slice(
+            offset,
+            CastleSiegeTributeWithdrawResponse.Length);
+        Assert.Multiple(() =>
+        {
+            Assert.That(withdrawal.Result, Is.EqualTo(1));
+            Assert.That(withdrawal.Money, Is.EqualTo(10_000));
+        });
+
+        offset += CastleSiegeTributeWithdrawResponse.Length;
+        var guard = (CastleSiegeHuntingZoneGuardInfo)data.Slice(
+            offset,
+            CastleSiegeHuntingZoneGuardInfo.Length);
+        Assert.Multiple(() =>
+        {
+            Assert.That(guard.Result, Is.EqualTo((byte)CastleSiegeHuntZoneAccessType.OwnerGuildMaster));
+            Assert.That(guard.IsEnabled, Is.True);
+            Assert.That(guard.CurrentPrice, Is.EqualTo(300_000));
+            Assert.That(guard.MaxPrice, Is.EqualTo(300_000));
+            Assert.That(guard.UnitPrice, Is.EqualTo(10_000));
+        });
+
+        offset += CastleSiegeHuntingZoneGuardInfo.Length;
+        var entranceSetting = (CastleSiegeHuntingZoneEntranceSettingResponse)data.Slice(
+            offset,
+            CastleSiegeHuntingZoneEntranceSettingResponse.Length);
+        Assert.Multiple(() =>
+        {
+            Assert.That(entranceSetting.Result, Is.EqualTo((byte)CastleSiegeRequestResult.Success));
+            Assert.That(entranceSetting.IsPublic, Is.True);
+        });
+
+        offset += CastleSiegeHuntingZoneEntranceSettingResponse.Length;
+        var enterResult = (CastleSiegeHuntingZoneEnterResponse)data.Slice(
+            offset,
+            CastleSiegeHuntingZoneEnterResponse.Length);
+        Assert.That(enterResult.Result, Is.EqualTo(1));
+    }
+}

--- a/tests/MUnique.OpenMU.Tests/CastleSiegeEconomyTests.cs
+++ b/tests/MUnique.OpenMU.Tests/CastleSiegeEconomyTests.cs
@@ -11,6 +11,8 @@ using MUnique.OpenMU.DataModel.Entities;
 using MUnique.OpenMU.GameLogic;
 using MUnique.OpenMU.GameLogic.CastleSiege;
 using MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+using MUnique.OpenMU.GameLogic.NPC;
+using MUnique.OpenMU.GameLogic.Views.CastleSiege;
 using MUnique.OpenMU.GameServer;
 using MUnique.OpenMU.GameServer.MessageHandler.CastleSiege;
 using MUnique.OpenMU.Interfaces;
@@ -31,7 +33,7 @@ public class CastleSiegeEconomyTests
     private const string OwnerGuildName = "CastleOwners";
 
     /// <summary>
-    /// Verifies tax calculation, atomic charging, persistence, and owner/alliance exemptions.
+    /// Verifies tax calculation, batched persistence, Chaos Machine scoping, and owner/alliance exemptions.
     /// </summary>
     [Test]
     public async ValueTask TaxesAreCollectedPersistedAndExemptOwnerAllianceAsync()
@@ -41,6 +43,7 @@ public class CastleSiegeEconomyTests
         fixture.Context.SiegeData.TaxChaos = 3;
         fixture.Context.SiegeData.TaxStore = 2;
         fixture.Visitor.Money = 2_000;
+        SetOpenedNpc(fixture.Visitor, NpcWindow.ChaosMachine);
 
         Assert.That(
             await provider.TryPayChaosCostAsync(fixture.Visitor, 1_000, fixture.Context).ConfigureAwait(false),
@@ -67,6 +70,7 @@ public class CastleSiegeEconomyTests
         var allianceMember = await PlayerTestHelper.CreatePlayerAsync(fixture.GameServerContext).ConfigureAwait(false);
         allianceMember.GuildStatus = new GuildMemberStatus(AllianceGuildId, GuildPosition.NormalMember);
         allianceMember.Money = 1_000;
+        SetOpenedNpc(allianceMember, NpcWindow.ChaosMachine);
         Assert.That(
             await provider.TryPayChaosCostAsync(allianceMember, 100, fixture.Context).ConfigureAwait(false),
             Is.True);
@@ -76,7 +80,19 @@ public class CastleSiegeEconomyTests
             Assert.That(fixture.Context.SiegeData.TributeMoney, Is.EqualTo(40));
         });
 
+        fixture.Visitor.Money = 1_000;
+        SetOpenedNpc(fixture.Visitor, NpcWindow.ElphisRefinery);
+        Assert.That(
+            await provider.TryPayChaosCostAsync(fixture.Visitor, 100, fixture.Context).ConfigureAwait(false),
+            Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(fixture.Visitor.Money, Is.EqualTo(900));
+            Assert.That(fixture.Context.SiegeData.TributeMoney, Is.EqualTo(40));
+        });
+
         fixture.Visitor.Money = 10;
+        SetOpenedNpc(fixture.Visitor, NpcWindow.ChaosMachine);
         Assert.That(
             await provider.TryPayChaosCostAsync(fixture.Visitor, 100, fixture.Context).ConfigureAwait(false),
             Is.False);
@@ -86,12 +102,66 @@ public class CastleSiegeEconomyTests
             Assert.That(fixture.Context.SiegeData.TributeMoney, Is.EqualTo(40));
         });
 
-        using var persistenceContext = fixture.PersistenceContextProvider.CreateNewTypedContext(
-            typeof(CastleSiegeData),
-            false,
-            fixture.GameServerContext.Configuration);
-        var persistedData = (await persistenceContext.GetAsync<CastleSiegeData>().ConfigureAwait(false)).Single();
-        Assert.That(persistedData.TributeMoney, Is.EqualTo(40));
+        Assert.That(fixture.Context.IsEconomyPersistencePending, Is.True);
+        var saveDueUtc = new DateTime(2026, 8, 3, 12, 0, 30, DateTimeKind.Utc);
+        fixture.Context.NextEconomySaveUtc = saveDueUtc;
+        await CastleSiegePlugIn
+            .PersistEconomyIfDueAsync(fixture.Context, saveDueUtc.AddTicks(-1))
+            .ConfigureAwait(false);
+        Assert.That(fixture.Context.IsEconomyPersistencePending, Is.True);
+
+        await CastleSiegePlugIn.PersistEconomyIfDueAsync(fixture.Context, saveDueUtc).ConfigureAwait(false);
+        Assert.That(fixture.Context.IsEconomyPersistencePending, Is.False);
+        using (var persistenceContext = fixture.PersistenceContextProvider.CreateNewTypedContext(
+                   typeof(CastleSiegeData),
+                   false,
+                   fixture.GameServerContext.Configuration))
+        {
+            var persistedData = (await persistenceContext.GetAsync<CastleSiegeData>().ConfigureAwait(false)).Single();
+            Assert.That(persistedData.TributeMoney, Is.EqualTo(40));
+        }
+    }
+
+    /// <summary>
+    /// Verifies that a zero store-tax rate keeps the purchase hot path free of guild-server calls.
+    /// </summary>
+    [Test]
+    public async ValueTask ZeroStoreTaxSkipsGuildLookupAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        fixture.Context.SiegeData.TaxStore = 0;
+        fixture.Visitor.Money = 100;
+
+        Assert.That(
+            await new CastleSiegeTaxProvider()
+                .TryPayStoreCostAsync(fixture.Visitor, 25, fixture.Context)
+                .ConfigureAwait(false),
+            Is.True);
+        Assert.That(fixture.Visitor.Money, Is.EqualTo(75));
+        fixture.GuildServer.Verify(
+            server => server.GetPersistentAllianceMasterGuildIdAsync(It.IsAny<uint>()),
+            Times.Never);
+    }
+
+    /// <summary>
+    /// Verifies that tax notifications are only sent to players who entered the world.
+    /// </summary>
+    [Test]
+    public async ValueTask TaxBroadcastSkipsPlayersOutsideTheWorldAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        Assert.That(
+            await fixture.Visitor.PlayerState.TryAdvanceToAsync(PlayerState.CharacterSelection).ConfigureAwait(false),
+            Is.True);
+        var ownerView = Mock.Get(fixture.Owner.ViewPlugIns.GetPlugIn<ICastleSiegeTaxChangeResultPlugIn>()!);
+        var visitorView = Mock.Get(fixture.Visitor.ViewPlugIns.GetPlugIn<ICastleSiegeTaxChangeResultPlugIn>()!);
+
+        await CastleSiegeEconomyNotifier
+            .BroadcastTaxRateAsync(fixture.Context, CastleSiegeTaxType.Store, 2)
+            .ConfigureAwait(false);
+
+        ownerView.Verify(view => view.ShowTaxRateUpdateAsync(CastleSiegeTaxType.Store, 2), Times.Once);
+        visitorView.Verify(view => view.ShowTaxRateUpdateAsync(It.IsAny<CastleSiegeTaxType>(), It.IsAny<byte>()), Times.Never);
     }
 
     /// <summary>
@@ -157,6 +227,8 @@ public class CastleSiegeEconomyTests
             Assert.That(fixture.Context.SiegeData.TributeMoney, Is.EqualTo(300));
             Assert.That(fixture.Owner.Money, Is.EqualTo(300));
         });
+        Mock.Get(fixture.Owner.ViewPlugIns.GetPlugIn<ICastleSiegeTaxChangeResultPlugIn>()!)
+            .Verify(view => view.ShowTaxRateUpdateAsync(CastleSiegeTaxType.Store, 3), Times.Once);
 
         fixture.Context.CurrentState = CastleSiegeState.Start;
         Assert.That(
@@ -374,20 +446,32 @@ public class CastleSiegeEconomyTests
         owner.GuildStatus = new GuildMemberStatus(OwnerGuildId, GuildPosition.GuildMaster);
         var visitor = await PlayerTestHelper.CreatePlayerAsync(gameServerContext).ConfigureAwait(false);
         visitor.GuildStatus = new GuildMemberStatus(VisitorGuildId, GuildPosition.NormalMember);
+        await gameServerContext.AddPlayerAsync(owner).ConfigureAwait(false);
+        await gameServerContext.AddPlayerAsync(visitor).ConfigureAwait(false);
         var context = new CastleSiegeContext(gameServerContext, castleSiegeConfiguration);
         await context.InitializeAsync(new DateTime(2026, 8, 3, 12, 0, 0, DateTimeKind.Utc)).ConfigureAwait(false);
 
         return new(
             persistenceContextProvider,
             gameServerContext,
+            guildServer,
             context,
             owner,
             visitor);
     }
 
+    private static void SetOpenedNpc(Player player, NpcWindow npcWindow)
+    {
+        player.OpenedNpc = new NonPlayerCharacter(
+            null!,
+            new MonsterDefinition { NpcWindow = npcWindow },
+            null!);
+    }
+
     private sealed record TestFixture(
         InMemoryPersistenceContextProvider PersistenceContextProvider,
         GameServerContext GameServerContext,
+        Mock<IGuildServer> GuildServer,
         CastleSiegeContext Context,
         Player Owner,
         Player Visitor);

--- a/tests/MUnique.OpenMU.Tests/CastleSiegeEconomyTests.cs
+++ b/tests/MUnique.OpenMU.Tests/CastleSiegeEconomyTests.cs
@@ -1,0 +1,394 @@
+// <copyright file="CastleSiegeEconomyTests.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Tests;
+
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.DataModel.Entities;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.CastleSiege;
+using MUnique.OpenMU.GameLogic.CastleSiege.Actions;
+using MUnique.OpenMU.GameServer;
+using MUnique.OpenMU.GameServer.MessageHandler.CastleSiege;
+using MUnique.OpenMU.Interfaces;
+using MUnique.OpenMU.Persistence.InMemory;
+using MUnique.OpenMU.PlugIns;
+using BasicModel = MUnique.OpenMU.Persistence.BasicModel;
+using RuntimeGuild = MUnique.OpenMU.Interfaces.Guild;
+
+/// <summary>
+/// Tests Castle Siege taxes, treasury operations, and Land of Trials access.
+/// </summary>
+[TestFixture]
+public class CastleSiegeEconomyTests
+{
+    private const uint OwnerGuildId = 10;
+    private const uint VisitorGuildId = 20;
+    private const uint AllianceGuildId = 30;
+    private const string OwnerGuildName = "CastleOwners";
+
+    /// <summary>
+    /// Verifies tax calculation, atomic charging, persistence, and owner/alliance exemptions.
+    /// </summary>
+    [Test]
+    public async ValueTask TaxesAreCollectedPersistedAndExemptOwnerAllianceAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var provider = new CastleSiegeTaxProvider();
+        fixture.Context.SiegeData.TaxChaos = 3;
+        fixture.Context.SiegeData.TaxStore = 2;
+        fixture.Visitor.Money = 2_000;
+
+        Assert.That(
+            await provider.TryPayChaosCostAsync(fixture.Visitor, 1_000, fixture.Context).ConfigureAwait(false),
+            Is.True);
+        Assert.That(
+            await provider.TryPayStoreCostAsync(fixture.Visitor, 500, fixture.Context).ConfigureAwait(false),
+            Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(fixture.Visitor.Money, Is.EqualTo(460));
+            Assert.That(fixture.Context.SiegeData.TributeMoney, Is.EqualTo(40));
+        });
+
+        fixture.Owner.Money = 1_000;
+        Assert.That(
+            await provider.TryPayStoreCostAsync(fixture.Owner, 100, fixture.Context).ConfigureAwait(false),
+            Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(fixture.Owner.Money, Is.EqualTo(900));
+            Assert.That(fixture.Context.SiegeData.TributeMoney, Is.EqualTo(40));
+        });
+
+        var allianceMember = await PlayerTestHelper.CreatePlayerAsync(fixture.GameServerContext).ConfigureAwait(false);
+        allianceMember.GuildStatus = new GuildMemberStatus(AllianceGuildId, GuildPosition.NormalMember);
+        allianceMember.Money = 1_000;
+        Assert.That(
+            await provider.TryPayChaosCostAsync(allianceMember, 100, fixture.Context).ConfigureAwait(false),
+            Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(allianceMember.Money, Is.EqualTo(900));
+            Assert.That(fixture.Context.SiegeData.TributeMoney, Is.EqualTo(40));
+        });
+
+        fixture.Visitor.Money = 10;
+        Assert.That(
+            await provider.TryPayChaosCostAsync(fixture.Visitor, 100, fixture.Context).ConfigureAwait(false),
+            Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(fixture.Visitor.Money, Is.EqualTo(10));
+            Assert.That(fixture.Context.SiegeData.TributeMoney, Is.EqualTo(40));
+        });
+
+        using var persistenceContext = fixture.PersistenceContextProvider.CreateNewTypedContext(
+            typeof(CastleSiegeData),
+            false,
+            fixture.GameServerContext.Configuration);
+        var persistedData = (await persistenceContext.GetAsync<CastleSiegeData>().ConfigureAwait(false)).Single();
+        Assert.That(persistedData.TributeMoney, Is.EqualTo(40));
+    }
+
+    /// <summary>
+    /// Verifies owner-only rate changes, valid limits, public-access changes, and treasury withdrawals.
+    /// </summary>
+    [Test]
+    public async ValueTask OwnerGuildMasterCanManageEconomyAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        fixture.Context.CurrentState = CastleSiegeState.End;
+        fixture.Context.SiegeData.TributeMoney = 500;
+        fixture.Owner.Money = 100;
+        var changeAction = new CastleSiegeTaxRateChangeAction();
+
+        Assert.That(
+            await changeAction.ChangeAsync(
+                    fixture.Owner,
+                    fixture.Context,
+                    CastleSiegeTaxType.Store,
+                    4)
+                .ConfigureAwait(false),
+            Is.False);
+        Assert.That(
+            await changeAction.ChangeAsync(
+                    fixture.Owner,
+                    fixture.Context,
+                    CastleSiegeTaxType.Store,
+                    3)
+                .ConfigureAwait(false),
+            Is.True);
+        Assert.That(
+            await changeAction.ChangeAsync(
+                    fixture.Owner,
+                    fixture.Context,
+                    CastleSiegeTaxType.HuntZone,
+                    300_001)
+                .ConfigureAwait(false),
+            Is.False);
+        Assert.That(
+            await changeAction.ChangeAsync(
+                    fixture.Owner,
+                    fixture.Context,
+                    CastleSiegeTaxType.HuntZone,
+                    300_000)
+                .ConfigureAwait(false),
+            Is.True);
+        Assert.That(
+            await new CastleSiegeHuntZoneToggleAction()
+                .SetPublicAccessAsync(fixture.Owner, fixture.Context, true)
+                .ConfigureAwait(false),
+            Is.True);
+        Assert.That(
+            await new CastleSiegeTributeWithdrawAction()
+                .WithdrawAsync(fixture.Owner, fixture.Context, 200)
+                .ConfigureAwait(false),
+            Is.True);
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(fixture.Context.SiegeData.TaxStore, Is.EqualTo(3));
+            Assert.That(fixture.Context.SiegeData.TaxHunt, Is.EqualTo(300_000));
+            Assert.That(fixture.Context.SiegeData.IsHuntZoneEnabled, Is.True);
+            Assert.That(fixture.Context.SiegeData.TributeMoney, Is.EqualTo(300));
+            Assert.That(fixture.Owner.Money, Is.EqualTo(300));
+        });
+
+        fixture.Context.CurrentState = CastleSiegeState.Start;
+        Assert.That(
+            await changeAction.ChangeAsync(
+                    fixture.Owner,
+                    fixture.Context,
+                    CastleSiegeTaxType.Store,
+                    2)
+                .ConfigureAwait(false),
+            Is.False);
+        Assert.That(
+            await new CastleSiegeHuntZoneToggleAction()
+                .SetPublicAccessAsync(fixture.Owner, fixture.Context, false)
+                .ConfigureAwait(false),
+            Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(fixture.Context.SiegeData.TaxStore, Is.EqualTo(3));
+            Assert.That(fixture.Context.SiegeData.IsHuntZoneEnabled, Is.True);
+        });
+
+        fixture.Context.CurrentState = CastleSiegeState.End;
+
+        fixture.Owner.GuildStatus = new GuildMemberStatus(OwnerGuildId, GuildPosition.NormalMember);
+        Assert.That(
+            await changeAction.ChangeAsync(
+                    fixture.Owner,
+                    fixture.Context,
+                    CastleSiegeTaxType.ChaosMachine,
+                    3)
+                .ConfigureAwait(false),
+            Is.False);
+        Assert.That(
+            await new CastleSiegeTributeWithdrawAction()
+                .WithdrawAsync(fixture.Owner, fixture.Context, 100)
+                .ConfigureAwait(false),
+            Is.False);
+
+        using var persistenceContext = fixture.PersistenceContextProvider.CreateNewTypedContext(
+            typeof(CastleSiegeData),
+            false,
+            fixture.GameServerContext.Configuration);
+        var persistedData = (await persistenceContext.GetAsync<CastleSiegeData>().ConfigureAwait(false)).Single();
+        Assert.Multiple(() =>
+        {
+            Assert.That(persistedData.TaxStore, Is.EqualTo(3));
+            Assert.That(persistedData.TaxHunt, Is.EqualTo(300_000));
+            Assert.That(persistedData.IsHuntZoneEnabled, Is.True);
+            Assert.That(persistedData.TributeMoney, Is.EqualTo(300));
+        });
+    }
+
+    /// <summary>
+    /// Verifies public Land of Trials access, configured entry fees, and owner exemption.
+    /// </summary>
+    [Test]
+    public async ValueTask HuntZoneFeeHonorsAccessAndOwnerExemptionAsync()
+    {
+        var fixture = await CreateFixtureAsync().ConfigureAwait(false);
+        var provider = new CastleSiegeTaxProvider();
+        fixture.Context.SiegeData.TaxHunt = 300_000;
+        fixture.Context.SiegeData.IsHuntZoneEnabled = false;
+        fixture.Visitor.Money = 400_000;
+        fixture.Owner.Money = 1_000;
+
+        Assert.That(
+            await provider.TryPayHuntEntryFeeAsync(fixture.Visitor, fixture.Context).ConfigureAwait(false),
+            Is.False);
+        Assert.That(
+            await provider.TryPayHuntEntryFeeAsync(fixture.Owner, fixture.Context).ConfigureAwait(false),
+            Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(fixture.Visitor.Money, Is.EqualTo(400_000));
+            Assert.That(fixture.Owner.Money, Is.EqualTo(1_000));
+            Assert.That(fixture.Context.SiegeData.TributeMoney, Is.Zero);
+        });
+
+        fixture.Context.SiegeData.IsHuntZoneEnabled = true;
+        Assert.That(
+            await provider.TryPayHuntEntryFeeAsync(fixture.Visitor, fixture.Context).ConfigureAwait(false),
+            Is.True);
+        Assert.Multiple(() =>
+        {
+            Assert.That(fixture.Visitor.Money, Is.EqualTo(100_000));
+            Assert.That(fixture.Context.SiegeData.TributeMoney, Is.EqualTo(300_000));
+        });
+
+        fixture.Context.SiegeData.TaxHunt = -1;
+        fixture.Visitor.Money = 100;
+        Assert.That(
+            await provider.TryPayHuntEntryFeeAsync(fixture.Visitor, fixture.Context).ConfigureAwait(false),
+            Is.False);
+        Assert.Multiple(() =>
+        {
+            Assert.That(fixture.Visitor.Money, Is.EqualTo(100));
+            Assert.That(fixture.Context.SiegeData.TributeMoney, Is.EqualTo(300_000));
+        });
+    }
+
+    /// <summary>
+    /// Verifies the request identifiers required by the Castle Siege economy protocol.
+    /// </summary>
+    [Test]
+    public void EconomyRequestHandlersUseExpectedIdentifiers()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(new CastleSiegeTaxInfoHandlerPlugIn().Key, Is.EqualTo(0x08));
+            Assert.That(new CastleSiegeTaxChangeHandlerPlugIn().Key, Is.EqualTo(0x09));
+            Assert.That(new CastleSiegeTributeWithdrawHandlerPlugIn().Key, Is.EqualTo(0x10));
+            Assert.That(new CastleSiegeHuntZoneToggleHandlerPlugIn().Key, Is.EqualTo(0x1F));
+            Assert.That(CastleSiegeHuntZoneGroupHandlerPlugIn.GroupKey, Is.EqualTo(0xB9));
+            Assert.That(new CastleSiegeHuntZoneEnterHandlerPlugIn().Key, Is.EqualTo(0x05));
+        });
+    }
+
+    private static async ValueTask<TestFixture> CreateFixtureAsync()
+    {
+        var persistenceContextProvider = new InMemoryPersistenceContextProvider();
+        BasicModel.GameConfiguration gameConfiguration;
+        BasicModel.CastleSiegeConfiguration castleSiegeConfiguration;
+        Guid persistentOwnerGuildId;
+        using (var persistenceContext = persistenceContextProvider.CreateNewContext())
+        {
+            gameConfiguration = persistenceContext.CreateNew<BasicModel.GameConfiguration>();
+            gameConfiguration.MaximumInventoryMoney = int.MaxValue;
+            var normalMap = persistenceContext.CreateNew<BasicModel.GameMapDefinition>();
+            normalMap.Number = 0;
+            normalMap.TerrainData = new byte[65_539];
+            gameConfiguration.Maps.Add(normalMap);
+            var siegeMap = persistenceContext.CreateNew<BasicModel.GameMapDefinition>();
+            siegeMap.Number = 30;
+            siegeMap.TerrainData = new byte[65_539];
+            gameConfiguration.Maps.Add(siegeMap);
+
+            castleSiegeConfiguration = persistenceContext.CreateNew<BasicModel.CastleSiegeConfiguration>();
+            castleSiegeConfiguration.Enabled = true;
+            castleSiegeConfiguration.CastleSiegeMapDefinition = siegeMap;
+            castleSiegeConfiguration.StateSchedule.Add(new BasicModel.CastleSiegeStateScheduleEntry
+            {
+                State = CastleSiegeState.Ready,
+                DayOfWeek = DayOfWeek.Monday,
+            });
+            castleSiegeConfiguration.StateSchedule.Add(new BasicModel.CastleSiegeStateScheduleEntry
+            {
+                State = CastleSiegeState.Start,
+                DayOfWeek = DayOfWeek.Tuesday,
+            });
+            gameConfiguration.CastleSiegeConfiguration = castleSiegeConfiguration;
+
+            var ownerGuild = persistenceContext.CreateNew<BasicModel.Guild>();
+            ownerGuild.Name = OwnerGuildName;
+            persistentOwnerGuildId = ownerGuild.Id;
+            var siegeData = persistenceContext.CreateNew<BasicModel.CastleSiegeData>();
+            siegeData.OwnerGuildId = persistentOwnerGuildId;
+            siegeData.IsOccupied = true;
+            await persistenceContext.SaveChangesAsync().ConfigureAwait(false);
+        }
+
+        var runtimeOwnerGuild = new RuntimeGuild { Name = OwnerGuildName };
+        var persistentVisitorGuildId = Guid.NewGuid();
+        var guildServer = new Mock<IGuildServer>();
+        guildServer
+            .Setup(server => server.GetGuildAsync(OwnerGuildId))
+            .Returns(new ValueTask<RuntimeGuild?>(runtimeOwnerGuild));
+        guildServer
+            .Setup(server => server.GetGuildAsync(VisitorGuildId))
+            .Returns(new ValueTask<RuntimeGuild?>(new RuntimeGuild { Name = "Visitors" }));
+        guildServer
+            .Setup(server => server.GetGuildAsync(AllianceGuildId))
+            .Returns(new ValueTask<RuntimeGuild?>(new RuntimeGuild
+            {
+                Name = "AllianceMember",
+                AllianceGuild = runtimeOwnerGuild,
+            }));
+        guildServer
+            .Setup(server => server.GetPersistentGuildIdAsync(OwnerGuildId))
+            .Returns(new ValueTask<Guid?>(persistentOwnerGuildId));
+        guildServer
+            .Setup(server => server.GetPersistentAllianceMasterGuildIdAsync(OwnerGuildId))
+            .Returns(new ValueTask<Guid?>(persistentOwnerGuildId));
+        guildServer
+            .Setup(server => server.GetPersistentAllianceMasterGuildIdAsync(VisitorGuildId))
+            .Returns(new ValueTask<Guid?>(persistentVisitorGuildId));
+        guildServer
+            .Setup(server => server.GetPersistentAllianceMasterGuildIdAsync(AllianceGuildId))
+            .Returns(new ValueTask<Guid?>(persistentOwnerGuildId));
+
+        var mapInitializer = new MapInitializer(
+            gameConfiguration,
+            new NullLogger<MapInitializer>(),
+            NullDropGenerator.Instance,
+            null);
+        var gameServerContext = new GameServerContext(
+            new BasicModel.GameServerDefinition
+            {
+                GameConfiguration = gameConfiguration,
+                ServerConfiguration = new BasicModel.GameServerConfiguration(),
+            },
+            guildServer.Object,
+            new Mock<IEventPublisher>().Object,
+            new Mock<ILoginServer>().Object,
+            new Mock<IFriendServer>().Object,
+            persistenceContextProvider,
+            mapInitializer,
+            NullLoggerFactory.Instance,
+            new PlugInManager([], NullLoggerFactory.Instance, null, null),
+            NullDropGenerator.Instance,
+            new ConfigurationChangeMediator());
+        mapInitializer.PlugInManager = gameServerContext.PlugInManager;
+        mapInitializer.PathFinderPool = gameServerContext.PathFinderPool;
+
+        var owner = await PlayerTestHelper.CreatePlayerAsync(gameServerContext).ConfigureAwait(false);
+        owner.GuildStatus = new GuildMemberStatus(OwnerGuildId, GuildPosition.GuildMaster);
+        var visitor = await PlayerTestHelper.CreatePlayerAsync(gameServerContext).ConfigureAwait(false);
+        visitor.GuildStatus = new GuildMemberStatus(VisitorGuildId, GuildPosition.NormalMember);
+        var context = new CastleSiegeContext(gameServerContext, castleSiegeConfiguration);
+        await context.InitializeAsync(new DateTime(2026, 8, 3, 12, 0, 0, DateTimeKind.Utc)).ConfigureAwait(false);
+
+        return new(
+            persistenceContextProvider,
+            gameServerContext,
+            context,
+            owner,
+            visitor);
+    }
+
+    private sealed record TestFixture(
+        InMemoryPersistenceContextProvider PersistenceContextProvider,
+        GameServerContext GameServerContext,
+        CastleSiegeContext Context,
+        Player Owner,
+        Player Visitor);
+}


### PR DESCRIPTION
Closes #729

## Summary

Implements the Castle Siege tax, tribute, and Land of Trials economy systems.

## Changes

- Applies the configured Castle Siege tax to Chaos Machine crafting costs.
- Applies the configured Castle Siege tax to NPC store purchases.
- Exempts members of the castle owner's guild and alliance from applicable taxes.
- Collects and persists paid taxes as castle tribute.
- Allows the castle owner guild master to:
  - configure Chaos Machine and NPC store taxes;
  - configure the Land of Trials entrance fee;
  - enable or disable public Land of Trials access;
  - withdraw accumulated tribute.
- Prevents economy configuration changes during the active siege battle.
- Implements Land of Trials access checks, entrance payment, and warping.
- Adds the Senior and Guardsman NPC interactions.
- Synchronizes percentage tax rates with clients after login, reconnect, initialization, configuration changes, and castle ownership changes.
- Resets taxes, tribute, and public Land of Trials access when castle ownership changes.
- Adds a mandatory Season 6 update plug-in for existing databases.
- Adds packet handlers, remote-view plug-ins, resources, and regression tests.

The implementation uses the existing Castle Siege persistence model and packet definitions. It contains no server-specific configuration behavior.

## Verification

- 99 Castle Siege tests passed.
- Season 6 initialization and update test passed.
- Changed files pass targeted StyleCop/compiler analyzer checks.
- Whitespace and diff checks pass.