### PR TITLE
Stop orphaned walk loops from spinning a CPU core forever

### DIFF
--- a/src/GameLogic/Walker.cs
+++ b/src/GameLogic/Walker.cs
@@ -107,6 +107,18 @@ public sealed class Walker : IDisposable
             return;
         }
 
+        if (this._walkCts is { } previousCts)
+        {
+            // A walk loop is still running for a previous walk. Replacing the source without cancelling it
+            // first orphans that loop: its token is the only thing which can end it, and once the field
+            // points at the new source nobody holds a reference to the old one any more. The orphan would
+            // then run forever - see the note in WalkLoopAsync - burning a core and keeping the walk
+            // supporter alive. Callers are expected to StopAsync first; this is the safety net for the
+            // window in which they did not.
+            await previousCts.CancelAsync().ConfigureAwait(false);
+            previousCts.Dispose();
+        }
+
         var cts = new CancellationTokenSource();
         this._walkCts = cts;
         _ = Task.Run(async () => await this.WalkLoopAsync(cts.Token).ConfigureAwait(false), cts.Token);
@@ -194,7 +206,16 @@ public sealed class Walker : IDisposable
                     await this.StopAsync().ConfigureAwait(false);
                 }
 
-                continue;
+                // A null step means this walk is over for good - the walker is disposed, the supporter is
+                // no longer active, the queue ran dry, or the token was cancelled. There is nothing to
+                // retry, so leave the loop instead of continuing it.
+                //
+                // Continuing here used to be load-bearing: it relied on the StopAsync above having
+                // cancelled our own token, so that the while-condition ended the loop on the next pass.
+                // That assumption breaks whenever _walkCts no longer refers to this loop's source, because
+                // StopAsync is then a no-op which leaves our token uncancelled - and since the null step
+                // is reproducible, the loop spins at full speed without ever awaiting anything.
+                break;
             }
 
             var delay = this.StepDelay(step);

--- a/src/GameLogic/Walker.cs
+++ b/src/GameLogic/Walker.cs
@@ -85,6 +85,12 @@ public sealed class Walker : IDisposable
             }
         }
 
+        // End the running walk before the new steps go into the queue: otherwise a loop of the previous
+        // walk can dequeue and execute the new walk's steps in the window between this method and
+        // StartWalkAsync, moving the supporter along the new path early and leaving the new loop one step
+        // short. We hold the writer lock here, so this is safe to do without releasing it.
+        await this.StopCurrentWalkAsync().ConfigureAwait(false);
+
         this.CurrentTarget = target;
         EnqueueSteps();
 

--- a/src/GameLogic/Walker.cs
+++ b/src/GameLogic/Walker.cs
@@ -113,15 +113,19 @@ public sealed class Walker : IDisposable
             // first orphans that loop: its token is the only thing which can end it, and once the field
             // points at the new source nobody holds a reference to the old one any more. The orphan would
             // then run forever - see the note in WalkLoopAsync - burning a core and keeping the walk
-            // supporter alive. Callers are expected to StopAsync first; this is the safety net for the
-            // window in which they did not.
+            // supporter alive.
             await previousCts.CancelAsync().ConfigureAwait(false);
             previousCts.Dispose();
         }
 
         var cts = new CancellationTokenSource();
+        var cancellationToken = cts.Token;
         this._walkCts = cts;
-        _ = Task.Run(async () => await this.WalkLoopAsync(cts.Token).ConfigureAwait(false), cts.Token);
+
+        // The loop is handed its own source as well as its token: it needs the source to recognize whether
+        // the walk it is running is still the current one before it stops anything. It cannot read that back
+        // from the field later (that is the whole point), nor from cts.Token once the source is disposed.
+        _ = Task.Run(async () => await this.WalkLoopAsync(cts, cancellationToken).ConfigureAwait(false), cancellationToken);
     }
 
     /// <summary>
@@ -161,22 +165,15 @@ public sealed class Walker : IDisposable
     }
 
     /// <summary>
