### PR TITLE
Fix duplicate key errors when a character enters the world

### DIFF
--- a/src/GameLogic/Attributes/ItemAwareAttributeSystem.cs
+++ b/src/GameLogic/Attributes/ItemAwareAttributeSystem.cs
@@ -20,7 +20,7 @@ public sealed class ItemAwareAttributeSystem : AttributeSystem, IDisposable
     /// <param name="gameConfiguration">The game configuration with global attributes.</param>
     public ItemAwareAttributeSystem(Account account, Character character, GameConfiguration gameConfiguration)
         : base(
-            character.Attributes.Concat(account.Attributes),
+            GetStatAttributes(account, character),
             character.CharacterClass!.BaseAttributeValues.Concat(gameConfiguration.GlobalBaseAttributeValues),
             character.CharacterClass.AttributeCombinations.Concat(gameConfiguration.GlobalAttributeCombinations))
     {
@@ -112,6 +112,23 @@ public sealed class ItemAwareAttributeSystem : AttributeSystem, IDisposable
     {
         attribute.ValueChanged -= this.OnAttributeValueChanged;
         base.OnAttributeRemoved(attribute);
+    }
+
+    /// <summary>
+    /// Gets the stat attributes of the character and its account, without duplicates.
+    /// The attribute system holds exactly one attribute per <see cref="AttributeDefinition"/>, so a
+    /// duplicated definition would fail the construction of the whole system - and with it the login
+    /// of the character. Duplicates can exist in the stored data, e.g. when a data update added a stat
+    /// attribute to a character class which already had it, and every character of that class then got
+    /// the attribute twice. The character's own attribute wins over the one of its account.
+    /// </summary>
+    /// <param name="account">The account.</param>
+    /// <param name="character">The character.</param>
+    /// <returns>The distinct stat attributes of the character and its account.</returns>
+    private static IEnumerable<IAttribute> GetStatAttributes(Account account, Character character)
+    {
+        return character.Attributes.Concat(account.Attributes)
+            .DistinctBy(attribute => attribute.Definition);
     }
 
     /// <summary>

--- a/src/GameLogic/Bots/BotGenerator.cs
+++ b/src/GameLogic/Bots/BotGenerator.cs
@@ -392,7 +392,11 @@ internal sealed class BotGenerator
         character.CreateDate = DateTime.UtcNow;
         character.KeyConfiguration = CreateDefaultKeyConfiguration();
 
-        foreach (var attribute in characterClass.StatAttributes.Select(a => context.CreateNew<StatAttribute>(a.Attribute, a.BaseValue)))
+        // Distinct, because a character class may define the same stat attribute more than once (data
+        // which got duplicated by an update); a character must never hold an attribute twice.
+        foreach (var attribute in characterClass.StatAttributes
+                     .DistinctBy(a => a.Attribute)
+                     .Select(a => context.CreateNew<StatAttribute>(a.Attribute, a.BaseValue)))
         {
             character.Attributes.Add(attribute);
         }

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -1651,10 +1651,44 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
             throw new InvalidOperationException($"The character {this.SelectedCharacter} has no assigned character class.");
         }
 
-        var missingStats = characterClass.StatAttributes.Where(a => this.SelectedCharacter.Attributes.All(c => c.Definition != a.Attribute));
+        this.RemoveDuplicateStatAttributes(character);
+
+        // The character class itself may define a stat attribute more than once (a data update which
+        // added an attribute the class already had), so the missing ones are taken distinctly - otherwise
+        // we would create the duplicates we just removed all over again.
+        var missingStats = characterClass.StatAttributes
+            .DistinctBy(a => a.Attribute)
+            .Where(a => character.Attributes.All(c => c.Definition != a.Attribute));
 
         var attributes = missingStats.Select(a => this.PersistenceContext.CreateNew<StatAttribute>(a.Attribute, a.BaseValue)).ToList();
         attributes.ForEach(character.Attributes.Add);
+    }
+
+    /// <summary>
+    /// Removes stat attributes which are assigned to the character more than once, keeping the one with
+    /// the highest value. An attribute system holds exactly one attribute per definition, so a duplicate
+    /// would make the character unable to enter the game at all.
+    /// </summary>
+    /// <param name="character">The character.</param>
+    private void RemoveDuplicateStatAttributes(Character character)
+    {
+        var duplicateGroups = character.Attributes
+            .GroupBy(a => a.Definition)
+            .Where(group => group.Count() > 1)
+            .ToList();
+
+        foreach (var duplicates in duplicateGroups)
+        {
+            // The highest value is kept, so a character never loses points that were invested into a stat.
+            var obsolete = duplicates.OrderByDescending(a => a.Value).Skip(1).ToList();
+            obsolete.ForEach(attribute => character.Attributes.Remove(attribute));
+
+            this.Logger.LogWarning(
+                "Removed {Count} duplicate stat attribute(s) '{Attribute}' of character '{Character}'.",
+                obsolete.Count,
+                duplicates.Key,
+                character.Name);
+        }
     }
 
     private async ValueTask OnPlayerEnteredWorldAsync()

