### PR TITLE
Fix bot stack overflow on a blocked safezone spawn gate

### DIFF
--- a/src/GameLogic/Bots/BotNavigator.cs
+++ b/src/GameLogic/Bots/BotNavigator.cs
@@ -156,6 +156,14 @@ internal sealed class BotNavigator : AsyncDisposable
     /// <summary>The game's own warp action, so a bot travels on exactly a player's terms - fare included.</summary>
     private static readonly WarpAction WarpAction = new();
 
+    /// <summary>
+    /// Cache of which maps' safezone spawn gates have a walkable tile, so a bot may safely be sent
+    /// there. Keyed by the resolved safezone map's id, not its number: map numbers are not unique -
+    /// the Devil Squares share number 9, and a server can host several game configurations whose
+    /// maps carry the same numbers over different terrain. See <see cref="HasWalkableSpawnGate"/>.
+    /// </summary>
+    private static readonly ConcurrentDictionary<Guid, bool> WalkableSpawnGateCache = new();
+
     private static readonly TimeSpan EvaluationInterval = TimeSpan.FromSeconds(1);
 
     private static readonly TimeSpan EmptyGroundGrace = TimeSpan.FromSeconds(8);
@@ -319,6 +327,59 @@ internal sealed class BotNavigator : AsyncDisposable
         // off the rest of the map.
         var proximity = (ProximityFalloff * ProximityFalloff) / (ProximityFalloff + GroundDistance(area, from));
         return Math.Max(1, (int)area.Quantity) * Math.Max(1, proximity);
+    }
+
+    /// <summary>
+    /// Whether a bot may safely be sent to the map: the safezone spawn gate it would be recovered to
+    /// has at least one walkable tile. A warp which lands a bot on a blocked tile is recovered by
+    /// <see cref="Player.WarpToSafezoneAsync"/>, and for a connection-less bot that recovery runs
+    /// inline (see <see cref="OfflineMapChangePlugIn"/>) - so a spawn gate with no walkable tile at
+    /// all used to recurse until the stack overflowed. The player's map transitions now bound that
+    /// recovery, so this filter is no longer what keeps the server alive; it keeps the bot from
+    /// picking a map it cannot stand in and being bounced straight back out of it.
+    /// </summary>
+    /// <param name="map">The map the bot considers warping to.</param>
+    /// <returns>True, if the map's resolved safezone spawn gate has a walkable tile.</returns>
+    /// <remarks>
+    /// The verdict is cached for the lifetime of the process, keyed by the resolved safezone map -
+    /// terrain is static configuration, so it is parsed once and shared by every bot. Terrain edited
+    /// through the admin panel therefore needs a server restart to be taken into account.
+    /// Only maps whose spawn gate has *zero* walkable tiles are excluded. A gate with a few walkable
+    /// tiles can still, under PlaceAtGateAsync's single random roll, miss and recover to town - a
+    /// quality glitch, not a crash, accepted by design.
+    /// </remarks>
+    internal static bool HasWalkableSpawnGate(GameMapDefinition map)
+    {
+        // The bot is not recovered to the destination map's own gate but to its safezone map's -
+        // mirroring Player.GetSpawnGateOfCurrentMapAsync. Many maps (dungeons, event maps, Icarus,
+        // Karutan 2, ...) point somewhere else entirely, so checking the destination itself would
+        // both reject safe maps and miss the ones which actually strand a bot.
+        var safezoneMap = map.SafezoneMap ?? map;
+        var mapId = safezoneMap.GetId();
+        if (mapId == Guid.Empty)
+        {
+            // GetId falls back to Guid.Empty for anything it cannot identify, so caching under it
+            // would file every such map under one entry and hand the first map's verdict to all the
+            // others - a single blocked one would then reject every map there is.
+            return HasWalkableSpawnGateCore(safezoneMap);
+        }
+
+        return WalkableSpawnGateCache.GetOrAdd(mapId, _ => HasWalkableSpawnGateCore(safezoneMap));
+    }
+
+    /// <summary>
+    /// The uncached terrain check behind <see cref="HasWalkableSpawnGate"/>, on an already resolved
+    /// safezone map.
+    /// </summary>
+    /// <param name="safezoneMap">The resolved safezone map.</param>
+    /// <returns>True, if the map's spawn gate has a walkable tile.</returns>
+    internal static bool HasWalkableSpawnGateCore(GameMapDefinition safezoneMap)
+    {
+        // The map is usually not loaded when a bot weighs it up, so its GameMap (which would expose
+        // Terrain and SafeZoneSpawnGate ready-made) may not exist - and forcing it to load just for
+        // this check would be far more expensive than parsing the terrain once.
+        var terrain = new GameMapTerrain(safezoneMap);
+        return terrain.GetWalkableCoordinate(safezoneMap.GetSafezoneGate(terrain)) is not null;
     }
 
     /// <inheritdoc />
