### PR TITLE
Fix event handler leaks of the live map page

### DIFF
--- a/src/Web/AdminPanel/Pages/MapPage.razor
+++ b/src/Web/AdminPanel/Pages/MapPage.razor
@@ -21,7 +21,7 @@
         <NavLink href="" Match="NavLinkMatch.All">
             <span>@Resources.All</span>
         </NavLink>
-        <span> / @this._map?.MapName
+        <span> / @this._mapName
             @if (this._followedPlayerName is not null)
             {
                 <span class="ms-2 badge bg-info">@string.Format("Following: {0}", this._followedPlayerName)</span>
@@ -39,7 +39,7 @@
 @code {
     internal const string LiveMapRoute = "map/";
 
-    private IGameMapInfo? _map;
+    private string? _mapName;
 
     private IObservableGameServer? _gameServer;
 
@@ -95,15 +95,20 @@
     {
         var gameServer = this.Servers.OfType<IGameServer>().First(gs => gs.Id == this.GameServerId);
         var context = (gameServer as IGameServerContextProvider)?.Context ?? throw new InvalidOperationException("This map page just works in a All-In-One deployment.");
+
+        // We just need the adapter to register the map observer of the shown map, so we can skip
+        // the creation of the map infos - creating them for all maps would be quite expensive.
         var adapter = new ObservableGameServerAdapter(context);
-        await adapter.InitializeAsync();
+        await adapter.InitializeAsync(withMapInfos: false);
 
         this._gameContext = context;
         this._gameServer = adapter;
         this._networkAnalyzerRoute = this.ServiceProvider.GetService(typeof(IPacketCaptureService)) is null
             ? string.Empty
             : NetworkAnalyzer.PlayerRoute;
-        this._map = this._gameServer.Maps.First(m => m.Id == this.MapId);
+
+        var maps = await context.GetMapsAsync();
+        this._mapName = maps.FirstOrDefault(m => m.Id == this.MapId)?.Definition.Name;
 
         var uri = new Uri(this.NavigationManager.Uri);
         var query = QueryHelpers.ParseQuery(uri.Query);

--- a/src/Web/Map/Components/Map.razor
+++ b/src/Web/Map/Components/Map.razor
@@ -3,7 +3,6 @@
 @using Nito.AsyncEx
 
 @implements IAsyncDisposable
-@implements IDisposable
 
 <div class="livemap">
     <LiveMap
@@ -104,9 +103,6 @@
             this.Logger.LogDebug(ex, "Unexpected JS interop error while selecting map object {ObjectId}.", objectId);
         }
     }
-
-    /// <inheritdoc />
-    public void Dispose() => Task.Run(this.DisposeAsync).Wait();
 
     /// <inheritdoc />
     public async ValueTask DisposeAsync()

--- a/src/Web/Map/Components/MapPlayerList.razor
+++ b/src/Web/Map/Components/MapPlayerList.razor
@@ -1,6 +1,8 @@
 ﻿@using MUnique.OpenMU.DataModel.Entities
 @using MUnique.OpenMU.Web.Map.Properties
 
+@implements IDisposable
+
 <table class="table table-striped table-hover">
     <thead>
     <tr>
@@ -45,6 +47,8 @@
     [Parameter]
     public IMapController MapController { get; set; } = null!;
 
+    private IMapController? _subscribedController;
+
     /// <summary>
     /// Gets or sets the identifier of the server which hosts the map.
     /// </summary>
@@ -81,9 +85,44 @@
     public EventCallback<int> OnSelectPlayer { get; set; }
 
     /// <inheritdoc />
+    public void Dispose()
+    {
+        this.Unsubscribe();
+    }
+
+    /// <inheritdoc />
     protected override void OnParametersSet()
     {
         base.OnParametersSet();
-        this.MapController.PlayersChanged += (_, _) => this.InvokeAsync(this.StateHasChanged);
+
+        // OnParametersSet is called on every re-render of the parent component, so we
+        // must only subscribe when the controller actually changed. Otherwise, the
+        // handlers would pile up and each change would cause multiple re-renders.
+        if (ReferenceEquals(this._subscribedController, this.MapController))
+        {
+            return;
+        }
+
+        this.Unsubscribe();
+
+        if (this.MapController is { } controller)
+        {
+            controller.PlayersChanged += this.OnPlayersChanged;
+            this._subscribedController = controller;
+        }
+    }
+
+    private void Unsubscribe()
+    {
+        if (this._subscribedController is { } controller)
+        {
+            controller.PlayersChanged -= this.OnPlayersChanged;
+            this._subscribedController = null;
+        }
+    }
+
+    private void OnPlayersChanged(object? sender, EventArgs e)
+    {
+        _ = this.InvokeAsync(this.StateHasChanged);
     }
 }