--- a/src/GameLogic/PlayerActions/Character/CreateCharacterAction.cs
+++ b/src/GameLogic/PlayerActions/Character/CreateCharacterAction.cs
@@ -103,7 +103,13 @@ public class CreateCharacterAction
         character.CharacterSlot = freeSlot.Value;
         character.CreateDate = DateTime.UtcNow;
         character.KeyConfiguration = CreateDefaultKeyConfiguration();
-        var attributes = character.CharacterClass.StatAttributes.Select(a => player.PersistenceContext.CreateNew<StatAttribute>(a.Attribute, a.BaseValue)).ToList();
+
+        // Distinct, because a character class may define the same stat attribute more than once (data
+        // which got duplicated by an update); a character must never hold an attribute twice.
+        var attributes = character.CharacterClass.StatAttributes
+            .DistinctBy(a => a.Attribute)
+            .Select(a => player.PersistenceContext.CreateNew<StatAttribute>(a.Attribute, a.BaseValue))
+            .ToList();
         attributes.ForEach(character.Attributes.Add);
         character.CurrentMap = characterClass.HomeMap;
         var randomSpawnGate = character.CurrentMap!.ExitGates.Where(g => g.IsSpawnGate).SelectRandom();

--- a/src/GameLogic/SkillList.cs
+++ b/src/GameLogic/SkillList.cs
@@ -5,6 +5,7 @@
 namespace MUnique.OpenMU.GameLogic;
 
 using System.ComponentModel;
+using Microsoft.Extensions.Logging;
 using MUnique.OpenMU.AttributeSystem;
 using MUnique.OpenMU.GameLogic.Attributes;
 using MUnique.OpenMU.GameLogic.Views.Character;
@@ -61,7 +62,7 @@ public sealed class SkillList : ISkillList, IDisposable
         this._learnedSkills = this._player.SelectedCharacter.LearnedSkills ?? new List<SkillEntry>();
         this._learnedSkills.Where(entry => entry.Skill is null).ForEach(entry => throw Error.NotInitializedProperty(entry, nameof(entry.Skill)));
 
-        this._availableSkills = this._learnedSkills.ToDictionary(skillEntry => skillEntry.Skill!.Number.ToUnsigned());
+        this._availableSkills = this.CreateAvailableSkills();
         this._itemSkills = new List<SkillEntry>();
         this._player.Inventory.EquippedItems
             .Where(item => item.HasSkill)