@@ -1772,7 +1833,8 @@ internal sealed class BotNavigator : AsyncDisposable
 
             if (!candidate.TryGetRequirementError(this._player, out _)
                 && this.TryGetLegalWarp(candidate, out var candidateWarp)
-                && this.CanAffordWarp(candidateWarp))
+                && this.CanAffordWarp(candidateWarp)
+                && HasWalkableSpawnGate(candidate))
             {
                 warp = candidateWarp;
                 mapDefinition = candidate;
@@ -1827,7 +1889,9 @@ internal sealed class BotNavigator : AsyncDisposable
                 continue;
             }
 
-            if (this.TryGetLegalWarp(candidate, out var candidateWarp) && this.CanAffordWarp(candidateWarp))
+            if (this.TryGetLegalWarp(candidate, out var candidateWarp)
+                && this.CanAffordWarp(candidateWarp)
+                && HasWalkableSpawnGate(candidate))
             {
                 candidates.Add((candidateWarp, candidate, best));
             }

--- a/src/GameLogic/GameMapTerrain.cs
+++ b/src/GameLogic/GameMapTerrain.cs
@@ -1,4 +1,4 @@
-// <copyright file="GameMapTerrain.cs" company="MUnique">
+﻿// <copyright file="GameMapTerrain.cs" company="MUnique">
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 // </copyright>
 
@@ -187,11 +187,6 @@ public class GameMapTerrain
         }
     }
 
-    /// <summary>
-    /// Builds the array of valid spawn points.
-    /// A valid spawn point is walkable and not in a safezone.
-    /// </summary>
-    /// <returns>Array of valid spawn points.</returns>
     /// <summary>
     /// Scans the terrain for the two lookups which are derived from it, in a single pass: the
     /// monster spawn points, and the coordinate behind <see cref="AnyWalkableCoordinate"/>.

--- a/src/GameLogic/GameMapTerrain.cs
+++ b/src/GameLogic/GameMapTerrain.cs
@@ -28,6 +28,8 @@ public class GameMapTerrain
     /// </summary>
     private readonly Point[] _spawnPoints;
 
+    private readonly Point? _anyWalkableCoordinate;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="GameMapTerrain"/> class.
     /// </summary>
@@ -52,7 +54,7 @@ public class GameMapTerrain
             this.ReadTerrainData(DefaultTerrain);
         }
 
-        this._spawnPoints = this.BuildSpawnPoints();
+        this._spawnPoints = this.BuildSpawnPoints(out this._anyWalkableCoordinate);
     }
 
     /// <summary>
@@ -86,6 +88,49 @@ public class GameMapTerrain
 
             return points[Random.Shared.Next(points.Length)];
         }