--- a/src/Web/Map/Map/GameMapInfoExtensions.cs
+++ b/src/Web/Map/Map/GameMapInfoExtensions.cs
@@ -24,15 +24,17 @@ public static class GameMapInfoExtensions
     /// <returns>The stream with the terrain as image.</returns>
     public static Stream GetTerrainStream(this IGameMapInfo map)
     {
-        if (CachedMapTerrainsPng.TryGetValue(map.MapNumber, out var data))
-        {
-            return new MemoryStream(data);
-        }
+        return GetTerrainStream(map.MapNumber, map.TerrainData);
+    }
 
-        data = RenderTerrain(map);
-        CachedMapTerrainsPng.TryAdd(map.MapNumber, data);
-
-        return new MemoryStream(data);
+    /// <summary>
+    /// Gets the terrain stream of the map image.
+    /// </summary>
+    /// <param name="map">The map.</param>
+    /// <returns>The stream with the terrain as image.</returns>
+    public static Stream GetTerrainStream(this GameMap map)
+    {
+        return GetTerrainStream(map.Definition.Number, map.Definition.TerrainData);
     }
 
     /// <summary>
@@ -47,20 +49,32 @@ public static class GameMapInfoExtensions
             return base64String;
         }
 
-        if (!CachedMapTerrainsPng.TryGetValue(map.MapNumber, out var rawData))
-        {
-            rawData = RenderTerrain(map);
-            CachedMapTerrainsPng.TryAdd(map.MapNumber, rawData);
-        }
-
-        base64String = "data:image/png;base64," + Convert.ToBase64String(rawData);
+        base64String = "data:image/png;base64," + Convert.ToBase64String(GetTerrainPng(map.MapNumber, map.TerrainData));
         CachedMapTerrainsBase64.TryAdd(map.MapNumber, base64String);
         return base64String;
     }
 
