### PR TITLE
Archive the traffic of observed accounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -325,3 +325,6 @@ src/AdminPanel/wwwroot/content/js/app.js.map
 .opencode/
 # Keys which are generated when the server runs locally.
 data-protection-keys/
+
+# The archive of the network observation, when the server is started from the repository.
+captures/

--- a/src/Dapr/GameServer.Host/Program.cs
+++ b/src/Dapr/GameServer.Host/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.Extensions.DependencyInjection;
 using MUnique.OpenMU.Dapr.Common;
 using MUnique.OpenMU.DataModel.Configuration;
 using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameServer;
 using MUnique.OpenMU.GameServer.Host;
 using MUnique.OpenMU.Interfaces;
 using MUnique.OpenMU.PlugIns;
@@ -43,6 +44,7 @@ services.AddSingleton<GameServer>()
     .AddPeristenceProvider()
     .AddPlugInManager(plugInConfigurations)
     .AddIpResolver(args)
+    .AddNetworkObservation()
     .AddHostedService<GameServerHostedServiceWrapper>()
     .PublishManageableServer<IGameServer>();
 

--- a/src/DataModel/Configuration/SystemConfiguration.cs
+++ b/src/DataModel/Configuration/SystemConfiguration.cs
@@ -88,6 +88,62 @@ public partial class SystemConfiguration
         ResourceType = typeof(Resources))]
     public string? TimeZoneId { get; set; }
 
+    /// <summary>
+    /// Gets or sets the number of data packets which are kept in memory per connection which
+    /// is watched in the network analyzer page of the admin panel.
+    /// </summary>
+    [Display(
+        Order = 7,
+        Name = nameof(Resources.SystemConfiguration_NetworkAnalyzerLiveBufferSize_Name),
+        Description = nameof(Resources.SystemConfiguration_NetworkAnalyzerLiveBufferSize_Description),
+        GroupName = nameof(Resources.SystemConfiguration_NetworkAnalyzer_Name),
+        ResourceType = typeof(Resources))]
+    public int NetworkAnalyzerLiveBufferSize { get; set; } = 5000;
+
+    /// <summary>
+    /// Gets or sets the path in which the traffic of the observed accounts is archived.
+    /// </summary>
+    [Display(
+        Order = 8,
+        Name = nameof(Resources.SystemConfiguration_NetworkObservationArchivePath_Name),
+        Description = nameof(Resources.SystemConfiguration_NetworkObservationArchivePath_Description),
+        GroupName = nameof(Resources.SystemConfiguration_NetworkAnalyzer_Name),
+        ResourceType = typeof(Resources))]
+    public string? NetworkObservationArchivePath { get; set; } = "captures";
+
+    /// <summary>
+    /// Gets or sets the maximum size of one file of an archived session, in megabytes.
+    /// </summary>
+    [Display(
+        Order = 9,
+        Name = nameof(Resources.SystemConfiguration_NetworkObservationMaxSessionSizeMb_Name),
+        Description = nameof(Resources.SystemConfiguration_NetworkObservationMaxSessionSizeMb_Description),
+        GroupName = nameof(Resources.SystemConfiguration_NetworkAnalyzer_Name),
+        ResourceType = typeof(Resources))]
+    public int NetworkObservationMaxSessionSizeMb { get; set; } = 50;
+
+    /// <summary>
+    /// Gets or sets the maximum size of the whole observation archive, in megabytes.
+    /// </summary>
+    [Display(
+        Order = 10,
+        Name = nameof(Resources.SystemConfiguration_NetworkObservationMaxTotalSizeMb_Name),
+        Description = nameof(Resources.SystemConfiguration_NetworkObservationMaxTotalSizeMb_Description),
+        GroupName = nameof(Resources.SystemConfiguration_NetworkAnalyzer_Name),
+        ResourceType = typeof(Resources))]
+    public int NetworkObservationMaxTotalSizeMb { get; set; } = 1000;
+
+    /// <summary>
+    /// Gets or sets the number of days after which an archived session is removed.
+    /// </summary>
+    [Display(
+        Order = 11,
+        Name = nameof(Resources.SystemConfiguration_NetworkObservationRetentionDays_Name),
+        Description = nameof(Resources.SystemConfiguration_NetworkObservationRetentionDays_Description),
+        GroupName = nameof(Resources.SystemConfiguration_NetworkAnalyzer_Name),
+        ResourceType = typeof(Resources))]
+    public int NetworkObservationRetentionDays { get; set; } = 30;
+
     /// <inheritdoc />
     public override string ToString()
     {

--- a/src/DataModel/Entities/Account.cs
+++ b/src/DataModel/Entities/Account.cs
@@ -138,6 +138,13 @@ public class Account
     public bool IsBot { get; set; }
 
     /// <summary>
+    /// Gets or sets a value indicating whether the network traffic of this account is
+    /// observed. The game server then archives the traffic of each of its sessions, so that
+    /// it can be analyzed later - for example when the account is suspected of cheating.
+    /// </summary>
+    public bool IsNetworkObservationActive { get; set; }
+
+    /// <summary>
     /// Gets or sets the characters.
     /// </summary>
     [MemberOfAggregate]

--- a/src/DataModel/Properties/Resources.Designer.cs
+++ b/src/DataModel/Properties/Resources.Designer.cs
@@ -235,5 +235,104 @@ namespace MUnique.OpenMU.DataModel.Properties {
                 return ResourceManager.GetString("SystemConfiguration_TimeZoneId_Description", resourceCulture);
             }
         }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Network Analyzer.