+    }
+
+    /// <summary>
+    /// Gets a walkable coordinate anywhere on the map, preferring a safezone tile. Used to get a
+    /// player off a blocked tile when its spawn gate has none - unlike
+    /// <see cref="RandomWalkableCoordinate"/>, which samples the monster spawn points and therefore
+    /// deliberately excludes every safezone tile, this is allowed to land in a town.
+    /// </summary>
+    /// <value>
+    /// A safezone coordinate; the first walkable one if the map has no safezone at all; or
+    /// <c>null</c> if the map has no walkable tile whatsoever.
+    /// </value>
+    public Point? AnyWalkableCoordinate => this._anyWalkableCoordinate;
+
+    /// <summary>
+    /// Gets the first walkable coordinate within the specified gate, if it has one. A gate without a
+    /// single walkable tile strands whoever is placed there, because a player is placed at a gate by
+    /// one random roll which is never retried - so callers use this to check a gate up front, or to
+    /// get out of one afterwards.
+    /// </summary>
+    /// <param name="gate">The gate to search. Its coordinates are bytes, so this grid can't be overrun.</param>
+    /// <returns>The first walkable coordinate of the gate, or <c>null</c> if it has none.</returns>
+    public Point? GetWalkableCoordinate(Gate? gate)
+    {
+        if (gate is null)
+        {
+            return null;
+        }
+
+        // The counters are ints on purpose: a gate reaching to coordinate 255 would make a byte
+        // counter wrap around and loop forever.
+        for (int x = gate.X1; x <= gate.X2; x++)
+        {
+            for (int y = gate.Y1; y <= gate.Y2; y++)
+            {
+                if (this.WalkMap[x, y])
+                {
+                    return new Point((byte)x, (byte)y);
+                }
+            }
+        }
+
+        return null;
     }
 
     /// <summary>
@@ -147,21 +192,42 @@ public class GameMapTerrain
     /// A valid spawn point is walkable and not in a safezone.
     /// </summary>
     /// <returns>Array of valid spawn points.</returns>
-    private Point[] BuildSpawnPoints()
+    /// <summary>
+    /// Scans the terrain for the two lookups which are derived from it, in a single pass: the
+    /// monster spawn points, and the coordinate behind <see cref="AnyWalkableCoordinate"/>.
+    /// </summary>
+    /// <param name="anyWalkableCoordinate">A safezone coordinate; the first walkable one if the map
+    /// has no safezone at all; or <c>null</c> if nothing on the map is walkable.</param>
+    /// <returns>The walkable coordinates outside the safezone, where monsters may spawn.</returns>
+    private Point[] BuildSpawnPoints(out Point? anyWalkableCoordinate)
     {
         var result = new List<Point>(MapSize * MapSize);
+        Point? safezone = null;
+        Point? outsideSafezone = null;
 
         for (var x = 0; x < MapSize; x++)
         {
             for (var y = 0; y < MapSize; y++)
             {
-                if (this.WalkMap[x, y] && !this.SafezoneMap[x, y])
+                if (!this.WalkMap[x, y])
                 {
-                    result.Add(new Point((byte)x, (byte)y));
+                    continue;
+                }
+
+                var point = new Point((byte)x, (byte)y);
+                if (this.SafezoneMap[x, y])
+                {
+                    safezone ??= point;
+                }
+                else
+                {
+                    result.Add(point);
+                    outsideSafezone ??= point;
                 }
             }
         }
 
+        anyWalkableCoordinate = safezone ?? outsideSafezone;
         return result.ToArray();
     }
 }

--- a/src/GameLogic/PlayerMapTransitions.cs
+++ b/src/GameLogic/PlayerMapTransitions.cs
@@ -24,6 +24,12 @@ internal sealed class PlayerMapTransitions
     private readonly PlayerSummon _summon;
 
     /// <summary>
+    /// Whether a <see cref="RecoverFromBlockedSpawnAsync"/> is currently in progress, so that a
+    /// nested one does not warp again. See there for why that recursion is fatal.
+    /// </summary>
+    private bool _isRecoveringFromBlockedSpawn;
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="PlayerMapTransitions"/> class.
     /// </summary>
     /// <param name="player">The player.</param>
@@ -244,10 +250,10 @@ internal sealed class PlayerMapTransitions
         player.IsAlive = true;
 
         await player.CurrentMap!.AddAsync(player).ConfigureAwait(false);
