### PR TITLE
Fix missing combo damage display flag

### DIFF
--- a/src/GameServer/RemoteView/World/ShowHitExtendedPlugIn.cs
+++ b/src/GameServer/RemoteView/World/ShowHitExtendedPlugIn.cs
@@ -56,7 +56,7 @@ public class ShowHitExtendedPlugIn : IShowHitPlugIn
             hitInfo.Attributes.HasFlag(DamageAttributes.RageFighterStreakHit),
             hitInfo.Attributes.HasFlag(DamageAttributes.RageFighterStreakFinalHit),
             hitInfo.Attributes.HasFlag(DamageAttributes.Double),
-            hitInfo.Attributes.HasFlag(DamageAttributes.Triple),
+            hitInfo.Attributes.HasFlag(DamageAttributes.Triple) || hitInfo.Attributes.HasFlag(DamageAttributes.Combo),
             targetId,
             healthStatus,
             shieldStatus,

--- a/src/GameServer/RemoteView/World/ShowHitPlugIn.cs
+++ b/src/GameServer/RemoteView/World/ShowHitPlugIn.cs
@@ -66,7 +66,7 @@ public class ShowHitPlugIn : IShowHitPlugIn
                 hitInfo.Attributes.HasFlag(DamageAttributes.RageFighterStreakHit),
                 hitInfo.Attributes.HasFlag(DamageAttributes.RageFighterStreakFinalHit),
                 hitInfo.Attributes.HasFlag(DamageAttributes.Double),
-                hitInfo.Attributes.HasFlag(DamageAttributes.Triple),
+                hitInfo.Attributes.HasFlag(DamageAttributes.Triple) || hitInfo.Attributes.HasFlag(DamageAttributes.Combo),
                 shieldDamage).ConfigureAwait(false);
 
             remainingShieldDamage -= shieldDamage;


### PR DESCRIPTION
Combo hits include the bonus damage, but the hit packets set the layered-number flag only for `DamageAttributes.Triple`.

Set that flag for **Triple or Combo** in:

- `src/GameServer/RemoteView/World/ShowHitPlugIn.cs`
- `src/GameServer/RemoteView/World/ShowHitExtendedPlugIn.cs`

Damage values and existing double/triple behavior remain unchanged. Only these two files are modified. No tests added.