### PR TITLE
Fix ConstValueAttribute constructor compatibility

### DIFF
--- a/src/Persistence/BasicModel/ConstValueAttribute.custom.cs
+++ b/src/Persistence/BasicModel/ConstValueAttribute.custom.cs
@@ -5,12 +5,24 @@
 namespace MUnique.OpenMU.Persistence.BasicModel;
 
 using System.Text.Json.Serialization;
+using MUnique.OpenMU.AttributeSystem;
 
 /// <summary>
 /// A plain implementation of <see cref="MUnique.OpenMU.AttributeSystem.ConstValueAttribute"/>.
 /// </summary>
 public partial class ConstValueAttribute
 {
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConstValueAttribute"/> class
+    /// using the default <see cref="AggregateType.AddRaw"/> aggregation mode.
+    /// </summary>
+    /// <param name="value">The value.</param>
+    /// <param name="definition">The attribute definition.</param>
+    public ConstValueAttribute(float value, AttributeDefinition definition)
+        : base(value, definition)
+    {
+    }
+
     /// <summary>
     /// Initializes a new instance of the <see cref="ConstValueAttribute"/> class.
     /// </summary>

--- a/src/Persistence/EntityFramework/Model/ExtendedTypes.Custom.cs
+++ b/src/Persistence/EntityFramework/Model/ExtendedTypes.Custom.cs
@@ -54,6 +54,17 @@ internal partial class PowerUpDefinitionValue
 internal partial class ConstValueAttribute
 {
     /// <summary>
+    /// Initializes a new instance of the <see cref="ConstValueAttribute"/> class
+    /// using the default <see cref="AggregateType.AddRaw"/> aggregation mode.
+    /// </summary>
+    /// <param name="value">The value.</param>
+    /// <param name="definition">The attribute definition.</param>
+    public ConstValueAttribute(float value, AttributeDefinition definition)
+        : base(value, definition)
+    {
+    }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="ConstValueAttribute"/> class.
     /// </summary>
     public ConstValueAttribute()


### PR DESCRIPTION
## Description

  Fixes an update initialization failure when creating persistent
  `ConstValueAttribute` instances with the two-argument constructor.

  The EF Core and BasicModel implementations now provide the missing
  two-argument overload while preserving the default `AggregateType.AddRaw`
  behavior.

  ## Root Cause

  `TypeHelper.CreateNew` uses reflection to instantiate persistent model types.
  The persistent `ConstValueAttribute` implementations only exposed the
  three-argument constructor, while several initialization updates used the
  two-argument form.

  This caused:

  `Constructor on type '...ConstValueAttribute' not found.`

  ## Verification

  - Docker image build completed successfully
  - 0 build errors
  - Local Docker services started successfully
  - Admin panel returned HTTP 200