-        if (!player.CurrentMap.Terrain.WalkMap[player.SelectedCharacter.PositionX, player.SelectedCharacter.PositionY])
+        if (!player.CurrentMap.Terrain.WalkMap[player.SelectedCharacter.PositionX, player.SelectedCharacter.PositionY]
+            && await this.RecoverFromBlockedSpawnAsync().ConfigureAwait(false))
         {
             // The warp starts another map change, which adds the summon again when it completed.
-            await this.WarpToSafezoneAsync().ConfigureAwait(false);
             return;
         }
 
@@ -341,5 +347,60 @@ internal sealed class PlayerMapTransitions
         await this._movement.ResetMovementStateAsync().ConfigureAwait(false);
 
         this._summon.PlaceAtGate(gate);
+    }
+
+    /// <summary>
+    /// Recovers a player which was placed on a non-walkable tile, by warping it to its safezone.
+    /// That warp re-enters <see cref="ClientReadyAfterMapChangeAsync"/>: for a player with a game
+    /// client the re-entry arrives later and on a fresh stack, with its F3 12 packet - but a
+    /// connection-less player (an <see cref="Offline.OfflinePlayer"/>, i.e. a bot) gets it inline
+    /// from <see cref="Offline.OfflineMapChangePlugIn"/>. Since <see cref="PlaceAtGateAsync"/>
+    /// rolls the position within the gate only once and never retries, a safezone spawn gate
+    /// without a single walkable tile recursed until the stack overflowed - taking the whole game
+    /// server process down with it. The recovery therefore warps at most once per such re-entry: a
+    /// nested attempt places the player on a walkable tile of the map it already stands on instead.
+    /// This bounds the recursion, which is what took the process down. It does not bound the case of
+    /// a player with a game client, whose re-entry arrives on a later, fresh stack with this flag
+    /// already reset - such a player can still be warped back and forth between two blocked gates,
+    /// exactly as before, which is a stuck client rather than a dead server.
+    /// </summary>
+    /// <returns>True, if the player was warped; false, if it was placed on this map instead.</returns>
+    private async ValueTask<bool> RecoverFromBlockedSpawnAsync()
+    {
+        var player = this._player;
+        if (!this._isRecoveringFromBlockedSpawn)
+        {
+            this._isRecoveringFromBlockedSpawn = true;
+            try
+            {
+                await this.WarpToSafezoneAsync().ConfigureAwait(false);
+                return true;
+            }
+            finally
+            {
+                this._isRecoveringFromBlockedSpawn = false;
+            }
+        }
+
+        if (player.CurrentMap is not { } map)
+        {
+            return false;
+        }
+
+        // No warp here - warping is exactly what would recurse. The terrain of the map we stand on
+        // is already parsed, so we just step to a tile we can actually stand on.
+        // Not RandomWalkableCoordinate: that samples the monster spawn points, which exclude every
+        // safezone tile by construction - it would drop a player who is being recovered into a
+        // hunting ground, and report failure on a map which is nothing but safezone.
+        var target = map.Terrain.GetWalkableCoordinate(map.SafeZoneSpawnGate) ?? map.Terrain.AnyWalkableCoordinate;
+        if (target is not { } point)
+        {
+            player.Logger.LogError("Map {0} has no walkable tile at all - player {1} stays on a blocked one.", map, player);
+            return false;
+        }
+
+        player.Logger.LogWarning("Spawn gate of map {0} is blocked - placing player {1} at {2} instead of warping again.", map, player, point);
+        await player.MoveAsync(point).ConfigureAwait(false);
+        return false;
     }
 }

