### PR TITLE
Let the outlaw (player killer) state actually wear off again

### DIFF
--- a/src/GameLogic/NPC/AttackableNpcBase.cs
+++ b/src/GameLogic/NPC/AttackableNpcBase.cs
@@ -365,6 +365,8 @@ public abstract class AttackableNpcBase : NonPlayerCharacter, IAttackable
             {
                 if (selectedCharacter.State > HeroState.Normal)
                 {
+                    // An outlaw can shorten its remaining state time by hunting monsters, on any map:
+                    // the level of the killed monster is subtracted in seconds.
                     selectedCharacter.StateRemainingSeconds -= (int)this.Attributes[Stats.Level];
                 }
 

--- a/src/GameLogic/Player.cs
+++ b/src/GameLogic/Player.cs
@@ -44,6 +44,18 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
         StopByDeath = false,
     };
 
+    /// <summary>
+    /// How long an outlaw (player killer) state lasts until it falls back one step. Each player kill
+    /// (re)starts it, and kills which can't escalate the state any further stack on top of it.
+    /// It can be shortened by killing monsters.
+    /// </summary>
+    private static readonly TimeSpan PlayerKillerStateDuration = TimeSpan.FromHours(3);
+
+    /// <summary>
+    /// The duration until a hero state falls back one step.
+    /// </summary>
+    private static readonly TimeSpan HeroStateDuration = TimeSpan.FromHours(1);
+
     private readonly PlayerExperience _experience;
 
     /// <summary>
@@ -1255,9 +1267,20 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
             {
                 this._selectedCharacter.State++;
             }
+
+            // Stepping up to the next outlaw state restarts the clock for that state. Math.Max, so that
+            // a kill can never shorten an already longer remaining time.
+            this._selectedCharacter.StateRemainingSeconds = Math.Max(
+                this._selectedCharacter.StateRemainingSeconds,
+                (int)PlayerKillerStateDuration.TotalSeconds);
+        }
+        else
+        {
+            // Further kills as a 2nd stage outlaw can't escalate the state anymore, so they stack on
+            // top of the remaining time instead.
+            this._selectedCharacter.StateRemainingSeconds += (int)PlayerKillerStateDuration.TotalSeconds;
         }
 
-        this._selectedCharacter.StateRemainingSeconds += (int)TimeSpan.FromHours(1).TotalSeconds;
         this._selectedCharacter.PlayerKillCount += 1;
         await this.ForEachWorldObserverAsync<IUpdateCharacterHeroStatePlugIn>(o => o.UpdateCharacterHeroStateAsync(this), true).ConfigureAwait(false);
     }
@@ -1392,33 +1415,48 @@ public class Player : AsyncDisposable, IBucketMapObserver, IAttackable, IAttacke
 
     private async ValueTask RegenerateHeroStateAsync()
     {
-        var currentCharacter = this._selectedCharacter;
-        if (currentCharacter?.StateRemainingSeconds > 0)
+        if (this._selectedCharacter is not { } currentCharacter
+            || currentCharacter.State == HeroState.Normal)
         {
-            var secondsSinceLastRegenerate = this._lastRegenerate.Subtract(DateTime.UtcNow).TotalSeconds;
-            currentCharacter.StateRemainingSeconds -= (int)Math.Round(secondsSinceLastRegenerate);
-            if (currentCharacter.StateRemainingSeconds <= 0)
-            {
-                // Change the status.
-                if (currentCharacter.State > HeroState.Normal)
-                {
-                    currentCharacter.State--;
-                }
-                else if (currentCharacter.State < HeroState.Normal)
-                {
-                    currentCharacter.State++;
-                }
-                else
-                {
-                    // State is already Normal, no change needed.
-                }
-
-                await this.ForEachWorldObserverAsync<IUpdateCharacterHeroStatePlugIn>(p => p.UpdateCharacterHeroStateAsync(this), true).ConfigureAwait(false);
-                currentCharacter.StateRemainingSeconds = currentCharacter.State == HeroState.Normal
-                    ? 0
-                    : (int)TimeSpan.FromHours(1).TotalSeconds;
-            }
+            return;
         }
+
+        if (currentCharacter.State < HeroState.Normal && currentCharacter.StateRemainingSeconds <= 0)
+        {
+            // A hero state without a running timer, e.g. a newly created character.
+            return;
+        }
+
+        currentCharacter.StateRemainingSeconds -= (int)Math.Round(DateTime.UtcNow.Subtract(this._lastRegenerate).TotalSeconds);
+        if (currentCharacter.StateRemainingSeconds > 0)
+        {
+            return;
+        }
+
+        // The time is up, so the state falls back one step towards the normal state. Killed monsters may
+        // have pushed the remaining time below zero, so the surplus is carried over to the next step.
+        var surplusSeconds = -currentCharacter.StateRemainingSeconds;
+        if (currentCharacter.State > HeroState.Normal)
+        {
+            currentCharacter.State--;
+        }
+        else
+        {
+            currentCharacter.State++;
+        }
+
+        if (currentCharacter.State == HeroState.Normal)
+        {
+            currentCharacter.StateRemainingSeconds = 0;
+            currentCharacter.PlayerKillCount = 0;
+        }
+        else
+        {
+            var stateDuration = currentCharacter.State > HeroState.Normal ? PlayerKillerStateDuration : HeroStateDuration;
+            currentCharacter.StateRemainingSeconds = Math.Max((int)stateDuration.TotalSeconds - surplusSeconds, 0);
+        }
+
+        await this.ForEachWorldObserverAsync<IUpdateCharacterHeroStatePlugIn>(p => p.UpdateCharacterHeroStateAsync(this), true).ConfigureAwait(false);
     }
 
     private async ValueTask HitAsync(HitInfo hitInfo, IAttacker attacker, Skill? skill, bool? isFinalStreakHit = null)


