### PR TITLE
Fix friend presence updates during concurrent logins

### DIFF
--- a/src/FriendServer/FriendServer.cs
+++ b/src/FriendServer/FriendServer.cs
@@ -4,6 +4,7 @@
 
 namespace MUnique.OpenMU.FriendServer;
 
+using System.Collections.Concurrent;
 using System.Collections.Immutable;
 using Microsoft.Extensions.Logging;
 using MUnique.OpenMU.Interfaces;
@@ -32,7 +33,7 @@ public class FriendServer : IFriendServer
         this._chatServer = chatServer;
         this._persistenceContextProvider = persistenceContextProvider;
         this._logger = logger;
-        this.OnlineFriends = new Dictionary<string, OnlineFriend>();
+        this.OnlineFriends = new ConcurrentDictionary<string, OnlineFriend>();
     }
 
     /// <summary>
@@ -48,7 +49,7 @@ public class FriendServer : IFriendServer
     /// <summary>
     /// Gets the online friends dictionary. The key is the name of the character of the corresponding OnlineFriend object.
     /// </summary>
-    protected IDictionary<string, OnlineFriend> OnlineFriends { get; }
+    protected ConcurrentDictionary<string, OnlineFriend> OnlineFriends { get; }
 
     /// <inheritdoc/>
     public ValueTask ForwardLetterAsync(LetterHeader letter)
@@ -260,11 +261,18 @@ public class FriendServer : IFriendServer
                 return;
             }
 
-            observer = new OnlineFriend(this._friendNotifier, characterName)
+            var candidate = new OnlineFriend(this._friendNotifier, characterName)
             {
                 ServerId = serverId,
             };
-            this.OnlineFriends.Add(characterName, observer);
+            observer = this.OnlineFriends.GetOrAdd(characterName, candidate);
+            if (!ReferenceEquals(observer, candidate))
+            {
+                candidate.Dispose();
+                observer.ChangeServer(serverId == InvisibleServerId ? OfflineServerId : serverId);
+                return;
+            }
+
             IFriendServerContext? newContext = null;
             var context = usedContext ?? (newContext = this._persistenceContextProvider.CreateNewFriendServerContext());
 
@@ -283,7 +291,7 @@ public class FriendServer : IFriendServer
 
         if (serverId == OfflineServerId)
         {
-            this.OnlineFriends.Remove(observer.PlayerName);
+            this.OnlineFriends.TryRemove(observer.PlayerName, out _);
             observer.OnCompleted();
         }
     }


### PR DESCRIPTION
Concurrent logins can corrupt the online-friend dictionary, throw `IndexOutOfRangeException`, and leave online friends shown as Offline. Use `ConcurrentDictionary` with atomic registration and removal. Live friend-status retest passed.

Mail note (separate issue): [MuMain still declares a 60-byte subject](https://github.com/sven-n/MuMain/blob/6dda36432b220a5e894fc949d3dd989a554272e2/src/source/Network/Server/WSclient.h#L1818) ([constant](https://github.com/sven-n/MuMain/blob/6dda36432b220a5e894fc949d3dd989a554272e2/src/source/Core/Globals/_define.h#L328)), but [OpenMU AddLetter sends 32 bytes](https://github.com/MUnique/OpenMU/blob/3b8831392ed8aacfc4c09e4ca338d1022907ee62/src/Network/Packets/ServerToClient/ServerToClientPackets.xml#L9952). The client reads the state at byte 106 instead of 78, which can hide letters. Please choose a client-side or compatible server-side fix to align the layouts; this PR only fixes friend presence.