--- a/tests/MUnique.OpenMU.Tests/BotWarpCandidateTest.cs
+++ b/tests/MUnique.OpenMU.Tests/BotWarpCandidateTest.cs
@@ -1,0 +1,114 @@
+// <copyright file="BotWarpCandidateTest.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Tests;
+
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.GameLogic.Bots;
+using NUnit.Framework;
+
+/// <summary>
+/// Tests for the check which keeps a bot from warping to a map it cannot stand in.
+/// </summary>
+[TestFixture]
+public class BotWarpCandidateTest
+{
+    /// <summary>
+    /// A spawn gate without a single walkable tile strands whoever is placed there, so the map is
+    /// not offered to a bot.
+    /// </summary>
+    [Test]
+    public void MapWithBlockedSpawnGateIsRejected()
+    {
+        var map = CreateMap(gateIsWalkable: false);
+
+        Assert.That(BotNavigator.HasWalkableSpawnGateCore(map), Is.False);
+    }
+
+    /// <summary>
+    /// A spawn gate with walkable tiles is fine.
+    /// </summary>
+    [Test]
+    public void MapWithWalkableSpawnGateIsAccepted()
+    {
+        var map = CreateMap(gateIsWalkable: true);
+
+        Assert.That(BotNavigator.HasWalkableSpawnGateCore(map), Is.True);
+    }
+
+    /// <summary>
+    /// A bot which lands on a blocked tile is not recovered to the destination's own spawn gate but
+    /// to the one of its <see cref="GameMapDefinition.SafezoneMap"/> - which for dungeons and event
+    /// maps (Icarus, Karutan 2, the Chaos Castles, ...) is a different map. So the destination's own
+    /// gate being blocked does not make the map unusable.
+    /// </summary>
+    [Test]
+    public void MapIsJudgedByItsSafezoneMapNotByItself()
+    {
+        var destination = CreateMap(gateIsWalkable: false);
+        destination.SafezoneMap = CreateMap(gateIsWalkable: true);
+
+        Assert.That(BotNavigator.HasWalkableSpawnGate(destination), Is.True);
+    }
+
+    /// <summary>
+    /// The other half of the same rule: a destination with a perfectly good gate of its own is still
+    /// rejected when the map it would be recovered to is the broken one.
+    /// </summary>
+    [Test]
+    public void MapWithBrokenSafezoneMapIsRejected()
+    {
+        var destination = CreateMap(gateIsWalkable: true);
+        destination.SafezoneMap = CreateMap(gateIsWalkable: false);
+
+        Assert.That(BotNavigator.HasWalkableSpawnGate(destination), Is.False);
+    }
+
+    /// <summary>
+    /// Creates a map with a single spawn gate, on terrain which is either walkable there or not.
+    /// </summary>
+    /// <param name="gateIsWalkable">Whether the tiles of the spawn gate are walkable.</param>
+    /// <returns>The map definition.</returns>
+    private static GameMapDefinition CreateMap(bool gateIsWalkable)
+    {
+        const byte gateX1 = 10;
+        const byte gateY1 = 10;
+        const byte gateX2 = 13;
+        const byte gateY2 = 13;
+
+        // Each map gets its own id, so the process-wide cache of HasWalkableSpawnGate can't carry a
+        // verdict over from another test.
+        var map = new MUnique.OpenMU.Persistence.BasicModel.GameMapDefinition
+        {
+            Id = Guid.NewGuid(),
+            Number = 0,
+            TerrainData = new byte[ushort.MaxValue + 3],
+        };
+
+        if (!gateIsWalkable)
+        {
+            for (int x = gateX1; x <= gateX2; x++)
+            {
+                for (int y = gateY1; y <= gateY2; y++)
+                {
+                    // Only the values 0 (walkable) and 1 (safezone) are walkable - see GameMapTerrain.
+                    map.TerrainData[3 + (y * 256) + x] = 4;
+                }
+            }
+        }
+
+        map.ExitGates.Add(new MUnique.OpenMU.Persistence.BasicModel.ExitGate
+        {
+            Id = Guid.NewGuid(),
+            Map = map,
+            X1 = gateX1,
+            Y1 = gateY1,
+            X2 = gateX2,
+            Y2 = gateY2,
+            IsSpawnGate = true,
+        });
+
+        return map;
+    }
+}

--- a/tests/MUnique.OpenMU.Tests/ClientReadyAfterMapChangeTests.cs
+++ b/tests/MUnique.OpenMU.Tests/ClientReadyAfterMapChangeTests.cs
@@ -6,6 +6,7 @@ namespace MUnique.OpenMU.Tests;
 
 using System.Linq;
 using System.Threading.Tasks;
+using MUnique.OpenMU.DataModel.Configuration;
 using MUnique.OpenMU.GameLogic;
 using MUnique.OpenMU.Pathfinding;
 using NUnit.Framework;
@@ -59,5 +60,65 @@ public class ClientReadyAfterMapChangeTests
         await map!.RemoveAsync(player).ConfigureAwait(false);
 
         Assert.That(map.GetAttackablesInRange(position, 1).Any(o => o == player), Is.False);
+    }
+
+    /// <summary>
+    /// Tests that a bot which arrives on a blocked tile of a map whose safezone spawn gate is itself
+    /// blocked is recovered without recursing. The recovery warps to the safezone, and for a
+    /// connection-less player that warp calls back into the client-ready handler inline - so an
+    /// unconditional recovery recursed until the stack overflowed and took the game server down.
+    /// </summary>
+    /// <returns>The task.</returns>
+    [Test]
+    public async Task BlockedSpawnGateRecoversWithoutRecursingAsync()
+    {
+        const byte gateX1 = 10;
+        const byte gateY1 = 10;
+        const byte gateX2 = 13;
+        const byte gateY2 = 13;
+
+        var gameContext = GameContextTestHelper.CreateGameContext();
+        var mapDefinition = gameContext.Configuration.Maps.First();
+        BlockTerrain(mapDefinition.TerrainData!, gateX1, gateY1, gateX2, gateY2);
+        mapDefinition.ExitGates.Add(new MUnique.OpenMU.Persistence.BasicModel.ExitGate
+        {
+            Id = Guid.NewGuid(),
+            Map = mapDefinition,
+            X1 = gateX1,
+            Y1 = gateY1,
+            X2 = gateX2,
+            Y2 = gateY2,
+            IsSpawnGate = true,
+        });
+
+        var player = await PlayerTestHelper.CreateOfflineLevelingPlayerAsync(gameContext).ConfigureAwait(false);
+
+        // Warping into the blocked gate is what the bot does when it picks this map; the arrival
+        // triggers the recovery, inline, on this very stack.
+        await player.WarpToAsync(mapDefinition.ExitGates.First()).ConfigureAwait(false);
+
+        Assert.That(player.CurrentMap, Is.Not.Null);
+        var position = player.Position;
+        Assert.That(player.CurrentMap!.Terrain.WalkMap[position.X, position.Y], Is.True, "the bot ends up on a tile it can stand on");
+    }
+
+    /// <summary>
+    /// Makes the given rectangle of the terrain non-walkable.
+    /// </summary>
+    /// <param name="terrainData">The terrain data, including its three byte header.</param>
+    /// <param name="x1">The left coordinate.</param>
+    /// <param name="y1">The top coordinate.</param>
+    /// <param name="x2">The right coordinate.</param>
+    /// <param name="y2">The bottom coordinate.</param>
+    private static void BlockTerrain(byte[] terrainData, byte x1, byte y1, byte x2, byte y2)
+    {
+        for (int x = x1; x <= x2; x++)
+        {
+            for (int y = y1; y <= y2; y++)
+            {
+                // Only the values 0 (walkable) and 1 (safezone) are walkable - see GameMapTerrain.
+                terrainData[3 + (y * 256) + x] = 4;
+            }
+        }
     }
 }