-    /// Stops the walk.
+    /// Stops the walk which is currently running - whichever one that is. This is what outside callers
+    /// want: they are ending "the walk of this object", not one particular walk they started earlier.
+    /// A walk loop stopping itself must use <see cref="StopOwnWalkAsync"/> instead.
     /// </summary>
     public async ValueTask StopAsync()
     {
         using var writeLock = await this._walkLock.WriterLockAsync();
 
-        if (this._walkCts != null)
-        {
-            await this._walkCts.CancelAsync().ConfigureAwait(false);
-            this._walkCts.Dispose();
-            this._walkCts = null;
-            this._nextSteps.Clear();
-            this._currentWalkStepCount = 0;
-            this._currentWalkToken = Guid.Empty;
-            this.CurrentTarget = default;
-        }
+        await this.StopCurrentWalkAsync().ConfigureAwait(false);
     }
 
     /// <summary>
@@ -191,19 +188,58 @@ public sealed class Walker : IDisposable
         }
     }
 
-    private async Task WalkLoopAsync(CancellationToken cancellationToken)
+    /// <summary>
+    /// Stops the walk, but only if <paramref name="ownCts"/> still belongs to the walk which is currently
+    /// running. A walk loop must never stop a walk other than its own: by the time it notices it has nothing
+    /// left to do, a newer walk may already be in place, and the unconditional <see cref="StopAsync"/> would
+    /// cancel that one - killing a walk a single step after it began. The loop cannot rule this out by
+    /// checking its own token either, because it may be parked on the writer lock, which is taken without a
+    /// token and therefore is not released by cancelling it.
+    /// </summary>
+    /// <param name="ownCts">The cancellation token source of the calling walk loop.</param>
+    private async ValueTask StopOwnWalkAsync(CancellationTokenSource ownCts)
+    {
+        using var writeLock = await this._walkLock.WriterLockAsync();
+
+        if (!ReferenceEquals(this._walkCts, ownCts))
+        {
+            // Our walk is already over; whatever runs now belongs to someone else and is not ours to stop.
+            return;
+        }
+
+        await this.StopCurrentWalkAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Ends the currently running walk and resets the walk state. The caller must hold the writer lock.
+    /// </summary>
+    private async ValueTask StopCurrentWalkAsync()
+    {
+        if (this._walkCts != null)
+        {
+            await this._walkCts.CancelAsync().ConfigureAwait(false);
+            this._walkCts.Dispose();
+            this._walkCts = null;
+            this._nextSteps.Clear();
+            this._currentWalkStepCount = 0;
+            this._currentWalkToken = Guid.Empty;
+            this.CurrentTarget = default;
+        }
+    }
+
+    private async Task WalkLoopAsync(CancellationTokenSource ownCts, CancellationToken cancellationToken)
     {
         // Task.Delay might take longer than we specify. We need to compensate that.
         var lastOffset = TimeSpan.Zero;
         while (!cancellationToken.IsCancellationRequested)
         {
             var sw = Stopwatch.StartNew();
-            var step = await this.WalkStepAsync(cancellationToken).ConfigureAwait(false);
+            var step = await this.WalkStepAsync(ownCts, cancellationToken).ConfigureAwait(false);
             if (step is null)
             {
                 if (!cancellationToken.IsCancellationRequested)
                 {
-                    await this.StopAsync().ConfigureAwait(false);
+                    await this.StopOwnWalkAsync(ownCts).ConfigureAwait(false);
                 }
 
                 // A null step means this walk is over for good - the walker is disposed, the supporter is
@@ -237,7 +273,7 @@ public sealed class Walker : IDisposable
     /// <summary>
     /// Performs the next step of a walk.
     /// </summary>
-    private async ValueTask<WalkingStep?> WalkStepAsync(CancellationToken cancellationToken)
+    private async ValueTask<WalkingStep?> WalkStepAsync(CancellationTokenSource ownCts, CancellationToken cancellationToken)
     {
         try
         {
@@ -255,7 +291,7 @@ public sealed class Walker : IDisposable
 
             if (stop)
             {
-                await this.StopAsync().ConfigureAwait(false);
+                await this.StopOwnWalkAsync(ownCts).ConfigureAwait(false);
                 return null;
             }
 

--- a/tests/MUnique.OpenMU.Tests/WalkerTest.cs
+++ b/tests/MUnique.OpenMU.Tests/WalkerTest.cs
@@ -1,0 +1,146 @@
+// <copyright file="WalkerTest.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Tests;
+
+using System.Threading;
+using Moq;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.Pathfinding;
+
+/// <summary>
+/// Tests for the <see cref="Walker"/>.
+/// </summary>
+[TestFixture]
+public class WalkerTest
+{
+    private static readonly Point StartPoint = new(100, 100);
+
+    /// <summary>
+    /// Tests that starting a walk while another one is still running does not leave the previous walk
+    /// loop behind. A loop which is orphaned this way used to keep its own (never cancelled) token,
+    /// find no step to take, and then retry without ever awaiting anything - spinning a CPU core for
+    /// the lifetime of the process and keeping the walk supporter alive with it.
+    /// </summary>
+    [Test]
+    public async Task StartingASecondWalkDoesNotLeaveASpinningLoopAsync()
+    {
+        var supporter = new TestWalkSupporter();
+        using var walker = new Walker(supporter.Object, _ => TimeSpan.FromMilliseconds(1));
+
+        // Deliberately start twice without a StopAsync in between - that is the caller mistake which
+        // stranded the first loop.
+        var firstToken = await walker.InitializeWalkToAsync(new Point(110, 100), CreateSteps()).ConfigureAwait(false);
+        await walker.StartWalkAsync(firstToken).ConfigureAwait(false);
+
+        var secondToken = await walker.InitializeWalkToAsync(new Point(120, 100), CreateSteps()).ConfigureAwait(false);
+        await walker.StartWalkAsync(secondToken).ConfigureAwait(false);
+
+        await AssertNoLoopKeepsPollingAsync(supporter).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Tests that starting the very same walk twice does not leave the first loop behind either. This
+    /// is the orphaning path which does not go through <see cref="Walker.InitializeWalkToAsync"/>, so
+    /// it is only <see cref="Walker.StartWalkAsync"/> itself which can still end the previous loop.
+    /// </summary>
+    [Test]
+    public async Task StartingTheSameWalkTwiceDoesNotLeaveASpinningLoopAsync()
+    {
+        var supporter = new TestWalkSupporter();
+        using var walker = new Walker(supporter.Object, _ => TimeSpan.FromMilliseconds(1));
+
+        var token = await walker.InitializeWalkToAsync(new Point(110, 100), CreateSteps()).ConfigureAwait(false);
+        await walker.StartWalkAsync(token).ConfigureAwait(false);
+        await walker.StartWalkAsync(token).ConfigureAwait(false);
+
+        await AssertNoLoopKeepsPollingAsync(supporter).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Tests that a walk loop ends when the walker is disposed while a walk is still in progress.
+    /// </summary>
+    [Test]
+    public async Task DisposingWhileWalkingEndsTheLoopAsync()
+    {
+        var supporter = new TestWalkSupporter();
+        var walker = new Walker(supporter.Object, _ => TimeSpan.FromMilliseconds(1));
+
+        var token = await walker.InitializeWalkToAsync(new Point(110, 100), CreateSteps()).ConfigureAwait(false);
+        await walker.StartWalkAsync(token).ConfigureAwait(false);
+
+        walker.Dispose();
+
+        await AssertNoLoopKeepsPollingAsync(supporter).ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Asserts that no walk loop is still running, by letting every started walk drain and then
+    /// counting how often the supporter is polled while the walker should be idle. A stranded loop
+    /// re-reads <see cref="IAttackable.IsAlive"/> through ShouldWalkerStop on every single pass, so
+    /// it racks up hundreds of thousands of reads in this window; a finished walker reads none.
+    /// </summary>
+    /// <param name="supporter">The supporter which counts the reads.</param>
+    private static async Task AssertNoLoopKeepsPollingAsync(TestWalkSupporter supporter)
+    {
+        await Task.Delay(500).ConfigureAwait(false);
+
+        var readsBefore = supporter.IsAliveReadCount;
+        await Task.Delay(200).ConfigureAwait(false);
+        var readsDuringIdleWindow = supporter.IsAliveReadCount - readsBefore;
+
+        Assert.That(readsDuringIdleWindow, Is.LessThan(10));
+    }
+
+    private static Memory<WalkingStep> CreateSteps()
+    {
+        var steps = new WalkingStep[4];
+        var current = StartPoint;
+        for (var i = 0; i < steps.Length; i++)
+        {
+            var next = new Point((byte)(current.X + 1), current.Y);
+            steps[i] = new WalkingStep(current, next, Direction.East);
+            current = next;
+        }
+
+        return steps;
+    }
+
+    /// <summary>
+    /// A minimal walk supporter which counts how often the walker asked whether it is still alive.
+    /// <see cref="Walker"/> only ever touches <see cref="ILocateable.Position"/> and, through
+    /// <see cref="LocateableExtensions.IsActive"/>, <see cref="IAttackable.IsAlive"/> and
+    /// <see cref="IAttackable.IsTeleporting"/> - everything else the two interfaces carry is left to
+    /// the mock's defaults.
+    /// </summary>
+    private sealed class TestWalkSupporter
+    {
+        private readonly Mock<ISupportWalk> _mock = new();
+        private int _isAliveReadCount;
+
+        public TestWalkSupporter()
+        {
+            this._mock.SetupProperty(s => s.Position, StartPoint);
+
+            var attackable = this._mock.As<IAttackable>();
+            attackable.SetupGet(a => a.IsTeleporting).Returns(false);
+            attackable.SetupGet(a => a.IsAlive).Returns(() =>
+            {
+                Interlocked.Increment(ref this._isAliveReadCount);
+                return true;
+            });
+        }
+
+        /// <summary>
+        /// Gets the supporter to hand to the <see cref="Walker"/>.
+        /// </summary>
+        public ISupportWalk Object => this._mock.Object;
+
+        /// <summary>
+        /// Gets the number of times <see cref="IAttackable.IsAlive"/> has been read.
+        /// </summary>
+        public int IsAliveReadCount => Volatile.Read(ref this._isAliveReadCount);
+    }
+}

--- a/tests/MUnique.OpenMU.Tests/WalkerTest.cs
+++ b/tests/MUnique.OpenMU.Tests/WalkerTest.cs
@@ -60,6 +60,42 @@ public class WalkerTest
     }
 
     /// <summary>
+    /// Tests that concurrent walk requests for the same walker leave no loop behind. This is the shape
+    /// the production bug actually had: several requests for the same object overlap, so a loop can be
+    /// on its way into a stop while a newer walk is already installed. Every iteration starts its walk
+    /// twice, so each one strands a loop unless the walker ends it.
+    /// </summary>
+    [Test]
+    public async Task ConcurrentWalkRestartsLeaveNoRunningLoopAsync()
+    {
+        var supporter = new TestWalkSupporter();
+        using var walker = new Walker(supporter.Object, _ => TimeSpan.FromMilliseconds(1));
+
+        var tasks = new Task[8];
+        for (var t = 0; t < tasks.Length; t++)
+        {
+            tasks[t] = Task.Run(async () =>
+            {
+                for (var i = 0; i < 50; i++)
+                {
+                    var token = await walker.InitializeWalkToAsync(new Point(110, 100), CreateSteps()).ConfigureAwait(false);
+
+                    // Twice on purpose. A single start would lose the race against the other tasks
+                    // most of the time - StartWalkAsync returns early once another task initialized
+                    // its own walk in between - and then no loop would ever be started to strand.
+                    await walker.StartWalkAsync(token).ConfigureAwait(false);
+                    await walker.StartWalkAsync(token).ConfigureAwait(false);
+                }
+            });
+        }
+
+        await Task.WhenAll(tasks).ConfigureAwait(false);
+        await walker.StopAsync().ConfigureAwait(false);
+
+        await AssertNoLoopKeepsPollingAsync(supporter).ConfigureAwait(false);
+    }
+
+    /// <summary>
     /// Tests that a walk loop ends when the walker is disposed while a walk is still in progress.
     /// </summary>
     [Test]


### PR DESCRIPTION
Fixes #911

A `Walker` whose walk loop got orphaned would spin at full speed for the lifetime of the
process, keeping its walk supporter alive with it. On a two-core server running a bot
population this pegged both cores and grew the heap by ~640 MB/day until the box went into
swap; a profile attributed 26% of on-CPU time to `Walker.StopAsync` and 34% to the saturated
finalizer thread.

`Walker` is used by every moving object — bots only make it likelier, because the navigator
re-paths every couple of seconds across the whole population.

## The two commits

**1. `Stop orphaned walk loops from spinning a CPU core forever`**

- `StartWalkAsync` cancels and disposes the previous `CancellationTokenSource` before replacing
  it. The token derived from a source is the only thing that can end the loop it belongs to, so
  once the field pointed elsewhere that loop could never be stopped by anyone.
- `WalkLoopAsync` leaves the loop instead of continuing it after a null step. A null step means
  the walk is over for good, so there is nothing to retry — and the previous `continue` relied
  on a `StopAsync` that is a silent no-op for an orphaned loop, producing a spin with no await
  in it at all.

**2. `Only let a walk loop stop the walk it owns`**

The first commit leaves a narrower race. `StopAsync` cancels whatever `_walkCts` happens to be
when it acquires the writer lock, which is not necessarily the walk the caller started. A loop
that has run out of steps enters `StopAsync` and blocks on `WriterLockAsync()` — an acquisition
that takes no token, so cancelling that loop cannot release it. If `StartWalkAsync` wins the
lock first, it cancels the old loop, installs a new walk and releases; the old loop then
acquires the lock and cancels the walk that just started, and the player stops moving one step
after being told to walk.

The loop now gets its own `CancellationTokenSource` and routes self-stops through
`StopOwnWalkAsync`, which only stops the walk while that source is still the current one. The
public `StopAsync` keeps its old meaning — outside callers are ending "the walk of this
object", not one particular walk — and both share `StopCurrentWalkAsync`.

`InitializeWalkToAsync` ends the running walk too, now that it can do so without releasing the
writer lock. It replaces the step queue, so a loop left running there would dequeue and execute
the steps of a walk that has not been started yet — moving the supporter along the new path
early and leaving the new loop one step short. Both callers in the engine (`PlayerMovement` and
`Monster`) already stop the walk before initializing the next one, so this closes the window
between their stop and their start rather than changing what they do.

## Tests

`tests/MUnique.OpenMU.Tests/WalkerTest.cs` is new. It uses a Moq double of `ISupportWalk` (cast
`.As<IAttackable>()`) whose `IsAlive` getter counts its reads, then measures reads in a 200 ms
window after every started walk should have finished. All four tests pass with the fix and three
of them fail against `master`:

| Test | Polls in the idle window against `master` |
|---|---|
| `StartingASecondWalkDoesNotLeaveASpinningLoopAsync` | 48,141 |
| `StartingTheSameWalkTwiceDoesNotLeaveASpinningLoopAsync` | 89,644 |
| `ConcurrentWalkRestartsLeaveNoRunningLoopAsync` | 23,927 |
| `DisposingWhileWalkingEndsTheLoopAsync` | passes either way — it guards the dispose path |

The threshold is 10 reads, so the margin is four orders of magnitude. (The counts are lower than
a hand-written double would give purely because Moq's interception slows the spin down.)

The concurrent test starts each walk twice on purpose: a single start loses the race against
the other seven tasks most of the time, because `StartWalkAsync` returns early once another task
initialized its own walk in between, and then no loop is ever started to strand.

Full `MUnique.OpenMU.Tests` suite passes (791/791), three runs in a row.

## Soak time

These two commits have been running on a private server with an active bot population since
2026-08-28. The step-shaped CPU growth and the ~640 MB/day heap growth both stopped.