+        /// </summary>
+        public static string SystemConfiguration_NetworkAnalyzer_Name {
+            get {
+                return ResourceManager.GetString("SystemConfiguration_NetworkAnalyzer_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Live buffer size.
+        /// </summary>
+        public static string SystemConfiguration_NetworkAnalyzerLiveBufferSize_Name {
+            get {
+                return ResourceManager.GetString("SystemConfiguration_NetworkAnalyzerLiveBufferSize_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The number of data packets which are kept in memory per connection which is watched in the network analyzer page. When more packets arrive, the oldest ones are dropped..
+        /// </summary>
+        public static string SystemConfiguration_NetworkAnalyzerLiveBufferSize_Description {
+            get {
+                return ResourceManager.GetString("SystemConfiguration_NetworkAnalyzerLiveBufferSize_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Observation archive path.
+        /// </summary>
+        public static string SystemConfiguration_NetworkObservationArchivePath_Name {
+            get {
+                return ResourceManager.GetString("SystemConfiguration_NetworkObservationArchivePath_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The path in which the traffic of the observed accounts is archived. A relative path is resolved against the directory of the application. It must not point into a folder which is served by the web server - an archived session contains the login packet of the player in plain text..
+        /// </summary>
+        public static string SystemConfiguration_NetworkObservationArchivePath_Description {
+            get {
+                return ResourceManager.GetString("SystemConfiguration_NetworkObservationArchivePath_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Maximum session size (MB).
+        /// </summary>
+        public static string SystemConfiguration_NetworkObservationMaxSessionSizeMb_Name {
+            get {
+                return ResourceManager.GetString("SystemConfiguration_NetworkObservationMaxSessionSizeMb_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The maximum size of one file of an archived session, in megabytes. A session which grows bigger is continued in another file..
+        /// </summary>
+        public static string SystemConfiguration_NetworkObservationMaxSessionSizeMb_Description {
+            get {
+                return ResourceManager.GetString("SystemConfiguration_NetworkObservationMaxSessionSizeMb_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Maximum archive size (MB).
+        /// </summary>
+        public static string SystemConfiguration_NetworkObservationMaxTotalSizeMb_Name {
+            get {
+                return ResourceManager.GetString("SystemConfiguration_NetworkObservationMaxTotalSizeMb_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The maximum size of the whole observation archive, in megabytes. When it&apos;s exceeded, the oldest sessions are removed. A value of 0 means that the size is unlimited..
+        /// </summary>
+        public static string SystemConfiguration_NetworkObservationMaxTotalSizeMb_Description {
+            get {
+                return ResourceManager.GetString("SystemConfiguration_NetworkObservationMaxTotalSizeMb_Description", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to Archive retention (days).
+        /// </summary>
+        public static string SystemConfiguration_NetworkObservationRetentionDays_Name {
+            get {
+                return ResourceManager.GetString("SystemConfiguration_NetworkObservationRetentionDays_Name", resourceCulture);
+            }
+        }
+
+        /// <summary>
+        ///   Looks up a localized string similar to The number of days after which an archived session is removed. A value of 0 means that the sessions are kept forever..
+        /// </summary>
+        public static string SystemConfiguration_NetworkObservationRetentionDays_Description {
+            get {
+                return ResourceManager.GetString("SystemConfiguration_NetworkObservationRetentionDays_Description", resourceCulture);
+            }
+        }
     }
 }

--- a/src/DataModel/Properties/Resources.resx
+++ b/src/DataModel/Properties/Resources.resx
@@ -160,4 +160,37 @@ or behind a firewall) and you want to use it within your computer or private net
     <data name="SocketAbbreviation" xml:space="preserve">
       <value>S</value>
     </data>
+	<data name="SystemConfiguration_NetworkAnalyzer_Name" xml:space="preserve">
+		<value>Network Analyzer</value>
+	</data>
+	<data name="SystemConfiguration_NetworkAnalyzerLiveBufferSize_Name" xml:space="preserve">
+		<value>Live buffer size</value>
+	</data>
+	<data name="SystemConfiguration_NetworkAnalyzerLiveBufferSize_Description" xml:space="preserve">
+		<value>The number of data packets which are kept in memory per connection which is watched in the network analyzer page. When more packets arrive, the oldest ones are dropped.</value>
+	</data>
+	<data name="SystemConfiguration_NetworkObservationArchivePath_Name" xml:space="preserve">
+		<value>Observation archive path</value>
+	</data>
+	<data name="SystemConfiguration_NetworkObservationArchivePath_Description" xml:space="preserve">
+		<value>The path in which the traffic of the observed accounts is archived. A relative path is resolved against the directory of the application. It must not point into a folder which is served by the web server - an archived session contains the login packet of the player in plain text.</value>
+	</data>
+	<data name="SystemConfiguration_NetworkObservationMaxSessionSizeMb_Name" xml:space="preserve">
+		<value>Maximum session size (MB)</value>
+	</data>
+	<data name="SystemConfiguration_NetworkObservationMaxSessionSizeMb_Description" xml:space="preserve">
+		<value>The maximum size of one file of an archived session, in megabytes. A session which grows bigger is continued in another file.</value>
+	</data>
+	<data name="SystemConfiguration_NetworkObservationMaxTotalSizeMb_Name" xml:space="preserve">
+		<value>Maximum archive size (MB)</value>
+	</data>
+	<data name="SystemConfiguration_NetworkObservationMaxTotalSizeMb_Description" xml:space="preserve">
+		<value>The maximum size of the whole observation archive, in megabytes. When it's exceeded, the oldest sessions are removed. A value of 0 means that the size is unlimited.</value>
+	</data>
+	<data name="SystemConfiguration_NetworkObservationRetentionDays_Name" xml:space="preserve">
+		<value>Archive retention (days)</value>
+	</data>
+	<data name="SystemConfiguration_NetworkObservationRetentionDays_Description" xml:space="preserve">
+		<value>The number of days after which an archived session is removed. A value of 0 means that the sessions are kept forever.</value>
+	</data>
 </root>

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -123,6 +123,11 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
     public event AsyncEventHandler<Player>? PlayerEnteredWorld;
 
     /// <summary>
+    /// Occurs when the player has been logged in, so that its <see cref="Account"/> is known.
+    /// </summary>
+    public event AsyncEventHandler<Player>? PlayerLoggedIn;
+
+    /// <summary>
     /// Occurs when the player left the world with his selected character.
     /// </summary>
     public event AsyncEventHandler<Player>? PlayerLeftWorld;
@@ -580,6 +585,18 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
     /// Gets a value indicating whether opening the player store after entering the game is supported by this instance.
     /// </summary>
     protected virtual bool IsPlayerStoreOpeningAfterEnterSupported => true;
+
+    /// <summary>
+    /// Sets the account of the player after a successful login and notifies the subscribers
+    /// of <see cref="PlayerLoggedIn"/>.
+    /// </summary>
+    /// <param name="account">The account of the player.</param>
+    /// <returns>The async task.</returns>
+    public async ValueTask SetAccountAsync(Account account)
+    {
+        this.Account = account;
+        await this.PlayerLoggedIn.SafeInvokeAsync(this).ConfigureAwait(false);
+    }
 
     /// <summary>
     /// Sets the selected character.

--- a/src/GameLogic/PlayerActions/LoginAction.cs
+++ b/src/GameLogic/PlayerActions/LoginAction.cs
@@ -200,7 +200,7 @@ public class LoginAction
 
     private async ValueTask FinishLoginAsync(Player player, string username, Account account)
     {
-        player.Account = account;
+        await player.SetAccountAsync(account).ConfigureAwait(false);
         player.Logger.LogDebug("Login successful, username: [{Username}].", username);
 
         if (player.IsTemplatePlayer)

--- a/src/GameServer/GameServer.cs
+++ b/src/GameServer/GameServer.cs
@@ -20,6 +20,7 @@ using MUnique.OpenMU.GameLogic.Views.Messenger;
 using MUnique.OpenMU.GameServer.RemoteView;
 using MUnique.OpenMU.Interfaces;
 using MUnique.OpenMU.Network.Analyzer;
+using MUnique.OpenMU.Network.Analyzer.Archive;
 using MUnique.OpenMU.Persistence;
 using MUnique.OpenMU.PlugIns;
 using Nito.AsyncEx;
@@ -35,6 +36,8 @@ public sealed class GameServer : IGameServer, IDisposable, IAsyncDisposable, IGa
 
     private readonly ICollection<IGameServerListener> _listeners = new List<IGameServerListener>();
 
+    private readonly NetworkObservationHandler? _observationHandler;
+
     private ServerState _serverState;
 
     /// <summary>
@@ -49,6 +52,8 @@ public sealed class GameServer : IGameServer, IDisposable, IAsyncDisposable, IGa
     /// <param name="loggerFactory">The logger factory.</param>
     /// <param name="plugInManager">The plug in manager.</param>
     /// <param name="changeMediator"> The change mediatior.</param>
+    /// <param name="packetArchive">The archive for the traffic of observed accounts. It's only
+    /// available when the network observation is configured.</param>
     public GameServer(
         GameServerDefinition gameServerDefinition,
         IGuildServer guildServer,
@@ -58,12 +63,16 @@ public sealed class GameServer : IGameServer, IDisposable, IAsyncDisposable, IGa
         IFriendServer friendServer,
         ILoggerFactory loggerFactory,
         PlugInManager plugInManager,
-        IConfigurationChangeMediator changeMediator)
+        IConfigurationChangeMediator changeMediator,
+        IPacketArchive? packetArchive = null)
     {
         this.Id = gameServerDefinition.ServerID;
         this.Description = gameServerDefinition.Description;
         this.ConfigurationId = gameServerDefinition.GetId();
         this._logger = loggerFactory.CreateLogger<GameServer>();
+        this._observationHandler = packetArchive is null
+            ? null
+            : new NetworkObservationHandler(packetArchive, this.Id, this.Description, loggerFactory.CreateLogger<NetworkObservationHandler>());
         try
         {
             var gameConfiguration = gameServerDefinition.GameConfiguration ?? throw Error.NotInitializedProperty(gameServerDefinition, nameof(gameServerDefinition.GameConfiguration));
@@ -489,6 +498,7 @@ public sealed class GameServer : IGameServer, IDisposable, IAsyncDisposable, IGa
     private async ValueTask OnPlayerConnectedAsync(PlayerConnectedEventArgs e)
     {
         var player = e.ConntectedPlayer;
+        this._observationHandler?.Watch(player);
         await this._gameContext.AddPlayerAsync(player).ConfigureAwait(false);
         await player.InvokeViewPlugInAsync<IShowLoginWindowPlugIn>(p => p.ShowLoginWindowAsync()).ConfigureAwait(false);
         await player.PlayerState.TryAdvanceToAsync(PlayerState.LoginScreen).ConfigureAwait(false);

--- a/src/GameServer/NetworkObservationExtensions.cs
+++ b/src/GameServer/NetworkObservationExtensions.cs
@@ -21,7 +21,7 @@ public static class NetworkObservationExtensions
     /// configuration of the database.
     /// </summary>
     /// <param name="services">The service collection.</param>
-    /// <returns>The service collection.</returns>
+    /// <returns>The given service collection, so that the calls can be chained.</returns>
     /// <remarks>
     /// It belongs to the game server, not to the admin panel: an observed account is archived
     /// as soon as it plays, no matter whether an admin panel is running somewhere.

--- a/src/GameServer/NetworkObservationExtensions.cs
+++ b/src/GameServer/NetworkObservationExtensions.cs
@@ -1,0 +1,94 @@
+// <copyright file="NetworkObservationExtensions.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer;
+
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.Network.Analyzer.Archive;
+using MUnique.OpenMU.Persistence;
+using Nito.AsyncEx.Synchronous;
+
+/// <summary>
+/// Extensions to register the archive for the traffic of observed accounts.
+/// </summary>
+public static class NetworkObservationExtensions
+{
+    /// <summary>
+    /// Adds the archive for the traffic of observed accounts, configured by the system
+    /// configuration of the database.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <returns>The service collection.</returns>
+    /// <remarks>
+    /// It belongs to the game server, not to the admin panel: an observed account is archived
+    /// as soon as it plays, no matter whether an admin panel is running somewhere.
+    /// </remarks>
+    public static IServiceCollection AddNetworkObservation(this IServiceCollection services)
+    {
+        return services
+            .AddSingleton(CreateOptions)
+            .AddSingleton<IPacketArchive, PacketArchive>();
+    }
+
+    /// <summary>
+    /// Creates the options of the network observation from the given system configuration.
+    /// </summary>
+    /// <param name="configuration">The system configuration, if it exists.</param>
+    /// <returns>The options of the network observation.</returns>
+    public static NetworkObservationOptions CreateOptions(SystemConfiguration? configuration)
+    {
+        var options = new NetworkObservationOptions();
+        if (configuration is null)
+        {
+            return options;
+        }
+
+        // A value which was never configured is left at its default, so that an existing
+        // database doesn't end up with an unlimited archive.
+        if (!string.IsNullOrWhiteSpace(configuration.NetworkObservationArchivePath))
+        {
+            options.ArchivePath = configuration.NetworkObservationArchivePath;
+        }
+
+        if (configuration.NetworkObservationMaxSessionSizeMb > 0)
+        {
+            options.MaximumSessionSizeMb = configuration.NetworkObservationMaxSessionSizeMb;
+        }
+
+        if (configuration.NetworkObservationMaxTotalSizeMb > 0)
+        {
+            options.MaximumTotalSizeMb = configuration.NetworkObservationMaxTotalSizeMb;
+        }
+
+        if (configuration.NetworkObservationRetentionDays > 0)
+        {
+            options.RetentionDays = configuration.NetworkObservationRetentionDays;
+        }
+
+        return options;
+    }
+
+    private static NetworkObservationOptions CreateOptions(IServiceProvider serviceProvider)
+    {
+        try
+        {
+            if (serviceProvider.GetService<IPersistenceContextProvider>() is { } contextProvider)
+            {
+                using var context = contextProvider.CreateNewTypedContext(typeof(SystemConfiguration), false);
+                var configuration = context.GetAsync<SystemConfiguration>().AsTask().WaitAndUnwrapException().FirstOrDefault();
+                return CreateOptions(configuration);
+            }
+        }
+        catch (Exception ex)
+        {
+            serviceProvider.GetService<ILoggerFactory>()?
+                .CreateLogger(typeof(NetworkObservationExtensions))
+                .LogWarning(ex, "Could not read the configuration of the network observation. The defaults are used.");
+        }
+
+        return new NetworkObservationOptions();
+    }
+}

--- a/src/GameServer/NetworkObservationHandler.cs
+++ b/src/GameServer/NetworkObservationHandler.cs
@@ -1,0 +1,145 @@
+// <copyright file="NetworkObservationHandler.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.GameServer;
+
+using System.Collections.Concurrent;
+using Microsoft.Extensions.Logging;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameServer.RemoteView;
+using MUnique.OpenMU.Interfaces;
+using MUnique.OpenMU.Network;
+using MUnique.OpenMU.Network.Analyzer.Archive;
+
+/// <summary>
+/// Archives the traffic of the players whose account is observed.
+/// </summary>
+/// <remarks>
+/// It's part of the game server and not of the admin panel, so that the traffic of an observed
+/// account is archived in a distributed deployment as well. The archive starts when the player
+/// is logged in - the few packets before that (version check, login request) are not part of
+/// it, because capturing them would mean to capture every connection unconditionally.
+/// </remarks>
+internal sealed class NetworkObservationHandler
+{
+    private readonly IPacketArchive _archive;
+
+    private readonly int _serverId;
+
+    private readonly string _serverDescription;
+
+    private readonly ILogger<NetworkObservationHandler> _logger;
+
+    private readonly ConcurrentDictionary<Player, ObservedSession> _sessions = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="NetworkObservationHandler"/> class.
+    /// </summary>
+    /// <param name="archive">The archive in which the sessions are written.</param>
+    /// <param name="serverId">The identifier of the game server.</param>
+    /// <param name="serverDescription">The description of the game server.</param>
+    /// <param name="logger">The logger.</param>
+    public NetworkObservationHandler(IPacketArchive archive, int serverId, string serverDescription, ILogger<NetworkObservationHandler> logger)
+    {
+        this._archive = archive;
+        this._serverId = serverId;
+        this._serverDescription = serverDescription;
+        this._logger = logger;
+    }
+
+    /// <summary>
+    /// Starts to watch the specified player, so that its traffic is archived when it logs in
+    /// with an observed account.
+    /// </summary>
+    /// <param name="player">The player which just connected.</param>
+    public void Watch(Player player)
+    {
+        if (player is not RemotePlayer)
+        {
+            // Without a connection there is no traffic - an offline player has none.
+            return;
+        }
+
+        player.PlayerLoggedIn += this.OnPlayerLoggedInAsync;
+        player.PlayerEnteredWorld += this.OnPlayerEnteredWorldAsync;
+        player.PlayerDisconnected += this.OnPlayerDisconnectedAsync;
+    }
+
+    private async ValueTask OnPlayerLoggedInAsync(Player player)
+    {
+        try
+        {
+            if (player.Account is not { IsNetworkObservationActive: true } account
+                || player is not RemotePlayer { Connection: { } connection } remotePlayer
+                || this._sessions.ContainsKey(player))
+            {
+                return;
+            }
+
+            var metadata = new ArchivedSessionMetadata
+            {
+                AccountName = account.LoginName,
+                ServerType = ServerType.GameServer,
+                ServerId = this._serverId,
+                ServerDescription = this._serverDescription,
+                RemoteEndPoint = connection.EndPoint?.ToString(),
+                ClientVersion = remotePlayer.ClientVersion,
+                StartTimestamp = DateTime.UtcNow,
+            };
+
+            if (await this._archive.StartSessionAsync(metadata).ConfigureAwait(false) is not { } writer)
+            {
+                return;
+            }
+
+            if (!this._sessions.TryAdd(player, new ObservedSession(writer, connection)))
+            {
+                await writer.DisposeAsync().ConfigureAwait(false);
+                return;
+            }
+
+            connection.AddCaptureSink(writer);
+        }
+        catch (Exception ex)
+        {
+            // The observation must never break the session of the player.
+            this._logger.LogWarning(ex, "Could not start to archive the traffic of {Player}.", player);
+        }
+    }
+
+    private async ValueTask OnPlayerEnteredWorldAsync(Player player)
+    {
+        if (this._sessions.TryGetValue(player, out var session)
+            && player.SelectedCharacter?.Name is { } characterName)
+        {
+            await session.Writer.AddCharacterNameAsync(characterName).ConfigureAwait(false);
+        }
+    }
+
+    private async ValueTask OnPlayerDisconnectedAsync(Player player)
+    {
+        player.PlayerLoggedIn -= this.OnPlayerLoggedInAsync;
+        player.PlayerEnteredWorld -= this.OnPlayerEnteredWorldAsync;
+        player.PlayerDisconnected -= this.OnPlayerDisconnectedAsync;
+
+        if (!this._sessions.TryRemove(player, out var session))
+        {
+            return;
+        }
+
+        try
+        {
+            // The connection is taken from the session: the player may not have it anymore
+            // when it's already tearing down.
+            session.Connection.RemoveCaptureSink(session.Writer);
+            await session.Writer.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            this._logger.LogWarning(ex, "Could not finish the archived session of {Player}.", player);
+        }
+    }
+
+    private sealed record ObservedSession(ArchivedSessionWriter Writer, IConnection Connection);
+}

--- a/src/Network/Analyzer/Archive/ArchivedSession.cs
+++ b/src/Network/Analyzer/Archive/ArchivedSession.cs
@@ -1,0 +1,124 @@
+// <copyright file="ArchivedSession.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Network.Analyzer.Archive;
+
+using System.ComponentModel;
+using System.Globalization;
+using System.IO;
+
+/// <summary>
+/// An archived session of an observed account, which is read from the archive.
+/// </summary>
+/// <remarks>
+/// The files can be read while the session is still running: they are opened without blocking
+/// the writer, and a line which isn't completely written yet is simply skipped.
+/// </remarks>
+public sealed class ArchivedSession : ICapturedConnection
+{
+    /// <summary>
+    /// The minimum size of a data packet: a type byte, the length and the code.
+    /// </summary>
+    private const int MinimumPacketSize = 3;
+
+    private ArchivedSession(ArchivedSessionInfo info, BindingList<Packet> packets)
+    {
+        this.Info = info;
+        this.PacketList = packets;
+        this.Name = info.DisplayName;
+        this.StartTimestamp = info.Metadata.StartTimestamp;
+    }
+
+    /// <summary>
+    /// Gets the information about the session.
+    /// </summary>
+    public ArchivedSessionInfo Info { get; }
+
+    /// <inheritdoc />
+    public string Name { get; }
+
+    /// <inheritdoc />
+    public BindingList<Packet> PacketList { get; }
+
+    /// <inheritdoc />
+    public DateTime StartTimestamp { get; }
+
+    /// <summary>
+    /// Loads the packets of the specified session.
+    /// </summary>
+    /// <param name="info">The information about the session.</param>
+    /// <param name="maximumPacketCount">The maximum number of packets which are loaded. When
+    /// the session contains more, only the newest ones are returned.</param>
+    /// <returns>The loaded session.</returns>
+    public static async ValueTask<ArchivedSession> LoadAsync(ArchivedSessionInfo info, int maximumPacketCount)
+    {
+        var packets = new List<Packet>();
+        foreach (var part in info.Metadata.Parts)
+        {
+            var path = Path.Combine(info.DirectoryPath, part);
+            if (!File.Exists(path))
+            {
+                continue;
+            }
+
+            await ReadPartAsync(path, packets).ConfigureAwait(false);
+        }
+
+        if (maximumPacketCount > 0 && packets.Count > maximumPacketCount)
+        {
+            packets.RemoveRange(0, packets.Count - maximumPacketCount);
+        }
+
+        return new ArchivedSession(info, new BindingList<Packet>(packets));
+    }
+
+    private static async ValueTask ReadPartAsync(string path, List<Packet> packets)
+    {
+        await using var stream = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        using var reader = new StreamReader(stream);
+
+        // The first line is the timestamp of the session, which is already in the metadata.
+        _ = await reader.ReadLineAsync().ConfigureAwait(false);
+        while (await reader.ReadLineAsync().ConfigureAwait(false) is { } line)
+        {
+            if (TryParsePacket(line, out var packet))
+            {
+                packets.Add(packet);
+            }
+        }
+    }
+
+    private static bool TryParsePacket(string line, out Packet packet)
+    {
+        packet = default!;
+
+        // The fifth field is the sequence number of the packet, which is only used to see
+        // whether packets are missing - the analyzer tool ignores it.
+        var fields = line.Split(';');
+        if (fields.Length < 4
+            || !long.TryParse(fields[0], NumberStyles.Integer, CultureInfo.InvariantCulture, out var ticks)
+            || !bool.TryParse(fields[1], out var toServer)
+            || !int.TryParse(fields[2], NumberStyles.Integer, CultureInfo.InvariantCulture, out var size)
+            || size < MinimumPacketSize)
+        {
+            return false;
+        }
+
+        try
+        {
+            if (!CapturedConnectionExtensions.TryParseArray(fields[3], out var data) || data.Length != size)
+            {
+                return false;
+            }
+
+            packet = new Packet(new TimeSpan(ticks), data, toServer);
+            return true;
+        }
+        catch (Exception)
+        {
+            // The line isn't completely written yet, or it's not a packet at all.
+            return false;
+        }
+    }
+}

--- a/src/Network/Analyzer/Archive/ArchivedSessionInfo.cs
+++ b/src/Network/Analyzer/Archive/ArchivedSessionInfo.cs
@@ -1,0 +1,69 @@
+// <copyright file="ArchivedSessionInfo.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Network.Analyzer.Archive;
+
+using System.Globalization;
+
+/// <summary>
+/// The information about one session in the archive.
+/// </summary>
+public sealed class ArchivedSessionInfo
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArchivedSessionInfo"/> class.
+    /// </summary>
+    /// <param name="id">The identifier of the session, which is its path relative to the
+    /// archive.</param>
+    /// <param name="directoryPath">The full path of the directory of the session.</param>
+    /// <param name="metadata">The metadata of the session.</param>
+    /// <param name="sizeInBytes">The size of the session on the file system.</param>
+    /// <param name="isRunning">If set to <c>true</c>, the session is currently being written.</param>
+    public ArchivedSessionInfo(string id, string directoryPath, ArchivedSessionMetadata metadata, long sizeInBytes, bool isRunning)
+    {
+        this.Id = id;
+        this.DirectoryPath = directoryPath;
+        this.Metadata = metadata;
+        this.SizeInBytes = sizeInBytes;
+        this.IsRunning = isRunning;
+    }
+
+    /// <summary>
+    /// Gets the identifier of the session, which is its path relative to the archive.
+    /// </summary>
+    public string Id { get; }
+
+    /// <summary>
+    /// Gets the full path of the directory of the session.
+    /// </summary>
+    public string DirectoryPath { get; }
+
+    /// <summary>
+    /// Gets the metadata of the session.
+    /// </summary>
+    public ArchivedSessionMetadata Metadata { get; }
+
+    /// <summary>
+    /// Gets the size of the session on the file system, in bytes.
+    /// </summary>
+    public long SizeInBytes { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the session is currently being written, because the
+    /// observed player is still online.
+    /// </summary>
+    public bool IsRunning { get; }
+
+    /// <summary>
+    /// Gets the duration of the session. For a running session, it's the duration so far.
+    /// </summary>
+    public TimeSpan Duration => (this.Metadata.EndTimestamp ?? DateTime.UtcNow) - this.Metadata.StartTimestamp;
+
+    /// <summary>
+    /// Gets the name which should be shown for this session.
+    /// </summary>
+    public string DisplayName => string.Create(
+        CultureInfo.InvariantCulture,
+        $"{this.Metadata.AccountName} ({this.Metadata.StartTimestamp:yyyy-MM-dd HH:mm:ss})");
+}

--- a/src/Network/Analyzer/Archive/ArchivedSessionMetadata.cs
+++ b/src/Network/Analyzer/Archive/ArchivedSessionMetadata.cs
@@ -1,0 +1,85 @@
+// <copyright file="ArchivedSessionMetadata.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Network.Analyzer.Archive;
+
+using MUnique.OpenMU.Interfaces;
+using MUnique.OpenMU.Network.PlugIns;
+
+/// <summary>
+/// The metadata of an archived session, which is saved next to the captured packets.
+/// </summary>
+/// <remarks>
+/// The packets themselves are saved in the same format as the capture files of the analyzer
+/// tool, which has no place for this kind of information.
+/// </remarks>
+public sealed class ArchivedSessionMetadata
+{
+    /// <summary>
+    /// Gets or sets the name of the observed account.
+    /// </summary>
+    public string AccountName { get; set; } = string.Empty;
+
+    /// <summary>
+    /// Gets or sets the names of the characters which were played during the session.
+    /// </summary>
+    public IList<string> CharacterNames { get; set; } = new List<string>();
+
+    /// <summary>
+    /// Gets or sets the type of the server which handled the connection.
+    /// </summary>
+    public ServerType ServerType { get; set; } = ServerType.GameServer;
+
+    /// <summary>
+    /// Gets or sets the identifier of the server which handled the connection.
+    /// </summary>
+    public int ServerId { get; set; }
+
+    /// <summary>
+    /// Gets or sets the description of the server which handled the connection.
+    /// </summary>
+    public string? ServerDescription { get; set; }
+
+    /// <summary>
+    /// Gets or sets the remote endpoint of the connection.
+    /// </summary>
+    public string? RemoteEndPoint { get; set; }
+
+    /// <summary>
+    /// Gets or sets the client version which applied to the connection.
+    /// </summary>
+    /// <remarks>
+    /// The archive starts when the player is logged in, so the version is already the one
+    /// which the client reported at the version check - it doesn't change afterwards.
+    /// </remarks>
+    public ClientVersion ClientVersion { get; set; }
+
+    /// <summary>
+    /// Gets or sets the point in time (UTC) at which the session started.
+    /// </summary>
+    public DateTime StartTimestamp { get; set; }
+
+    /// <summary>
+    /// Gets or sets the point in time (UTC) at which the session ended. It's <c>null</c> as
+    /// long as it's running - and stays <c>null</c> when the server process died.
+    /// </summary>
+    public DateTime? EndTimestamp { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of packets which were archived.
+    /// </summary>
+    public long PacketCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the number of packets which had to be dropped, because they arrived
+    /// faster than they could be written.
+    /// </summary>
+    public long DroppedPacketCount { get; set; }
+
+    /// <summary>
+    /// Gets or sets the names of the files which contain the packets of this session, in the
+    /// order in which they were written.
+    /// </summary>
+    public IList<string> Parts { get; set; } = new List<string>();
+}

--- a/src/Network/Analyzer/Archive/ArchivedSessionWriter.cs
+++ b/src/Network/Analyzer/Archive/ArchivedSessionWriter.cs
@@ -1,0 +1,313 @@
+// <copyright file="ArchivedSessionWriter.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Network.Analyzer.Archive;
+
+using System.Globalization;
+using System.IO;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Channels;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// Writes the captured packets of an observed session into the archive, while it's running.
+/// </summary>
+/// <remarks>
+/// The packets are written by an own task, so that the network thread which captured a packet
+/// is never waiting for the file system. They are appended and flushed as soon as the queue
+/// ran empty, so that a running session can be read - and survives a crash of the process.
+/// </remarks>
+public sealed class ArchivedSessionWriter : IPacketCaptureSink, IAsyncDisposable
+{
+    /// <summary>
+    /// The name of the file which contains the metadata of the session.
+    /// </summary>
+    public const string MetadataFileName = "session.json";
+
+    /// <summary>
+    /// The extension of the files which contain the packets. It's the one of the analyzer
+    /// tool, so that an archived session can be opened with it.
+    /// </summary>
+    public const string PartFileExtension = ".mucap";
+
+    /// <summary>
+    /// The maximum number of packets which are waiting to be written. When the file system
+    /// can't keep up with the traffic, the packets above it are dropped - the connection of
+    /// the player must not be slowed down by the observation.
+    /// </summary>
+    private const int QueueCapacity = 10000;
+
+    private static readonly JsonSerializerOptions JsonOptions = new() { WriteIndented = true };
+
+    private readonly string _directoryPath;
+
+    private readonly ArchivedSessionMetadata _metadata;
+
+    private readonly long _maximumPartSize;
+
+    private readonly ILogger _logger;
+
+    private readonly Func<ValueTask>? _onClosedAsync;
+
+    private readonly Channel<CapturedPacket> _channel = Channel.CreateBounded<CapturedPacket>(
+        new BoundedChannelOptions(QueueCapacity) { SingleReader = true, FullMode = BoundedChannelFullMode.Wait });
+
+    private readonly SemaphoreSlim _metadataSemaphore = new(1);
+
+    private readonly Task _writeLoop;
+
+    private StreamWriter? _currentPart;
+
+    private long _currentPartSize;
+
+    private long _sequence;
+
+    private long _droppedPacketCount;
+
+    private bool _isDisposed;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ArchivedSessionWriter"/> class.
+    /// </summary>
+    /// <param name="directoryPath">The path of the directory of this session.</param>
+    /// <param name="metadata">The metadata of the session.</param>
+    /// <param name="maximumPartSize">The maximum size of one file of the session, in bytes.</param>
+    /// <param name="logger">The logger.</param>
+    /// <param name="onClosedAsync">The callback which is invoked when the session is closed.</param>
+    public ArchivedSessionWriter(
+        string directoryPath,
+        ArchivedSessionMetadata metadata,
+        long maximumPartSize,
+        ILogger logger,
+        Func<ValueTask>? onClosedAsync = null)
+    {
+        this._directoryPath = directoryPath;
+        this._metadata = metadata;
+        this._maximumPartSize = maximumPartSize;
+        this._logger = logger;
+        this._onClosedAsync = onClosedAsync;
+        this._writeLoop = Task.Run(this.WriteLoopAsync);
+    }
+
+    /// <summary>
+    /// Gets the metadata of the session.
+    /// </summary>
+    public ArchivedSessionMetadata Metadata => this._metadata;
+
+    /// <summary>
+    /// Adds the name of a character which is played in this session.
+    /// </summary>
+    /// <param name="characterName">The name of the character.</param>
+    /// <returns>The async task.</returns>
+    public async ValueTask AddCharacterNameAsync(string characterName)
+    {
+        if (string.IsNullOrWhiteSpace(characterName))
+        {
+            return;
+        }
+
+        await this._metadataSemaphore.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            if (this._metadata.CharacterNames.Contains(characterName))
+            {
+                return;
+            }
+
+            this._metadata.CharacterNames.Add(characterName);
+        }
+        finally
+        {
+            this._metadataSemaphore.Release();
+        }
+
+        await this.SaveMetadataAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Saves the current state of the metadata, so that the session is visible in the archive
+    /// while it's still running.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    public async ValueTask SaveMetadataAsync()
+    {
+        await this._metadataSemaphore.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            this._metadata.PacketCount = Interlocked.Read(ref this._sequence);
+            this._metadata.DroppedPacketCount = Interlocked.Read(ref this._droppedPacketCount);
+            var json = JsonSerializer.Serialize(this._metadata, JsonOptions);
+            var path = Path.Combine(this._directoryPath, MetadataFileName);
+            await File.WriteAllTextAsync(path, json).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            this._logger.LogWarning(ex, "Could not save the metadata of the archived session at {Path}.", this._directoryPath);
+        }
+        finally
+        {
+            this._metadataSemaphore.Release();
+        }
+    }
+
+    /// <inheritdoc />
+    public void PacketCaptured(ReadOnlySpan<byte> packet, bool sent)
+    {
+        // A packet which was sent to the remote endpoint of a server connection is a packet
+        // which goes to the client; a received one goes to the server.
+        var captured = new CapturedPacket(
+            DateTime.UtcNow - this._metadata.StartTimestamp,
+            packet.ToArray(),
+            !sent,
+            Interlocked.Increment(ref this._sequence));
+
+        if (!this._channel.Writer.TryWrite(captured))
+        {
+            // The sequence numbers make such a gap visible in the archived session.
+            Interlocked.Increment(ref this._droppedPacketCount);
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask DisposeAsync()
+    {
+        if (this._isDisposed)
+        {
+            return;
+        }
+
+        this._isDisposed = true;
+        this._channel.Writer.TryComplete();
+        try
+        {
+#pragma warning disable VSTHRD003 // The loop is started by this instance, so awaiting it here can't deadlock.
+            await this._writeLoop.ConfigureAwait(false);
+#pragma warning restore VSTHRD003
+        }
+        catch (Exception ex)
+        {
+            this._logger.LogWarning(ex, "Error while finishing the archived session at {Path}.", this._directoryPath);
+        }
+
+        await this.CloseCurrentPartAsync().ConfigureAwait(false);
+        this._metadata.EndTimestamp = DateTime.UtcNow;
+        await this.SaveMetadataAsync().ConfigureAwait(false);
+        this._metadataSemaphore.Dispose();
+
+        if (this._onClosedAsync is { } onClosedAsync)
+        {
+            await onClosedAsync().ConfigureAwait(false);
+        }
+    }
+
+    private async Task WriteLoopAsync()
+    {
+        var reader = this._channel.Reader;
+        while (await reader.WaitToReadAsync().ConfigureAwait(false))
+        {
+            while (reader.TryRead(out var packet))
+            {
+                await this.WritePacketAsync(packet).ConfigureAwait(false);
+            }
+
+            if (this._currentPart is { } currentPart)
+            {
+                try
+                {
+                    await currentPart.FlushAsync().ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    this._logger.LogWarning(ex, "Could not flush the archived session at {Path}.", this._directoryPath);
+                }
+            }
+        }
+    }
+
+    private async ValueTask WritePacketAsync(CapturedPacket packet)
+    {
+        try
+        {
+            var writer = await this.GetCurrentPartAsync().ConfigureAwait(false);
+            if (writer is null)
+            {
+                return;
+            }
+
+            var data = new Packet(packet.Timestamp, packet.Data, packet.ToServer);
+            var line = string.Create(
+                CultureInfo.InvariantCulture,
+                $"{packet.Timestamp.Ticks};{packet.ToServer};{data.Size};{data.PacketData};{packet.Sequence}");
+            await writer.WriteLineAsync(line).ConfigureAwait(false);
+            this._currentPartSize += line.Length + Environment.NewLine.Length;
+            if (this._currentPartSize >= this._maximumPartSize)
+            {
+                // The session continues in another file, so that a single one stays small
+                // enough to be opened by the analyzer tool.
+                await this.CloseCurrentPartAsync().ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            this._logger.LogWarning(ex, "Could not write a packet of the archived session at {Path}.", this._directoryPath);
+        }
+    }
+
+    private async ValueTask<StreamWriter?> GetCurrentPartAsync()
+    {
+        if (this._currentPart is { } currentPart)
+        {
+            return currentPart;
+        }
+
+        var partName = string.Create(CultureInfo.InvariantCulture, $"part-{this._metadata.Parts.Count:D3}{PartFileExtension}");
+        var stream = new FileStream(
+            Path.Combine(this._directoryPath, partName),
+            FileMode.Create,
+            FileAccess.Write,
+            FileShare.ReadWrite | FileShare.Delete);
+        this._currentPart = new StreamWriter(stream);
+        this._currentPartSize = 0;
+
+        // Each part starts with the timestamp of the session, so that it can be loaded on its
+        // own - the timestamps of the packets are relative to it.
+        var startTimestamp = this._metadata.StartTimestamp.ToString("O", CultureInfo.InvariantCulture);
+        await this._currentPart.WriteLineAsync(startTimestamp).ConfigureAwait(false);
+        await this._currentPart.FlushAsync().ConfigureAwait(false);
+
+        await this._metadataSemaphore.WaitAsync().ConfigureAwait(false);
+        try
+        {
+            this._metadata.Parts.Add(partName);
+        }
+        finally
+        {
+            this._metadataSemaphore.Release();
+        }
+
+        await this.SaveMetadataAsync().ConfigureAwait(false);
+        return this._currentPart;
+    }
+
+    private async ValueTask CloseCurrentPartAsync()
+    {
+        if (this._currentPart is not { } currentPart)
+        {
+            return;
+        }
+
+        this._currentPart = null;
+        try
+        {
+            await currentPart.DisposeAsync().ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            this._logger.LogWarning(ex, "Could not close a file of the archived session at {Path}.", this._directoryPath);
+        }
+    }
+
+    private readonly record struct CapturedPacket(TimeSpan Timestamp, byte[] Data, bool ToServer, long Sequence);
+}

--- a/src/Network/Analyzer/Archive/IPacketArchive.cs
+++ b/src/Network/Analyzer/Archive/IPacketArchive.cs
@@ -1,0 +1,53 @@
+// <copyright file="IPacketArchive.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Network.Analyzer.Archive;
+
+/// <summary>
+/// The archive which holds the traffic of the sessions of observed accounts.
+/// </summary>
+/// <remarks>
+/// It's a feature of the game server: an observed account is archived as soon as it plays,
+/// regardless of whether an admin panel is running somewhere.
+/// </remarks>
+public interface IPacketArchive
+{
+    /// <summary>
+    /// Starts a new session in the archive.
+    /// </summary>
+    /// <param name="metadata">The metadata of the session. Its start timestamp is used as the
+    /// reference for the timestamps of the packets.</param>
+    /// <returns>The writer of the session, which is a sink of the connection; Or
+    /// <see langword="null"/>, if the session couldn't be started.</returns>
+    ValueTask<ArchivedSessionWriter?> StartSessionAsync(ArchivedSessionMetadata metadata);
+
+    /// <summary>
+    /// Gets the sessions which are in the archive, newest first.
+    /// </summary>
+    /// <param name="accountName">The name of the account, if only its sessions are wanted.</param>
+    /// <returns>The sessions which are in the archive.</returns>
+    ValueTask<IReadOnlyList<ArchivedSessionInfo>> GetSessionsAsync(string? accountName = null);
+
+    /// <summary>
+    /// Gets the information about the session with the specified identifier.
+    /// </summary>
+    /// <param name="sessionId">The identifier of the session.</param>
+    /// <returns>The information about the session, if it exists; Otherwise,
+    /// <see langword="null"/>.</returns>
+    ValueTask<ArchivedSessionInfo?> GetSessionAsync(string sessionId);
+
+    /// <summary>
+    /// Deletes the session with the specified identifier.
+    /// </summary>
+    /// <param name="sessionId">The identifier of the session.</param>
+    /// <returns><see langword="true"/>, if the session has been deleted.</returns>
+    ValueTask<bool> DeleteSessionAsync(string sessionId);
+
+    /// <summary>
+    /// Applies the retention and the size limit of the archive, by removing the oldest
+    /// sessions. A session which is currently written is never removed.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    ValueTask ApplyHousekeepingAsync();
+}

--- a/src/Network/Analyzer/Archive/NetworkObservationOptions.cs
+++ b/src/Network/Analyzer/Archive/NetworkObservationOptions.cs
@@ -1,0 +1,86 @@
+// <copyright file="NetworkObservationOptions.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Network.Analyzer.Archive;
+
+using System.IO;
+
+/// <summary>
+/// The options of the network observation, which archives the traffic of the accounts whose
+/// observation is active.
+/// </summary>
+/// <remarks>
+/// They are configured in the system configuration of the database. This class is the plain
+/// counterpart of it, so that the archive doesn't need to know the data model.
+/// </remarks>
+public sealed class NetworkObservationOptions
+{
+    /// <summary>
+    /// The default path of the archive, relative to the directory of the application.
+    /// </summary>
+    public const string DefaultArchivePath = "captures";
+
+    /// <summary>
+    /// The default maximum size of one file of a session, in megabytes.
+    /// </summary>
+    public const int DefaultMaximumSessionSizeMb = 50;
+
+    /// <summary>
+    /// The default maximum size of the whole archive, in megabytes.
+    /// </summary>
+    public const int DefaultMaximumTotalSizeMb = 1000;
+
+    /// <summary>
+    /// The default number of days after which an archived session is removed.
+    /// </summary>
+    public const int DefaultRetentionDays = 30;
+
+    /// <summary>
+    /// Gets or sets the path of the archive. A relative path is resolved against the directory
+    /// of the application.
+    /// </summary>
+    /// <remarks>
+    /// It must not point into a folder which is served by the web server - an archived session
+    /// contains the login packet of the player in plain text.
+    /// </remarks>
+    public string ArchivePath { get; set; } = DefaultArchivePath;
+
+    /// <summary>
+    /// Gets or sets the maximum size of one file of a session, in megabytes. A session which
+    /// grows bigger is continued in another file.
+    /// </summary>
+    public int MaximumSessionSizeMb { get; set; } = DefaultMaximumSessionSizeMb;
+
+    /// <summary>
+    /// Gets or sets the maximum size of the whole archive, in megabytes. When it's exceeded,
+    /// the oldest sessions are removed. A value of 0 or less means that the size is unlimited.
+    /// </summary>
+    public int MaximumTotalSizeMb { get; set; } = DefaultMaximumTotalSizeMb;
+
+    /// <summary>
+    /// Gets or sets the number of days after which an archived session is removed. A value of
+    /// 0 or less means that the sessions are kept forever.
+    /// </summary>
+    public int RetentionDays { get; set; } = DefaultRetentionDays;
+
+    /// <summary>
+    /// Gets the maximum size of one file of a session, in bytes.
+    /// </summary>
+    /// <returns>The maximum size of one file of a session, in bytes.</returns>
+    public long GetMaximumSessionSizeInBytes()
+    {
+        var sizeInMegabytes = this.MaximumSessionSizeMb > 0 ? this.MaximumSessionSizeMb : DefaultMaximumSessionSizeMb;
+        return (long)sizeInMegabytes * 1024 * 1024;
+    }
+
+    /// <summary>
+    /// Gets the full path of the archive.
+    /// </summary>
+    /// <returns>The full path of the archive.</returns>
+    public string GetFullArchivePath()
+    {
+        var path = string.IsNullOrWhiteSpace(this.ArchivePath) ? DefaultArchivePath : this.ArchivePath;
+        return Path.GetFullPath(Path.IsPathRooted(path) ? path : Path.Combine(AppContext.BaseDirectory, path));
+    }
+}

--- a/src/Network/Analyzer/Archive/PacketArchive.cs
+++ b/src/Network/Analyzer/Archive/PacketArchive.cs
@@ -1,0 +1,282 @@
+// <copyright file="PacketArchive.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Network.Analyzer.Archive;
+
+using System.Collections.Concurrent;
+using System.Globalization;
+using System.IO;
+using System.Text.Json;
+using Microsoft.Extensions.Logging;
+
+/// <summary>
+/// The implementation of the <see cref="IPacketArchive"/>, which keeps the sessions on the
+/// file system.
+/// </summary>
+/// <remarks>
+/// A session is a directory below the one of its account, which holds the captured packets in
+/// one or more files of the analyzer tool format, plus the metadata as json. That way, a
+/// session can be deleted, copied or opened as a whole.
+/// </remarks>
+public sealed class PacketArchive : IPacketArchive
+{
+    private readonly NetworkObservationOptions _options;
+
+    private readonly ILogger<PacketArchive> _logger;
+
+    private readonly ConcurrentDictionary<string, ArchivedSessionWriter> _runningSessions = new();
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="PacketArchive"/> class.
+    /// </summary>
+    /// <param name="options">The options of the network observation.</param>
+    /// <param name="logger">The logger.</param>
+    public PacketArchive(NetworkObservationOptions options, ILogger<PacketArchive> logger)
+    {
+        this._options = options;
+        this._logger = logger;
+    }
+
+    /// <summary>
+    /// Gets the full path of the archive.
+    /// </summary>
+    public string ArchivePath => this._options.GetFullArchivePath();
+
+    /// <inheritdoc />
+    public async ValueTask<ArchivedSessionWriter?> StartSessionAsync(ArchivedSessionMetadata metadata)
+    {
+        await this.ApplyHousekeepingAsync().ConfigureAwait(false);
+
+        if (metadata.StartTimestamp == default)
+        {
+            metadata.StartTimestamp = DateTime.UtcNow;
+        }
+
+        string sessionId;
+        string directoryPath;
+        try
+        {
+            var accountDirectory = GetSafeName(metadata.AccountName);
+            var sessionDirectory = string.Create(
+                CultureInfo.InvariantCulture,
+                $"{metadata.StartTimestamp:yyyy-MM-dd_HH-mm-ss}_{metadata.ServerId}");
+            sessionId = $"{accountDirectory}/{sessionDirectory}";
+            directoryPath = Path.Combine(this.ArchivePath, accountDirectory, sessionDirectory);
+            Directory.CreateDirectory(directoryPath);
+        }
+        catch (Exception ex)
+        {
+            this._logger.LogError(ex, "Could not create the archive directory for the account {AccountName}.", metadata.AccountName);
+            return null;
+        }
+
+        var writer = new ArchivedSessionWriter(
+            directoryPath,
+            metadata,
+            this._options.GetMaximumSessionSizeInBytes(),
+            this._logger,
+            () => this.OnSessionClosedAsync(sessionId));
+        this._runningSessions[sessionId] = writer;
+        await writer.SaveMetadataAsync().ConfigureAwait(false);
+
+        // Observing a player is an intrusion into their privacy, so it leaves a trace.
+        this._logger.LogInformation(
+            "Started to archive the traffic of the observed account {AccountName} at {SessionId}.",
+            metadata.AccountName,
+            sessionId);
+        return writer;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<IReadOnlyList<ArchivedSessionInfo>> GetSessionsAsync(string? accountName = null)
+    {
+        var archivePath = this.ArchivePath;
+        if (!Directory.Exists(archivePath))
+        {
+            return [];
+        }
+
+        var accountDirectories = string.IsNullOrEmpty(accountName)
+            ? Directory.EnumerateDirectories(archivePath)
+            : [Path.Combine(archivePath, GetSafeName(accountName))];
+
+        var result = new List<ArchivedSessionInfo>();
+        foreach (var accountDirectory in accountDirectories)
+        {
+            if (!Directory.Exists(accountDirectory))
+            {
+                continue;
+            }
+
+            foreach (var sessionDirectory in Directory.EnumerateDirectories(accountDirectory))
+            {
+                if (await this.TryReadSessionAsync(sessionDirectory).ConfigureAwait(false) is { } session)
+                {
+                    result.Add(session);
+                }
+            }
+        }
+
+        result.Sort((left, right) => right.Metadata.StartTimestamp.CompareTo(left.Metadata.StartTimestamp));
+        return result;
+    }
+
+    /// <inheritdoc />
+    public async ValueTask<ArchivedSessionInfo?> GetSessionAsync(string sessionId)
+    {
+        if (this.TryGetSessionDirectory(sessionId) is not { } directoryPath)
+        {
+            return null;
+        }
+
+        return await this.TryReadSessionAsync(directoryPath).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public ValueTask<bool> DeleteSessionAsync(string sessionId)
+    {
+        if (this._runningSessions.ContainsKey(sessionId))
+        {
+            this._logger.LogInformation("The archived session {SessionId} is still running and was not deleted.", sessionId);
+            return ValueTask.FromResult(false);
+        }
+
+        if (this.TryGetSessionDirectory(sessionId) is not { } directoryPath || !Directory.Exists(directoryPath))
+        {
+            return ValueTask.FromResult(false);
+        }
+
+        try
+        {
+            Directory.Delete(directoryPath, true);
+            this.RemoveAccountDirectoryIfEmpty(Path.GetDirectoryName(directoryPath));
+            this._logger.LogInformation("The archived session {SessionId} has been deleted.", sessionId);
+            return ValueTask.FromResult(true);
+        }
+        catch (Exception ex)
+        {
+            this._logger.LogWarning(ex, "Could not delete the archived session {SessionId}.", sessionId);
+            return ValueTask.FromResult(false);
+        }
+    }
+
+    /// <inheritdoc />
+    public async ValueTask ApplyHousekeepingAsync()
+    {
+        try
+        {
+            var sessions = await this.GetSessionsAsync().ConfigureAwait(false);
+            var removable = sessions.Where(session => !session.IsRunning).ToList();
+
+            if (this._options.RetentionDays > 0)
+            {
+                var oldestAllowedStart = DateTime.UtcNow.AddDays(-this._options.RetentionDays);
+                foreach (var session in removable.Where(session => session.Metadata.StartTimestamp < oldestAllowedStart).ToList())
+                {
+                    await this.DeleteSessionAsync(session.Id).ConfigureAwait(false);
+                    removable.Remove(session);
+                }
+            }
+
+            if (this._options.MaximumTotalSizeMb <= 0)
+            {
+                return;
+            }
+
+            var maximumTotalSize = (long)this._options.MaximumTotalSizeMb * 1024 * 1024;
+            var totalSize = sessions.Sum(session => session.SizeInBytes);
+
+            // The oldest sessions are removed first - the newest traffic is the interesting one.
+            foreach (var session in removable.OrderBy(session => session.Metadata.StartTimestamp))
+            {
+                if (totalSize <= maximumTotalSize)
+                {
+                    return;
+                }
+
+                if (await this.DeleteSessionAsync(session.Id).ConfigureAwait(false))
+                {
+                    totalSize -= session.SizeInBytes;
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            this._logger.LogWarning(ex, "Error during the housekeeping of the packet archive.");
+        }
+    }
+
+    private static string GetSafeName(string name)
+    {
+        var safeName = string.Join('_', name.Split(Path.GetInvalidFileNameChars(), StringSplitOptions.RemoveEmptyEntries));
+        return string.IsNullOrWhiteSpace(safeName) ? "unknown" : safeName;
+    }
+
+    private async ValueTask OnSessionClosedAsync(string sessionId)
+    {
+        this._runningSessions.TryRemove(sessionId, out _);
+        this._logger.LogInformation("Finished the archived session {SessionId}.", sessionId);
+        await this.ApplyHousekeepingAsync().ConfigureAwait(false);
+    }
+
+    private string? TryGetSessionDirectory(string sessionId)
+    {
+        if (string.IsNullOrWhiteSpace(sessionId))
+        {
+            return null;
+        }
+
+        var archivePath = this.ArchivePath;
+        var directoryPath = Path.GetFullPath(Path.Combine(archivePath, sessionId.Replace('/', Path.DirectorySeparatorChar)));
+
+        // The identifier comes from the outside, so it must not be able to point somewhere else.
+        if (!directoryPath.StartsWith(archivePath + Path.DirectorySeparatorChar, StringComparison.Ordinal))
+        {
+            this._logger.LogWarning("The session identifier {SessionId} points outside of the archive.", sessionId);
+            return null;
+        }
+
+        return directoryPath;
+    }
+
+    private async ValueTask<ArchivedSessionInfo?> TryReadSessionAsync(string directoryPath)
+    {
+        var metadataPath = Path.Combine(directoryPath, ArchivedSessionWriter.MetadataFileName);
+        if (!File.Exists(metadataPath))
+        {
+            return null;
+        }
+
+        try
+        {
+            await using var stream = new FileStream(metadataPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+            if (await JsonSerializer.DeserializeAsync<ArchivedSessionMetadata>(stream).ConfigureAwait(false) is not { } metadata)
+            {
+                return null;
+            }
+
+            var archivePath = this.ArchivePath;
+            var sessionId = Path.GetRelativePath(archivePath, directoryPath).Replace(Path.DirectorySeparatorChar, '/');
+            var size = new DirectoryInfo(directoryPath).EnumerateFiles().Sum(file => file.Length);
+            return new ArchivedSessionInfo(sessionId, directoryPath, metadata, size, this._runningSessions.ContainsKey(sessionId));
+        }
+        catch (Exception ex)
+        {
+            this._logger.LogWarning(ex, "Could not read the archived session at {Path}.", directoryPath);
+            return null;
+        }
+    }
+
+    private void RemoveAccountDirectoryIfEmpty(string? accountDirectory)
+    {
+        if (accountDirectory is null
+            || !Directory.Exists(accountDirectory)
+            || Directory.EnumerateFileSystemEntries(accountDirectory).Any())
+        {
+            return;
+        }
+
+        Directory.Delete(accountDirectory);
+    }
+}

--- a/src/Persistence/EntityFramework/Migrations/20260829211237_AddNetworkObservation.Designer.cs
+++ b/src/Persistence/EntityFramework/Migrations/20260829211237_AddNetworkObservation.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using MUnique.OpenMU.Persistence.EntityFramework;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
 {
     [DbContext(typeof(EntityDataContext))]
-    partial class EntityDataContextModelSnapshot : ModelSnapshot
+    [Migration("20260829211237_AddNetworkObservation")]
+    partial class AddNetworkObservation
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Persistence/EntityFramework/Migrations/20260829211237_AddNetworkObservation.cs
+++ b/src/Persistence/EntityFramework/Migrations/20260829211237_AddNetworkObservation.cs
@@ -1,0 +1,96 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace MUnique.OpenMU.Persistence.EntityFramework.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNetworkObservation : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "NetworkAnalyzerLiveBufferSize",
+                schema: "config",
+                table: "SystemConfiguration",
+                type: "integer",
+                nullable: false,
+                defaultValue: 5000);
+
+            migrationBuilder.AddColumn<string>(
+                name: "NetworkObservationArchivePath",
+                schema: "config",
+                table: "SystemConfiguration",
+                type: "text",
+                nullable: true,
+                defaultValue: "captures");
+
+            migrationBuilder.AddColumn<int>(
+                name: "NetworkObservationMaxSessionSizeMb",
+                schema: "config",
+                table: "SystemConfiguration",
+                type: "integer",
+                nullable: false,
+                defaultValue: 50);
+
+            migrationBuilder.AddColumn<int>(
+                name: "NetworkObservationMaxTotalSizeMb",
+                schema: "config",
+                table: "SystemConfiguration",
+                type: "integer",
+                nullable: false,
+                defaultValue: 1000);
+
+            migrationBuilder.AddColumn<int>(
+                name: "NetworkObservationRetentionDays",
+                schema: "config",
+                table: "SystemConfiguration",
+                type: "integer",
+                nullable: false,
+                defaultValue: 30);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsNetworkObservationActive",
+                schema: "data",
+                table: "Account",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "NetworkAnalyzerLiveBufferSize",
+                schema: "config",
+                table: "SystemConfiguration");
+
+            migrationBuilder.DropColumn(
+                name: "NetworkObservationArchivePath",
+                schema: "config",
+                table: "SystemConfiguration");
+
+            migrationBuilder.DropColumn(
+                name: "NetworkObservationMaxSessionSizeMb",
+                schema: "config",
+                table: "SystemConfiguration");
+
+            migrationBuilder.DropColumn(
+                name: "NetworkObservationMaxTotalSizeMb",
+                schema: "config",
+                table: "SystemConfiguration");
+
+            migrationBuilder.DropColumn(
+                name: "NetworkObservationRetentionDays",
+                schema: "config",
+                table: "SystemConfiguration");
+
+            migrationBuilder.DropColumn(
+                name: "IsNetworkObservationActive",
+                schema: "data",
+                table: "Account");
+        }
+    }
+}

--- a/src/Startup/GameServerContainer.cs
+++ b/src/Startup/GameServerContainer.cs
@@ -12,6 +12,7 @@ using MUnique.OpenMU.GameLogic;
 using MUnique.OpenMU.GameServer;
 using MUnique.OpenMU.Interfaces;
 using MUnique.OpenMU.Network;
+using MUnique.OpenMU.Network.Analyzer.Archive;
 using MUnique.OpenMU.Network.PlugIns;
 using MUnique.OpenMU.Persistence;
 using MUnique.OpenMU.Persistence.Initialization;
@@ -36,6 +37,8 @@ public sealed class GameServerContainer : ServerContainerBase, IGameServerInstan
     private readonly IDictionary<int, IGameServer> _gameServers;
     private readonly IEventPublisher _eventPublisher;
 
+    private readonly IPacketArchive? _packetArchive;
+
     /// <summary>
     /// Initializes a new instance of the <see cref="GameServerContainer" /> class.
     /// </summary>
@@ -51,6 +54,7 @@ public sealed class GameServerContainer : ServerContainerBase, IGameServerInstan
     /// <param name="plugInManager">The plug in manager.</param>
     /// <param name="setupService">The setup service.</param>
     /// <param name="changeMediator">The change mediator.</param>
+    /// <param name="packetArchive">The archive for the traffic of observed accounts.</param>
     public GameServerContainer(
         ILoggerFactory loggerFactory,
         IList<IManageableServer> servers,
@@ -63,7 +67,8 @@ public sealed class GameServerContainer : ServerContainerBase, IGameServerInstan
         IIpAddressResolver ipResolver,
         PlugInManager plugInManager,
         SetupService setupService,
-        IConfigurationChangeMediator changeMediator)
+        IConfigurationChangeMediator changeMediator,
+        IPacketArchive? packetArchive = null)
         : base(setupService, loggerFactory.CreateLogger<GameServerContainer>())
     {
         this._loggerFactory = loggerFactory;
@@ -80,6 +85,7 @@ public sealed class GameServerContainer : ServerContainerBase, IGameServerInstan
 
         this._logger = this._loggerFactory.CreateLogger<GameServerContainer>();
         this._eventPublisher = new InMemoryEventPublisher(this._gameServers, this._friendServer, this._guildServer);
+        this._packetArchive = packetArchive;
     }
 
     /// <inheritdoc />
@@ -174,7 +180,7 @@ public sealed class GameServerContainer : ServerContainerBase, IGameServerInstan
     private void InitializeGameServer(GameServerDefinition gameServerDefinition)
     {
         using var loggerScope = this._logger.BeginScope("GameServer: {0}", gameServerDefinition.ServerID);
-        var gameServer = new GameServer(gameServerDefinition, this._guildServer, this._eventPublisher, this._loginServer, this._persistenceContextProvider, this._friendServer, this._loggerFactory, this._plugInManager, this._changeMediator);
+        var gameServer = new GameServer(gameServerDefinition, this._guildServer, this._eventPublisher, this._loginServer, this._persistenceContextProvider, this._friendServer, this._loggerFactory, this._plugInManager, this._changeMediator, this._packetArchive);
         gameServer.Context.ServerTimeZone = Program.ServerTimeZone;
         foreach (var endpoint in gameServerDefinition.Endpoints)
         {

--- a/src/Startup/Program.cs
+++ b/src/Startup/Program.cs
@@ -20,6 +20,7 @@ using MUnique.OpenMU.ConnectServer;
 using MUnique.OpenMU.DataModel.Configuration;
 using MUnique.OpenMU.FriendServer;
 using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameServer;
 using MUnique.OpenMU.GuildServer;
 using MUnique.OpenMU.Interfaces;
 using MUnique.OpenMU.LoginServer;
@@ -311,7 +312,7 @@ internal sealed class Program : IDisposable
             .AddSingleton<IFriendNotifier, FriendNotifierToGameServer>()
             .AddSingleton<PlugInManager>()
             .AddSingleton<IServerProvider, LocalServerProvider>()
-            .AddSingleton<IPacketCaptureService, PacketCaptureService>()
+            .AddSingleton<IPacketCaptureService>(CreatePacketCaptureService)
             .AddSingleton<ICollection<PlugInConfiguration>>(this.PlugInConfigurationsFactory)
             .AddTransient<ReferenceHandler, ByDataSourceReferenceHandler>(provider =>
             {
@@ -329,6 +330,7 @@ internal sealed class Program : IDisposable
             .AddHostedService<GameServerContainer>()
             .AddHostedService(provider => provider.GetService<GameServerContainer>()!)
             .AddHostedService(provider => provider.GetService<ConnectServerContainer>()!)
+            .AddNetworkObservation()
             .AddControllers().AddApplicationPart(typeof(ServerController).Assembly);
 
         var host = builder.Build();
@@ -551,6 +553,16 @@ internal sealed class Program : IDisposable
         }
 
         return contextProvider;
+    }
+
+    private static IPacketCaptureService CreatePacketCaptureService(IServiceProvider serviceProvider)
+    {
+        var serverProvider = serviceProvider.GetService<IServerProvider>()
+                             ?? throw new InvalidOperationException($"{nameof(IServerProvider)} not registered.");
+        var bufferSize = _systemConfiguration?.NetworkAnalyzerLiveBufferSize ?? 0;
+        return new PacketCaptureService(
+            serverProvider,
+            bufferSize > 0 ? bufferSize : LiveCapturedConnection.DefaultMaximumPacketCount);
     }
 
     private async Task ReadSystemConfigurationAsync(IPersistenceContextProvider persistenceContextProvider)

--- a/tests/MUnique.OpenMU.Network.Tests/PacketArchiveTest.cs
+++ b/tests/MUnique.OpenMU.Network.Tests/PacketArchiveTest.cs
@@ -1,0 +1,423 @@
+// <copyright file="PacketArchiveTest.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Network.Tests;
+
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Microsoft.Extensions.Logging.Abstractions;
+using MUnique.OpenMU.Interfaces;
+using MUnique.OpenMU.Network.Analyzer.Archive;
+using MUnique.OpenMU.Network.PlugIns;
+
+/// <summary>
+/// Tests for the <see cref="PacketArchive"/>, which keeps the traffic of the observed accounts.
+/// </summary>
+[TestFixture]
+public class PacketArchiveTest
+{
+    private static readonly byte[] LoginPacket = [0xC1, 0x06, 0xF1, 0x01, 0x01, 0x02];
+
+    private static readonly byte[] ResponsePacket = [0xC1, 0x05, 0xF1, 0x00, 0x01];
+
+    private string _archivePath = null!;
+
+    /// <summary>
+    /// Creates the archive directory of the test.
+    /// </summary>
+    [SetUp]
+    public void SetUp()
+    {
+        this._archivePath = Path.Combine(Path.GetTempPath(), "openmu-archive-test-" + Guid.NewGuid().ToString("N"));
+    }
+
+    /// <summary>
+    /// Removes the archive directory of the test.
+    /// </summary>
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(this._archivePath))
+        {
+            Directory.Delete(this._archivePath, true);
+        }
+    }
+
+    /// <summary>
+    /// Tests if the archived packets are the same as the captured ones, and that the metadata
+    /// describes the finished session.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Test]
+    public async Task ArchivedSessionContainsTheCapturedPacketsAsync()
+    {
+        var archive = this.CreateArchive();
+        var writer = await archive.StartSessionAsync(CreateMetadata()).ConfigureAwait(false);
+        Assert.That(writer, Is.Not.Null);
+
+        writer!.PacketCaptured(LoginPacket, false);
+        writer.PacketCaptured(ResponsePacket, true);
+        await writer.DisposeAsync().ConfigureAwait(false);
+
+        var sessions = await archive.GetSessionsAsync().ConfigureAwait(false);
+        Assert.That(sessions, Has.Count.EqualTo(1));
+
+        var session = await ArchivedSession.LoadAsync(sessions[0], 0).ConfigureAwait(false);
+        Assert.That(session.PacketList, Has.Count.EqualTo(2));
+        Assert.That(session.PacketList[0].PacketData, Is.EqualTo("C1 06 F1 01 01 02"));
+        Assert.That(session.PacketList[0].ToServer, Is.True, "A received packet goes to the server.");
+        Assert.That(session.PacketList[1].PacketData, Is.EqualTo("C1 05 F1 00 01"));
+        Assert.That(session.PacketList[1].ToServer, Is.False, "A sent packet goes to the client.");
+
+        Assert.That(sessions[0].Metadata.PacketCount, Is.EqualTo(2));
+        Assert.That(sessions[0].Metadata.EndTimestamp, Is.Not.Null);
+        Assert.That(sessions[0].Metadata.AccountName, Is.EqualTo("TestAccount"));
+        Assert.That(sessions[0].Metadata.ClientVersion, Is.EqualTo(new ClientVersion(6, 3, ClientLanguage.English)));
+        Assert.That(sessions[0].IsRunning, Is.False);
+    }
+
+    /// <summary>
+    /// Tests if a session can be read while it's still being written - an admin should be able
+    /// to look at the traffic of a player which is still online.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Test]
+    public async Task RunningSessionCanBeReadAsync()
+    {
+        var archive = this.CreateArchive();
+        var writer = await archive.StartSessionAsync(CreateMetadata()).ConfigureAwait(false);
+        writer!.PacketCaptured(LoginPacket, false);
+
+        var session = await this.WaitForPacketsAsync(archive, 1).ConfigureAwait(false);
+        Assert.That(session.PacketList, Has.Count.EqualTo(1));
+        Assert.That(session.Info.IsRunning, Is.True, "The session is still being written.");
+        Assert.That(session.Info.Metadata.EndTimestamp, Is.Null);
+
+        writer.PacketCaptured(ResponsePacket, true);
+        var updated = await this.WaitForPacketsAsync(archive, 2).ConfigureAwait(false);
+        Assert.That(updated.PacketList, Has.Count.EqualTo(2));
+
+        await writer.DisposeAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Tests if a session which grows over the configured size is continued in another file,
+    /// so that a single one stays small enough to be opened by the analyzer tool.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Test]
+    public async Task BigSessionIsSplitIntoSeveralFilesAsync()
+    {
+        var archive = this.CreateArchive();
+        var metadata = CreateMetadata();
+        var directoryPath = Path.Combine(this._archivePath, "TestAccount", $"{metadata.StartTimestamp:yyyy-MM-dd_HH-mm-ss}_1");
+        Directory.CreateDirectory(directoryPath);
+
+        // One packet is about 30 bytes as text, so each one of them exceeds this maximum.
+        await using (var writer = new ArchivedSessionWriter(directoryPath, metadata, 10, new NullLogger<PacketArchive>()))
+        {
+            for (int i = 0; i < 5; i++)
+            {
+                writer.PacketCaptured(LoginPacket, false);
+            }
+        }
+
+        var sessions = await archive.GetSessionsAsync().ConfigureAwait(false);
+        var session = await ArchivedSession.LoadAsync(sessions[0], 0).ConfigureAwait(false);
+        Assert.That(sessions[0].Metadata.Parts, Has.Count.EqualTo(5), "Each packet exceeds the maximum, so each one gets an own file.");
+        Assert.That(session.PacketList, Has.Count.EqualTo(5), "All packets are read, over all files.");
+    }
+
+    /// <summary>
+    /// Tests if only the newest packets are loaded when a maximum is specified.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Test]
+    public async Task OnlyTheNewestPacketsAreLoadedAsync()
+    {
+        var archive = this.CreateArchive();
+        var writer = await archive.StartSessionAsync(CreateMetadata()).ConfigureAwait(false);
+        for (byte i = 0; i < 10; i++)
+        {
+            writer!.PacketCaptured([0xC1, 0x04, 0xF1, i], false);
+        }
+
+        await writer!.DisposeAsync().ConfigureAwait(false);
+
+        var sessions = await archive.GetSessionsAsync().ConfigureAwait(false);
+        var session = await ArchivedSession.LoadAsync(sessions[0], 3).ConfigureAwait(false);
+        Assert.That(session.PacketList, Has.Count.EqualTo(3));
+        Assert.That(session.PacketList[2].PacketData, Is.EqualTo("C1 04 F1 09"), "The newest packet is the last one.");
+    }
+
+    /// <summary>
+    /// Tests if the sessions of one account can be requested, so that the page doesn't have to
+    /// read the whole archive.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Test]
+    public async Task SessionsCanBeFilteredByAccountAsync()
+    {
+        var archive = this.CreateArchive();
+        await this.CreateFinishedSessionAsync(archive, "FirstAccount").ConfigureAwait(false);
+        await this.CreateFinishedSessionAsync(archive, "SecondAccount").ConfigureAwait(false);
+
+        var sessions = await archive.GetSessionsAsync("SecondAccount").ConfigureAwait(false);
+
+        Assert.That(sessions, Has.Count.EqualTo(1));
+        Assert.That(sessions[0].Metadata.AccountName, Is.EqualTo("SecondAccount"));
+    }
+
+    /// <summary>
+    /// Tests if a session can be deleted again.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Test]
+    public async Task SessionCanBeDeletedAsync()
+    {
+        var archive = this.CreateArchive();
+        var session = await this.CreateFinishedSessionAsync(archive, "TestAccount").ConfigureAwait(false);
+
+        Assert.That(await archive.DeleteSessionAsync(session.Id).ConfigureAwait(false), Is.True);
+        Assert.That(await archive.GetSessionsAsync().ConfigureAwait(false), Is.Empty);
+        Assert.That(Directory.Exists(session.DirectoryPath), Is.False);
+    }
+
+    /// <summary>
+    /// Tests if a running session is not deleted, because its file is still written.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Test]
+    public async Task RunningSessionIsNotDeletedAsync()
+    {
+        var archive = this.CreateArchive();
+        var writer = await archive.StartSessionAsync(CreateMetadata()).ConfigureAwait(false);
+        var sessions = await archive.GetSessionsAsync().ConfigureAwait(false);
+
+        Assert.That(await archive.DeleteSessionAsync(sessions[0].Id).ConfigureAwait(false), Is.False);
+        Assert.That(await archive.GetSessionsAsync().ConfigureAwait(false), Has.Count.EqualTo(1));
+
+        await writer!.DisposeAsync().ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Tests if an identifier which points outside of the archive is refused - it comes from
+    /// the outside, over the route of a page.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Test]
+    public async Task SessionOutsideOfTheArchiveIsNotFoundAsync()
+    {
+        var archive = this.CreateArchive();
+        await this.CreateFinishedSessionAsync(archive, "TestAccount").ConfigureAwait(false);
+
+        Assert.That(await archive.GetSessionAsync("../../etc").ConfigureAwait(false), Is.Null);
+        Assert.That(await archive.DeleteSessionAsync("../..").ConfigureAwait(false), Is.False);
+    }
+
+    /// <summary>
+    /// Tests if the sessions which are older than the retention are removed.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Test]
+    public async Task OldSessionsAreRemovedAsync()
+    {
+        var archive = this.CreateArchive(options => options.RetentionDays = 30);
+        var oldId = await this.WriteSessionOnDiskAsync("OldAccount", DateTime.UtcNow.AddDays(-31)).ConfigureAwait(false);
+        var recentId = await this.WriteSessionOnDiskAsync("RecentAccount", DateTime.UtcNow.AddDays(-1)).ConfigureAwait(false);
+
+        await archive.ApplyHousekeepingAsync().ConfigureAwait(false);
+
+        var sessions = await archive.GetSessionsAsync().ConfigureAwait(false);
+        Assert.That(sessions.Select(session => session.Id), Is.EqualTo(new[] { recentId }));
+        Assert.That(Directory.Exists(Path.Combine(this._archivePath, oldId)), Is.False);
+    }
+
+    /// <summary>
+    /// Tests if the oldest sessions are removed when the archive gets too big.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Test]
+    public async Task OldestSessionsAreRemovedWhenTheArchiveIsFullAsync()
+    {
+        var archive = this.CreateArchive(options =>
+        {
+            options.RetentionDays = 0;
+            options.MaximumTotalSizeMb = 1;
+        });
+
+        // Together they are bigger than the maximum, so the older one has to go.
+        var oldestId = await this.WriteSessionOnDiskAsync("FirstAccount", DateTime.UtcNow.AddHours(-2), 600 * 1024).ConfigureAwait(false);
+        var newestId = await this.WriteSessionOnDiskAsync("SecondAccount", DateTime.UtcNow.AddHours(-1), 600 * 1024).ConfigureAwait(false);
+
+        await archive.ApplyHousekeepingAsync().ConfigureAwait(false);
+
+        var sessions = await archive.GetSessionsAsync().ConfigureAwait(false);
+        Assert.That(sessions.Select(session => session.Id), Is.EqualTo(new[] { newestId }), "The oldest session should have been removed.");
+        Assert.That(Directory.Exists(Path.Combine(this._archivePath, oldestId)), Is.False);
+    }
+
+    /// <summary>
+    /// Tests if the housekeeping is applied when a session is finished, so that the archive
+    /// doesn't grow between the logins of the observed players.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Test]
+    public async Task HousekeepingIsAppliedWhenASessionEndsAsync()
+    {
+        var archive = this.CreateArchive(options => options.RetentionDays = 30);
+        var oldId = await this.WriteSessionOnDiskAsync("OldAccount", DateTime.UtcNow.AddDays(-31)).ConfigureAwait(false);
+
+        await this.CreateFinishedSessionAsync(archive, "TestAccount").ConfigureAwait(false);
+
+        Assert.That(Directory.Exists(Path.Combine(this._archivePath, oldId)), Is.False);
+    }
+
+    /// <summary>
+    /// Tests if an account name which can't be a directory name is still archived.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Test]
+    public async Task AccountNameIsSanitizedAsync()
+    {
+        var archive = this.CreateArchive();
+        var metadata = CreateMetadata();
+        metadata.AccountName = "../etc/pass:wd";
+
+        var writer = await archive.StartSessionAsync(metadata).ConfigureAwait(false);
+        await writer!.DisposeAsync().ConfigureAwait(false);
+
+        var sessions = await archive.GetSessionsAsync().ConfigureAwait(false);
+        Assert.That(sessions, Has.Count.EqualTo(1));
+        Assert.That(sessions[0].DirectoryPath, Does.StartWith(this._archivePath));
+        Assert.That(sessions[0].Metadata.AccountName, Is.EqualTo("../etc/pass:wd"), "The real name is kept in the metadata.");
+    }
+
+    /// <summary>
+    /// Tests if a file which contains an incomplete line - which happens when the process died
+    /// while writing - is still readable.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Test]
+    public async Task IncompleteLineIsSkippedAsync()
+    {
+        var archive = this.CreateArchive();
+        var session = await this.CreateFinishedSessionAsync(archive, "TestAccount").ConfigureAwait(false);
+        var partPath = Path.Combine(session.DirectoryPath, session.Metadata.Parts[0]);
+        await File.AppendAllTextAsync(partPath, "1234567;True;6;C1 06 F1 01 01").ConfigureAwait(false);
+
+        var loaded = await ArchivedSession.LoadAsync(session, 0).ConfigureAwait(false);
+
+        Assert.That(loaded.PacketList, Has.Count.EqualTo(1), "Only the complete packet should be loaded.");
+    }
+
+    /// <summary>
+    /// Tests if the metadata is written in a format which can be read again, so that the
+    /// sessions of a previous run of the server are still described.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Test]
+    public async Task MetadataIsReadableAsJsonAsync()
+    {
+        var archive = this.CreateArchive();
+        var session = await this.CreateFinishedSessionAsync(archive, "TestAccount").ConfigureAwait(false);
+
+        var json = await File.ReadAllTextAsync(Path.Combine(session.DirectoryPath, ArchivedSessionWriter.MetadataFileName)).ConfigureAwait(false);
+        var metadata = JsonSerializer.Deserialize<ArchivedSessionMetadata>(json);
+
+        Assert.That(metadata, Is.Not.Null);
+        Assert.That(metadata!.AccountName, Is.EqualTo("TestAccount"));
+        Assert.That(metadata.ServerType, Is.EqualTo(ServerType.GameServer));
+        Assert.That(metadata.Parts, Has.Count.EqualTo(1));
+    }
+
+    private static ArchivedSessionMetadata CreateMetadata(string accountName = "TestAccount", DateTime? startTimestamp = null)
+    {
+        return new ArchivedSessionMetadata
+        {
+            AccountName = accountName,
+            ServerType = ServerType.GameServer,
+            ServerId = 1,
+            ServerDescription = "Test Server",
+            RemoteEndPoint = "127.0.0.1:1234",
+            ClientVersion = new ClientVersion(6, 3, ClientLanguage.English),
+            StartTimestamp = startTimestamp ?? DateTime.UtcNow,
+        };
+    }
+
+    private PacketArchive CreateArchive(Action<NetworkObservationOptions>? configure = null)
+    {
+        var options = new NetworkObservationOptions { ArchivePath = this._archivePath };
+        configure?.Invoke(options);
+        return new PacketArchive(options, new NullLogger<PacketArchive>());
+    }
+
+    private async ValueTask<ArchivedSessionInfo> CreateFinishedSessionAsync(
+        PacketArchive archive,
+        string accountName,
+        DateTime? startTimestamp = null,
+        int packetCount = 1)
+    {
+        var metadata = CreateMetadata(accountName, startTimestamp);
+        var writer = await archive.StartSessionAsync(metadata).ConfigureAwait(false);
+        for (int i = 0; i < packetCount; i++)
+        {
+            writer!.PacketCaptured(LoginPacket, false);
+        }
+
+        await writer!.DisposeAsync().ConfigureAwait(false);
+
+        var sessions = await archive.GetSessionsAsync(accountName).ConfigureAwait(false);
+        return sessions.First(session => session.Metadata.StartTimestamp == metadata.StartTimestamp);
+    }
+
+    private async ValueTask<string> WriteSessionOnDiskAsync(string accountName, DateTime startTimestamp, int approximateSize = 0)
+    {
+        var sessionDirectory = $"{startTimestamp:yyyy-MM-dd_HH-mm-ss}_1";
+        var sessionId = $"{accountName}/{sessionDirectory}";
+        var directoryPath = Path.Combine(this._archivePath, accountName, sessionDirectory);
+        Directory.CreateDirectory(directoryPath);
+
+        var line = $"{TimeSpan.FromSeconds(1).Ticks};True;6;C1 06 F1 01 01 02;1";
+        var content = new StringBuilder(startTimestamp.ToString("O")).AppendLine();
+        do
+        {
+            content.AppendLine(line);
+        }
+        while (content.Length < approximateSize);
+
+        await File.WriteAllTextAsync(Path.Combine(directoryPath, "part-000.mucap"), content.ToString()).ConfigureAwait(false);
+
+        var metadata = CreateMetadata(accountName, startTimestamp);
+        metadata.EndTimestamp = startTimestamp.AddMinutes(1);
+        metadata.Parts.Add("part-000.mucap");
+        await File.WriteAllTextAsync(
+            Path.Combine(directoryPath, ArchivedSessionWriter.MetadataFileName),
+            JsonSerializer.Serialize(metadata)).ConfigureAwait(false);
+        return sessionId;
+    }
+
+    private async ValueTask<ArchivedSession> WaitForPacketsAsync(PacketArchive archive, int packetCount)
+    {
+        // The packets are written by another task, so the file needs a moment to catch up.
+        var watch = Stopwatch.StartNew();
+        ArchivedSession? session = null;
+        while (watch.Elapsed < TimeSpan.FromSeconds(10))
+        {
+            var sessions = await archive.GetSessionsAsync().ConfigureAwait(false);
+            session = await ArchivedSession.LoadAsync(sessions[0], 0).ConfigureAwait(false);
+            if (session.PacketList.Count >= packetCount)
+            {
+                return session;
+            }
+
+            await Task.Delay(50).ConfigureAwait(false);
+        }
+
+        return session!;
+    }
+}

--- a/tests/MUnique.OpenMU.Tests/NetworkObservationTests.cs
+++ b/tests/MUnique.OpenMU.Tests/NetworkObservationTests.cs
@@ -1,0 +1,281 @@
+// <copyright file="NetworkObservationTests.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Tests;
+
+using System.Buffers;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Pipelines;
+using System.Net;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using MUnique.OpenMU.DataModel.Configuration;
+using MUnique.OpenMU.DataModel.Entities;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameServer;
+using MUnique.OpenMU.GameServer.RemoteView;
+using MUnique.OpenMU.Network;
+using MUnique.OpenMU.Network.Analyzer;
+using MUnique.OpenMU.Network.Analyzer.Archive;
+using MUnique.OpenMU.Persistence;
+using MUnique.OpenMU.PlugIns;
+using Nito.AsyncEx;
+
+/// <summary>
+/// Tests for the archiving of the traffic of observed accounts.
+/// </summary>
+[TestFixture]
+public class NetworkObservationTests
+{
+    private static readonly byte[] TestPacket = [0xC1, 0x06, 0xF1, 0x01, 0x01, 0x02];
+
+    private string _archivePath = null!;
+
+    /// <summary>
+    /// Creates the archive directory of the test.
+    /// </summary>
+    [SetUp]
+    public void SetUp()
+    {
+        this._archivePath = Path.Combine(Path.GetTempPath(), "openmu-observation-test-" + Guid.NewGuid().ToString("N"));
+    }
+
+    /// <summary>
+    /// Removes the archive directory of the test.
+    /// </summary>
+    [TearDown]
+    public void TearDown()
+    {
+        if (Directory.Exists(this._archivePath))
+        {
+            Directory.Delete(this._archivePath, true);
+        }
+    }
+
+    /// <summary>
+    /// Tests if the traffic of a player is archived when the observation of its account is
+    /// active.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Test]
+    public async Task TrafficOfAnObservedAccountIsArchivedAsync()
+    {
+        var archive = this.CreateArchive();
+        var handler = CreateHandler(archive);
+        var (player, connection) = CreateRemotePlayer();
+        handler.Watch(player);
+
+        await player.SetAccountAsync(CreateAccount(isObserved: true)).ConfigureAwait(false);
+
+        Assert.That(connection.Sinks, Has.Count.EqualTo(1), "The archive should be a sink of the connection.");
+        var sessions = await archive.GetSessionsAsync().ConfigureAwait(false);
+        Assert.That(sessions, Has.Count.EqualTo(1));
+        Assert.That(sessions[0].Metadata.AccountName, Is.EqualTo("ObservedAccount"));
+        Assert.That(sessions[0].IsRunning, Is.True);
+
+        connection.Sinks[0].PacketCaptured(TestPacket, false);
+        var session = await this.WaitForPacketsAsync(archive, 1).ConfigureAwait(false);
+        Assert.That(session.PacketList[0].PacketData, Is.EqualTo("C1 06 F1 01 01 02"));
+    }
+
+    /// <summary>
+    /// Tests if the traffic of a player is not archived when the observation of its account
+    /// is not active - which is the case for every account by default.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Test]
+    public async Task TrafficOfAnUnobservedAccountIsNotArchivedAsync()
+    {
+        var archive = this.CreateArchive();
+        var handler = CreateHandler(archive);
+        var (player, connection) = CreateRemotePlayer();
+        handler.Watch(player);
+
+        await player.SetAccountAsync(CreateAccount(isObserved: false)).ConfigureAwait(false);
+
+        Assert.That(connection.Sinks, Is.Empty, "Nothing should be captured.");
+        Assert.That(await archive.GetSessionsAsync().ConfigureAwait(false), Is.Empty);
+    }
+
+    /// <summary>
+    /// Tests if the archived session is finished when the player disconnects.
+    /// </summary>
+    /// <returns>The async task.</returns>
+    [Test]
+    public async Task SessionIsFinishedWhenThePlayerDisconnectsAsync()
+    {
+        var archive = this.CreateArchive();
+        var handler = CreateHandler(archive);
+        var (player, connection) = CreateRemotePlayer();
+        handler.Watch(player);
+
+        // That's the state a player is in while it's at the login screen of the client.
+        await player.PlayerState.TryAdvanceToAsync(PlayerState.LoginScreen).ConfigureAwait(false);
+        await player.SetAccountAsync(CreateAccount(isObserved: true)).ConfigureAwait(false);
+
+        await player.DisconnectAsync().ConfigureAwait(false);
+
+        Assert.That(connection.Sinks, Is.Empty, "The archive should not be a sink anymore.");
+        var sessions = await archive.GetSessionsAsync().ConfigureAwait(false);
+        Assert.That(sessions, Has.Count.EqualTo(1));
+        Assert.That(sessions[0].IsRunning, Is.False);
+        Assert.That(sessions[0].Metadata.EndTimestamp, Is.Not.Null);
+    }
+
+    /// <summary>
+    /// Tests if the options of the observation are taken from the system configuration.
+    /// </summary>
+    [Test]
+    public void OptionsAreTakenFromTheSystemConfiguration()
+    {
+        var configuration = new SystemConfiguration
+        {
+            NetworkObservationArchivePath = "/tmp/openmu-captures",
+            NetworkObservationMaxSessionSizeMb = 5,
+            NetworkObservationMaxTotalSizeMb = 100,
+            NetworkObservationRetentionDays = 7,
+        };
+
+        var options = NetworkObservationExtensions.CreateOptions(configuration);
+
+        Assert.That(options.ArchivePath, Is.EqualTo("/tmp/openmu-captures"));
+        Assert.That(options.MaximumSessionSizeMb, Is.EqualTo(5));
+        Assert.That(options.MaximumTotalSizeMb, Is.EqualTo(100));
+        Assert.That(options.RetentionDays, Is.EqualTo(7));
+    }
+
+    /// <summary>
+    /// Tests if the defaults are used for the values which are not configured - an existing
+    /// database has no values for them until they are saved once.
+    /// </summary>
+    [Test]
+    public void UnconfiguredOptionsFallBackToTheDefaults()
+    {
+        var configuration = new SystemConfiguration
+        {
+            NetworkObservationArchivePath = null,
+            NetworkObservationMaxSessionSizeMb = 0,
+            NetworkObservationMaxTotalSizeMb = 0,
+            NetworkObservationRetentionDays = 0,
+        };
+
+        var options = NetworkObservationExtensions.CreateOptions(configuration);
+
+        Assert.That(options.ArchivePath, Is.EqualTo(NetworkObservationOptions.DefaultArchivePath));
+        Assert.That(options.MaximumSessionSizeMb, Is.EqualTo(NetworkObservationOptions.DefaultMaximumSessionSizeMb));
+        Assert.That(options.MaximumTotalSizeMb, Is.EqualTo(NetworkObservationOptions.DefaultMaximumTotalSizeMb));
+        Assert.That(options.RetentionDays, Is.EqualTo(NetworkObservationOptions.DefaultRetentionDays));
+    }
+
+    private static NetworkObservationHandler CreateHandler(IPacketArchive archive)
+    {
+        return new NetworkObservationHandler(archive, 1, "Test Server", new NullLogger<NetworkObservationHandler>());
+    }
+
+    private static Account CreateAccount(bool isObserved)
+    {
+        return new Account
+        {
+            LoginName = isObserved ? "ObservedAccount" : "NormalAccount",
+            IsNetworkObservationActive = isObserved,
+        };
+    }
+
+    private static (RemotePlayer Player, TestConnection Connection) CreateRemotePlayer()
+    {
+        var connection = new TestConnection();
+        var manager = new PlugInManager(null, new NullLoggerFactory(), null, null);
+        var gameContext = new Mock<IGameServerContext>();
+        gameContext.Setup(c => c.PersistenceContextProvider).Returns(new Mock<IPersistenceContextProvider>().Object);
+        gameContext.Setup(c => c.Configuration).Returns(new GameConfiguration());
+        gameContext.Setup(c => c.PlugInManager).Returns(manager);
+        gameContext.Setup(c => c.LoggerFactory).Returns(new NullLoggerFactory());
+        return (new RemotePlayer(gameContext.Object, connection, default), connection);
+    }
+
+    private PacketArchive CreateArchive()
+    {
+        var options = new NetworkObservationOptions { ArchivePath = this._archivePath };
+        return new PacketArchive(options, new NullLogger<PacketArchive>());
+    }
+
+    private async ValueTask<ArchivedSession> WaitForPacketsAsync(PacketArchive archive, int packetCount)
+    {
+        // The packets are written by another task, so the file needs a moment to catch up.
+        var watch = Stopwatch.StartNew();
+        ArchivedSession? session = null;
+        while (watch.Elapsed < TimeSpan.FromSeconds(10))
+        {
+            var sessions = await archive.GetSessionsAsync().ConfigureAwait(false);
+            session = await ArchivedSession.LoadAsync(sessions[0], 0).ConfigureAwait(false);
+            if (session.PacketList.Count >= packetCount)
+            {
+                return session;
+            }
+
+            await Task.Delay(50).ConfigureAwait(false);
+        }
+
+        return session!;
+    }
+
+    /// <summary>
+    /// A connection which just keeps the registered capture sinks.
+    /// </summary>
+    private sealed class TestConnection : IConnection
+    {
+        private readonly MemoryStream _output = new();
+
+        public TestConnection()
+        {
+            this.Output = PipeWriter.Create(this._output, new StreamPipeWriterOptions(leaveOpen: true));
+        }
+
+        /// <summary>
+        /// Occurs when a packet got received. It's never raised by this test double.
+        /// </summary>
+        public event AsyncEventHandler<ReadOnlySequence<byte>>? PacketReceived
+        {
+            add { /* not raised */ }
+            remove { /* not raised */ }
+        }
+
+        /// <summary>
+        /// Occurs when the client disconnected. It's never raised by this test double.
+        /// </summary>
+        public event AsyncEventHandler? Disconnected
+        {
+            add { /* not raised */ }
+            remove { /* not raised */ }
+        }
+
+        public IList<IPacketCaptureSink> Sinks { get; } = new List<IPacketCaptureSink>();
+
+        public Guid Id { get; } = Guid.NewGuid();
+
+        public bool Connected => true;
+
+        public EndPoint? EndPoint => null;
+
+        public EndPoint? LocalEndPoint => null;
+
+        public PipeWriter Output { get; }
+
+        public AsyncLock OutputLock { get; } = new();
+
+        public void AddCaptureSink(IPacketCaptureSink sink) => this.Sinks.Add(sink);
+
+        public void RemoveCaptureSink(IPacketCaptureSink sink) => this.Sinks.Remove(sink);
+
+        public Task BeginReceiveAsync() => Task.CompletedTask;
+
+        public ValueTask DisconnectAsync() => ValueTask.CompletedTask;
+
+        public void Dispose()
+        {
+            this._output.Dispose();
+        }
+    }
+}


### PR DESCRIPTION
Phase 5 of #895 — the observation flag, the session archive and its settings. It doesn't touch anything of phase 4 (#916), so the two are independent.

An account can be marked with the new `Account.IsNetworkObservationActive`. While it's set, the game server archives the traffic of every session of that account on the file system. The flag renders in the account editor through `AutoForm`, so there is no new page for it.

## Where it runs

The archive belongs to the **game server**, not to the admin panel (decision 9 of the issue): it's registered in the all-in-one host *and* in `Dapr/GameServer.Host`, so an observed account is archived even when no admin panel is running anywhere. `GameServer` takes an optional `IPacketArchive`; without one, nothing changes at all.

## What a session looks like

```
captures/
  SuspiciousAccount/
    2026-08-29_21-12-37_1/
      session.json
      part-000.mucap
      part-001.mucap
```

A session is a **directory** rather than a single file — the plan sketched `<account>/<date>_<server>.mucap` plus a sidecar, but with rotation a session has more than one file, and a directory keeps "open it", "copy it", "delete it" and "measure it" simple. Each part is a `.mucap` in the format of the WinForms tool, complete with its own start-timestamp header, so a part can be opened there directly.

`session.json` carries what the capture format has no place for: account, character names (added when the player enters the world), server type/id/description, remote endpoint, client version, start/end time, packet count, dropped packet count and the list of parts.

Each packet line gets the **sequence number as a fifth field**. The existing loader reads fields 0..3 and ignores the rest, so the files stay backwards compatible. It's what makes a gap visible: when the file system can't keep up, the writer drops packets instead of slowing the player's connection down (the count ends up in the metadata).

## Writing

The packets go through a bounded channel into an own task, which appends lines and flushes as soon as the queue ran empty. So the network thread never waits for the file system, a session is readable **while it runs**, and a crashed process leaves everything up to the last flush. Reader and writer share the files (`FileShare.ReadWrite | FileShare.Delete`), and a half-written last line is skipped rather than throwing.

**The archive starts at login**, not at connect: the version check and the login request are not part of it. Capturing them would mean capturing every connection unconditionally — exactly what this feature avoids (also stated in the issue).

`Player` got a `PlayerLoggedIn` event, raised by a new `SetAccountAsync`. The state machine reaches `Authenticated` *before* `LoginAction` assigns `player.Account`, so the state change is not the right moment to decide whether a session has to be archived — the account isn't there yet.

## Housekeeping

Rotation (per file), quota (whole archive, oldest first) and retention (age) keep it bounded. It runs when a session starts and when one ends; a session which is currently being written is never removed.

## Settings

`SystemConfiguration` gained five properties, editable in the admin panel like the existing ones:

| Property | Default |
|---|---|
| `NetworkAnalyzerLiveBufferSize` | 5000 |
| `NetworkObservationArchivePath` | `captures` |
| `NetworkObservationMaxSessionSizeMb` | 50 |
| `NetworkObservationMaxTotalSizeMb` | 1000 |
| `NetworkObservationRetentionDays` | 30 |

The live buffer size is now used by the capture service of phase 2 instead of its hard-coded default.

One migration covers the five properties and the account flag. It was generated with `dotnet ef migrations add`; the only hand edit is the `defaultValue` of each new column, so that an **existing** database gets the documented defaults instead of `0` (which would mean "no quota, no retention"). A value of `0` is still read as "unlimited"/"default" at runtime, so a database which was updated by other means behaves sensibly too.

## Deviations worth knowing

* **No client version change points** in the metadata. The plan wanted them because a capture may start before the version is known — but this archive starts at login, where the version is already final, so there is exactly one.
* The observation toggle **in the analyzer page** and the archive browser are phase 6, as the issue splits them.

## Data protection

Starting a session, finishing it and deleting one are logged at information level, so observing a player leaves a trace. The default archive path (`captures`, next to the binaries) is outside anything served statically, and `captures/` was added to `.gitignore`.

## Tests

* `PacketArchiveTest` (14): round trip of the captured packets and their direction, reading a session **while it's being written**, rotation into several files, the newest-packets cap, filtering by account, delete, "a running session is not deleted", an id which points outside the archive, retention, quota, a sanitized account name, an incomplete last line, and the metadata being readable as json.
* `NetworkObservationTests` (5): the traffic of an observed account is archived and the archive is a sink of the connection; an unobserved account is not touched; the session is finished when the player disconnects; and the mapping of the system configuration to the options, including the fallbacks. The disconnect test found a real bug on the way: the sink was read back from `RemotePlayer.Connection`, which is already gone during the teardown, so the session kept its sink. The connection is part of the session state now.
* `dotnet build src/MUnique.OpenMU.sln -p:ci=true` → 0 errors, no warning from a file this PR touches.
* Complete test suite green: `MUnique.OpenMU.Tests` 807, `Network.Tests` 73 (4 skipped), `Network.Packets.Tests` 588, `Web.Tests` 63, `ChatServer.Tests` 26, `PlugIns.Tests` 41, `Persistence.Initialization.Tests` 12 (2 skipped), `AttributeSystem.Tests` 44, `Pathfinding.Tests` 9.

Not verified against a real PostgreSQL database or a running server — that's yours, as agreed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pb82LmoaUVdZtBtQs7xrtA

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pb82LmoaUVdZtBtQs7xrtA)_