### PR DESCRIPTION
## Summary
The remaining time of a hero or outlaw state was never counted down. A player killer therefore
stayed an outlaw forever — in practice a permanent 2nd stage outlaw that only `/pkclear` could
remove — no matter how long the player stayed online or how many monsters they hunted. This fixes
the countdown and restores the classic timings around it.

## The symptom
1. Kill another player three times (no self-defense, no duel, no rival guild), so the character
   becomes a 2nd stage outlaw.
2. Stay online for hours, hunt any amount of monsters.
3. The character never returns to the 1st stage, let alone to normal. Its name stays red/black,
   the drop and experience penalties stay, and `Character.StateRemainingSeconds` in the database
   keeps growing instead of shrinking.

What did work: escalating into the states, the `IUpdateCharacterHeroStatePlugIn` notification to
the observers, and `/pkclear`, which is why this stayed unnoticed for so long. Our servers are
populated with offline/bot players which occasionally kill each other, and every single one of
them accumulated a permanent outlaw state.

## Root cause
Two defects in `Player.RegenerateHeroStateAsync()` (`src/GameLogic/Player.cs`), which is called
from `RegenerateAsync()` on the recovery timer:

- The elapsed time was calculated as `this._lastRegenerate.Subtract(DateTime.UtcNow)`. The field
  holds the *previous* tick, so the result is negative — despite the variable being named
  `secondsSinceLastRegenerate`. Subtracting it made `StateRemainingSeconds` *grow* by exactly the
  elapsed time, so the countdown stood still (in net terms) forever.
- The whole method body was guarded by `if (currentCharacter?.StateRemainingSeconds > 0)`. Killing
  monsters reduces the remaining time by the monster's level
  (`AttackableNpcBase.OnDeathAsync()`), which can push it to zero or below between two ticks.
  From that moment on, the guard was false and the state change was never reached again.

Together they meant that the state could only ever escalate. `git blame` dates both to
`db15dea508` (2021-11-13); nothing else in the code base lowers `Character.State` except
`/pkclear` and the GM command `/pk`.

## The fix
`RegenerateHeroStateAsync()` is rewritten with early returns:

- The elapsed time is now `DateTime.UtcNow.Subtract(this._lastRegenerate)`. It is subtracted in
  whole seconds, and the remaining fraction is kept for the next tick. Rounding every tick made the countdown speed depend on `GameConfiguration.RecoveryInterval`
  (at 500 ms it never counted down at all).
- A remaining time which ran below zero steps the state one step towards normal and carries the
  whole surplus over into the next step, so a hunting spree can drop more than one step at a time.
- `HeroState.New` (a freshly created character, which has no running timer) is now excluded
  explicitly. Previously the `> 0` guard did that by accident, and without the guard such a
  character would have been promoted towards `HeroState.Hero`.
- When a character enters the world, its remaining time is limited to what its state can
  legitimately have: one state duration, and for a 2nd stage outlaw one duration per kill after the
  one which reached that stage. Characters of servers which ran with the broken countdown would
  otherwise carry a remaining time which grew by all the time they spent online.
- Returning to `HeroState.Normal` also resets `PlayerKillCount`, which otherwise kept charging the
  `/pkclear` price for kills the player had already atoned for.

The timings follow the classic (pre-Season 9) behavior again, where they were wrong before:

- An outlaw state lasts three hours instead of one (`PlayerKillerStateDuration`).
- Stepping up to the next outlaw state restarts that clock instead of adding to it; only kills
  which can no longer escalate the state (i.e. as a 2nd stage outlaw) stack on top of the
  remaining time. Three kills in a row therefore take 3 h + 3 h + 3 h to wear off, and every
  further kill adds another three hours.
- A `Math.Max` makes sure a kill can never shorten an already longer remaining time.
- Hero states keep their one hour (`HeroStateDuration`).

Reducing the remaining time by the level of a killed monster is left as it is, and deliberately
stays available on every map and in every outlaw state: that matches the classic rule, where the
penalty was shortened by the monster's level in seconds anywhere, long before later seasons
restricted it to Vulcanus. The only change in `AttackableNpcBase` is a clarifying comment.

Since the timer is only advanced while the player is in the game — `_lastRegenerate` is reset when
entering the world — offline time still does not count towards wearing the state off.

## Testing
- `dotnet build src/GameLogic/MUnique.OpenMU.GameLogic.csproj -p:ci=true` in the
  `mcr.microsoft.com/dotnet/sdk:10.0` container: 0 errors, and no analyzer warning in either of
  the two touched files.
- Not verified at runtime: this has not been run on a game server yet, so the state transitions
  were reviewed by reading the code only.
- No unit tests added. There is currently no test coverage for the hero state at all; the only
  related test is `PKClearChatCommandPlugInTest`.

## Possible follow-ups (not in this change)
- The three hours and one hour could be made configurable (e.g. in `GameConfiguration`) instead of
  being constants in `Player`.
- `WarpAction` does not check the hero state at all, so an outlaw can still use the warp list. The
  classic rule forbids warping as a 2nd stage outlaw (the original client protocol even has a
  `MAPMOVE_FAILED_MURDERER` result), and later seasons charge 50x the zen instead.