--- a/tests/MUnique.OpenMU.Tests/GameMapTerrainTests.cs
+++ b/tests/MUnique.OpenMU.Tests/GameMapTerrainTests.cs
@@ -1,0 +1,82 @@
+// <copyright file="GameMapTerrainTests.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Tests;
+
+using MUnique.OpenMU.GameLogic;
+
+/// <summary>
+/// Tests for the terrain lookups which are used to get a player off a tile it cannot stand on.
+/// </summary>
+[TestFixture]
+public class GameMapTerrainTests
+{
+    private const byte Walkable = 0;
+    private const byte Safezone = 1;
+    private const byte Blocked = 4;
+
+    /// <summary>
+    /// Tests that a map whose walkable tiles are all safezone still yields a coordinate.
+    /// <see cref="GameMapTerrain.RandomWalkableCoordinate"/> samples the monster spawn points, which
+    /// exclude the safezone by construction, so it returns nothing here - which would leave a player
+    /// stranded on a blocked tile of a town.
+    /// </summary>
+    [Test]
+    public void AnyWalkableCoordinateIsFoundOnASafezoneOnlyMap()
+    {
+        var terrain = new GameMapTerrain(CreateTerrainData(safezoneAt: (10, 10), walkableAt: null));
+
+        Assert.That(terrain.RandomWalkableCoordinate, Is.Null, "precondition: the map has no monster spawn point");
+        Assert.That(terrain.AnyWalkableCoordinate, Is.EqualTo(new Pathfinding.Point(10, 10)));
+    }
+
+    /// <summary>
+    /// Tests that the safezone is preferred over an ordinary walkable tile, so a player who is
+    /// recovered from a blocked spawn gate ends up in town rather than in a hunting ground.
+    /// </summary>
+    [Test]
+    public void AnyWalkableCoordinatePrefersTheSafezone()
+    {
+        // The walkable tile comes first in scan order, so a naive "first walkable tile" would pick it.
+        var terrain = new GameMapTerrain(CreateTerrainData(safezoneAt: (20, 20), walkableAt: (5, 5)));
+
+        Assert.That(terrain.AnyWalkableCoordinate, Is.EqualTo(new Pathfinding.Point(20, 20)));
+    }
+
+    /// <summary>
+    /// Tests that a map without a single walkable tile reports that honestly, so the caller can log
+    /// it instead of moving the player somewhere impossible.
+    /// </summary>
+    [Test]
+    public void AnyWalkableCoordinateIsNullWhenNothingIsWalkable()
+    {
+        var terrain = new GameMapTerrain(CreateTerrainData(safezoneAt: null, walkableAt: null));
+
+        Assert.That(terrain.AnyWalkableCoordinate, Is.Null);
+    }
+
+    /// <summary>
+    /// Creates fully blocked terrain data with at most one safezone and one ordinary walkable tile.
+    /// </summary>
+    /// <param name="safezoneAt">The coordinate to mark as safezone, if any.</param>
+    /// <param name="walkableAt">The coordinate to mark as walkable but outside the safezone, if any.</param>
+    /// <returns>The terrain data, including its three byte header.</returns>
+    private static byte[] CreateTerrainData((byte X, byte Y)? safezoneAt, (byte X, byte Y)? walkableAt)
+    {
+        var data = new byte[ushort.MaxValue + 3];
+        Array.Fill(data, Blocked, 3, ushort.MaxValue);
+
+        if (safezoneAt is { } safezone)
+        {
+            data[3 + (safezone.Y * 256) + safezone.X] = Safezone;
+        }
+
+        if (walkableAt is { } walkable)
+        {
+            data[3 + (walkable.Y * 256) + walkable.X] = Walkable;
+        }
+
+        return data;
+    }
+}


### PR DESCRIPTION
This is the same crash #844 reports, fixed at its source and with two corrections to that PR's
approach. Credit to @therpr for finding it — the `BotNavigator` filter idea is theirs and is
kept here.

## The crash is still reachable on current master

A player placed on a non-walkable tile is recovered by `WarpToSafezoneAsync`, which re-enters
`ClientReadyAfterMapChangeAsync`. A player with a game client re-enters later and on a fresh
stack, with its F3 12 packet — but a connection-less player (an `OfflinePlayer`, i.e. a bot)
gets it inline from `OfflineMapChangePlugIn`. Since `PlaceAtGateAsync` rolls the position within
the gate once and never retries, a safezone spawn gate without a single walkable tile recurses
until the stack overflows, taking the game server process down.

The repeated-packet guard recently added at the top of `ClientReadyAfterMapChangeAsync` does not
stop this: `WarpToAsync` sets `CurrentMap` to null before raising the map change, so the nested
call walks straight past the guard. The added test reproduces the stack overflow against
`master` as it stands today:

