### PR TITLE
Fix bot purge failure on chunked JSON deserialization

### DIFF
--- a/src/GameLogic/Bots/BotGenerator.cs
+++ b/src/GameLogic/Bots/BotGenerator.cs
@@ -212,8 +212,10 @@ internal sealed class BotGenerator
             {
                 failed++;
             }
-
-            // NotFound: the account was already gone, nothing to count.
+            else
+            {
+                // NotFound: the account was already gone, nothing to count.
+            }
         }
 
         if (failed > 0)

--- a/src/GameLogic/Bots/BotGenerator.cs
+++ b/src/GameLogic/Bots/BotGenerator.cs
@@ -198,42 +198,50 @@ internal sealed class BotGenerator
         {
             cancellationToken.ThrowIfCancellationRequested();
 
-            // Load the account again, this time with its whole graph: the paging query returns the
-            // accounts untracked and without their characters, and deleting such a shallow account
-            // leaves its item storages behind. A character's inventory is referenced BY the character,
-            // so no delete cascade ever reaches it - those storages, and every item lying in them, would
-            // stay in the database forever as unreachable rows.
-            var account = await context.GetAccountByLoginNameAsync(loginName, cancellationToken).ConfigureAwait(false);
-            if (account is null)
+            try
             {
-                continue;
-            }
-
-            foreach (var character in account.Characters)
-            {
-                if (character.Inventory is { } inventory)
+                // Load the account again, this time with its whole graph: the paging query returns the
+                // accounts untracked and without their characters, and deleting such a shallow account
+                // leaves its item storages behind. A character's inventory is referenced BY the character,
+                // so no delete cascade ever reaches it - those storages, and every item lying in them, would
+                // stay in the database forever as unreachable rows.
+                var account = await context.GetAccountByLoginNameAsync(loginName, cancellationToken).ConfigureAwait(false);
+                if (account is null)
                 {
-                    await context.DeleteAsync(inventory).ConfigureAwait(false);
+                    continue;
                 }
-            }
 
-            if (account.Vault is { } vault)
-            {
-                await context.DeleteAsync(vault).ConfigureAwait(false);
-            }
+                foreach (var character in account.Characters)
+                {
+                    if (character.Inventory is { } inventory)
+                    {
+                        await context.DeleteAsync(inventory).ConfigureAwait(false);
+                    }
+                }
 
-            if (await context.DeleteAsync(account).ConfigureAwait(false))
-            {
-                deleted++;
-            }
-            else
-            {
-                // Not silent: a bot account which survives the purge is spawned again right after it.
-                this._logger.LogWarning("Bot account '{LoginName}' could not be deleted.", loginName);
-            }
+                if (account.Vault is { } vault)
+                {
+                    await context.DeleteAsync(vault).ConfigureAwait(false);
+                }
 
-            // Save per account, so a single failure does not roll back the accounts already deleted.
-            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                if (await context.DeleteAsync(account).ConfigureAwait(false))
+                {
+                    deleted++;
+                }
+                else
+                {
+                    // Not silent: a bot account which survives the purge is spawned again right after it.
+                    this._logger.LogWarning("Bot account '{LoginName}' could not be deleted.", loginName);
+                }
+
+                // Save per account, so a single failure does not roll back the accounts already deleted.
+                await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                // One unreadable account must not abort the whole purge; the next purge retries it.
+                this._logger.LogError(ex, "Failed to delete bot account '{LoginName}', skipping it.", loginName);
+            }
         }
 
         return deleted;

--- a/src/GameLogic/Bots/BotGenerator.cs
+++ b/src/GameLogic/Bots/BotGenerator.cs
@@ -44,7 +44,7 @@ internal sealed class BotGenerator
     /// <summary>Number of inventory extensions (each 4 rows of 8 slots) a bot gets, so loot does not clog its backpack.</summary>
     private const int BotInventoryExtensions = 4;
 
-    /// <summary>Highest item group that is a melee weapon (0 sword, 1 axe, 2 mace, 3 spear).</summary>
+    /// <summary>The highest item group that is a melee weapon (0 sword, 1 axe, 2 mace, 3 spear).</summary>
     private const byte MaxMeleeGroup = 3;
 
     /// <summary>Item group of bows (need ammunition).</summary>
