### PR TITLE
Fix stale connect-server load percentages

### DIFF
--- a/src/ConnectServer/ServerList.cs
+++ b/src/ConnectServer/ServerList.cs
@@ -160,6 +160,7 @@ internal class ServerList
                     var serverBlock = response[i];
                     serverBlock.ServerId = (byte)server.ServerId;
                     serverBlock.LoadPercentage = server.ServerLoadPercentage;
+                    server.LoadIndex = ServerListResponseOld.GetRequiredSize(i) + 1;
                     i++;
                 }
             }
@@ -176,6 +177,7 @@ internal class ServerList
                     var serverBlock = response[i];
                     serverBlock.ServerId = server.ServerId;
                     serverBlock.LoadPercentage = server.ServerLoadPercentage;
+                    server.LoadIndex = ServerListResponse.GetRequiredSize(i) + 2;
                     i++;
                 }
             }

--- a/src/ConnectServer/ServerList.cs
+++ b/src/ConnectServer/ServerList.cs
@@ -160,7 +160,7 @@ internal class ServerList
                     var serverBlock = response[i];
                     serverBlock.ServerId = (byte)server.ServerId;
                     serverBlock.LoadPercentage = server.ServerLoadPercentage;
-                    server.LoadIndex = ServerListResponseOld.GetRequiredSize(i) + 1;
+                    server.LoadIndex = ServerListResponseOld.GetRequiredSize(i) + 1; // GetRequiredSize(i) is the block offset; +1 is LoadPercentage.
                     i++;
                 }
             }
@@ -177,7 +177,7 @@ internal class ServerList
                     var serverBlock = response[i];
                     serverBlock.ServerId = server.ServerId;
                     serverBlock.LoadPercentage = server.ServerLoadPercentage;
-                    server.LoadIndex = ServerListResponse.GetRequiredSize(i) + 2;
+                    server.LoadIndex = ServerListResponse.GetRequiredSize(i) + 2; // GetRequiredSize(i) is the block offset; +2 is LoadPercentage.
                     i++;
                 }
             }

--- a/src/ConnectServer/ServerListItem.cs
+++ b/src/ConnectServer/ServerListItem.cs
@@ -55,7 +55,7 @@ internal class ServerListItem : IGameServerEntry
         {
             this._serverLoadPercentage = value;
             var cache = this._owner.Cache;
-            if (cache != null && this.LoadIndex != -1)
+            if (cache != null && this.LoadIndex >= 0 && this.LoadIndex < cache.Length)
             {
                 cache[this.LoadIndex] = value;
             }


### PR DESCRIPTION
Restore LoadIndex for both server-list packet formats so player-count changes update the cached load percentage in place instead of leaving it stale.