-    private static byte[] RenderTerrain(IGameMapInfo map)
+    private static Stream GetTerrainStream(short mapNumber, byte[]? terrainData)
     {
-        var terrain = new GameMapTerrain(map.TerrainData);
+        return new MemoryStream(GetTerrainPng(mapNumber, terrainData));
+    }
+
+    private static byte[] GetTerrainPng(short mapNumber, byte[]? terrainData)
+    {
+        if (CachedMapTerrainsPng.TryGetValue(mapNumber, out var data))
+        {
+            return data;
+        }
+
+        data = RenderTerrain(terrainData);
+        CachedMapTerrainsPng.TryAdd(mapNumber, data);
+
+        return data;
+    }
+
+    private static byte[] RenderTerrain(byte[]? terrainData)
+    {
+        var terrain = new GameMapTerrain(terrainData);
         using var bitmap = terrain.ToImage();
         using var memoryStream = new MemoryStream();
         bitmap.SaveAsPng(memoryStream);

--- a/src/Web/Map/Map/MapController.cs
+++ b/src/Web/Map/Map/MapController.cs
@@ -115,7 +115,7 @@ public sealed class MapController : IMapController, IWorldObserver, ILocateable,
     {
         await this._disposeCts.CancelAsync().ConfigureAwait(false);
         await this._gameServer.UnregisterMapObserverAsync(this._mapId, this.Id).ConfigureAwait(false);
-        this._adapterToWorldView.Dispose();
+        await this._adapterToWorldView.DisposeAsync().ConfigureAwait(false);
         try
         {
             await this._jsRuntime.InvokeVoidAsync("DisposeMap", this._identifier).ConfigureAwait(false);

--- a/src/Web/Map/Map/TerrainController.cs
+++ b/src/Web/Map/Map/TerrainController.cs
@@ -46,10 +46,8 @@ public class TerrainController : Controller
             return this.NotFound();
         }
 
-        // TODO: Do this without creating an ObservableGameServerAdapter, because that's a very expensive operation.
-        using var gameServer = new ObservableGameServerAdapter(server.Context);
-        await gameServer.InitializeAsync().ConfigureAwait(false);
-        var map = gameServer.Maps.FirstOrDefault(m => m.Id == mapId);
+        var maps = await server.Context.GetMapsAsync().ConfigureAwait(false);
+        var map = maps.FirstOrDefault(m => m.Id == mapId);
         if (map is null)
         {
             this._logger.LogWarning($"requested map not available. map id: {mapId}");

--- a/src/Web/Map/ObservableGameServerAdapter.cs
+++ b/src/Web/Map/ObservableGameServerAdapter.cs
@@ -37,8 +37,19 @@ public class ObservableGameServerAdapter : Disposable, IObservableGameServer
     /// <summary>
     /// Initializes this instance.
     /// </summary>
-    public async ValueTask InitializeAsync()
+    /// <param name="withMapInfos">
+    /// If set to <c>true</c> (the default), an <see cref="IGameMapInfo"/> is created and kept up-to-date for
+    /// each hosted map, so that <see cref="Maps"/> is populated. That's a rather expensive operation, because
+    /// it attaches to the events of every live game map. Pass <c>false</c> if you just need to register map
+    /// observers and don't access <see cref="Maps"/>.
+    /// </param>
+    public async ValueTask InitializeAsync(bool withMapInfos = true)
     {
+        if (!withMapInfos)
+        {
+            return;
+        }
+
         foreach (var map in await this._gameContext.GetMapsAsync().ConfigureAwait(false))
         {
             var mapAdapter = await this.CreateMapAdapterAsync(map).ConfigureAwait(false);
@@ -88,6 +99,17 @@ public class ObservableGameServerAdapter : Disposable, IObservableGameServer
         base.Dispose(disposing);
         this._gameContext.GameMapCreated -= this.OnGameMapCreated;
         this._gameContext.GameMapRemoved -= this.OnGameMapRemoved;
+
+        // The map adapters are subscribed to the events of the long-living game maps.
+        // If we don't dispose them here, they stay subscribed forever - which is not just a
+        // memory leak, but also slows down the game loop with each leaked instance.
+        foreach (var mapInfo in this._gameMapInfos)
+        {
+            mapInfo.PropertyChanged -= this.OnMapPropertyChanged;
+            (mapInfo as IDisposable)?.Dispose();
+        }
+
+        this._gameMapInfos.Clear();
     }
 
     /// <summary>
@@ -124,6 +146,14 @@ public class ObservableGameServerAdapter : Disposable, IObservableGameServer
             }
 
             var map = await this.CreateMapAdapterAsync(gameMap).ConfigureAwait(false);
+            if (this.IsDisposed || this.IsDisposing)
+            {
+                // We got disposed while the adapter was created - don't leave it subscribed to the map.
+                map.PropertyChanged -= this.OnMapPropertyChanged;
+                map.Dispose();
+                return;
+            }
+
             this._gameMapInfos.Add(map);
             this.RaisePropertyChanged(nameof(this.Maps));
         }


### PR DESCRIPTION
Fixes #919.

Every visit of the admin panel live map page (`/gameServer/{id}/map/{mapId}`) — and every terrain image request — permanently leaked one `GameMapInfoAdapter` per hosted map, because `ObservableGameServerAdapter` never disposed them. The leaked adapters stayed subscribed to the `ObjectAdded` / `ObjectRemoved` events of the live `GameMap`s, so they were rooted forever and additionally slowed down the game loop: those events are awaited sequentially on every spawn, drop, despawn and map transition.

## Changes

### The leak itself

* **`ObservableGameServerAdapter.Dispose(bool)`** now unsubscribes and disposes its `IGameMapInfo`s and clears the list. That's the actual fix — `MapPage` and `GameServer` already disposed the adapter, but the disposal didn't reach the map adapters.
* **`OnGameMapCreated`** additionally disposes a map adapter which was created concurrently to the disposal, instead of adding it to the already cleared list.

### Avoiding the expensive adapter creation altogether

* **`InitializeAsync`** got a `withMapInfos` parameter (default `true`, so the Dapr singleton registration is unaffected). Callers which only need to register a map observer can skip creating and observing an adapter for every map on the server.
* **`MapPage`** only needed the map infos to show the map name in the breadcrumb. It now initializes the adapter without them and resolves the name directly at the `IGameServerContext`.
* **`TerrainController`** doesn't create an `ObservableGameServerAdapter` at all anymore. It looks the `GameMap` up at the context and renders the terrain through a new `GetTerrainStream(this GameMap)` overload. This resolves the existing `// TODO: Do this without creating an ObservableGameServerAdapter, because that's a very expensive operation.` The PNG cache is shared between both overloads, so nothing is rendered twice.

### Component defects found in the same code

* **`MapPlayerList`** subscribed to `IMapController.PlayersChanged` in `OnParametersSet` — which runs on every re-render of the parent `Map` component — and never unsubscribed. Handlers piled up, so after *n* parent renders a single player entering scope triggered *n* re-renders of the whole player table. It now subscribes only when the controller instance actually changed, keeps the handler in a field and unsubscribes in `Dispose`.
* **`Map` component**: removed the synchronous `Dispose`. `Task.Run(this.DisposeAsync).Wait()` bound to `Task.Run(Func<TResult>)` and produced a `Task<ValueTask>`, so the inner `ValueTask` was never awaited — and it would have blocked the renderer thread. Blazor prefers `IAsyncDisposable` when a component implements both, so the remaining `DisposeAsync` is the path that was already taken.
* **`MapController.DisposeAsync`** now awaits `ObserverToWorldViewAdapter.DisposeAsync()` instead of calling the synchronous no-op `Dispose()`, so its `DisposeAsyncCore` (clearing `_observingObjects` and asserting that `ObservingBuckets` is empty) actually runs.

## Testing

* `dotnet build src/MUnique.OpenMU.sln -p:ci=true` — succeeds, no new warnings in the touched files.
* `dotnet test tests/MUnique.OpenMU.Web.Tests` — 88 passed, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XyXbCxbtDecRjhoarSC8qP

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyXbCxbtDecRjhoarSC8qP)_