### PR TITLE
Block personal store mutations while open

### DIFF
--- a/src/GameLogic/PlayerActions/Items/MoveItemAction.cs
+++ b/src/GameLogic/PlayerActions/Items/MoveItemAction.cs
@@ -399,7 +399,7 @@ public class MoveItemAction
             Storages.Inventory => state == PlayerState.EnteredWorld
                                   || state == PlayerState.NpcDialogOpened
                                   || state == PlayerState.TradeOpened,
-            Storages.PersonalStore => state == PlayerState.EnteredWorld,
+            Storages.PersonalStore => state == PlayerState.EnteredWorld && !(player.ShopStorage?.StoreOpen ?? true),
             Storages.Vault => state == PlayerState.NpcDialogOpened && openedWindow == NpcWindow.VaultStorage,
             Storages.Trade => state == PlayerState.TradeOpened,
             Storages.ChaosMachine => state == PlayerState.NpcDialogOpened && openedWindow == NpcWindow.ChaosMachine,

--- a/src/GameLogic/PlayerActions/PlayerStore/SetItemPriceAction.cs
+++ b/src/GameLogic/PlayerActions/PlayerStore/SetItemPriceAction.cs
@@ -21,7 +21,11 @@ public class SetItemPriceAction
     public async ValueTask SetPriceAsync(Player player, byte slot, int price)
     {
         ItemPriceResult result;
-        if (player.Level < 6)
+        if (player.ShopStorage?.StoreOpen ?? false)
+        {
+            result = ItemPriceResult.Failed;
+        }
+        else if (player.Level < 6)
         {
             result = ItemPriceResult.CharacterLevelTooLow;
         }


### PR DESCRIPTION
Blocks item moves and price changes while a personal store is open.