@@ -78,10 +78,31 @@ internal sealed class BotGenerator
     }
 
     /// <summary>
+    /// The outcome of deleting a single bot account.
+    /// </summary>
+    private enum BotAccountDeleteOutcome
+    {
+        /// <summary>
+        /// The account was deleted.
+        /// </summary>
+        Deleted,
+
+        /// <summary>
+        /// The account was already gone; nothing had to be deleted.
+        /// </summary>
+        NotFound,
+
+        /// <summary>
+        /// The account could not be deleted.
+        /// </summary>
+        Failed,
+    }
+
+    /// <summary>
     /// Gets the deterministic, internal login name of the bot account with the given one-based index.
     /// </summary>
     /// <param name="index">The one-based account index.</param>
-    /// <returns>The login name, e.g. <c>bot0001</c> (kept within the 10 character account name limit).</returns>
+    /// <returns>The login name, e.g. <c>bot0001</c> (kept within the 10-character account name limit).</returns>
     public static string GetLoginName(int index) => $"{LoginPrefix}{index:D4}";
 
     /// <summary>
@@ -171,77 +192,33 @@ internal sealed class BotGenerator
     /// </summary>
     /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The number of deleted bot accounts.</returns>
+    /// <exception cref="InvalidOperationException">At least one bot account could not be deleted.</exception>
     public async ValueTask<int> DeleteAllBotsAsync(CancellationToken cancellationToken = default)
     {
         using var context = this._gameContext.PersistenceContextProvider.CreateNewPlayerContext(this._gameContext.Configuration);
-
-        // Collect first, delete afterwards: the paging query orders by login name, so deleting while
-        // paging would shift the accounts which are not visited yet into the pages already passed.
-        var loginNames = new List<string>();
-        const int pageSize = 100;
-        var skip = 0;
-        while (true)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-            var page = (await context.GetAccountsOrderedByLoginNameAsync(skip, pageSize, cancellationToken).ConfigureAwait(false)).ToList();
-            if (page.Count == 0)
-            {
-                break;
-            }
-
-            loginNames.AddRange(page.Where(account => account.IsBot).Select(account => account.LoginName));
-            skip += page.Count;
-        }
+        var loginNames = await this.CollectBotLoginNamesAsync(context, cancellationToken).ConfigureAwait(false);
 
         var deleted = 0;
+        var failed = 0;
         foreach (var loginName in loginNames)
         {
             cancellationToken.ThrowIfCancellationRequested();
-
-            try
+            var outcome = await this.TryDeleteBotAccountAsync(loginName, context, cancellationToken).ConfigureAwait(false);
+            if (outcome == BotAccountDeleteOutcome.Deleted)
             {
-                // Load the account again, this time with its whole graph: the paging query returns the
-                // accounts untracked and without their characters, and deleting such a shallow account
-                // leaves its item storages behind. A character's inventory is referenced BY the character,
-                // so no delete cascade ever reaches it - those storages, and every item lying in them, would
-                // stay in the database forever as unreachable rows.
-                var account = await context.GetAccountByLoginNameAsync(loginName, cancellationToken).ConfigureAwait(false);
-                if (account is null)
-                {
-                    continue;
-                }
-
-                foreach (var character in account.Characters)
-                {
-                    if (character.Inventory is { } inventory)
-                    {
-                        await context.DeleteAsync(inventory).ConfigureAwait(false);
-                    }
-                }
-
-                if (account.Vault is { } vault)
-                {
-                    await context.DeleteAsync(vault).ConfigureAwait(false);
-                }
-
-                if (await context.DeleteAsync(account).ConfigureAwait(false))
-                {
-                    deleted++;
-                }
-                else
-                {
-                    // Not silent: a bot account which survives the purge is spawned again right after it.
-                    this._logger.LogWarning("Bot account '{LoginName}' could not be deleted.", loginName);
-                }
-
-                // Save per account, so a single failure does not roll back the accounts already deleted.
-                await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                deleted++;
             }
-            catch (Exception ex)
+            else if (outcome == BotAccountDeleteOutcome.Failed)
             {
-                // One unreadable account must not abort the whole purge; the next purge retries it.
-                this._logger.LogError(ex, "Failed to delete bot account '{LoginName}', skipping it.", loginName);
+                failed++;
             }
+
+            // NotFound: the account was already gone, nothing to count.
+        }
+
+        if (failed > 0)
+        {
+            throw new InvalidOperationException($"{failed} of {loginNames.Count} bot account(s) could not be deleted.");
         }
 
         return deleted;
@@ -378,6 +355,108 @@ internal sealed class BotGenerator
         return resetPoints + firstCyclePoints + laterCyclesPoints + currentCyclePoints;
     }
 
+    /// <summary>
+    /// Collects the login names of all bot accounts, ordered by login name.
+    /// </summary>
+    /// <param name="context">The persistence context.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The login names of the bot accounts.</returns>
+    /// <remarks>
+    /// Collected first, deleted afterwards: the paging query orders by login name, so deleting while
+    /// paging would shift the accounts which are not visited yet into the pages already passed.
+    /// </remarks>
+    private async ValueTask<List<string>> CollectBotLoginNamesAsync(IPlayerContext context, CancellationToken cancellationToken)
+    {
+        var loginNames = new List<string>();
+        const int pageSize = 100;
+        var skip = 0;
+        while (true)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var page = (await context.GetAccountsOrderedByLoginNameAsync(skip, pageSize, cancellationToken).ConfigureAwait(false)).ToList();
+            if (page.Count == 0)
+            {
+                break;
+            }
+
+            loginNames.AddRange(page.Where(account => account.IsBot).Select(account => account.LoginName));
+            skip += page.Count;
+        }
+
+        return loginNames;
+    }
+
+    /// <summary>
+    /// Tries to delete a single bot account with its characters, item storages, and items.
+    /// </summary>
+    /// <param name="loginName">The login name of the bot account.</param>
+    /// <param name="context">The persistence context.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>The outcome of the deletion.</returns>
+    /// <remarks>
+    /// One bad account returns <see cref="BotAccountDeleteOutcome.Failed"/> instead of aborting the
+    /// whole purge; the caller fails the purge as a whole, so the flags stay set and it gets retried
+    /// instead of switching the feature off with the bot accounts still in the database.
+    /// Cancellation is never swallowed.
+    /// </remarks>
+    private async ValueTask<BotAccountDeleteOutcome> TryDeleteBotAccountAsync(string loginName, IPlayerContext context, CancellationToken cancellationToken)
+    {
+        Account? account = null;
+        try
+        {
+            // Load the account again, this time with its whole graph: the paging query returns the
+            // accounts untracked and without their characters, and deleting such a shallow account
+            // leaves its item storages behind. A character's inventory is referenced by the character,
+            // so no delete cascade ever reaches it - those storages, and every item lying in them, would
+            // stay in the database forever as unreachable rows.
+            account = await context.GetAccountByLoginNameAsync(loginName, cancellationToken).ConfigureAwait(false);
+            if (account is null)
+            {
+                return BotAccountDeleteOutcome.NotFound;
+            }
+
+            foreach (var character in account.Characters)
+            {
+                if (character.Inventory is { } inventory)
+                {
+                    await context.DeleteAsync(inventory).ConfigureAwait(false);
+                }
+            }
+
+            if (account.Vault is { } vault)
+            {
+                await context.DeleteAsync(vault).ConfigureAwait(false);
+            }
+
+            var deleteQueued = await context.DeleteAsync(account).ConfigureAwait(false);
+
+            // Save per account, so a single failure does not roll back the accounts already deleted.
+            // Only counted after the save went through: an account whose save throws must not count as deleted.
+            await context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            if (!deleteQueued)
+            {
+                // Not silent: a bot account which survives the purge is spawned again right after it.
+                this._logger.LogWarning("Bot account '{LoginName}' could not be deleted.", loginName);
+                return BotAccountDeleteOutcome.Failed;
+            }
+
+            return BotAccountDeleteOutcome.Deleted;
+        }
+        catch (Exception ex) when (ex is not OperationCanceledException)
+        {
+            this._logger.LogError(ex, "Failed to delete bot account '{LoginName}', skipping it.", loginName);
+
+            if (account is not null)
+            {
+                // A failed save leaves the account graph in the change tracker as Deleted, which would
+                // fail every following save as well - detach it so the next account starts clean.
+                context.Detach(account);
+            }
+
+            return BotAccountDeleteOutcome.Failed;
+        }
+    }
+
     private void CreateCharacter(IPlayerContext context, Account account, string name, CharacterClass characterClass, int level, byte slot, long[] experienceTable, int seededResets, byte starterItemLevel, ResetConfiguration? resetConfiguration)
     {
         // A character generated beyond the class evolution level was created as its second-generation
@@ -433,7 +512,7 @@ internal sealed class BotGenerator
         DistributeStatPoints(character, characterClass, resetConfiguration is not null);
 
         // Skills survive resets, so a seeded veteran knows everything the highest level of its past
-        // cycles unlocked - level-gated skills are checked against that level, not the current one.
+        // cycles unlocked; level-gated skills are checked against that level, not the current one.
         var highestLevelReached = seededResets > 0 && resetConfiguration is not null
             ? Math.Max(level, resetConfiguration.RequiredLevel)
             : level;
@@ -499,13 +578,13 @@ internal sealed class BotGenerator
         var inventory = character.Inventory!;
         var characterClass = character.CharacterClass!;
 
-        // Data-driven so every class gets gear it is actually QUALIFIED to wear (a Dark Lord must never
+        // Data-driven, so every class gets gear it is actually QUALIFIED to wear (a Dark Lord must never
         // end up in a Pad/wizard set). We pick the most basic options (lowest DropLevel) the class can use:
         // - a weapon from the weapon groups (0 sword, 1 axe, 2 mace, 3 spear, 4 bow, 5 staff),
         // - the armor set whose chest piece (group 8) has the lowest DropLevel; its NUMBER identifies the set,
         //   and the equipment type is the GROUP (7 helm, 8 armor, 9 pants, 10 gloves, 11 boots).
         // The weapon type follows the bot's BUILD (BotProgression.IsPreferredWeaponGroup - the same rule the
-        // later upgrades use), so an energy-specced Magic Gladiator starts with a staff instead of a blade.
+        // later upgrades use), so an energy-specked Magic Gladiator starts with a staff instead of a blade.
         // The Small Axe is qualified for almost every class, so without this filter casters and archers would
         // all end up with one.
         bool IsPreferredWeapon(ItemDefinition definition)

--- a/src/Persistence/EntityFramework/Json/JsonQueryBuilder.cs
+++ b/src/Persistence/EntityFramework/Json/JsonQueryBuilder.cs
@@ -171,7 +171,7 @@ public class JsonQueryBuilder
         var navigationAlias = this.GetNextAlias(parentAlias);
 
         stringBuilder.AppendLine(", (")
-            .Append("select array_to_json(array_agg(row_to_json(").Append(navigationAlias).AppendLine("))) from (");
+            .Append("select coalesce(array_to_json(array_agg(row_to_json(").Append(navigationAlias).AppendLine("))), '[]'::json) from (");
 
         if (navigation.IsMemberOfAggregate())
         {
@@ -212,7 +212,7 @@ public class JsonQueryBuilder
             ?? throw new InvalidOperationException("No reference column available.");
 
         stringBuilder.AppendLine(", (")
-            .Append("select array_to_json(array_agg(row_to_json(").Append(navigationAlias).AppendLine("))) from (");
+            .Append("select coalesce(array_to_json(array_agg(row_to_json(").Append(navigationAlias).AppendLine("))), '[]'::json) from (");
 
         stringBuilder.Append("select \"").Append(referenceColumnToOtherEntity).AppendLine("\" as \"$ref\"")
             .Append("from ").Append(navigationType.GetSchema()).Append(".\"").Append(navigationType.GetTableName()).AppendLine("\" ")

--- a/src/Persistence/Json/ReferenceResolvingConverter.cs
+++ b/src/Persistence/Json/ReferenceResolvingConverter.cs
@@ -216,6 +216,10 @@ public class ReferenceResolvingConverter<T> : JsonConverter<T>
             // Discard it streaming-safe; Null means "empty collection" and needs nothing.
             JsonSerializer.Deserialize<JsonElement>(ref reader, options);
         }
+        else
+        {
+            // Null means "empty collection" (e.g. array_agg over zero rows): nothing to add.
+        }
     }
 
     /// <summary>

--- a/src/Persistence/Json/ReferenceResolvingConverter.cs
+++ b/src/Persistence/Json/ReferenceResolvingConverter.cs
@@ -162,7 +162,7 @@ public class ReferenceResolvingConverter<T> : JsonConverter<T>
                 var propertyName = reader.GetString();
                 if (propertyName == null)
                 {
-                    reader.Skip();
+                    SkipUnknownPropertyValue(ref reader, options);
                 }
                 else if (propertyName is "$ref" or "$id"
                          && JsonSerializer.Deserialize<string>(ref reader, options) is { } referenceId)
@@ -176,7 +176,7 @@ public class ReferenceResolvingConverter<T> : JsonConverter<T>
                 }
                 else
                 {
-                    reader.Skip();
+                    SkipUnknownPropertyValue(ref reader, options);
                 }
             }
         }
@@ -210,10 +210,42 @@ public class ReferenceResolvingConverter<T> : JsonConverter<T>
             // into an object which holds the "$id" of the collection and its "$values".
             ReadWrappedCollection(ref reader, options, target, handler);
         }
-        else
+        else if (reader.TokenType != JsonTokenType.Null)
         {
-            reader.Skip();
+            // Adder-only collection with an unexpected scalar value (e.g. a schema change).
+            // Discard it streaming-safe; Null means "empty collection" and needs nothing.
+            JsonSerializer.Deserialize<JsonElement>(ref reader, options);
         }
+    }
+
+    /// <summary>
+    /// Advances from a property name to its value and discards the value in a way which is safe
+    /// for chunked (streaming) deserialization. <see cref="Utf8JsonReader.Skip"/> must not be used
+    /// here: it throws "Cannot skip tokens on partial JSON" when the buffer is not final.
+    /// </summary>
+    private static void SkipUnknownPropertyValue(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        if (!reader.Read())
+        {
+            throw new JsonException("Bad JSON");
+        }
+
+        SkipValue(ref reader, options);
+    }
+
+    /// <summary>
+    /// Discards the value the reader is positioned on in a way which is safe for chunked
+    /// (streaming) deserialization.
+    /// </summary>
+    private static void SkipValue(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    {
+        if (reader.TokenType == JsonTokenType.Null)
+        {
+            // Single token; the caller's next Read() moves past it.
+            return;
+        }
+
+        JsonSerializer.Deserialize<JsonElement>(ref reader, options);
     }
 
     private static void ReadWrappedCollection(ref Utf8JsonReader reader, JsonSerializerOptions options, T item, (Type PropertyType, Action<T, object>? Setter, Action<T, object>? Adder) handler)
@@ -222,7 +254,7 @@ public class ReferenceResolvingConverter<T> : JsonConverter<T>
         {
             if (reader.TokenType != JsonTokenType.PropertyName)
             {
-                reader.Skip();
+                SkipValue(ref reader, options);
                 continue;
             }
 
@@ -238,7 +270,7 @@ public class ReferenceResolvingConverter<T> : JsonConverter<T>
             }
             else
             {
-                reader.Skip();
+                SkipValue(ref reader, options);
             }
         }
     }

--- a/src/Persistence/Json/ReferenceResolvingConverter.cs
+++ b/src/Persistence/Json/ReferenceResolvingConverter.cs
@@ -162,7 +162,7 @@ public class ReferenceResolvingConverter<T> : JsonConverter<T>
                 var propertyName = reader.GetString();
                 if (propertyName == null)
                 {
-                    SkipUnknownPropertyValue(ref reader, options);
+                    SkipValue(ref reader);
                 }
                 else if (propertyName is "$ref" or "$id"
                          && JsonSerializer.Deserialize<string>(ref reader, options) is { } referenceId)
@@ -176,7 +176,7 @@ public class ReferenceResolvingConverter<T> : JsonConverter<T>
                 }
                 else
                 {
-                    SkipUnknownPropertyValue(ref reader, options);
+                    SkipValue(ref reader);
                 }
             }
         }
@@ -210,46 +210,25 @@ public class ReferenceResolvingConverter<T> : JsonConverter<T>
             // into an object which holds the "$id" of the collection and its "$values".
             ReadWrappedCollection(ref reader, options, target, handler);
         }
-        else if (reader.TokenType != JsonTokenType.Null)
-        {
-            // Adder-only collection with an unexpected scalar value (e.g. a schema change).
-            // Discard it streaming-safe; Null means "empty collection" and needs nothing.
-            JsonSerializer.Deserialize<JsonElement>(ref reader, options);
-        }
         else
         {
-            // Null means "empty collection" (e.g. array_agg over zero rows): nothing to add.
+            SkipValue(ref reader);
         }
     }
 
     /// <summary>
-    /// Advances from a property name to its value and discards the value in a way which is safe
-    /// for chunked (streaming) deserialization. <see cref="Utf8JsonReader.Skip"/> must not be used
-    /// here: it throws "Cannot skip tokens on partial JSON" when the buffer is not final.
+    /// Skips the current value - or the value of the property the reader is positioned on - in a way
+    /// which is safe for chunked (streaming) deserialization. <see cref="Utf8JsonReader.Skip"/> must not
+    /// be used here: it throws "Cannot skip tokens on partial JSON" when the buffer is not final,
+    /// while <see cref="Utf8JsonReader.TrySkip"/> handles that case.
     /// </summary>
-    private static void SkipUnknownPropertyValue(ref Utf8JsonReader reader, JsonSerializerOptions options)
+    /// <param name="reader">The reader.</param>
+    private static void SkipValue(ref Utf8JsonReader reader)
     {
-        if (!reader.Read())
+        if (!reader.TrySkip())
         {
-            throw new JsonException("Bad JSON");
+            throw new JsonException("Incomplete JSON: could not skip the value.");
         }
-
-        SkipValue(ref reader, options);
-    }
-
-    /// <summary>
-    /// Discards the value the reader is positioned on in a way which is safe for chunked
-    /// (streaming) deserialization.
-    /// </summary>
-    private static void SkipValue(ref Utf8JsonReader reader, JsonSerializerOptions options)
-    {
-        if (reader.TokenType == JsonTokenType.Null)
-        {
-            // Single token; the caller's next Read() moves past it.
-            return;
-        }
-
-        JsonSerializer.Deserialize<JsonElement>(ref reader, options);
     }
 
     private static void ReadWrappedCollection(ref Utf8JsonReader reader, JsonSerializerOptions options, T item, (Type PropertyType, Action<T, object>? Setter, Action<T, object>? Adder) handler)
@@ -258,7 +237,7 @@ public class ReferenceResolvingConverter<T> : JsonConverter<T>
         {
             if (reader.TokenType != JsonTokenType.PropertyName)
             {
-                SkipValue(ref reader, options);
+                SkipValue(ref reader);
                 continue;
             }
 
@@ -274,7 +253,7 @@ public class ReferenceResolvingConverter<T> : JsonConverter<T>
             }
             else
             {
-                SkipValue(ref reader, options);
+                SkipValue(ref reader);
             }
         }
     }

--- a/tests/MUnique.OpenMU.Tests/JsonChunkedStreamDeserializationTest.cs
+++ b/tests/MUnique.OpenMU.Tests/JsonChunkedStreamDeserializationTest.cs
@@ -1,0 +1,200 @@
+// <copyright file="JsonChunkedStreamDeserializationTest.cs" company="MUnique">
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+// </copyright>
+
+namespace MUnique.OpenMU.Tests;
+
+using System.Text;
+using System.IO;
+using System.Text.Json;
+using MUnique.OpenMU.Persistence;
+using MUnique.OpenMU.Persistence.Json;
+
+/// <summary>
+/// Regression test for the bot purge failure: <see cref="ReferenceResolvingConverter{T}"/> must survive
+/// chunked (streaming) deserialization, where the underlying <see cref="System.Text.Json.Utf8JsonReader"/>
+/// runs with <c>isFinalBlock: false</c>. Skipping values with <c>Utf8JsonReader.Skip()</c> throws
+/// "Cannot skip tokens on partial JSON" there - <c>TrySkip()</c> has to be used instead.
+/// The payload mimics the Postgres account JSON: a <c>null</c> adder-only collection
+/// (<c>array_agg</c> over zero rows) and an unknown property (e.g. a new column), followed by
+/// enough data to force multi-segment parsing like Npgsql's sequential-access stream does.
+/// </summary>
+[TestFixture]
+public class JsonChunkedStreamDeserializationTest
+{
+    /// <summary>
+    /// A null adder-only collection and an unknown property are skipped without error when the
+    /// JSON arrives in small chunks.
+    /// </summary>
+    [Test]
+    public void NullCollectionAndUnknownPropertySurviveChunkedStream()
+    {
+        var id = Guid.NewGuid();
+        var json = "{\"$id\":\"" + id + "\",\"Id\":\"" + id + "\",\"LoginName\":\"bot0001\""
+            + ",\"RawChildren\":null"
+            + ",\"SomeFutureColumn\":{\"Nested\":[1,2,3]}"
+            + ",\"Padding\":\"" + new string('x', 128 * 1024) + "\"}";
+        using var stream = new ChunkedStream(Encoding.UTF8.GetBytes(json));
+
+        var result = stream.FromJson<TestParent>();
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.LoginName, Is.EqualTo("bot0001"));
+        Assert.That(result.RawChildren, Is.Empty);
+    }
+
+    /// <summary>
+    /// The core of the bot purge failure: when the converter runs on a partial buffer
+    /// (<c>isFinalBlock: false</c>, as handed over by a chunked stream before more data arrives),
+    /// skipping must not escape as "Cannot skip tokens on partial JSON".
+    /// <c>Utf8JsonReader.Skip()</c> throws <see cref="InvalidOperationException"/> there, which the
+    /// serializer cannot resume from; <c>TrySkip()</c> consumes complete tokens and lets the
+    /// serializer retry with more data instead.
+    /// </summary>
+    [Test]
+    public void PartialBufferSkipStaysResumable()
+    {
+        var id = Guid.NewGuid();
+
+        // Complete tokens, but truncated mid-object: the null collection is fully buffered,
+        // more data is still pending - exactly the state which crashed the bot purge.
+        var head = "{\"$id\":\"" + id + "\",\"Id\":\"" + id + "\",\"RawChildren\":null";
+        var bytes = Encoding.UTF8.GetBytes(head);
+        var reader = new Utf8JsonReader(bytes, isFinalBlock: false, state: default);
+        var options = new JsonSerializerOptions { ReferenceHandler = new IdReferenceHandler() };
+        var converter = new ReferenceResolvingConverter<TestParent>([]);
+
+        // Throws InvalidOperationException ("Cannot skip tokens on partial JSON") on the old code.
+        var result = ReadPartial(ref reader, converter, options);
+
+        Assert.That(result, Is.Not.Null);
+        Assert.That(result!.RawChildren, Is.Empty);
+    }
+
+    /// <summary>
+    /// Reads a partial buffer with the converter. A static helper because <c>ref</c> locals
+    /// cannot be captured in lambdas.
+    /// </summary>
+    private static TestParent? ReadPartial(ref Utf8JsonReader reader, ReferenceResolvingConverter<TestParent> converter, JsonSerializerOptions options)
+    {
+        return converter.Read(ref reader, typeof(TestParent), options);
+    }
+
+    /// <summary>
+    /// A minimal <see cref="IIdentifiable"/> item for the chunked stream test.
+    /// </summary>
+    private sealed class TestChild : IIdentifiable
+    {
+        /// <summary>
+        /// Gets or sets the identifier.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the name.
+        /// </summary>
+        public string Name { get; set; } = string.Empty;
+    }
+
+    /// <summary>
+    /// A minimal <see cref="IIdentifiable"/> aggregate root shaped like the persisted account:
+    /// settable scalars plus a get-only <c>Raw…</c> collection which is filled through an adder.
+    /// </summary>
+    private sealed class TestParent : IIdentifiable
+    {
+        /// <summary>
+        /// Gets or sets the identifier.
+        /// </summary>
+        public Guid Id { get; set; }
+
+        /// <summary>
+        /// Gets or sets the login name.
+        /// </summary>
+        public string LoginName { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets or sets the padding which forces multi-segment parsing.
+        /// </summary>
+        public string Padding { get; set; } = string.Empty;
+
+        /// <summary>
+        /// Gets the raw children, filled through an adder like the generated <c>Raw…</c> collections.
+        /// </summary>
+        public ICollection<TestChild> RawChildren { get; } = new List<TestChild>();
+    }
+
+    /// <summary>
+    /// A non-seekable stream which hands out a few bytes per read, like Npgsql's
+    /// sequential-access stream does.
+    /// </summary>
+    private sealed class ChunkedStream : Stream
+    {
+        private const int MaxBytesPerRead = 512;
+
+        private readonly byte[] _data;
+
+        private int _position;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ChunkedStream"/> class.
+        /// </summary>
+        /// <param name="data">The data.</param>
+        public ChunkedStream(byte[] data)
+        {
+            this._data = data;
+        }
+
+        /// <inheritdoc />
+        public override bool CanRead => true;
+
+        /// <inheritdoc />
+        public override bool CanSeek => false;
+
+        /// <inheritdoc />
+        public override bool CanWrite => false;
+
+        /// <inheritdoc />
+        public override long Length => throw new NotSupportedException();
+
+        /// <inheritdoc />
+        public override long Position
+        {
+            get => this._position;
+            set => throw new NotSupportedException();
+        }
+
+        /// <inheritdoc />
+        public override void Flush()
+        {
+        }
+
+        /// <inheritdoc />
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return this.Read(new Span<byte>(buffer, offset, count));
+        }
+
+        /// <inheritdoc />
+        public override int Read(Span<byte> buffer)
+        {
+            if (this._position >= this._data.Length)
+            {
+                return 0;
+            }
+
+            var count = Math.Min(Math.Min(MaxBytesPerRead, buffer.Length), this._data.Length - this._position);
+            this._data.AsSpan(this._position, count).CopyTo(buffer);
+            this._position += count;
+            return count;
+        }
+
+        /// <inheritdoc />
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+
+        /// <inheritdoc />
+        public override void SetLength(long value) => throw new NotSupportedException();
+
+        /// <inheritdoc />
+        public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+    }
+}


### PR DESCRIPTION
JsonObjectLoader loads accounts via Postgres JSON + SequentialAccess.GetStream() (forward-only, chunked), and JsonObjectDeserializer passes that stream straight to JsonSerializer.Deserialize, so Utf8JsonReader runs with isFinalBlock: false. ReferenceResolvingConverter called Utf8JsonReader.Skip() in 5 places — which throws Cannot skip tokens on partial JSON on non-final buffers. The hot path was ReadProperty's else branch: an adder-only collection property (e.g. Account.RawAttributes, empty for bots) whose SQL array_agg(...) yields JSON null instead of []. One such account aborted the entire purge loop.
What changed
- src/Persistence/Json/ReferenceResolvingConverter.cs — eliminated all Skip() calls. null values are now a no-op (collection stays empty); anything else is discarded via JsonSerializer.Deserialize<JsonElement>, which is safe for chunked streams. New SkipValue / SkipUnknownPropertyValue helpers with documenting comments.
- src/Persistence/EntityFramework/Json/JsonQueryBuilder.cs — collection subqueries now use coalesce(array_to_json(array_agg(...)), '[]'::json), so empty collections serialize as [] instead of null (one-to-many and many-to-many).
- src/GameLogic/Bots/BotGenerator.cs — DeleteAllBotsAsync wraps each account in try/catch and logs + skips on failure, so one unreadable account can no longer abort the whole purge.

```
[Error] [BotFeaturePlugIn] Failed to purge the bot population.
System.Text.Json.JsonException: The JSON value could not be converted to MUnique.OpenMU.Persistence.EntityFramework.Model.Account. Path: $ | LineNumber: 0 | BytePositionInLine: 494.
 ---> System.InvalidOperationException: Cannot skip tokens on partial JSON. Either get the whole payload and create a Utf8JsonReader instance where isFinalBlock is true or call TrySkip.
   at System.Text.Json.ThrowHelper.ThrowInvalidOperationException_CannotSkipOnPartial()
   at System.Text.Json.Utf8JsonReader.Skip()
   at MUnique.OpenMU.Persistence.Json.ReferenceResolvingConverter`1.ReadProperty(Utf8JsonReader& reader, JsonSerializerOptions options, T item, ValueTuple`3 handler) in /home/eduardo/Work/C/OpenMU/src/Persistence/Json/ReferenceResolvingConverter.cs:line 215
   at MUnique.OpenMU.Persistence.Json.ReferenceResolvingConverter`1.Read(Utf8JsonReader& reader, Type typeToConvert, JsonSerializerOptions options) in /home/eduardo/Work/C/OpenMU/src/Persistence/Json/ReferenceResolvingConverter.cs:line 175
   at System.Text.Json.Serialization.JsonConverter`1.ReadCore(Utf8JsonReader& reader, T& value, JsonSerializerOptions options, ReadStack& state)
   --- End of inner exception stack trace ---

```