```
   at MUnique.OpenMU.GameLogic.PlayerMapTransitions.ClientReadyAfterMapChangeAsync()
   at MUnique.OpenMU.GameLogic.Player.ClientReadyAfterMapChangeAsync()
   at MUnique.OpenMU.GameLogic.Offline.OfflineMapChangePlugIn.MapChangeAsync()
   at MUnique.OpenMU.GameLogic.PlayerMapTransitions.WarpToAsync()
   ... (repeats until the test host aborts)
```

## The fix

**Bound the recursion where it happens.** `PlayerMapTransitions.RecoverFromBlockedSpawnAsync`
warps at most once per re-entry; a nested attempt places the player on a walkable tile of the map
it already stands on instead. This covers every path into the recursion — the bot navigator,
escape and home gates, death respawn, portals, mini-games and GM warps alike — rather than only
the one the bots happen to take. It returns whether it warped, so the client-ready frame keeps
its existing behaviour of not adding the summon a second time.

To be precise about the scope: this bounds the *inline* re-entry, which is the one that kills the
process. A player with a game client re-enters on a later, fresh stack with the flag already
reset, so it can still be warped back and forth between two blocked gates — exactly as today.
That is a stuck client rather than a dead server, and fixing it is a separate change.

The tile the nested attempt falls back to comes from a new `GameMapTerrain.AnyWalkableCoordinate`,
which prefers the safezone. It is computed in the terrain scan that already builds the spawn
points, so it costs nothing at lookup time. The obvious candidate, `RandomWalkableCoordinate`, is wrong here: it
samples the monster spawn points, which exclude every safezone tile by construction
(`BuildSpawnPoints` requires `WalkMap[x,y] && !SafezoneMap[x,y]`). It would drop a player who is
being recovered into a hunting ground, and return nothing at all on a map that is only safezone —
stranding the player on the very tile it was meant to rescue it from.

**Keep bots out of maps they cannot stand in**, so a bot does not pick one and get bounced
straight back out. This is #844's `BotNavigator` filter, with two corrections:

1. **Resolve `SafezoneMap` first**, mirroring `GetSpawnGateOfCurrentMapAsync`. A bot is not
   recovered to the destination map's own gate but to its safezone map's, and many maps
   (dungeons and event maps — Icarus, Karutan 2, the Chaos Castles) point somewhere else
   entirely. Checking the destination itself both rejects safe maps and misses the ones that
   actually strand a bot.
2. **Key the cache by the resolved map's id, not its number.** Map numbers are not unique — the
   Devil Squares all share number 9 — and a server can host several game configurations whose
   maps carry the same numbers over different terrain. The verdict is not cached at all when the
   map has no id of its own: `ObjectExtensions.GetId` falls back to `Guid.Empty`, and every such
   map would otherwise share a single entry, so one blocked map would reject all of them.

The gate scan itself lives on `GameMapTerrain.GetWalkableCoordinate`, shared by both halves. Its
loop counters are `int` on purpose: a gate reaching coordinate 255 would make a byte counter
wrap around and loop forever.

Only maps whose spawn gate has *zero* walkable tiles are excluded. A gate with a few walkable
tiles can still, under `PlaceAtGateAsync`'s single random roll, miss and recover to town — a
quality glitch, not a crash, accepted by design.

## Scope

No map in the seeded Season 6 configuration has a blocked safezone gate today (the tightest is
Doppelgaenger 4 at 39 of 64 tiles), so this is reachable only through custom maps or edited
terrain. It is a process-killer when it is reached.

## Tests

- `ClientReadyAfterMapChangeTests.BlockedSpawnGateRecoversWithoutRecursingAsync` blocks a map's
  spawn gate, warps an offline-leveling player into it, and asserts the bot ends on a tile it can
  stand on. Against `master` this overflows the stack and aborts the test run.
- `BotWarpCandidateTest` covers the navigator filter, including the safezone resolution and the
  id-keyed cache.
- `GameMapTerrainTests` covers the new lookup: it finds a tile on a safezone-only map (where
  `RandomWalkableCoordinate` returns nothing — the test asserts that as its precondition),
  prefers a safezone tile over an ordinary walkable one that comes earlier in scan order, and
  returns `null` only when nothing at all is walkable.

Full `MUnique.OpenMU.Tests` suite passes (795/795).