@@ -114,17 +115,23 @@ public sealed class SkillList : ISkillList, IDisposable
     /// <inheritdoc/>
     public async ValueTask<bool> RemoveItemSkillAsync(ushort skillId)
     {
-        this._availableSkills.TryGetValue(skillId, out var skillEntry);
+        // The entry is looked up in the item skills, not in the available skills: when the same skill
+        // is also learned by the character, the available skills hold the learned entry - removing that
+        // one would take a learned skill away just because an item was taken off.
+        var skillEntry = this._itemSkills.FirstOrDefault(s => s.Skill!.Number.ToUnsigned() == skillId);
         if (skillEntry is null)
         {
             return false;
         }
 
-        // We need to take into account that we there might be multiple items equipped with the same skill
-        var skillRemoved = this._itemSkills.Remove(skillEntry);
-        if (skillRemoved && this._itemSkills.All(s => s.Skill!.Number != skillId))
+        this._itemSkills.Remove(skillEntry);
+
+        // We need to take into account that there might be multiple items equipped with the same skill
+        if (this._itemSkills.All(s => s.Skill!.Number.ToUnsigned() != skillId)
+            && this._availableSkills.TryGetValue(skillId, out var availableSkill)
+            && !this._learnedSkills.Contains(availableSkill))
         {
-            await this._player.InvokeViewPlugInAsync<ISkillListViewPlugIn>(p => p.RemoveSkillAsync(skillEntry.Skill!)).ConfigureAwait(false);
+            await this._player.InvokeViewPlugInAsync<ISkillListViewPlugIn>(p => p.RemoveSkillAsync(availableSkill.Skill!)).ConfigureAwait(false);
             this._availableSkills.Remove(skillId);
         }
 
@@ -135,6 +142,41 @@ public sealed class SkillList : ISkillList, IDisposable
     public bool ContainsSkill(ushort skillId)
     {
         return this._availableSkills.ContainsKey(skillId);
+    }
+
+    /// <summary>
+    /// Creates the dictionary of the available skills from the learned skills of the character.
+    /// A character may have the same skill in its stored skill list more than once - it's data which
+    /// shouldn't exist, but it must never keep the character from entering the game. Such duplicates
+    /// are removed from the character, keeping the entry with the highest level.
+    /// </summary>
+    /// <returns>The dictionary of the available skills.</returns>
+    private Dictionary<ushort, SkillEntry> CreateAvailableSkills()
+    {
+        var availableSkills = new Dictionary<ushort, SkillEntry>();
+        foreach (var skillEntry in this._learnedSkills.ToList())
+        {
+            var skillId = skillEntry.Skill!.Number.ToUnsigned();
+            if (availableSkills.TryAdd(skillId, skillEntry))
+            {
+                continue;
+            }
+
+            var previousEntry = availableSkills[skillId];
+            var (keptEntry, obsoleteEntry) = skillEntry.Level > previousEntry.Level
+                ? (skillEntry, previousEntry)
+                : (previousEntry, skillEntry);
+            availableSkills[skillId] = keptEntry;
+            this._learnedSkills.Remove(obsoleteEntry);
+
+            this._player.Logger.LogWarning(
+                "Removed a duplicate learned skill '{Skill}' (number {Number}) of character '{Character}'.",
+                skillEntry.Skill.Name,
+                skillEntry.Skill.Number,
+                this._player.SelectedCharacter?.Name);
+        }
+
+        return availableSkills;
     }
 
     private async ValueTask AddItemSkillAsync(Skill skill)
@@ -167,7 +209,10 @@ public sealed class SkillList : ISkillList, IDisposable
 
     private async ValueTask AddLearnedSkillAsync(SkillEntry skill)
     {
-        this._availableSkills.Add(skill.Skill!.Number.ToUnsigned(), skill);
+        // A learned skill replaces the entry of an equipped item which grants the same skill: an item
+        // skill is always level 0, while the learned one keeps its own level. The item skill entry stays
+        // in the item skill list, so unequipping the item doesn't take the learned skill away.
+        this._availableSkills[skill.Skill!.Number.ToUnsigned()] = skill;
         this._learnedSkills.Add(skill);
 
         if (skill.Skill.SkillType == SkillType.PassiveBoost || this._castedSkillsWithPassiveBoost.Contains(skill.Skill.Number))

--- a/src/GameLogic/SkillList.cs
+++ b/src/GameLogic/SkillList.cs
@@ -118,6 +118,7 @@ public sealed class SkillList : ISkillList, IDisposable
         // The entry is looked up in the item skills, not in the available skills: when the same skill
         // is also learned by the character, the available skills hold the learned entry - removing that
         // one would take a learned skill away just because an item was taken off.
+        // This should actually never happen with default configs, but the admin panel allows to configure stuff like that.
         var skillEntry = this._itemSkills.FirstOrDefault(s => s.Skill!.Number.ToUnsigned() == skillId);
         if (skillEntry is null)
         {

--- a/src/Persistence/Initialization/PlugIns/CharacterCreated/AddInitialSkillPlugInBase.cs
+++ b/src/Persistence/Initialization/PlugIns/CharacterCreated/AddInitialSkillPlugInBase.cs
@@ -52,6 +52,16 @@ public class AddInitialSkillPlugInBase : ICharacterCreatedPlugIn
             return;
         }
 
+        if (createdCharacter.LearnedSkills.Any(entry => entry.Skill?.Number == skillDefinition.Number))
+        {
+            // This plug-in is not only called when a character is created, but also for characters which
+            // were created outside the game (e.g. on the database or with the admin panel) and are missing
+            // their inventory. Adding the skill again would give the character the same skill twice, which
+            // its skill list can't handle.
+            player.Logger.LogDebug("Skill {0} is already learned by character {1}.", skillDefinition.Name, createdCharacter.Name);
+            return;
+        }
+
         var skillEntry = player.PersistenceContext.CreateNew<SkillEntry>();
         skillEntry.Skill = skillDefinition;
         createdCharacter.LearnedSkills.Add(skillEntry);

--- a/src/Persistence/Initialization/Updates/RegenerationsRefactorPlugInBase.cs
+++ b/src/Persistence/Initialization/Updates/RegenerationsRefactorPlugInBase.cs
@@ -39,9 +39,11 @@ public abstract class RegenerationsRefactorPlugInBase : UpdatePlugInBase
     /// <inheritdoc />
     protected override async ValueTask ApplyAsync(IContext context, GameConfiguration gameConfiguration)
     {
-        // Create new Stats
-        var isResting = context.CreateNew<AttributeDefinition>(Stats.IsResting.Id, Stats.IsResting.Designation, Stats.IsResting.Description);
-        gameConfiguration.Attributes.Add(isResting);
+        // Create new Stats. Only when they don't exist yet - a configuration which was initialized after
+        // these attributes were introduced already contains them, and adding them again would create
+        // duplicated attribute definitions.
+        this.AddStatIfNotExists(context, gameConfiguration, Stats.IsResting);
+        var isResting = Stats.IsResting.GetPersistent(gameConfiguration);
 
         var areTwoWeaponsEquipped = Stats.AreTwoWeaponsEquipped.GetPersistent(gameConfiguration);
         var attackSpeedByWeapon = Stats.AttackSpeedByWeapon.GetPersistent(gameConfiguration);
@@ -57,6 +59,14 @@ public abstract class RegenerationsRefactorPlugInBase : UpdatePlugInBase
 
         gameConfiguration.CharacterClasses.ForEach(charClass =>
         {
+            void AddStatAttributeIfNotExists(AttributeDefinition attribute)
+            {
+                if (charClass.StatAttributes.All(sa => sa.Attribute != attribute))
+                {
+                    charClass.StatAttributes.Add(context.CreateNew<StatAttributeDefinition>(attribute, 0, false));
+                }
+            }
+
             var attrCombos = charClass.AttributeCombinations;
 
             // Remove temp attack speed combos
@@ -161,9 +171,11 @@ public abstract class RegenerationsRefactorPlugInBase : UpdatePlugInBase
 
             charClass.BaseAttributeValues.Add(context.CreateNew<ConstValueAttribute>(0.037f, manaRecoveryMultiplier, AggregateType.AddRaw));
 
-            // Create new StatAttributDefinitions
-            charClass.StatAttributes.Add(context.CreateNew<StatAttributeDefinition>(isResting, 0, false));
-            charClass.StatAttributes.Add(context.CreateNew<StatAttributeDefinition>(nearbyPartyMemberCount, 0, false));
+            // Create new StatAttributDefinitions, if the class doesn't have them already. A class which was
+            // initialized after these stats were introduced already has them, and a character of a class
+            // holding the same stat attribute twice can't enter the game at all.
+            AddStatAttributeIfNotExists(isResting);
+            AddStatAttributeIfNotExists(nearbyPartyMemberCount);
 
             // Change base ability recovery multiplier
             if (charClass.Number != 4 && charClass.Number != 6 && charClass.Number != 7) // DK classes

--- a/src/Persistence/Initialization/Updates/RegenerationsRefactorPlugInSeason6.cs
+++ b/src/Persistence/Initialization/Updates/RegenerationsRefactorPlugInSeason6.cs
@@ -40,14 +40,15 @@ public class RegenerationsRefactorPlugInSeason6 : RegenerationsRefactorPlugInBas
     {
         await base.ApplyAsync(context, gameConfiguration).ConfigureAwait(false);
 
-        // Create new Stats
-        var isShieldRecoveryActive = context.CreateNew<AttributeDefinition>(Stats.IsShieldRecoveryActive.Id, Stats.IsShieldRecoveryActive.Designation, Stats.IsShieldRecoveryActive.Description);
-        gameConfiguration.Attributes.Add(isShieldRecoveryActive);
-        var shieldRecoveryHiatus = context.CreateNew<AttributeDefinition>(Stats.ShieldRecoveryHiatus.Id, Stats.ShieldRecoveryHiatus.Designation, Stats.ShieldRecoveryHiatus.Description);
-        gameConfiguration.Attributes.Add(shieldRecoveryHiatus);
-        var shieldRecoveryRampFactor = context.CreateNew<AttributeDefinition>(Stats.ShieldRecoveryRampFactor.Id, Stats.ShieldRecoveryRampFactor.Designation, Stats.ShieldRecoveryRampFactor.Description);
+        // Create new Stats, but only when the configuration doesn't contain them already - it would
+        // create duplicated attribute definitions otherwise.
+        this.AddStatIfNotExists(context, gameConfiguration, Stats.IsShieldRecoveryActive);
+        var isShieldRecoveryActive = Stats.IsShieldRecoveryActive.GetPersistent(gameConfiguration);
+        this.AddStatIfNotExists(context, gameConfiguration, Stats.ShieldRecoveryHiatus);
+        var shieldRecoveryHiatus = Stats.ShieldRecoveryHiatus.GetPersistent(gameConfiguration);
+        this.AddStatIfNotExists(context, gameConfiguration, Stats.ShieldRecoveryRampFactor);
+        var shieldRecoveryRampFactor = Stats.ShieldRecoveryRampFactor.GetPersistent(gameConfiguration);
         shieldRecoveryRampFactor.MaximumValue = 3;
-        gameConfiguration.Attributes.Add(shieldRecoveryRampFactor);
 
         var isInSafezone = Stats.IsInSafezone.GetPersistent(gameConfiguration);
         var shieldRecoveryMultiplier = Stats.ShieldRecoveryMultiplier.GetPersistent(gameConfiguration);

--- a/src/Persistence/Initialization/Updates/RemoveDuplicateStatAttributesPlugIn075.cs
+++ b/src/Persistence/Initialization/Updates/RemoveDuplicateStatAttributesPlugIn075.cs
@@ -1,0 +1,23 @@
+// <copyright file="RemoveDuplicateStatAttributesPlugIn075.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Persistence.Initialization.Updates;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// This update removes stat attributes which are defined more than once for a character class.
+/// </summary>
+[PlugIn]
+[Display(Name = PlugInName, Description = PlugInDescription)]
+[Guid("6B0A9D2C-6E4F-4C1B-9B5A-2E7F8D4C0A31")]
+public class RemoveDuplicateStatAttributesPlugIn075 : RemoveDuplicateStatAttributesPlugInBase
+{
+    /// <inheritdoc />
+    public override UpdateVersion Version => UpdateVersion.RemoveDuplicateStatAttributes075;
+
+    /// <inheritdoc />
+    public override string DataInitializationKey => Version075.DataInitialization.Id;
+}

--- a/src/Persistence/Initialization/Updates/RemoveDuplicateStatAttributesPlugIn095d.cs
+++ b/src/Persistence/Initialization/Updates/RemoveDuplicateStatAttributesPlugIn095d.cs
@@ -1,0 +1,23 @@
+// <copyright file="RemoveDuplicateStatAttributesPlugIn095d.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Persistence.Initialization.Updates;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// This update removes stat attributes which are defined more than once for a character class.
+/// </summary>
+[PlugIn]
+[Display(Name = PlugInName, Description = PlugInDescription)]
+[Guid("D1F4C7A8-3B62-4E05-8A9C-5C1B6E3F7D24")]
+public class RemoveDuplicateStatAttributesPlugIn095D : RemoveDuplicateStatAttributesPlugInBase
+{
+    /// <inheritdoc />
+    public override UpdateVersion Version => UpdateVersion.RemoveDuplicateStatAttributes095d;
+
+    /// <inheritdoc />
+    public override string DataInitializationKey => Version095d.DataInitialization.Id;
+}

--- a/src/Persistence/Initialization/Updates/RemoveDuplicateStatAttributesPlugInBase.cs
+++ b/src/Persistence/Initialization/Updates/RemoveDuplicateStatAttributesPlugInBase.cs
@@ -1,0 +1,59 @@
+// <copyright file="RemoveDuplicateStatAttributesPlugInBase.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Persistence.Initialization.Updates;
+
+using MUnique.OpenMU.DataModel.Configuration;
+
+/// <summary>
+/// This update removes stat attributes which are defined more than once for a character class.
+/// </summary>
+/// <remarks>
+/// The <see cref="RegenerationsRefactorPlugInBase"/> added the "Is resting" and "Nearby party member count"
+/// stat attributes to every character class without checking if the class already had them. For a
+/// configuration which was initialized after these attributes were introduced, that resulted in classes
+/// holding the same stat attribute twice - and every character of such a class got the attribute twice as
+/// well, which made it impossible to enter the game with it.
+/// </remarks>
+public abstract class RemoveDuplicateStatAttributesPlugInBase : UpdatePlugInBase
+{
+    /// <summary>
+    /// The plug in name.
+    /// </summary>
+    internal const string PlugInName = "Remove duplicate stat attributes";
+
+    /// <summary>
+    /// The plug in description.
+    /// </summary>
+    internal const string PlugInDescription = "This update removes stat attributes which are defined more than once for a character class.";
+
+    /// <inheritdoc />
+    public override string Name => PlugInName;
+
+    /// <inheritdoc />
+    public override string Description => PlugInDescription;
+
+    /// <inheritdoc />
+    public override bool IsMandatory => true;
+
+    /// <inheritdoc />
+    public override DateTime CreatedAt => new(2026, 9, 1, 12, 0, 0, DateTimeKind.Utc);
+
+    /// <inheritdoc />
+    protected override ValueTask ApplyAsync(IContext context, GameConfiguration gameConfiguration)
+    {
+        foreach (var characterClass in gameConfiguration.CharacterClasses)
+        {
+            var duplicates = characterClass.StatAttributes
+                .GroupBy(statAttribute => statAttribute.Attribute)
+                .Where(group => group.Count() > 1)
+                .SelectMany(group => group.Skip(1))
+                .ToList();
+
+            duplicates.ForEach(duplicate => characterClass.StatAttributes.Remove(duplicate));
+        }
+
+        return ValueTask.CompletedTask;
+    }
+}

--- a/src/Persistence/Initialization/Updates/RemoveDuplicateStatAttributesPlugInSeason6.cs
+++ b/src/Persistence/Initialization/Updates/RemoveDuplicateStatAttributesPlugInSeason6.cs
@@ -1,0 +1,24 @@
+// <copyright file="RemoveDuplicateStatAttributesPlugInSeason6.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Persistence.Initialization.Updates;
+
+using System.Runtime.InteropServices;
+using MUnique.OpenMU.Persistence.Initialization.VersionSeasonSix;
+using MUnique.OpenMU.PlugIns;
+
+/// <summary>
+/// This update removes stat attributes which are defined more than once for a character class.
+/// </summary>
+[PlugIn]
+[Display(Name = PlugInName, Description = PlugInDescription)]
+[Guid("9C3E5B71-8D04-42A6-BF19-7A2D6C8E5B03")]
+public class RemoveDuplicateStatAttributesPlugInSeason6 : RemoveDuplicateStatAttributesPlugInBase
+{
+    /// <inheritdoc />
+    public override UpdateVersion Version => UpdateVersion.RemoveDuplicateStatAttributesSeason6;
+
+    /// <inheritdoc />
+    public override string DataInitializationKey => DataInitialization.Id;
+}

--- a/src/Persistence/Initialization/Updates/UpdateVersion.cs
+++ b/src/Persistence/Initialization/Updates/UpdateVersion.cs
@@ -549,4 +549,19 @@ public enum UpdateVersion
     /// The version of the <see cref="ConfigureCastleSiegeEconomyUpdatePlugIn"/>.
     /// </summary>
     ConfigureCastleSiegeEconomy = 108,
+
+    /// <summary>
+    /// The version of the <see cref="RemoveDuplicateStatAttributesPlugIn075"/>.
+    /// </summary>
+    RemoveDuplicateStatAttributes075 = 109,
+
+    /// <summary>
+    /// The version of the <see cref="RemoveDuplicateStatAttributesPlugIn095D"/>.
+    /// </summary>
+    RemoveDuplicateStatAttributes095d = 110,
+
+    /// <summary>
+    /// The version of the <see cref="RemoveDuplicateStatAttributesPlugInSeason6"/>.
+    /// </summary>
+    RemoveDuplicateStatAttributesSeason6 = 111,
 }

--- a/tests/MUnique.OpenMU.Tests/DuplicateStatAttributeTests.cs
+++ b/tests/MUnique.OpenMU.Tests/DuplicateStatAttributeTests.cs
@@ -1,0 +1,59 @@
+// <copyright file="DuplicateStatAttributeTests.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Tests;
+
+using MUnique.OpenMU.AttributeSystem;
+using MUnique.OpenMU.DataModel.Entities;
+using MUnique.OpenMU.GameLogic;
+using MUnique.OpenMU.GameLogic.Attributes;
+using MUnique.OpenMU.GameLogic.Offline;
+
+/// <summary>
+/// Tests for characters which hold the same stat attribute more than once.
+/// Such data shouldn't exist, but it must never keep a character from entering the game.
+/// </summary>
+[TestFixture]
+public class DuplicateStatAttributeTests
+{
+    /// <summary>
+    /// Tests that an attribute system can be created for a character which holds the same stat
+    /// attribute twice, instead of failing with an "item with the same key" exception.
+    /// </summary>
+    [Test]
+    public async ValueTask AttributeSystemIsCreatedForDuplicatedStatAttributeAsync()
+    {
+        var player = await PlayerTestHelper.CreatePlayerAsync().ConfigureAwait(false);
+        var character = player.SelectedCharacter!;
+        character.Attributes.Add(new StatAttribute(Stats.BaseStrength, 99));
+
+        using var attributeSystem = new ItemAwareAttributeSystem(player.Account!, character, player.GameContext.Configuration);
+
+        Assert.That(attributeSystem[Stats.BaseStrength], Is.Not.EqualTo(0));
+    }
+
+    /// <summary>
+    /// Tests that duplicated stat attributes of a character are removed when it enters the world,
+    /// keeping the attribute with the highest value.
+    /// </summary>
+    [Test]
+    public async ValueTask DuplicatedStatAttributesAreRemovedWhenEnteringWorldAsync()
+    {
+        var player = await PlayerTestHelper.CreatePlayerAsync().ConfigureAwait(false);
+        var character = player.SelectedCharacter!;
+        var baseStrength = character.Attributes.First(a => a.Definition == Stats.BaseStrength);
+        baseStrength.Value = 28;
+        character.Attributes.Add(new StatAttribute(Stats.BaseStrength, 55));
+
+        var secondPlayer = new OfflinePlayer(player.GameContext) { Account = player.Account };
+        await secondPlayer.PlayerState.TryAdvanceToAsync(PlayerState.LoginScreen).ConfigureAwait(false);
+        await secondPlayer.PlayerState.TryAdvanceToAsync(PlayerState.Authenticated).ConfigureAwait(false);
+        await secondPlayer.PlayerState.TryAdvanceToAsync(PlayerState.CharacterSelection).ConfigureAwait(false);
+        await secondPlayer.SetSelectedCharacterAsync(character).ConfigureAwait(false);
+
+        var remaining = character.Attributes.Where(a => a.Definition == Stats.BaseStrength).ToList();
+        Assert.That(remaining, Has.Count.EqualTo(1));
+        Assert.That(remaining[0].Value, Is.EqualTo(55));
+    }
+}

--- a/tests/MUnique.OpenMU.Tests/SkillListTest.cs
+++ b/tests/MUnique.OpenMU.Tests/SkillListTest.cs
@@ -64,6 +64,65 @@ public class SkillListTest
     }
 
     /// <summary>
+    /// Tests that a skill which is granted by more than one equipped item is only removed from the
+    /// skill list when the last of these items is taken off.
+    /// </summary>
+    [Test]
+    public async ValueTask ItemSkillRemovedWithLastItemAsync()
+    {
+        var player = await PlayerTestHelper.CreatePlayerAsync().ConfigureAwait(false);
+        var characterClass = player.SelectedCharacter!.CharacterClass;
+        await player.Inventory!.AddItemAsync(0, this.CreateItemWithSkill(QualifiedItemSkillId, characterClass)).ConfigureAwait(false);
+        await player.Inventory!.AddItemAsync(1, this.CreateItemWithSkill(QualifiedItemSkillId, characterClass)).ConfigureAwait(false);
+        var skillList = new SkillList(player);
+
+        Assert.That(await skillList.RemoveItemSkillAsync(QualifiedItemSkillId).ConfigureAwait(false), Is.True);
+        Assert.That(skillList.ContainsSkill(QualifiedItemSkillId), Is.True);
+
+        Assert.That(await skillList.RemoveItemSkillAsync(QualifiedItemSkillId).ConfigureAwait(false), Is.True);
+        Assert.That(skillList.ContainsSkill(QualifiedItemSkillId), Is.False);
+    }
+
+    /// <summary>
+    /// Tests that a character which has the same skill twice in its learned skills can still
+    /// create its skill list - the duplicate with the lower level is dropped.
+    /// </summary>
+    [Test]
+    public async ValueTask DuplicateLearnedSkillIsRemovedAsync()
+    {
+        var player = await PlayerTestHelper.CreatePlayerAsync().ConfigureAwait(false);
+        var learnedSkills = player.SelectedCharacter!.LearnedSkills;
+        var lowLevelEntry = this.CreateSkillEntry(LearnedSkillId);
+        var highLevelEntry = this.CreateSkillEntry(LearnedSkillId);
+        highLevelEntry.Level = 5;
+        learnedSkills.Add(lowLevelEntry);
+        learnedSkills.Add(highLevelEntry);
+
+        var skillList = new SkillList(player);
+
+        Assert.That(skillList.ContainsSkill(LearnedSkillId), Is.True);
+        Assert.That(learnedSkills, Is.EquivalentTo(new[] { highLevelEntry }));
+        Assert.That(skillList.GetSkill(LearnedSkillId)!.Level, Is.EqualTo(5));
+    }
+
+    /// <summary>
+    /// Tests that a learned skill isn't lost when an item which grants the same skill is unequipped.
+    /// </summary>
+    [Test]
+    public async ValueTask LearnedSkillKeptWhenItemSkillRemovedAsync()
+    {
+        var player = await PlayerTestHelper.CreatePlayerAsync().ConfigureAwait(false);
+        player.SelectedCharacter!.LearnedSkills.Add(this.CreateSkillEntry(QualifiedItemSkillId));
+        var item = this.CreateItemWithSkill(QualifiedItemSkillId, player.SelectedCharacter!.CharacterClass);
+        item.Durability = 1;
+        await player.Inventory!.AddItemAsync(0, item).ConfigureAwait(false);
+        var skillList = new SkillList(player);
+
+        Assert.That(await skillList.RemoveItemSkillAsync(QualifiedItemSkillId).ConfigureAwait(false), Is.True);
+        Assert.That(skillList.ContainsSkill(QualifiedItemSkillId), Is.True);
+    }
+
+    /// <summary>
     /// Tests if the skill list does not contain non-learned skills.
     /// </summary>
     [Test]


### PR DESCRIPTION
Two `System.ArgumentException: An item with the same key has already been added` errors could keep a character - and offline/bot players - from entering the game:

```
Error while processing the message: C1 0E F3 03 45 72 69 63 44 72 61 76 65 6E
System.ArgumentException: An item with the same key has already been added. Key: Nearby party member count
   at MUnique.OpenMU.GameLogic.Attributes.ItemAwareAttributeSystem..ctor(...)
   at MUnique.OpenMU.GameLogic.Player.OnPlayerEnteredWorldAsync()

Failed to initialize offline player for "bot0040".
System.ArgumentException: An item with the same key has already been added. Key: 238
   at MUnique.OpenMU.GameLogic.SkillList..ctor(Player player)
   at MUnique.OpenMU.GameLogic.Player.OnPlayerEnteredWorldAsync()
```

## Cause

The `AttributeSystem` holds exactly one attribute per `AttributeDefinition` and the `SkillList` one entry per skill number, so a character which holds the same stat attribute (or the same learned skill) twice can't enter the game at all.

The duplicated stat attributes come from the *Regenerations Refactor* update: it adds the `Is resting` and `Nearby party member count` stat attributes to every character class without checking whether the class already has them. Since the character classes of a freshly initialized configuration contain both attributes, a configuration which was initialized after they were introduced and then received the update ends up with each of them twice - and every character of such a class gets the attribute twice as well. The same applies to the attribute definitions the update adds to the game configuration.

## Changes

**Don't create the duplicates**
* `RegenerationsRefactorPlugInBase` / `RegenerationsRefactorPlugInSeason6` only add attribute definitions and stat attributes which don't exist yet.
* `CreateCharacterAction` and `BotGenerator` take the class' stat attributes distinctly.
* `AddInitialSkillPlugInBase` doesn't add a skill the character already knows (it is also called for characters which were created outside the game).

**Repair the existing data**
* New `RemoveDuplicateStatAttributes` update (075 / 095d / Season 6) removes the duplicated stat attributes from the character classes.
* `Player.AddMissingStatAttributes` removes stat attributes which the character holds more than once, keeping the one with the highest value, so nothing that was invested into a stat is lost.
* The `SkillList` constructor removes duplicated learned skills, keeping the entry with the highest level.
* Both repairs are logged as a warning.

**Never fail on such data again**
* The attribute system of a character is built from the distinct stat attributes of the character and its account.

**Item skill removal fix**
While looking at the skill list, `RemoveItemSkillAsync` looked its entry up in the *available* skills, which holds the learned entry when the same skill is also learned. As a result a skill granted by two equipped items stayed in the list forever after both items were taken off, and the item skill list leaked entries. The entry is now looked up in the item skills, and the skill is only removed from the list when the last item granting it is gone and it isn't learned.

## Tests

* `SkillListTest.DuplicateLearnedSkillIsRemovedAsync`
* `SkillListTest.LearnedSkillKeptWhenItemSkillRemovedAsync`
* `SkillListTest.ItemSkillRemovedWithLastItemAsync`
* `DuplicateStatAttributeTests.AttributeSystemIsCreatedForDuplicatedStatAttributeAsync`
* `DuplicateStatAttributeTests.DuplicatedStatAttributesAreRemovedWhenEnteringWorldAsync`

`MUnique.OpenMU.Tests` (814 tests) and `MUnique.OpenMU.Persistence.Initialization.Tests` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LYr3urpQESKCEPXEpBV6rh


---
_Generated by [Claude Code](https://claude.ai/code/session_01LYr3urpQESKCEPXEpBV6rh)_