### PR TITLE
Fix spelling in ClientErrorLogDecryptor README

### DIFF
--- a/src/ClientErrorLogDecryptor/Readme.md
+++ b/src/ClientErrorLogDecryptor/Readme.md
@@ -3,7 +3,7 @@
 This tool can be used to decrypt the MuError.log files which are created by the
 game client on every start.
 
-It might help to find/analyse errors which occured on the client side.
+It might help to find/analyse errors which occurred on the client side.
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Correct `occured` to `occurred` in the ClientErrorLogDecryptor README.

This is a documentation-only spelling fix with no behavior change.

## Verification

- `codespell src/ClientErrorLogDecryptor/Readme.md`
- `git diff --check`

## AI assistance

AI assistance was used to locate the typo and prepare this documentation-only change. The final diff was manually reviewed and verified with `codespell` before submission.
