### PR TITLE
Fix socket option level encoding

### DIFF
--- a/src/GameServer/RemoteView/ItemSerializerHelper.cs
+++ b/src/GameServer/RemoteView/ItemSerializerHelper.cs
@@ -138,7 +138,7 @@ public static class ItemSerializerHelper
                 return EmptySocket;
             }
 
-            var sphereLevel = optionLink.Level;
+            var sphereLevel = optionLink.Level - 1;
             var elementType = optionLink.ItemOption!.SubOptionType;
             var elementOption = optionLink.ItemOption.Number;
             var optionIndex = SocketOptionIndexOffsets[elementType] + elementOption;
@@ -193,7 +193,7 @@ public static class ItemSerializerHelper
                 continue;
             }
 
-            var sphereLevel = socketByte / MaximumSocketOptions;
+            var sphereLevel = (socketByte / MaximumSocketOptions) + 1;
             var optionIndex = socketByte % MaximumSocketOptions;
             var indexOffset = SocketOptionIndexOffsets.Last(offset => offset <= optionIndex);
             var elementType = Array.IndexOf(SocketOptionIndexOffsets, indexOffset);


### PR DESCRIPTION
Socket levels are stored as 1–5, but packet sphere ranks are 0–4. Encoding the stored level directly shifts values and makes level-5 options overflow into different seed types.

Subtract one when encoding and add one when decoding. This fixes both standard and extended item packets.